### PR TITLE
fix(accounts): clamp crashed-account balance at accepted loss floor

### DIFF
--- a/lib/account-metrics.ts
+++ b/lib/account-metrics.ts
@@ -153,7 +153,7 @@ export function computeAccountMetrics(
     if (runningBalance > highestBalance) highestBalance = runningBalance
   }
   const totalPayouts = validPayouts.reduce((s, p) => s + p.amount, 0)
-  const currentBalance = runningBalance - totalPayouts
+  const rawCurrentBalance = runningBalance - totalPayouts
 
   let drawdownLevel: number
   if (account.trailingDrawdown) {
@@ -166,6 +166,13 @@ export function computeAccountMetrics(
   } else {
     drawdownLevel = (account.startingBalance || 0) - (account.drawdownThreshold || 0)
   }
+  // For prop-firm accounts, losses beyond the accepted drawdown are not realized.
+  // Clamp displayed balance at the drawdown floor once the account is breached.
+  const currentBalance =
+    (account.drawdownThreshold || 0) > 0
+      ? Math.max(rawCurrentBalance, drawdownLevel)
+      : rawCurrentBalance
+
   const remainingLoss = Math.max(0, currentBalance - drawdownLevel)
   const dd = account.drawdownThreshold || 0
   const drawdownProgress = dd > 0 ? (((dd) - remainingLoss) / dd) * 100 : 0


### PR DESCRIPTION
## Problem
Issue #86 reports account balances can display losses below accepted drawdown after a crash.

## Changes
- In account metrics calculation:
  - compute raw balance as before
  - clamp displayed `currentBalance` to drawdown floor when drawdown applies
  - keep `remainingLoss` aligned to clamped balance

## Why
Prevents over-reporting post-breach losses and aligns display with accepted prop-firm loss behavior.

## Testing
- Lint on changed file
- Runtime script check:
  - breach case now clamps to drawdown floor
  - non-breach case unchanged

## Scope
Metrics display fix only; no schema/API changes.

Closes #86
