### PR TITLE
perf: dedupe getShared with React cache and parallelize updates page fetches

### DIFF
--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -140,27 +140,33 @@ export default async function Page({ params }: PageProps) {
   const { slug, locale } = resolvedParams;
   setStaticParamsLocale(locale);
 
-  let post: Awaited<ReturnType<typeof getPost>>;
+  const [postResult, adjacentPostsResult] = await Promise.allSettled([
+    getPost(slug, locale),
+    getAdjacentPosts(slug, locale),
+  ]);
 
-  try {
-    post = await getPost(slug, locale);
-  } catch (postError) {
-    console.error("Error fetching post data:", postError);
+  if (postResult.status === "rejected") {
+    console.error("Error fetching post data:", postResult.reason);
     notFound();
   }
 
+  const post = postResult.value;
   if (!post) {
     notFound();
   }
 
-  let adjacentPosts: Awaited<ReturnType<typeof getAdjacentPosts>>;
-
-  try {
-    adjacentPosts = await getAdjacentPosts(slug, locale);
-  } catch (adjacentPostsError) {
-    console.error("Error fetching adjacent post data:", adjacentPostsError);
-    adjacentPosts = { previous: null, next: null };
-  }
+  const adjacentPosts =
+    adjacentPostsResult.status === "fulfilled"
+      ? adjacentPostsResult.value
+      : (() => {
+          console.error(
+            "Error fetching adjacent post data:",
+            adjacentPostsResult.reason
+          );
+          return { previous: null, next: null } as Awaited<
+            ReturnType<typeof getAdjacentPosts>
+          >;
+        })();
 
   const { previous, next } = adjacentPosts;
   const { meta, content } = post;

--- a/app/[locale]/shared/[slug]/page.tsx
+++ b/app/[locale]/shared/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next"
+import { cache } from "react"
 import { notFound } from "next/navigation"
 import { getShared } from "@/server/shared"
 import { SharedPageClient } from "./shared-page-client"
 import { getRequestOrigin, siteUrl } from "@/lib/site-url"
 import { headers } from "next/headers"
+
+const getCachedShared = cache(getShared)
 
 interface SharedPageProps {
   params: Promise<{
@@ -19,7 +22,7 @@ export async function generateMetadata({ params }: SharedPageProps): Promise<Met
   let sharedData: Awaited<ReturnType<typeof getShared>> = null
 
   try {
-    sharedData = await getShared(slug)
+    sharedData = await getCachedShared(slug)
   } catch (error) {
     console.error("Error loading shared metadata:", error)
   }
@@ -60,17 +63,13 @@ export async function generateMetadata({ params }: SharedPageProps): Promise<Met
   }
 }
 
-// Main page component - Server Component
 export default async function SharedPage({ params }: SharedPageProps) {
-  // Await the params Promise
   const resolvedParams = await params
-  // Fetch shared data on the server
-  const sharedData = await getShared(resolvedParams.slug)
+  const sharedData = await getCachedShared(resolvedParams.slug)
   
   if (!sharedData) {
     notFound()
   }
 
-  // Pass the resolved params and fetched data to the client component
   return <SharedPageClient params={resolvedParams} initialData={sharedData} />
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two performance issues in the Next.js pages:

1. **Shared page (`/shared/[slug]`)** — `getShared(slug)` was called twice per request: once in `generateMetadata` and again in the page component. Since `getShared` runs a Prisma transaction that queries the DB for trades, tick details, and groups (and also increments the view counter), the duplicate call doubled both latency and cost per page load, and inflated view counts.

2. **Updates page (`/updates/[slug]`)** — `getPost` and `getAdjacentPosts` are independent data fetches but were running sequentially, adding unnecessary latency.

## Solution

### Shared page — React `cache()` deduplication
Wrapped `getShared` with React's `cache()` at module scope (`getCachedShared`). React `cache` deduplicates calls with the same arguments within a single server render, so `generateMetadata` and the page component now share a single DB call.

### Updates page — `Promise.allSettled` parallelization
Replaced the sequential `await getPost()` / `await getAdjacentPosts()` with `Promise.allSettled([...])` so both fetches run concurrently. `allSettled` preserves the existing error-handling behavior: a failed `getAdjacentPosts` gracefully falls back to `{ previous: null, next: null }` without blocking the page render.

## Changed files
- `app/[locale]/shared/[slug]/page.tsx`
- `app/[locale]/(landing)/updates/[slug]/page.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae2aac42-1b27-411d-9961-4965f4dcb44e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae2aac42-1b27-411d-9961-4965f4dcb44e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

