### PR TITLE
feat(dashboard): prevent pagination reset on data change in TradeTableReview

### DIFF
--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -899,6 +899,7 @@ export function TradeTableReview() {
       },
     },
     paginateExpandedRows: false,
+    autoResetPageIndex: false, // Prevents pageIndex from resetting on data change
     onExpandedChange: setExpanded,
     onPaginationChange: handlePaginationChange,
     getSubRows: (row) => row.trades,


### PR DESCRIPTION
- Added autoResetPageIndex property to the TradeTableReview component to maintain the current page index when data changes, enhancing user experience during trade reviews.