### PR TITLE
feat(terms): enhance terms of service with additional clarifications and data export information

### DIFF
--- a/app/[locale]/(landing)/terms/page.tsx
+++ b/app/[locale]/(landing)/terms/page.tsx
@@ -30,6 +30,9 @@ export default function TermsOfService() {
         <h2 className="text-2xl font-semibold mb-3">{t('terms.sections.subscriptionPayments.title')}</h2>
         <p>{t('terms.sections.subscriptionPayments.content')}</p>
         
+        <h3 className="text-lg font-semibold mt-4 mb-2">{t('terms.sections.subscriptionPayments.storageClarification')}</h3>
+        <p className="mb-3">{t('terms.sections.subscriptionPayments.fairUse')}</p>
+        
         <h3 className="text-lg font-semibold mt-4 mb-2">{t('terms.sections.subscriptionPayments.lifetimePlan.title')}</h3>
         <p>{t('terms.sections.subscriptionPayments.lifetimePlan.description')}</p>
         <ul className="list-disc ml-6 mt-2 space-y-1">
@@ -50,6 +53,7 @@ export default function TermsOfService() {
       <section className="mb-6">
         <h2 className="text-2xl font-semibold mb-3">{t('terms.sections.dataProtection.title')}</h2>
         <p>{t('terms.sections.dataProtection.content')}</p>
+        <p className="mt-2">{t('terms.sections.dataProtection.dataExport')}</p>
       </section>
 
       <section className="mb-6">

--- a/locales/en/terms.ts
+++ b/locales/en/terms.ts
@@ -18,6 +18,8 @@ export default {
             subscriptionPayments: {
                 title: "4. Subscription and Payments",
                 content: "We offer paid plans on a monthly, quarterly, yearly, and lifetime basis. Payment is processed through Stripe. Refunds are generally not provided after the subscription period, but may be considered on a case-by-case basis. Any refunds may be subject to processing fees charged by our payment service provider.",
+                storageClarification: "The unlimited storage provided in the lifetime plan covers texts, images, and standard documents related to trades. Recording or storing video files is not supported.",
+                fairUse: "The term \"unlimited\" is understood within the framework of normal and non-abusive use of the service. We reserve the right to limit or restrict usage in case of excessive use or use contrary to the platform's purpose.",
                 lifetimePlan: {
                     title: "Lifetime Plan Terms",
                     description: "The \"Lifetime\" plan provides access to the Deltalytix service for the operational lifetime of the service, subject to the following conditions:",
@@ -35,7 +37,8 @@ export default {
             },
             dataProtection: {
                 title: "6. Data Protection and Privacy",
-                content: "We comply with the General Data Protection Regulation (GDPR) and other applicable data protection laws. We protect user data by using Supabase, which is SOC 2 compliant, and by anonymizing data in our database. We do not use third-party analytics services. For more information, please see our Privacy Policy."
+                content: "We comply with the General Data Protection Regulation (GDPR) and other applicable data protection laws. We protect user data by using Supabase, which is SOC 2 compliant, and by anonymizing data in our database. We do not use third-party analytics services. For more information, please see our Privacy Policy.",
+                dataExport: "Users can, at any time, request a copy of their data in a readable format (CSV, JSON)."
             },
             liability: {
                 title: "7. Limitation of Liability",
@@ -43,7 +46,7 @@ export default {
             },
             termination: {
                 title: "8. Termination",
-                content: "We reserve the right to suspend or terminate your access to the service at any time for any reason, including but not limited to a violation of these Terms. You may terminate your account at any time by contacting us."
+                content: "We reserve the right to suspend or terminate your access to the service at any time for any reason, including but not limited to a violation of these Terms. You may terminate your account at any time directly from the service interface or by contacting us. This termination will take effect immediately or at the end of your subscription period."
             },
             serviceAvailability: {
                 title: "9. Service Availability and Continuity",

--- a/locales/fr/terms.ts
+++ b/locales/fr/terms.ts
@@ -18,6 +18,8 @@ export default {
             subscriptionPayments: {
                 title: "4. Abonnement et paiements",
                 content: "Nous proposons des plans payants sur une base mensuelle, trimestrielle, annuelle et à vie. Le paiement est traité via Stripe. Les remboursements ne sont généralement pas fournis après la période d'abonnement, mais peuvent être considérés au cas par cas. Tout remboursement peut être soumis aux frais de traitement facturés par notre fournisseur de services de paiement.",
+                storageClarification: "Le stockage illimité prévu dans le plan à vie couvre les textes, images et documents standards liés aux trades. L'enregistrement ou le stockage de fichiers vidéo n'est pas pris en charge.",
+                fairUse: "Le terme \"illimité\" s'entend dans le cadre d'un usage normal et non abusif du service. Nous nous réservons le droit de limiter ou restreindre l'usage en cas d'utilisation excessive ou contraire à la finalité de la plateforme.",
                 lifetimePlan: {
                     title: "Conditions du plan à vie",
                     description: "Le plan \"À vie\" fournit l'accès au service Deltalytix pour la durée de vie opérationnelle du service, sous réserve des conditions suivantes :",
@@ -35,7 +37,8 @@ export default {
             },
             dataProtection: {
                 title: "6. Protection des données et confidentialité",
-                content: "Nous nous conformons au Règlement Général sur la Protection des Données (RGPD) et aux autres lois applicables sur la protection des données. Nous protégeons les données utilisateur en utilisant Supabase, qui est conforme SOC 2, et en anonymisant les données dans notre base de données. Nous n'utilisons pas de services d'analyse tiers. Pour plus d'informations, veuillez consulter notre Politique de confidentialité."
+                content: "Nous nous conformons au Règlement Général sur la Protection des Données (RGPD) et aux autres lois applicables sur la protection des données. Nous protégeons les données utilisateur en utilisant Supabase, qui est conforme SOC 2, et en anonymisant les données dans notre base de données. Nous n'utilisons pas de services d'analyse tiers. Pour plus d'informations, veuillez consulter notre Politique de confidentialité.",
+                dataExport: "Les utilisateurs peuvent, à tout moment, demander une copie de leurs données dans un format lisible (CSV, JSON)."
             },
             liability: {
                 title: "7. Limitation de responsabilité",
@@ -43,7 +46,7 @@ export default {
             },
             termination: {
                 title: "8. Résiliation",
-                content: "Nous nous réservons le droit de suspendre ou de résilier votre accès au service à tout moment pour toute raison, y compris mais sans s'y limiter à une violation de ces Conditions. Vous pouvez résilier votre compte à tout moment en nous contactant."
+                content: "Nous nous réservons le droit de suspendre ou de résilier votre accès au service à tout moment pour toute raison, y compris mais sans s'y limiter à une violation de ces Conditions. Vous pouvez résilier votre compte à tout moment directement depuis l'interface du service ou en nous contactant. Cette résiliation prendra effet immédiatement ou à la fin de votre période d'abonnement."
             },
             serviceAvailability: {
                 title: "9. Disponibilité et continuité du service",


### PR DESCRIPTION
- Added sections for storage clarification and fair use under subscription payments in both English and French localization files.
- Included a new data export clause in the data protection section, specifying user rights to request their data in readable formats.
- Updated the terms of service page to reflect these changes, improving clarity and user understanding of service terms.