### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/public/AGENTS.md
+++ b/public/AGENTS.md
@@ -45,3 +45,27 @@ turn raw trade history into clear insights, better habits, and consistent result
 ## Sharing and collaboration
 - Team dashboards for shared analytics.
 - Public and embed-friendly views for sharing results.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+- **Next.js dev server**: `npm run dev` (port 3000). Single app, not a monorepo.
+- **PostgreSQL 16**: started via `docker compose up db -d` from the repo root. Default creds: `devuser`/`devpass`/`deltalytix_dev`.
+- **Prisma 7**: uses `@prisma/adapter-pg` at runtime (`DATABASE_URL`) and `DIRECT_URL` for CLI migrations via `prisma.config.ts`.
+
+### Key commands
+| Task | Command |
+|---|---|
+| Install deps | `npm install` |
+| Generate Prisma client | `npx prisma generate` |
+| Run migrations | `DIRECT_URL="postgresql://devuser:devpass@localhost:5432/deltalytix_dev" npx prisma migrate dev` |
+| Lint | `npm run lint` (ESLint; expect ~400 pre-existing errors) |
+| Type-check | `npm run typecheck` (`tsc --noEmit` — should pass clean) |
+| Dev server | `npm run dev` |
+
+### Gotchas
+- **`prisma.config.ts` uses `dotenv/config`**, which reads `.env` (not `.env.local`). For Prisma CLI commands (`migrate`, `db push`), either create a `.env` with `DIRECT_URL`/`DATABASE_URL`, or pass them as shell env vars explicitly.
+- **No lockfile is committed**. `npm install` creates `package-lock.json` locally. Do not commit it.
+- **Docker-in-Docker**: the Cloud Agent VM requires `fuse-overlayfs` storage driver and `iptables-legacy` for Docker to work. The update script handles Docker daemon startup.
+- **Supabase auth**: without real Supabase keys, the landing page and public routes work, but login/dashboard routes requiring auth will redirect. Set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` secrets for full auth flow.
+- **canvas native module**: `npm install` builds the `canvas` package which needs system libs. These are pre-installed in the Cloud Agent VM. If `canvas` build fails, install `build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `public/AGENTS.md` with development environment guidance for future Cloud Agents.

### What's included

- **Services overview**: Next.js dev server, PostgreSQL 16 (via Docker Compose), Prisma 7 adapter architecture
- **Key commands table**: `npm install`, `npx prisma generate`, migrations, lint, typecheck, dev server
- **Gotchas discovered during setup**:
  - `prisma.config.ts` uses `dotenv/config` which reads `.env` (not `.env.local`) — Prisma CLI commands need env vars passed explicitly or a `.env` file
  - No lockfile is committed; `npm install` creates one locally
  - Docker-in-Docker requires `fuse-overlayfs` and `iptables-legacy` in Cloud Agent VMs
  - Supabase auth requires real keys for login/dashboard; landing page works with placeholders
  - `canvas` native module build dependencies

### Environment validation

[deltalytix-dev-server-demo.mp4](https://cursor.com/agents/bc-8c795bff-87b9-4d4e-8e49-36a7ad44150e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeltalytix-dev-server-demo.mp4)

Demo of the dev server running on localhost:3000 with working navigation.

| Check | Result |
|---|---|
| Node.js 20.20.2 + npm 10.8.2 | ✅ |
| `npm install` (1469 packages) | ✅ |
| PostgreSQL 16 via Docker Compose | ✅ |
| `npx prisma generate` (Prisma 7.8.0) | ✅ |
| `npx prisma migrate dev` (80+ migrations) | ✅ |
| `npm run lint` (ESLint runs, pre-existing warnings) | ✅ |
| `npm run typecheck` (clean pass) | ✅ |
| `npm run dev` (Next.js 16.2.4 on port 3000) | ✅ |
| Browser navigation and interactivity | ✅ |


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c795bff-87b9-4d4e-8e49-36a7ad44150e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c795bff-87b9-4d4e-8e49-36a7ad44150e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

