### PR TITLE
Fix equity widget data fetch

### DIFF
--- a/context/data-provider.tsx
+++ b/context/data-provider.tsx
@@ -530,10 +530,6 @@ export const DataProvider: React.FC<{
       setTickDetails(data.tickDetails);
       setIsFirstConnection(data.userData?.isFirstConnection || false);
 
-      // Compute the equity chart data
-      if (hasEquityChartWidget && !isSharedView) {
-        fetchEquityChartData();
-      }
     } catch (error) {
       console.error("Error loading data:", error);
       // Optionally handle specific error cases here
@@ -582,6 +578,17 @@ export const DataProvider: React.FC<{
       mounted = false;
     };
   }, [isSharedView]); // Only depend on isSharedView
+
+  useEffect(() => {
+    if (isSharedView || !supabaseUser?.id || !hasEquityChartWidget) return;
+
+    void fetchEquityChartData();
+  }, [
+    isSharedView,
+    supabaseUser?.id,
+    hasEquityChartWidget,
+    fetchEquityChartData,
+  ]);
 
   // Persist language changes without blocking UI
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fetch equity chart data reactively once the dashboard layout exposes the equity widget.
- Prevent the widget from rendering empty when the layout is loaded during the initial data load pass.

## Test plan
- `npm run lint -- context/data-provider.tsx`
- `npm run typecheck` *(fails on existing unrelated `private/Platform Development/PropTradingProtocol.ts` isolatedModules namespace error)*


Made with [Cursor](https://cursor.com)