### PR TITLE
fix(stripe): restore payment method collection option for subscription mode

### DIFF
--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -89,7 +89,6 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
         success_url: `${websiteURL}dashboard?success=true`,
         cancel_url: `${websiteURL}pricing?canceled=true`,
         allow_promotion_codes: true,
-        payment_method_collection: 'if_required'
     };
 
     if (isLifetimePlan) {
@@ -98,6 +97,7 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
     } else {
         // Subscription mode for recurring plans
         sessionConfig.mode = 'subscription';
+        sessionConfig.payment_method_collection = 'if_required';
         
         // Add subscription-specific configuration
         if (trialDays > 0) {


### PR DESCRIPTION
- Reintroduced the 'payment_method_collection' parameter set to 'if_required' in the checkout session configuration for subscription plans, ensuring proper payment handling during checkout.