### PR TITLE
feat(settings): add base currency preference and symbol switching

### DIFF
--- a/app/[locale]/dashboard/components/accounts/account-card.tsx
+++ b/app/[locale]/dashboard/components/accounts/account-card.tsx
@@ -7,6 +7,8 @@ import { useI18n } from "@/locales/client"
 import { TradeProgressChart } from "./trade-progress-chart"
 import { Account } from "@/context/data-provider"
 import { WidgetSize } from '../../types/dashboard'
+import { useUserStore } from "@/store/user-store"
+import { formatCurrencyWithSymbol } from "@/lib/currency"
 
 interface AccountCardProps {
   account: Account
@@ -16,6 +18,7 @@ interface AccountCardProps {
 
 export function AccountCard({ account, onClick, size = 'large' }: AccountCardProps) {
   const t = useI18n()
+  const baseCurrency = useUserStore((state) => state.baseCurrency)
   
   // Extract metrics from account (computed server-side)
   const metrics = account.metrics
@@ -84,7 +87,7 @@ export function AccountCard({ account, onClick, size = 'large' }: AccountCardPro
           <span className={cn(
             "font-semibold truncate ml-2",
             size === 'small' || size === 'small-long' ? "text-sm" : "text-base"
-          )}>${currentBalance.toFixed(2)}</span>
+          )}>{formatCurrencyWithSymbol(currentBalance, baseCurrency)}</span>
         </div>
         {isConfigured ? (
           <div className={cn(
@@ -101,7 +104,7 @@ export function AccountCard({ account, onClick, size = 'large' }: AccountCardPro
             <div className="space-y-1">
               <div className="flex justify-between text-xs">
                 <span className="text-muted-foreground">{t('propFirm.card.remainingToTarget')}</span>
-                <span>${remainingToTarget.toFixed(2)}</span>
+                <span>{formatCurrencyWithSymbol(remainingToTarget, baseCurrency)}</span>
               </div>
               <Progress
                 value={progress}
@@ -167,11 +170,15 @@ export function AccountCard({ account, onClick, size = 'large' }: AccountCardPro
                 </div>
                 <div className="flex justify-between text-xs text-muted-foreground">
                   <span>{t('propFirm.card.maxAllowedDailyProfit')}</span>
-                  <span>${metrics.maxAllowedDailyProfit?.toFixed(2) || '-'}</span>
+                  <span>{metrics.maxAllowedDailyProfit !== null && metrics.maxAllowedDailyProfit !== undefined
+                    ? formatCurrencyWithSymbol(metrics.maxAllowedDailyProfit, baseCurrency)
+                    : '-'}</span>
                 </div>
                 <div className="flex justify-between text-xs text-muted-foreground">
                   <span>{t('propFirm.card.highestDailyProfit')}</span>
-                  <span>${metrics.highestProfitDay?.toFixed(2) || '-'}</span>
+                  <span>{metrics.highestProfitDay !== null && metrics.highestProfitDay !== undefined
+                    ? formatCurrencyWithSymbol(metrics.highestProfitDay, baseCurrency)
+                    : '-'}</span>
                 </div>
                 
                 {/* Trading Days Section */}
@@ -185,7 +192,7 @@ export function AccountCard({ account, onClick, size = 'large' }: AccountCardPro
                       {metrics.validTradingDays}/{metrics.totalTradingDays}
                       {account.minPnlToCountAsDay && account.minPnlToCountAsDay > 0 && (
                         <span className="ml-1 text-xs opacity-75">
-                          (≥${account.minPnlToCountAsDay})
+                          {`(≥${formatCurrencyWithSymbol(account.minPnlToCountAsDay, baseCurrency)})`}
                         </span>
                       )}
                     </span>

--- a/app/[locale]/dashboard/settings/page.tsx
+++ b/app/[locale]/dashboard/settings/page.tsx
@@ -59,6 +59,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { LinkedAccounts } from "@/components/linked-accounts"
+import { SupportedCurrency, supportedCurrencies } from "@/lib/currency"
 
 type Locale = 'en' | 'fr'
 
@@ -83,6 +84,8 @@ export default function SettingsPage() {
   const user = useUserStore(state => state.supabaseUser)
   const timezone = useUserStore(state => state.timezone)
   const setTimezone = useUserStore(state => state.setTimezone)
+  const baseCurrency = useUserStore(state => state.baseCurrency)
+  const setBaseCurrency = useUserStore(state => state.setBaseCurrency)
   
   const [emailNotifications, setEmailNotifications] = useState(true)
   const [pushNotifications, setPushNotifications] = useState(false)
@@ -103,6 +106,16 @@ export default function SettingsPage() {
     { value: 'en', label: 'English' },
     { value: 'fr', label: 'Français' },
   ]
+
+  const currencyLabels: Record<SupportedCurrency, string> = {
+    USD: "USD ($)",
+    EUR: "EUR (€)",
+    GBP: "GBP (£)",
+    JPY: "JPY (¥)",
+    CAD: "CAD (C$)",
+    AUD: "AUD (A$)",
+    CHF: "CHF (CHF)",
+  }
 
   const handleThemeChange = (value: string) => {
     setTheme(value as "light" | "dark" | "system")
@@ -325,6 +338,40 @@ export default function SettingsPage() {
                         ))}
                       </DropdownMenuRadioGroup>
                     </ScrollArea>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Currency Settings */}
+            <div>
+              <Label className="text-base font-medium flex items-center gap-2">
+                <CreditCard className="h-4 w-4" />
+                Base Currency
+              </Label>
+              <div className="mt-2">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" className="w-[200px] justify-start">
+                      {currencyLabels[baseCurrency]}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuRadioGroup
+                      value={baseCurrency}
+                      onValueChange={(value) => setBaseCurrency(value as SupportedCurrency)}
+                    >
+                      {supportedCurrencies.map((currency) => (
+                        <DropdownMenuRadioItem
+                          key={currency}
+                          value={currency}
+                        >
+                          {currencyLabels[currency]}
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,0 +1,49 @@
+export const supportedCurrencies = [
+  "USD",
+  "EUR",
+  "GBP",
+  "JPY",
+  "CAD",
+  "AUD",
+  "CHF",
+] as const
+
+export type SupportedCurrency = (typeof supportedCurrencies)[number]
+
+const currencySymbols: Record<SupportedCurrency, string> = {
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  JPY: "¥",
+  CAD: "C$",
+  AUD: "A$",
+  CHF: "CHF",
+}
+
+export function getCurrencySymbol(currency: SupportedCurrency): string {
+  return currencySymbols[currency] ?? "$"
+}
+
+export function formatCurrencyAmount(
+  value: number,
+  currency: SupportedCurrency,
+  options?: {
+    minimumFractionDigits?: number
+    maximumFractionDigits?: number
+  },
+): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: options?.minimumFractionDigits,
+    maximumFractionDigits: options?.maximumFractionDigits,
+  }).format(value)
+}
+
+export function formatCurrencyWithSymbol(
+  value: number,
+  currency: SupportedCurrency,
+  decimals = 2,
+): string {
+  return `${getCurrencySymbol(currency)}${value.toFixed(decimals)}`
+}

--- a/store/user-store.ts
+++ b/store/user-store.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@/prisma/generated/prisma/browser";
 import { User as SupabaseUser } from "@supabase/supabase-js";
 import { Group, Account } from "@/context/data-provider";
 import { Widget } from "@/app/[locale]/dashboard/types/dashboard";
+import { SupportedCurrency } from "@/lib/currency";
 import {
   deleteGroupAction,
   saveGroupAction,
@@ -43,6 +44,8 @@ type UserStore = {
   isSharedView: boolean;
   timezone: string;
   setTimezone: (timezone: string) => void;
+  baseCurrency: SupportedCurrency;
+  setBaseCurrency: (currency: SupportedCurrency) => void;
   setUser: (user: User | null) => void;
   setSupabaseUser: (supabaseUser: SupabaseUser | null) => void;
   setSubscription: (subscription: Subscription | null) => void;
@@ -79,6 +82,8 @@ export const useUserStore = create<UserStore>()(
       isSharedView: false,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       setTimezone: (timezone: string) => set({ timezone }),
+      baseCurrency: "USD",
+      setBaseCurrency: (baseCurrency) => set({ baseCurrency }),
       setUser: (user) => set({ user }),
       setSupabaseUser: (supabaseUser) => set({ supabaseUser }),
       setSubscription: (subscription) =>
@@ -200,6 +205,7 @@ export const useUserStore = create<UserStore>()(
       partialize: (state) => ({
         dashboardLayout: state.dashboardLayout,
         timezone: state.timezone,
+        baseCurrency: state.baseCurrency,
         isMobile: state.isMobile,
         isSharedView: state.isSharedView,
       }),


### PR DESCRIPTION
## Problem
Issue #39 requests ability to switch base currency (first phase: symbol-level support).

## Changes
- Added new currency utility module with:
  - supported currency list
  - symbol helpers
  - formatting helpers
- Added persisted `baseCurrency` in user store
- Added base currency selector in dashboard settings
- Applied selected currency symbol formatting in account card money display fields

## Testing
- Lint run on touched files (existing unrelated lint debt in these files remains)
- Runtime utility check for non-USD formatting
- Full dashboard manual auth-gated checks blocked by email-code auth requirement in this environment

## Scope / follow-up
This PR implements stage 1 (symbol/base preference). Per-trade currency modeling remains a follow-up.

Closes #39
