### PR TITLE
fix(account-card): update localization for next payment notification

### DIFF
--- a/app/[locale]/dashboard/components/accounts/account-card.tsx
+++ b/app/[locale]/dashboard/components/accounts/account-card.tsx
@@ -136,7 +136,7 @@ export function AccountCard({ account, trades, metrics, onClick, size = 'large' 
                         Math.floor((new Date(account.nextPaymentDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24)) < 5 ? 'text-red-500 blink' : 'text-muted-foreground'
                       )}>
                         {Math.floor((new Date(account.nextPaymentDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24))}
-                        {t('propFirm.card.daysBeforeReset')}
+                        {t('propFirm.card.daysBeforeNextPayment')}
                       </div>
                     )
                   }

--- a/locales/en/propfirm.ts
+++ b/locales/en/propfirm.ts
@@ -11,7 +11,7 @@ export default {
             drawdownBreached: 'Drawdown breached',
             maxLoss: 'Max Loss: ${amount}',
             needsConfiguration: 'Account needs to be configured',
-            daysBeforeReset: ' days before reset',
+            daysBeforeNextPayment: ' days before next payment',
             consistency: 'Consistency',
             highestDailyProfit: 'Highest Daily Profit',
             maxAllowedDailyProfit: 'Max Allowed Daily Profit',

--- a/locales/fr/propfirm.ts
+++ b/locales/fr/propfirm.ts
@@ -11,7 +11,7 @@ export default {
             drawdownBreached: 'Perte maximale dépassée',
             maxLoss: 'Perte max : ${amount}',
             needsConfiguration: 'Le compte doit être configuré',
-            daysBeforeReset: ' jours avant remise à zéro',
+            daysBeforeNextPayment: ' jours avant le prochain paiement',
             consistency: 'Cohérence',
             highestDailyProfit: 'Plus haut profit journalier',
             maxAllowedDailyProfit: 'Profit journalier maximum autorisé',


### PR DESCRIPTION
- Changed the label from 'days before reset' to 'days before next payment' in both English and French localization files to accurately reflect the context of the countdown for upcoming payments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the label text in the account card to reference days before the next payment instead of days before reset.
- **Documentation**
  - Revised English and French translations to match the updated label, improving clarity for users in both languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->