### PR TITLE
Add persisted calendar toggle for max profit and max DD visibility

### DIFF
--- a/app/[locale]/dashboard/components/calendar/desktop-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/desktop-calendar.tsx
@@ -8,6 +8,7 @@ import { ChevronLeft, ChevronRight, Newspaper, Calendar, CalendarDays } from "lu
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
 import { FinancialEvent } from "@/prisma/generated/prisma/browser"
 import { CalendarModal } from "./daily-modal"
@@ -325,7 +326,9 @@ export default function CalendarPnl({ calendarData, hideFiltersOnMobile = false 
     selectedDate,
     setSelectedDate,
     selectedWeekDate,
-    setSelectedWeekDate
+    setSelectedWeekDate,
+    showMaxProfitAndDrawdown,
+    setShowMaxProfitAndDrawdown
   } = useCalendarViewStore()
 
   // Use the global news filter store
@@ -648,7 +651,7 @@ export default function CalendarPnl({ calendarData, hideFiltersOnMobile = false 
                             ? `${dayData.tradeNumber} ${dayData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`
                             : t('calendar.noTrades')}
                         </div>
-                        {dayData && (
+                        {dayData && showMaxProfitAndDrawdown && (
                           <>
                             <div className={cn(
                               "text-[7px] sm:text-[9px] text-green-600 dark:text-green-400 truncate text-center",
@@ -720,32 +723,44 @@ export default function CalendarPnl({ calendarData, hideFiltersOnMobile = false 
         isLoading={isLoading}
       />
       <CardFooter className="flex justify-end">
-        {/* View Mode Toggle */}
-        <div className="flex items-center gap-1 border rounded-md p-0.5 bg-muted">
-          <Button
-            variant={viewMode === 'daily' ? 'default' : 'ghost'}
-            size="sm"
-            className={cn(
-              "h-7 px-2 transition-colors",
-              viewMode === 'daily' && "bg-primary text-primary-foreground shadow-sm font-semibold"
-            )}
-            onClick={() => setViewMode('daily')}
-          >
-            <Calendar className="h-4 w-4 mr-1" />
-            <span className="text-xs">{t('calendar.viewMode.daily')}</span>
-          </Button>
-          <Button
-            variant={viewMode === 'weekly' ? 'default' : 'ghost'}
-            size="sm"
-            className={cn(
-              "h-7 px-2 transition-colors",
-              viewMode === 'weekly' && "bg-primary text-primary-foreground shadow-sm font-semibold"
-            )}
-            onClick={() => setViewMode('weekly')}
-          >
-            <CalendarDays className="h-4 w-4 mr-1" />
-            <span className="text-xs">{t('calendar.viewMode.weekly')}</span>
-          </Button>
+        <div className="flex items-center justify-between gap-4 w-full">
+          <div className="flex items-center gap-2">
+            <span className="text-xs sm:text-sm text-muted-foreground">
+              {t('calendar.viewOptions.showMaxProfitAndDD')}
+            </span>
+            <Switch
+              checked={showMaxProfitAndDrawdown}
+              onCheckedChange={setShowMaxProfitAndDrawdown}
+              className="data-[state=checked]:bg-primary"
+            />
+          </div>
+          {/* View Mode Toggle */}
+          <div className="flex items-center gap-1 border rounded-md p-0.5 bg-muted">
+            <Button
+              variant={viewMode === 'daily' ? 'default' : 'ghost'}
+              size="sm"
+              className={cn(
+                "h-7 px-2 transition-colors",
+                viewMode === 'daily' && "bg-primary text-primary-foreground shadow-sm font-semibold"
+              )}
+              onClick={() => setViewMode('daily')}
+            >
+              <Calendar className="h-4 w-4 mr-1" />
+              <span className="text-xs">{t('calendar.viewMode.daily')}</span>
+            </Button>
+            <Button
+              variant={viewMode === 'weekly' ? 'default' : 'ghost'}
+              size="sm"
+              className={cn(
+                "h-7 px-2 transition-colors",
+                viewMode === 'weekly' && "bg-primary text-primary-foreground shadow-sm font-semibold"
+              )}
+              onClick={() => setViewMode('weekly')}
+            >
+              <CalendarDays className="h-4 w-4 mr-1" />
+              <span className="text-xs">{t('calendar.viewMode.weekly')}</span>
+            </Button>
+          </div>
         </div>
       </CardFooter>
     </Card>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2151,6 +2151,9 @@ export default {
     weekly: "Weekly View",
     title: "Calendar View Mode",
   },
+  "calendar.viewOptions": {
+    showMaxProfitAndDD: "Show Max Profit & Max DD",
+  },
   notification: {
     title: "Current Progress",
     noAccount: "No account being processed",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2283,6 +2283,9 @@ export default {
     weekly: "Vue Hebdomadaire",
     title: "Mode d'Affichage du Calendrier",
   },
+  "calendar.viewOptions": {
+    showMaxProfitAndDD: "Afficher max profit et max DD",
+  },
   notification: {
     title: "Progression en cours",
     noAccount: "Aucun compte en cours de traitement",

--- a/store/widgets/calendar-view.ts
+++ b/store/widgets/calendar-view.ts
@@ -10,6 +10,8 @@ interface CalendarViewState {
   setSelectedDate: (date: Date | null) => void
   selectedWeekDate: Date | null
   setSelectedWeekDate: (date: Date | null) => void
+  showMaxProfitAndDrawdown: boolean
+  setShowMaxProfitAndDrawdown: (show: boolean) => void
 }
 
 export const useCalendarViewStore = create<CalendarViewState>()(
@@ -20,7 +22,9 @@ export const useCalendarViewStore = create<CalendarViewState>()(
       selectedDate: null,
       setSelectedDate: (date) => set({ selectedDate: date }),
       selectedWeekDate: null,
-      setSelectedWeekDate: (date) => set({ selectedWeekDate: date })
+      setSelectedWeekDate: (date) => set({ selectedWeekDate: date }),
+      showMaxProfitAndDrawdown: true,
+      setShowMaxProfitAndDrawdown: (show) => set({ showMaxProfitAndDrawdown: show })
     }),
     {
       name: "calendar-view-store",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a persisted Zustand setting in the calendar view store to control visibility of max profit / max drawdown values
- add a footer toggle in the desktop calendar widget to hide/show max profit and max DD
- wire the day-cell rendering to respect the toggle and keep the setting persisted across sessions
- add translation keys for the new toggle label in English and French

## Testing
- `npm run typecheck` (pass)
- `npm run lint -- "app/[locale]/dashboard/components/calendar/desktop-calendar.tsx" "store/widgets/calendar-view.ts" "locales/en.ts" "locales/fr.ts"` (fails due pre-existing lint issues in `desktop-calendar.tsx` unrelated to this feature)
- manual browser walkthrough on localhost showing toggle behavior + persistence

## Walkthrough artifacts
[calendar_toggle_max_profit_dd_short_demo.mp4](https://cursor.com/agents/bc-cb50e199-8b47-4f9c-b2e7-0a501abb1e19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_toggle_max_profit_dd_short_demo.mp4)
[toggle on state](https://cursor.com/agents/bc-cb50e199-8b47-4f9c-b2e7-0a501abb1e19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_toggle_on_state.webp)
[toggle off state](https://cursor.com/agents/bc-cb50e199-8b47-4f9c-b2e7-0a501abb1e19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_toggle_off_state.webp)
[toggle persisted after refresh](https://cursor.com/agents/bc-cb50e199-8b47-4f9c-b2e7-0a501abb1e19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_toggle_persist_after_refresh.webp)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb50e199-8b47-4f9c-b2e7-0a501abb1e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb50e199-8b47-4f9c-b2e7-0a501abb1e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

