### PR TITLE
feat(charts): update trade distribution tooltips to include total trades

### DIFF
--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -75,9 +75,9 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
     const beRate = Number((nbBe / nbTrades * 100).toFixed(2))
 
     return [
-      { name: t('tradeDistribution.lossWithCount', { count: nbLoss }), value: lossRate, color: 'hsl(var(--destructive))', count: nbLoss },
-      { name: t('tradeDistribution.breakevenWithCount', { count: nbBe }), value: beRate, color: 'hsl(var(--muted-foreground))', count: nbBe },
-      { name: t('tradeDistribution.winWithCount', { count: nbWin }), value: winRate, color: 'hsl(var(--success))', count: nbWin }
+      { name: t('tradeDistribution.winWithCount', { count: nbWin, total: nbTrades }), value: winRate, color: 'hsl(var(--success))', count: nbWin },
+      { name: t('tradeDistribution.breakevenWithCount', { count: nbBe, total: nbTrades }), value: beRate, color: 'hsl(var(--muted-foreground))', count: nbBe },
+      { name: t('tradeDistribution.lossWithCount', { count: nbLoss, total: nbTrades }), value: lossRate, color: 'hsl(var(--destructive))', count: nbLoss }
     ]
   }, [nbWin, nbLoss, nbBe, nbTrades, t])
 

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -793,9 +793,9 @@ export default {
         win: "Winning trades",
         loss: "Losing trades",
         breakeven: "Breakeven trades",
-        winWithCount: "Winning trades ({count})",
-        lossWithCount: "Losing trades ({count})",
-        breakevenWithCount: "Breakeven trades ({count})",
+        winWithCount: "Winning trades ({count}/{total})",
+        lossWithCount: "Losing trades ({count}/{total})",
+        breakevenWithCount: "Breakeven trades ({count}/{total})",
         tooltip: {
             type: "Type",
             percentage: "Percentage"

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -523,9 +523,9 @@ export default {
         win: "Trades gagnants",
         loss: "Trades perdants",
         breakeven: "Trades à l'équilibre",
-        winWithCount: "Trades gagnants ({count})",
-        lossWithCount: "Trades perdants ({count})",
-        breakevenWithCount: "Trades à l'équilibre ({count})",
+        winWithCount: "Trades gagnants ({count}/{total})",
+        lossWithCount: "Trades perdants ({count}/{total})",
+        breakevenWithCount: "Trades à l'équilibre ({count}/{total})",
         tooltip: {
             type: "Type",
             percentage: "Pourcentage"


### PR DESCRIPTION
- Modified the trade distribution chart to display total trades in the tooltip for win, breakeven, and loss categories.
- Updated localization files for English and French to reflect the new tooltip format, enhancing clarity for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart legends and tooltips for trade distribution now display both the count and the total number of trades for each category, providing clearer context.

* **Style**
  * The order of categories in the trade distribution chart has been updated to show winning trades first, followed by breakeven and losing trades.

* **Documentation**
  * Updated English and French localization strings to reflect the new count/total format in trade distribution labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->