### PR TITLE
Improve dashboard mobile responsiveness

### DIFF
--- a/app/[locale]/dashboard/components/accounts/account-table.tsx
+++ b/app/[locale]/dashboard/components/accounts/account-table.tsx
@@ -64,7 +64,7 @@ export function AccountTable({
     return (
       <div className="space-y-4">
         <div className="rounded-md border">
-          <Table>
+          <Table className="min-w-[760px]">
             {renderTableHeader()}
             <TableBody>
               <TableRow>
@@ -283,14 +283,14 @@ export function AccountTable({
   }
 
   return (
-    <div className="space-y-8">
+    <div className="min-w-0 space-y-8">
       {resetDate && metricsBeforeReset.length > 0 && (
         <div>
           <div className="mb-2 text-sm font-medium text-muted-foreground">
             {t('propFirm.beforeReset')}
           </div>
           <div className="rounded-md border">
-            <Table>
+            <Table className="min-w-[760px]">
               {renderTableHeader()}
               <TableBody>
                 {(() => {
@@ -318,12 +318,12 @@ export function AccountTable({
 
       {resetDate && (
         <div className="rounded-md border bg-yellow-100/50 dark:bg-yellow-900/20 p-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <div className="font-medium">{t('propFirm.resetDate.label')}</div>
               <div className="text-sm text-muted-foreground">{format(resetDate, 'PP', { locale: dateLocale })}</div>
             </div>
-            <div className="text-right">
+            <div className="sm:text-right">
               <div className="text-sm text-muted-foreground">{t('propFirm.startingBalance')}</div>
               <div className="font-medium">${startingBalance.toFixed(2)}</div>
             </div>
@@ -338,7 +338,7 @@ export function AccountTable({
           </div>
         )}
         <div className="rounded-md border">
-          <Table>
+          <Table className="min-w-[760px]">
             {renderTableHeader()}
             <TableBody>
               {(() => {

--- a/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
@@ -1177,14 +1177,14 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
 
 
   return (
-    <Card className="w-full h-full flex flex-col">
+    <Card className="w-full h-full min-w-0 flex flex-col">
       <CardHeader
         className={cn(
           "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
+          size === 'small' ? "p-2 min-h-10" : "p-3 sm:p-4 min-h-14"
         )}
       >
-        <div className="flex items-center justify-between w-full">
+        <div className="flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-1.5">
             <CardTitle
               className={cn(
@@ -1208,18 +1208,18 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
               </UITooltip>
             </TooltipProvider>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 sm:justify-end">
             <Button
               variant="outline"
               size="sm"
               onClick={() => setAccountGroupBoardOpen(true)}
               className={cn(
                 "gap-1.5",
-                size === "small" ? "h-7 px-2 text-xs" : "h-8"
+                size === "small" ? "h-7 px-2 text-xs" : "h-8 px-2 sm:px-3"
               )}
             >
               <Settings className="h-3.5 w-3.5" />
-              <span className={cn(size === "small" && "sr-only")}>
+              <span className={cn((size === "small") && "sr-only", "hidden min-[420px]:inline")}>
                 {t("filters.manageAccounts")}
               </span>
             </Button>
@@ -1230,18 +1230,18 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                   size="sm"
                   className={cn(
                     "gap-1.5",
-                    size === "small" ? "h-7 px-2 text-xs" : "h-8"
+                    size === "small" ? "h-7 px-2 text-xs" : "h-8 px-2 sm:px-3"
                   )}
                 >
                   <ListOrdered className="h-3.5 w-3.5" />
-                  <span className={cn(size === "small" && "sr-only")}>
+                  <span className={cn((size === "small") && "sr-only", "hidden min-[420px]:inline")}>
                     {sorting.length > 0
                       ? t("table.sortingRules", { count: sorting.length })
                       : t("table.sorting")}
                   </span>
                 </Button>
               </PopoverTrigger>
-              <PopoverContent align="end" className="w-80 p-3">
+              <PopoverContent align="end" className="w-[calc(100vw-2rem)] max-w-80 p-3">
                 <div className="space-y-3">
                   {sorting.length === 0 ? (
                     <div className="text-sm text-muted-foreground">
@@ -1393,15 +1393,15 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
       {/* Unconfigured accounts banner */}
       {(unconfiguredAccounts.length > 0 && !isLoading) && (
         <div className="border-b border-orange-200/30 bg-orange-50/40 dark:border-orange-700/30 dark:bg-orange-950/30">
-          <div className="px-4 py-2 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="flex items-center gap-2">
+          <div className="px-3 py-2 sm:px-4">
+            <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex shrink-0 items-center gap-2">
                 <div className="w-2 h-2 rounded-full bg-orange-400 animate-pulse" />
                 <span className="text-sm font-medium text-orange-700 dark:text-orange-300">
                   {t('propFirm.status.needsConfiguration')}:
                 </span>
               </div>
-              <div className="flex gap-2 overflow-x-auto">
+              <div className="flex min-w-0 gap-2 overflow-x-auto pb-1">
                 {unconfiguredAccounts.map((accountNumber, index) => (
                   <div
                     key={accountNumber}
@@ -1592,24 +1592,26 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
           open={!!selectedAccountForTable}
           onOpenChange={(open) => !open && setSelectedAccountForTable(null)}
         >
-          <DialogContent className="max-w-7xl h-[80vh] flex flex-col overflow-y-auto">
-            <DialogHeader className="pb-4 border-b">
-              <div className="flex items-center justify-between">
-                <div>
+          <DialogContent className="flex h-[92dvh] w-[calc(100vw-1rem)] max-w-7xl flex-col overflow-hidden p-0 sm:h-[85vh] sm:w-[calc(100vw-2rem)] sm:p-6">
+            <DialogHeader className="shrink-0 border-b p-4 pb-4 sm:p-0 sm:pb-4">
+              <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0 pr-8 sm:pr-0">
                   <DialogTitle>{t('propFirm.configurator.title', { accountNumber: selectedAccountForTable?.number })}</DialogTitle>
                   <DialogDescription>{t('propFirm.configurator.description')}</DialogDescription>
                 </div>
-                <div className="flex items-center gap-2 pr-4">
+                <div className="grid grid-cols-2 gap-2 sm:flex sm:items-center sm:pr-4">
 
                   <Button
                     variant="default"
                     onClick={handleSave}
                     disabled={pendingChanges === null}
+                    className="min-w-0"
                   >
                     {isSaving ? t('common.saving') : t('common.save')}
                   </Button>
                   <Button
                     variant="outline"
+                    className="min-w-0"
                     onClick={() => {
                       setSelectedPayout(undefined)
                       setPayoutDialogOpen(true)
@@ -1624,6 +1626,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                         variant="destructive"
                         size="sm"
                         disabled={isDeleting || !canDeleteAccount}
+                        className="min-w-0"
                       >
                         <Trash2 className="w-4 h-4 mr-2" />
                         {t('propFirm.common.delete')}
@@ -1651,7 +1654,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
               </div>
             </DialogHeader>
 
-            <div className="p-6 pt-4 flex-1 overflow-y-auto">
+            <div className="flex-1 overflow-y-auto p-3 pt-4 sm:p-6 sm:pt-4">
               {selectedAccountForTable && (
                 <Tabs
                   defaultValue={selectedAccountForTable.profitTarget === 0 ? "configurator" : "table"}

--- a/app/[locale]/dashboard/components/accounts/accounts-table-view.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-table-view.tsx
@@ -364,9 +364,12 @@ function AccountsTableSection({
   }
 
   return (
-    <div className="relative">
+    <div className="relative min-w-0">
       <div className="overflow-x-auto" ref={tableWrapperRef}>
-        <table className="w-full border-separate border-spacing-0 text-sm">
+        <table
+          className="w-full border-separate border-spacing-0 text-sm"
+          style={{ minWidth: table.getTotalSize() }}
+        >
           <thead className="sticky top-0 z-10 bg-muted/90 backdrop-blur-xs shadow-xs border-b [&_tr]:border-b">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr
@@ -376,7 +379,7 @@ function AccountsTableSection({
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
-                    className="whitespace-nowrap px-3 py-2 text-left text-sm font-semibold bg-muted/90 border-r border-border last:border-r-0 first:border-l align-middle text-muted-foreground"
+                    className="whitespace-nowrap px-2 py-2 text-left text-xs font-semibold bg-muted/90 border-r border-border last:border-r-0 first:border-l align-middle text-muted-foreground sm:px-3 sm:text-sm"
                     style={{ width: header.getSize() }}
                   >
                     {header.isPlaceholder
@@ -401,7 +404,7 @@ function AccountsTableSection({
                     {table.getVisibleLeafColumns().map((column) => (
                       <td
                         key={`${entry.summary.id}-${column.id}`}
-                        className="px-3 py-2 text-sm border-r border-border/50 last:border-r-0 first:border-l align-middle"
+                        className="px-2 py-2 text-xs border-r border-border/50 last:border-r-0 first:border-l align-middle sm:px-3 sm:text-sm"
                         style={{ width: column.getSize() }}
                       >
                         {renderSummaryCell(column.id, entry.summary)}
@@ -434,7 +437,7 @@ function AccountsTableSection({
                     <td
                       key={cell.id}
                       className={cn(
-                        "px-3 py-2 text-sm border-r border-border/50 last:border-r-0 first:border-l align-middle",
+                        "px-2 py-2 text-xs border-r border-border/50 last:border-r-0 first:border-l align-middle sm:px-3 sm:text-sm",
                         row.depth > 0 && cell.column.id === "account" && "pl-6"
                       )}
                       style={{ width: cell.column.getSize() }}

--- a/app/[locale]/dashboard/components/add-widget-sheet.tsx
+++ b/app/[locale]/dashboard/components/add-widget-sheet.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner"
 interface AddWidgetSheetProps {
   onAddWidget: (type: WidgetType, size?: WidgetSize) => void
   isCustomizing: boolean
+  compact?: boolean
 }
 
 interface PreviewCardProps {
@@ -122,12 +123,13 @@ const PreviewCard = forwardRef<HTMLDivElement, PreviewCardProps>(
 PreviewCard.displayName = "PreviewCard"
 
 export const AddWidgetSheet = forwardRef<HTMLButtonElement, AddWidgetSheetProps>(
-  ({ onAddWidget, isCustomizing }, ref) => {
+  ({ onAddWidget, isCustomizing, compact = false }, ref) => {
     const t = useI18n()
     const { isMobile } = useData()
     const [isOpen, setIsOpen] = React.useState(false)
     const [loadedItems, setLoadedItems] = useState<Set<number>>(new Set())
     const [loadingStarted, setLoadingStarted] = useState(false)
+    const useCompactButton = compact || isMobile
 
     const handleAddWidget = (type: WidgetType) => {
       const config = WIDGET_REGISTRY[type]
@@ -211,11 +213,11 @@ export const AddWidgetSheet = forwardRef<HTMLButtonElement, AddWidgetSheetProps>
             variant="ghost"
             className={cn(
               "h-10 rounded-full flex items-center justify-center transition-transform active:scale-95",
-              isMobile ? "w-10 p-0" : "min-w-[120px] gap-3 px-4"
+              useCompactButton ? "w-10 p-0" : "min-w-[120px] gap-3 px-4"
             )}
           >
             <Plus className="h-4 w-4 shrink-0" />
-            {!isMobile && (
+            {!useCompactButton && (
               <span className="text-sm font-medium">
                 {t('widgets.addWidget')}
               </span>

--- a/app/[locale]/dashboard/components/charts/account-selection-popover.tsx
+++ b/app/[locale]/dashboard/components/charts/account-selection-popover.tsx
@@ -17,7 +17,7 @@ interface AccountSelectionPopoverProps {
   accountNumbers: string[]
   selectedAccounts: string[]
   onToggleAccount: (accountNumber: string) => void
-  t: any
+  t: (key: string) => string
 }
 
 export const AccountSelectionPopover = React.memo(({ 
@@ -28,8 +28,6 @@ export const AccountSelectionPopover = React.memo(({
 }: AccountSelectionPopoverProps) => {
   const [open, setOpen] = React.useState(false)
   const [searchTerm, setSearchTerm] = React.useState('')
-  
-  const maxAccounts = 10 // Hardcoded for performance
   
   // Filter accounts based on search term
   const filteredAccounts = React.useMemo(() => {
@@ -61,7 +59,7 @@ export const AccountSelectionPopover = React.memo(({
           {t('equity.legend.selectAccounts')}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-96 h-80 p-4" align="start">
+      <PopoverContent className="h-[min(20rem,var(--radix-popover-content-available-height))] w-[min(24rem,calc(100vw-2rem))] p-4" align="start">
         <div className="space-y-3 h-full flex flex-col">
             <div className="space-y-2">
               <div className="flex items-center justify-between">

--- a/app/[locale]/dashboard/components/filters/account-filter.tsx
+++ b/app/[locale]/dashboard/components/filters/account-filter.tsx
@@ -1,16 +1,17 @@
 "use client"
 
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command"
+import { Command, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Label } from "@/components/ui/label"
 import { useI18n } from "@/locales/client"
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { Settings } from "lucide-react"
 import { useModalStateStore } from "../../../../../store/modal-state-store"
 import { useData } from "@/context/data-provider"
 import { useTradesStore } from "../../../../../store/trades-store"
 import { useUserStore } from "../../../../../store/user-store"
+import { cn } from "@/lib/utils"
 
 
 interface AccountFilterProps {
@@ -107,12 +108,13 @@ export function AccountFilter({ showAccountNumbers, className }: AccountFilterPr
       accountNumbers.includes(account.number)
     )
     
-    setAccountNumbers(prev => 
-      allAvailableSelected ? [] : availableAccounts.map(i => i.number)
-    )
+    setAccountNumbers(allAvailableSelected ? [] : availableAccounts.map(i => i.number))
   }
 
-  const isItemDisabled = (item: Account | TradeAccount) => false
+  const isItemDisabled = (_item: Account | TradeAccount) => {
+    void _item
+    return false
+  }
 
   const isItemSelected = (item: Account | TradeAccount): boolean => {
     return accountNumbers.includes(item.number)
@@ -145,7 +147,7 @@ export function AccountFilter({ showAccountNumbers, className }: AccountFilterPr
   }
 
   return (
-    <div className="space-y-2">
+    <div className={cn("space-y-2", className)}>
       <Label className="text-sm font-medium">{t('filters.accounts')}</Label>
       <Command className="rounded-lg border" shouldFilter={false}>
         <div className="border-b">
@@ -157,7 +159,7 @@ export function AccountFilter({ showAccountNumbers, className }: AccountFilterPr
           />
         </div>
         <CommandList>
-          <ScrollArea className="h-[300px]">
+          <ScrollArea className="h-[min(300px,calc(100dvh-12rem))]">
             <CommandGroup>
               <CommandItem
                 onSelect={() => setAccountGroupBoardOpen(true)}

--- a/app/[locale]/dashboard/components/filters/filter-command-menu.tsx
+++ b/app/[locale]/dashboard/components/filters/filter-command-menu.tsx
@@ -24,16 +24,21 @@ import { Kbd, KbdGroup } from "@/components/ui/kbd"
 interface FilterCommandMenuProps {
   className?: string
   variant?: "navbar" | "toolbar"
+  compactBreakpoint?: number
 }
 
-export function FilterCommandMenu({ className, variant = "navbar" }: FilterCommandMenuProps) {
+export function FilterCommandMenu({
+  className,
+  variant = "navbar",
+  compactBreakpoint = 768,
+}: FilterCommandMenuProps) {
   const t = useI18n()
   const { isMobile, dateRange, setDateRange, setWeekdayFilter } = useData()
   const [open, setOpen] = useState(false)
   const [searchValue, setSearchValue] = useState("")
   const [inputWidth, setInputWidth] = useState<number | undefined>(undefined)
   const [isParsingDate, setIsParsingDate] = useState(false)
-  const isMobileDevice = useMediaQuery("(max-width: 768px)")
+  const isMobileDevice = useMediaQuery(`(max-width: ${compactBreakpoint}px)`)
   const inputRef = useRef<HTMLInputElement>(null)
   const commandRef = useRef<HTMLDivElement>(null)
   const dateRangeSectionRef = useRef<HTMLDivElement>(null)
@@ -259,14 +264,14 @@ export function FilterCommandMenu({ className, variant = "navbar" }: FilterComma
     <Button
       variant="outline"
       className={cn(
-        "justify-start text-left font-normal",
-        variant === "toolbar" && "h-10 rounded-full",
+        "justify-start text-left font-normal overflow-hidden",
+        variant === "toolbar" && "h-10 rounded-full max-w-full",
         className
       )}
       onClick={() => setOpen(true)}
     >
       <Search className="h-4 w-4 mr-2" />
-      <span className="text-muted-foreground">{t('filters.commandMenu.searchPlaceholderMobile')}</span>
+      <span className="text-muted-foreground truncate">{t('filters.commandMenu.searchPlaceholderMobile')}</span>
     </Button>
   )
 
@@ -305,7 +310,7 @@ export function FilterCommandMenu({ className, variant = "navbar" }: FilterComma
   // Trigger on desktop: real input that opens popover and controls search
   const DesktopTriggerInput = (
     <PopoverAnchor asChild>
-      <div className={cn("relative w-[400px]", className)}>
+      <div className={cn("relative w-full max-w-[400px]", className)}>
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none z-10" />
         <Input
           ref={inputRef}
@@ -549,7 +554,7 @@ export function FilterCommandMenu({ className, variant = "navbar" }: FilterComma
       {DesktopTriggerInput}
       <PopoverContent 
         className="p-0" 
-        style={{ width: inputWidth ? `${inputWidth}px` : '400px' }}
+        style={{ width: inputWidth ? `${inputWidth}px` : 'min(400px, calc(100vw - 2rem))' }}
         align="start"
         onOpenAutoFocus={(e) => e.preventDefault()}
         onInteractOutside={(e) => {

--- a/app/[locale]/dashboard/components/filters/filter-dropdown.tsx
+++ b/app/[locale]/dashboard/components/filters/filter-dropdown.tsx
@@ -18,33 +18,22 @@ import { InstrumentFilter } from "./instrument-filter"
 import { AccountFilter } from "./account-filter"
 import { useData } from "@/context/data-provider"
 import { cn } from "@/lib/utils"
-import { useState, useEffect } from "react"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { AccountGroupBoard } from "./account-group-board"
+import { useState } from "react"
 import { useModalStateStore } from "../../../../../store/modal-state-store"
 
 export function FilterDropdown() {
   const t = useI18n()
   const { isMobile } = useData()
-  const [open, setOpen] = useState(false)
-  const [accountFilterOpen, setAccountFilterOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
   const { accountGroupBoardOpen } = useModalStateStore()
-
-  // Close both dropdowns when account board is open
-  useEffect(() => {
-    if (accountGroupBoardOpen) {
-      setOpen(false)
-    }
-  }, [accountGroupBoardOpen])
+  const open = accountGroupBoardOpen ? false : menuOpen
 
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenu
+        open={open}
+        onOpenChange={(nextOpen) => setMenuOpen(accountGroupBoardOpen ? false : nextOpen)}
+      >
         <DropdownMenuTrigger asChild>
           <Button 
             variant="ghost"
@@ -61,13 +50,13 @@ export function FilterDropdown() {
             )}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56">
+        <DropdownMenuContent className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-1rem))] w-56 overflow-y-auto overscroll-contain">
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               {t('filters.accounts')}
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
-              <DropdownMenuSubContent className="w-[300px]">
+              <DropdownMenuSubContent className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-1rem))] w-[min(300px,calc(100vw-2rem))] overflow-y-auto overscroll-contain">
                 <AccountFilter showAccountNumbers={true}/>
               </DropdownMenuSubContent>
             </DropdownMenuPortal>

--- a/app/[locale]/dashboard/components/navbar.tsx
+++ b/app/[locale]/dashboard/components/navbar.tsx
@@ -34,7 +34,7 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky py-2 top-0 left-0 right-0 flex flex-col text-primary bg-background/80 backdrop-blur-md border-b shadow-xs w-full z-1">
+      <nav className="sticky py-2 top-0 left-0 right-0 z-40 flex w-full flex-col border-b bg-background/80 text-primary shadow-xs backdrop-blur-md">
         <div className="flex items-center justify-between px-3 sm:px-6 lg:px-10 h-16 gap-3 sm:gap-4">
           <div className="flex items-center gap-x-4">
             <div className="flex flex-col items-center">

--- a/app/[locale]/dashboard/components/navbar.tsx
+++ b/app/[locale]/dashboard/components/navbar.tsx
@@ -14,7 +14,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import { FilterCommandMenu } from './filters/filter-command-menu'
 import { UsersIcon, type UsersIconHandle } from '@/components/animated-icons/users'
 import { useModalStateStore } from '@/store/modal-state-store'
 import { useUserStore } from '@/store/user-store'
@@ -36,7 +35,7 @@ export default function Navbar() {
   return (
     <>
       <nav className="sticky py-2 top-0 left-0 right-0 flex flex-col text-primary bg-background/80 backdrop-blur-md border-b shadow-xs w-full z-1">
-        <div className="flex items-center justify-between px-10 h-16 gap-4">
+        <div className="flex items-center justify-between px-3 sm:px-6 lg:px-10 h-16 gap-3 sm:gap-4">
           <div className="flex items-center gap-x-4">
             <div className="flex flex-col items-center">
               <Popover open={isLogoPopoverOpen} onOpenChange={setIsLogoPopoverOpen} modal={false}>

--- a/app/[locale]/dashboard/components/share-button.tsx
+++ b/app/[locale]/dashboard/components/share-button.tsx
@@ -49,6 +49,7 @@ interface ShareButtonProps {
     desktop: any[]
     mobile: any[]
   }
+  compact?: boolean
 }
 
 function useIsMobile() {
@@ -111,7 +112,7 @@ function triggerConfetti() {
 }
 
 export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
-  ({ variant = "ghost", size = "icon", currentLayout }, ref) => {
+  ({ variant = "ghost", size = "icon", currentLayout, compact = false }, ref) => {
     const t = useI18n()
     const locale = useCurrentLocale()
     const dateLocale = locale === 'fr' ? fr : undefined
@@ -126,6 +127,7 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
     const [showManager, setShowManager] = useState(false)
     const [shareTitle, setShareTitle] = useState("")
     const [shareAllAccounts, setShareAllAccounts] = useState(true)
+    const useCompactButton = compact || isMobile
 
     // Get the earliest and latest trade dates
     const defaultDateRange = useMemo(() => {
@@ -386,11 +388,11 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
             variant={variant}
             className={cn(
               "h-10 rounded-full flex items-center justify-center transition-transform active:scale-95",
-              isMobile ? "w-10 p-0" : "min-w-[120px] gap-3 px-4"
+              useCompactButton ? "w-10 p-0" : "min-w-[120px] gap-3 px-4"
             )}
           >
             <Share className="h-4 w-4 shrink-0" />
-            {!isMobile && (
+            {!useCompactButton && (
               <span className="text-sm font-medium">
                 {t("share.button")}
               </span>

--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -1259,12 +1259,12 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
 
   return (
     <Card
-      className="h-full flex flex-col w-full"
+      className="h-full flex min-w-0 flex-col w-full"
       style={cardStyle}
     >
       {showHeader && (
         <CardHeader className="border-b shrink-0 p-3 sm:p-4">
-        <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex w-full min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex min-w-0 items-center gap-1.5">
             <CardTitle className="line-clamp-1 text-base">
               {t("trade-table.title")}
@@ -1280,13 +1280,13 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
               </Tooltip>
             </TooltipProvider>
           </div>
-          <div className="flex flex-wrap items-center justify-start gap-2 lg:justify-end">
+          <div className="grid w-full min-w-0 grid-cols-1 gap-2 sm:grid-cols-2 xl:flex xl:w-auto xl:flex-wrap xl:items-center xl:justify-end">
             {selectedTrades.length > 0 && (
               <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
                 <AlertDialogTrigger asChild>
                   <Button
                     variant="destructive"
-                    className="h-10 max-w-full font-normal whitespace-nowrap"
+                    className="h-10 w-full max-w-full font-normal whitespace-nowrap xl:w-auto"
                     onClick={() => setShowDeleteDialog(true)}
                   >
                     <Trash className="mr-2 h-4 w-4" />
@@ -1316,7 +1316,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             {config?.groupTrades !== false && selectedTrades.length >= 2 && (
               <Button
                 variant="outline"
-                className="h-10 max-w-full font-normal whitespace-nowrap"
+                className="h-10 w-full max-w-full font-normal whitespace-nowrap xl:w-auto"
                 onClick={handleGroupTrades}
               >
                 {t("trade-table.groupTrades")}
@@ -1325,7 +1325,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             {config?.groupTrades !== false && selectedTrades.length > 0 && (
               <Button
                 variant="outline"
-                className="h-10 max-w-full font-normal whitespace-nowrap"
+                className="h-10 w-full max-w-full font-normal whitespace-nowrap xl:w-auto"
                 onClick={handleUngroupTrades}
               >
                 {t("trade-table.ungroupTrades")}
@@ -1338,7 +1338,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                   handleGroupingModeChange(value)
                 }
               >
-                <SelectTrigger className="w-full min-w-[min(100%,180px)] sm:w-auto sm:min-w-[180px] max-w-full sm:max-w-[250px]">
+                <SelectTrigger className="w-full min-w-0 max-w-full xl:w-[180px] xl:max-w-[250px]">
                   <SelectValue
                     placeholder={t("trade-table.groupingMode.label")}
                     className="truncate"
@@ -1365,7 +1365,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 }
                 disabled={groupingMode !== "time"}
               >
-                <SelectTrigger className="w-full min-w-[min(100%,180px)] sm:w-auto sm:min-w-[180px] max-w-full sm:max-w-[250px]">
+                <SelectTrigger className="w-full min-w-0 max-w-full xl:w-[180px] xl:max-w-[250px]">
                   <div className="flex items-center w-full">
                     <TooltipProvider>
                       <Tooltip>
@@ -1417,8 +1417,11 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
       </CardHeader>
       )}
       <CardContent className="flex-1 min-h-0 overflow-auto p-0">
-        <div className="relative w-full min-w-fit">
-          <table className="w-full border-separate border-spacing-0 caption-bottom text-sm">
+        <div className="relative w-full min-w-max">
+          <table
+            className="w-full border-separate border-spacing-0 caption-bottom text-sm"
+            style={{ minWidth: table.getTotalSize() }}
+          >
             <thead className="sticky top-0 z-10 bg-muted/90 backdrop-blur-xs shadow-xs border-b [&_tr]:border-b">
                 {table.getHeaderGroups().map((headerGroup) => (
                   <tr
@@ -1428,7 +1431,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                     {headerGroup.headers.map((header) => (
                       <th
                         key={header.id}
-                        className="whitespace-nowrap px-3 py-2 text-left text-sm font-semibold bg-muted/90 border-r border-border last:border-r-0 first:border-l h-12 align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
+                        className="whitespace-nowrap px-3 py-2 text-left text-sm font-semibold bg-muted/90 border-r border-border last:border-r-0 first:border-l h-12 align-middle text-muted-foreground [&:has([role=checkbox])]:pr-0"
                         style={{ width: header.getSize() }}
                       >
                         {header.isPlaceholder
@@ -1598,21 +1601,22 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           </table>
         </div>
       </CardContent>
-      <CardFooter className="flex flex-col items-start gap-3 border-t bg-background px-3 py-3 sm:px-4 md:flex-row md:items-center md:justify-between">
+      <CardFooter className="flex flex-col items-start gap-3 border-t bg-background px-3 py-3 sm:px-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="text-sm text-muted-foreground">
           {t("trade-table.totalTrades", { count: groupedTrades.length })}
         </div>
-        <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:justify-end">
+        <div className="grid w-full grid-cols-2 items-center gap-2 sm:flex sm:flex-wrap lg:w-auto lg:justify-end">
           <Button
             variant="outline"
             size="sm"
+            className="min-w-0"
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
           >
             <ChevronLeft className="h-4 w-4" />
             {!isCompactScreen && t("trade-table.previous")}
           </Button>
-          <span className="text-sm whitespace-nowrap">
+          <span className="col-span-2 text-center text-sm whitespace-nowrap sm:col-span-1 sm:text-left">
             {t("trade-table.pageInfo", {
               current: table.getState().pagination.pageIndex + 1,
               total: table.getPageCount(),
@@ -1621,6 +1625,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           <Button
             variant="outline"
             size="sm"
+            className="min-w-0"
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}
           >
@@ -1630,7 +1635,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           <Button
             variant="outline"
             size="sm"
-            className="flex-1 min-w-[120px] sm:flex-none"
+            className="min-w-0 sm:flex-none"
             onClick={() => {
               const newPageSize = pageSize + 10;
               handlePageSizeChange(newPageSize);
@@ -1642,7 +1647,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           <Button
             variant="outline"
             size="sm"
-            className="flex-1 min-w-[150px] sm:w-[180px]"
+            className="min-w-0 sm:w-[180px]"
             onClick={() => {
               handlePageSizeChange(50);
               table.resetPageSize();
@@ -1654,7 +1659,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           <Button
             variant="outline"
             size="sm"
-            className="flex-1 min-w-[130px] sm:flex-none"
+            className="min-w-0 sm:flex-none"
             onClick={() => {
               const maxPageSize = groupedTrades.length;
               handlePageSizeChange(maxPageSize);

--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -100,6 +100,7 @@ import {
 import { EditableTimeCell } from "./editable-time-cell";
 import { EditableInstrumentCell } from "./editable-instrument-cell";
 import { BulkEditPanel } from "./bulk-edit-panel";
+import { useMediaQuery } from "@/hooks/use-media-query";
 
 // Custom Tags Header Component
 function TagsColumnHeader() {
@@ -1251,6 +1252,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
   // Determine if Card header should be shown (default to true if not specified)
   // Note: This only controls the Card header, not the table column headers
   const showHeader = config?.showHeader !== false;
+  const isCompactScreen = useMediaQuery("(max-width: 1100px)");
 
   // Visible columns are used for rendering header/body/footer so hidden columns don't create gaps
   const visibleColumns = table.getVisibleLeafColumns();
@@ -1261,9 +1263,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
       style={cardStyle}
     >
       {showHeader && (
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b shrink-0 p-3 sm:p-4 h-[56px]">
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
+        <CardHeader className="border-b shrink-0 p-3 sm:p-4">
+        <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex min-w-0 items-center gap-1.5">
             <CardTitle className="line-clamp-1 text-base">
               {t("trade-table.title")}
             </CardTitle>
@@ -1278,13 +1280,13 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
               </Tooltip>
             </TooltipProvider>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-start gap-2 lg:justify-end">
             {selectedTrades.length > 0 && (
               <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
                 <AlertDialogTrigger asChild>
                   <Button
                     variant="destructive"
-                    className="h-10 font-normal whitespace-nowrap"
+                    className="h-10 max-w-full font-normal whitespace-nowrap"
                     onClick={() => setShowDeleteDialog(true)}
                   >
                     <Trash className="mr-2 h-4 w-4" />
@@ -1314,7 +1316,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             {config?.groupTrades !== false && selectedTrades.length >= 2 && (
               <Button
                 variant="outline"
-                className="h-10 font-normal whitespace-nowrap"
+                className="h-10 max-w-full font-normal whitespace-nowrap"
                 onClick={handleGroupTrades}
               >
                 {t("trade-table.groupTrades")}
@@ -1323,7 +1325,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             {config?.groupTrades !== false && selectedTrades.length > 0 && (
               <Button
                 variant="outline"
-                className="h-10 font-normal whitespace-nowrap"
+                className="h-10 max-w-full font-normal whitespace-nowrap"
                 onClick={handleUngroupTrades}
               >
                 {t("trade-table.ungroupTrades")}
@@ -1336,7 +1338,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                   handleGroupingModeChange(value)
                 }
               >
-                <SelectTrigger className="min-w-[180px] max-w-[250px]">
+                <SelectTrigger className="w-full min-w-[min(100%,180px)] sm:w-auto sm:min-w-[180px] max-w-full sm:max-w-[250px]">
                   <SelectValue
                     placeholder={t("trade-table.groupingMode.label")}
                     className="truncate"
@@ -1363,7 +1365,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 }
                 disabled={groupingMode !== "time"}
               >
-                <SelectTrigger className="min-w-[180px] max-w-[250px]">
+                <SelectTrigger className="w-full min-w-[min(100%,180px)] sm:w-auto sm:min-w-[180px] max-w-full sm:max-w-[250px]">
                   <div className="flex items-center w-full">
                     <TooltipProvider>
                       <Tooltip>
@@ -1596,11 +1598,11 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           </table>
         </div>
       </CardContent>
-      <CardFooter className="flex items-center justify-between border-t bg-background px-4 py-3">
+      <CardFooter className="flex flex-col items-start gap-3 border-t bg-background px-3 py-3 sm:px-4 md:flex-row md:items-center md:justify-between">
         <div className="text-sm text-muted-foreground">
           {t("trade-table.totalTrades", { count: groupedTrades.length })}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:justify-end">
           <Button
             variant="outline"
             size="sm"
@@ -1608,9 +1610,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             disabled={!table.getCanPreviousPage()}
           >
             <ChevronLeft className="h-4 w-4" />
-            {t("trade-table.previous")}
+            {!isCompactScreen && t("trade-table.previous")}
           </Button>
-          <span className="text-sm">
+          <span className="text-sm whitespace-nowrap">
             {t("trade-table.pageInfo", {
               current: table.getState().pagination.pageIndex + 1,
               total: table.getPageCount(),
@@ -1622,12 +1624,13 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}
           >
-            {t("trade-table.next")}
+            {!isCompactScreen && t("trade-table.next")}
             <ChevronRight className="h-4 w-4" />
           </Button>
           <Button
             variant="outline"
             size="sm"
+            className="flex-1 min-w-[120px] sm:flex-none"
             onClick={() => {
               const newPageSize = pageSize + 10;
               handlePageSizeChange(newPageSize);
@@ -1639,7 +1642,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           <Button
             variant="outline"
             size="sm"
-            className="w-[180px]"
+            className="flex-1 min-w-[150px] sm:w-[180px]"
             onClick={() => {
               handlePageSizeChange(50);
               table.resetPageSize();
@@ -1651,6 +1654,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           <Button
             variant="outline"
             size="sm"
+            className="flex-1 min-w-[130px] sm:flex-none"
             onClick={() => {
               const maxPageSize = groupedTrades.length;
               handlePageSizeChange(maxPageSize);

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -193,7 +193,8 @@ export function Toolbar({
         <motion.div
           ref={toolbarRef}
           className={cn(
-            "fixed inset-x-0 mx-auto z-10 w-fit max-w-[calc(100vw-1rem)] px-2 sm:px-0",
+            "fixed inset-x-0 mx-auto z-10 max-w-[calc(100vw-1rem)] px-2 sm:px-0",
+            useCompactLayout ? "w-full sm:w-fit" : "w-fit",
             isConsentVisible ? "bottom-36 sm:bottom-20" : "bottom-4"
           )}
           style={{
@@ -214,7 +215,7 @@ export function Toolbar({
             className={cn(
               "flex items-center justify-center bg-background/95 border shadow-lg relative",
               useCompactLayout
-                ? "max-w-full flex-wrap gap-2 rounded-3xl px-2.5 py-2"
+                ? "max-h-[calc(100dvh-2rem)] max-w-full flex-wrap gap-2 overflow-y-auto rounded-3xl px-2.5 py-2"
                 : "gap-4 rounded-full p-3"
             )}
           >
@@ -237,13 +238,13 @@ export function Toolbar({
               )}
             </Button>
 
-            <ShareButton currentLayout={currentLayout} />
+            <ShareButton currentLayout={currentLayout} compact={useCompactLayout} />
 
-            <AddWidgetSheet onAddWidget={onAddWidget} isCustomizing={isCustomizing} />
+            <AddWidgetSheet onAddWidget={onAddWidget} isCustomizing={isCustomizing} compact={useCompactLayout} />
 
             <FilterCommandMenu
               variant="toolbar"
-              className={cn(useCompactLayout ? "min-w-0 flex-1 basis-[11rem]" : "w-auto")}
+              className={cn(useCompactLayout ? "min-w-0 flex-1 basis-full sm:basis-44" : "w-auto")}
               compactBreakpoint={1100}
             />
 

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -8,7 +8,7 @@ import { Pencil, Trash2, RotateCcw } from "lucide-react"
 import { ShareButton } from "./share-button"
 import { AddWidgetSheet } from "./add-widget-sheet"
 import { FilterCommandMenu } from "./filters/filter-command-menu"
-import { WidgetType, WidgetSize } from "../types/dashboard"
+import { WidgetType, WidgetSize, Layouts } from "../types/dashboard"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -28,17 +28,15 @@ import {
 } from "@/components/ui/context-menu"
 import { useState, useEffect, useRef } from "react"
 import { useToolbarSettingsStore } from "@/store/toolbar-settings-store"
-import { motion, AnimatePresence } from "framer-motion"
+import { motion } from "framer-motion"
 import { toast } from "sonner"
+import { useMediaQuery } from "@/hooks/use-media-query"
 
 interface ToolbarProps {
   onAddWidget: (type: WidgetType, size?: WidgetSize) => void
   isCustomizing: boolean
   onEditToggle: () => void
-  currentLayout: {
-    desktop: any[]
-    mobile: any[]
-  }
+  currentLayout: Layouts
   onRemoveAll: () => void
   onRestoreDefaults: () => void
 }
@@ -54,6 +52,10 @@ export function Toolbar({
   const t = useI18n()
   const { isMobile } = useData()
   const { settings, setAutoHide } = useToolbarSettingsStore()
+  const isCompactScreen = useMediaQuery("(max-width: 1100px)")
+  const [isConsentVisible, setIsConsentVisible] = useState(
+    typeof document !== "undefined" && document.body.hasAttribute("data-consent-banner")
+  )
 
   // Handle auto-hide toggle with proper state management
   const handleAutoHideToggle = () => {
@@ -70,12 +72,9 @@ export function Toolbar({
     )
   }
 
-  // Check if consent banner is visible
-  const [isConsentVisible, setIsConsentVisible] = useState(false)
-
   // Auto-hide functionality
   const [isHovered, setIsHovered] = useState(false)
-  const [isVisible, setIsVisible] = useState(!settings.autoHide) // Start hidden if auto-hide is enabled
+  const [isPinnedVisible, setIsPinnedVisible] = useState(() => !settings.autoHide)
   const [toolbarHeight, setToolbarHeight] = useState(0)
   const autoHideTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const toolbarRef = useRef<HTMLDivElement>(null)
@@ -90,9 +89,6 @@ export function Toolbar({
       attributes: true,
       attributeFilter: ['data-consent-banner']
     })
-
-    // Initial check
-    setIsConsentVisible(document.body.hasAttribute('data-consent-banner'))
 
     return () => observer.disconnect()
   }, [])
@@ -114,24 +110,14 @@ export function Toolbar({
 
   // Handle auto-hide functionality
   useEffect(() => {
-    if (!settings.autoHide) {
-      setIsVisible(true)
-      if (autoHideTimeoutRef.current) {
-        clearTimeout(autoHideTimeoutRef.current)
-        autoHideTimeoutRef.current = null
-      }
-      return
+    if (autoHideTimeoutRef.current) {
+      clearTimeout(autoHideTimeoutRef.current)
+      autoHideTimeoutRef.current = null
     }
 
-    if (isHovered) {
-      setIsVisible(true)
-      if (autoHideTimeoutRef.current) {
-        clearTimeout(autoHideTimeoutRef.current)
-        autoHideTimeoutRef.current = null
-      }
-    } else {
+    if (settings.autoHide && !isHovered) {
       autoHideTimeoutRef.current = setTimeout(() => {
-        setIsVisible(false)
+        setIsPinnedVisible(false)
       }, settings.autoHideDelay)
     }
 
@@ -158,12 +144,12 @@ export function Toolbar({
 
       // Also check if mouse is near the toolbar area horizontally
       const toolbarCenterX = viewportWidth / 2
-      const toolbarWidth = 400 // Approximate toolbar width
+      const toolbarWidth = toolbarRef.current?.offsetWidth ?? 400
       const horizontalThreshold = toolbarWidth / 2 + 50
       const inHorizontalRange = Math.abs(mouseX - toolbarCenterX) < horizontalThreshold
 
       if (shouldShow && inHorizontalRange) {
-        setIsVisible(true)
+        setIsPinnedVisible(true)
         setIsHovered(true)
       } else {
         setIsHovered(false)
@@ -198,13 +184,16 @@ export function Toolbar({
     }
   }
 
+  const useCompactLayout = isMobile || isCompactScreen
+  const isVisible = !settings.autoHide || isHovered || isPinnedVisible
+
   return (
     <ContextMenu>
       <ContextMenuTrigger>
         <motion.div
           ref={toolbarRef}
           className={cn(
-            "fixed inset-x-0 mx-auto z-10 w-fit",
+            "fixed inset-x-0 mx-auto z-10 w-fit max-w-[calc(100vw-1rem)] px-2 sm:px-0",
             isConsentVisible ? "bottom-36 sm:bottom-20" : "bottom-4"
           )}
           style={{
@@ -222,21 +211,26 @@ export function Toolbar({
             <div className="absolute inset-0 bg-linear-to-t from-background/90 via-background/40 to-transparent h-4 rounded-t-full pointer-events-none" />
           )}
           <motion.div
-            className="flex items-center justify-center gap-4 p-3 bg-background/95 border rounded-full shadow-lg relative"
+            className={cn(
+              "flex items-center justify-center bg-background/95 border shadow-lg relative",
+              useCompactLayout
+                ? "max-w-full flex-wrap gap-2 rounded-3xl px-2.5 py-2"
+                : "gap-4 rounded-full p-3"
+            )}
           >
             <Button
               variant={isCustomizing ? "default" : "ghost"}
               onClick={onEditToggle}
               className={cn(
                 "h-10 rounded-full flex items-center justify-center transition-transform active:scale-95",
-                isMobile ? "w-10 p-0" : "min-w-[120px] gap-3 px-4"
+                useCompactLayout ? "w-10 shrink-0 p-0" : "min-w-[120px] gap-3 px-4"
               )}
             >
               <Pencil className={cn(
                 "h-4 w-4 shrink-0",
                 isCustomizing && "text-background"
               )} />
-              {!isMobile && (
+              {!useCompactLayout && (
                 <span className="text-sm font-medium">
                   {isCustomizing ? t('widgets.done') : t('widgets.edit')}
                 </span>
@@ -247,7 +241,11 @@ export function Toolbar({
 
             <AddWidgetSheet onAddWidget={onAddWidget} isCustomizing={isCustomizing} />
 
-            <FilterCommandMenu variant="toolbar" />
+            <FilterCommandMenu
+              variant="toolbar"
+              className={cn(useCompactLayout ? "min-w-0 flex-1 basis-[11rem]" : "w-auto")}
+              compactBreakpoint={1100}
+            />
 
             {isCustomizing && (
               <div className="flex items-center gap-2">

--- a/app/[locale]/dashboard/components/user-menu.tsx
+++ b/app/[locale]/dashboard/components/user-menu.tsx
@@ -98,7 +98,10 @@ export default function UserMenu() {
             <SubscriptionBadge className="absolute -bottom-1 -right-1 px-1 py-0 text-[10px] leading-3" />
           </div>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56">
+        <DropdownMenuContent
+          align="end"
+          className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-1rem))] w-56 overflow-y-auto overscroll-contain"
+        >
           <DropdownMenuLabel>{t('dashboard.myAccount')}</DropdownMenuLabel>
           <div className="px-2 py-1.5 text-sm text-muted-foreground">
             {user?.email}
@@ -164,7 +167,7 @@ export default function UserMenu() {
               <span className="ml-2">{t('landing.navbar.toggleTheme')}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
-              <DropdownMenuSubContent className="w-[200px]">
+              <DropdownMenuSubContent className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-1rem))] w-[200px] overflow-y-auto overscroll-contain">
                 <DropdownMenuRadioGroup value={theme} onValueChange={handleThemeChange}>
                   <DropdownMenuRadioItem value="light">
                     <Sun className="mr-2 h-4 w-4" />
@@ -203,8 +206,8 @@ export default function UserMenu() {
               <span>{t('dashboard.language')}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
-              <DropdownMenuSubContent>
-                <ScrollArea className="h-[64px]">
+              <DropdownMenuSubContent className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-1rem))] overflow-y-auto overscroll-contain">
+                <ScrollArea className="max-h-32">
                   <DropdownMenuRadioGroup value={currentLocale}>
                     {languages.map((lang) => (
                       <DropdownMenuRadioItem
@@ -228,8 +231,8 @@ export default function UserMenu() {
               <span>{t('dashboard.timezone')}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
-              <DropdownMenuSubContent>
-                <ScrollArea className="h-[40px] sm:h-[120px]">
+              <DropdownMenuSubContent className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-1rem))] overflow-y-auto overscroll-contain">
+                <ScrollArea className="max-h-64">
                   <DropdownMenuRadioGroup value={timezone} onValueChange={setTimezone}>
                     {timezones.map((tz) => (
                       <DropdownMenuRadioItem key={tz} value={tz}>

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -132,11 +132,14 @@ export default function Home() {
   }, []);
 
   return (
-    <main ref={mainRef}>
-      <Tabs defaultValue="widgets" className="w-full h-full">
+    <main ref={mainRef} className="overflow-x-hidden">
+      <Tabs defaultValue="widgets" className="w-full h-full pt-(--tabs-height,3rem)">
         {/* Fixed TabsList positioned under navbar */}
-        <div ref={tabsListRef} className="sticky bg-background border-b top-(--navbar-height) z-1">
-          <TabsList className="w-full max-w-none">
+        <div
+          ref={tabsListRef}
+          className="fixed inset-x-0 top-(--navbar-height,5rem) z-30 w-full overflow-x-auto border-b bg-background shadow-xs"
+        >
+          <TabsList className="h-12 w-full min-w-max max-w-none rounded-none bg-muted/70 sm:min-w-0">
             <TabsTrigger value="widgets">
               {t("dashboard.tabs.widgets")}
             </TabsTrigger>
@@ -147,15 +150,15 @@ export default function Home() {
           </TabsList>
         </div>
 
-        <TabsContent value="table" className="h-[calc(100vh-var(--navbar-height)-var(--tabs-height)-16px)] p-4">
+        <TabsContent value="table" className="h-[calc(100dvh-var(--navbar-height)-var(--tabs-height)-16px)] min-w-0 p-2 sm:p-4">
           <TradeTableReview />
         </TabsContent>
 
-        <TabsContent value="accounts" className="flex-1 mt-0">
+        <TabsContent value="accounts" className="flex-1 mt-0 min-w-0">
           <AccountsOverview size="large" />
         </TabsContent>
 
-        <TabsContent value="widgets" className="px-4">
+        <TabsContent value="widgets" className="min-w-0 px-2 sm:px-4">
           <WidgetCanvas />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the floating dashboard toolbar adapt earlier on narrow and low-density screens
- wrap the trade table header and pagination controls so they avoid clipping on smaller widths
- reduce navbar horizontal padding and make the filter trigger width shrink safely

## Testing
- `npx eslint "app/[locale]/dashboard/components/toolbar.tsx" "app/[locale]/dashboard/components/filters/filter-command-menu.tsx" "app/[locale]/dashboard/components/navbar.tsx" "app/[locale]/dashboard/components/tables/trade-table-review.tsx"`
- `npx tsc --noEmit`
- started the app with `npm run dev`
- attempted manual dashboard verification, but local auth is blocked by backend/database setup and redirects back to `authentication?auth_error=session_invalid`

## Artifacts
[Password tab filled before auth retry](https://cursor.com/agents/bc-483481bf-607b-4941-af0c-3a2db84c1473/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_retry_filled.png)
[Auth page after failed submit](https://cursor.com/agents/bc-483481bf-607b-4941-af0c-3a2db84c1473/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_retry_after_submit.png)
[auth_retry_log.txt](https://cursor.com/agents/bc-483481bf-607b-4941-af0c-3a2db84c1473/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_retry_log.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-483481bf-607b-4941-af0c-3a2db84c1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-483481bf-607b-4941-af0c-3a2db84c1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

