### PR TITLE
Add Codex Cloud PR review setup

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,56 @@
+# Codex Cloud Environment
+
+Use this repository with a Codex Cloud environment configured for Bun.
+
+## Setup Command
+
+```bash
+bun run codex:setup
+```
+
+The setup script installs Bun if needed, installs native libraries used by the app's image/PDF dependencies, installs JS dependencies from `bun.lock`, and generates the Prisma client.
+
+## Secrets
+
+Configure real values as Codex Cloud environment secrets. Do not commit them.
+
+Minimum useful review/build secrets mirror `.env.example`:
+
+- `DATABASE_URL`
+- `DIRECT_URL`
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `OPENAI_API_KEY`
+- `ENCRYPTION_KEY`
+- `RESEND_API_KEY`
+- `GITHUB_TOKEN`
+
+For PR review-only tasks, most app secrets can be absent. Full builds and runtime checks should use the same values as the local Deltalytix `.env`.
+
+## Review A PR
+
+```bash
+bun run codex:review-pr -- 132
+```
+
+This checks out the PR and writes repeatable review context under `codex-pr-context/pr-132/`.
+
+Use those files before making findings:
+
+- `summary.json`
+- `comments.json`
+- `review-comments.json`
+- `diff.stat`
+- `diff.patch`
+
+## Follow-Up PR Pattern
+
+When a review needs code changes:
+
+```bash
+git checkout -b <follow-up-branch>
+git push -u origin <follow-up-branch>
+gh pr create --base <original-pr-head-branch> --head <follow-up-branch>
+```
+
+After the follow-up PR is accepted, merge it into the original PR branch, then re-check the original PR before merge.

--- a/.codex/review-pr.sh
+++ b/.codex/review-pr.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "" ]; then
+  echo "Usage: bun run codex:review-pr -- <pr-number>"
+  exit 2
+fi
+
+PR_NUMBER="$1"
+ROOT="$(git rev-parse --show-toplevel)"
+OUT_DIR="$ROOT/codex-pr-context/pr-$PR_NUMBER"
+
+cd "$ROOT"
+mkdir -p "$OUT_DIR"
+
+echo "==> Loading PR #$PR_NUMBER"
+gh pr view "$PR_NUMBER" \
+  --json number,title,state,url,baseRefName,headRefName,headRefOid,author,mergeable,reviewDecision,statusCheckRollup,files,comments,reviews \
+  > "$OUT_DIR/summary.json"
+
+BASE_REF="$(node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('$OUT_DIR/summary.json','utf8')); process.stdout.write(p.baseRefName)")"
+HEAD_REF="$(node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('$OUT_DIR/summary.json','utf8')); process.stdout.write(p.headRefName)")"
+
+gh api "repos/:owner/:repo/pulls/$PR_NUMBER/comments" --paginate > "$OUT_DIR/review-comments.json"
+gh api "repos/:owner/:repo/issues/$PR_NUMBER/comments" --paginate > "$OUT_DIR/comments.json"
+
+git fetch origin "$BASE_REF"
+if ! gh pr checkout "$PR_NUMBER"; then
+  REVIEW_BRANCH="codex-review-pr-$PR_NUMBER"
+  git fetch origin "pull/$PR_NUMBER/head:$REVIEW_BRANCH"
+  git checkout "$REVIEW_BRANCH"
+fi
+
+git diff --stat "origin/$BASE_REF"...HEAD > "$OUT_DIR/diff.stat"
+git diff --find-renames "origin/$BASE_REF"...HEAD > "$OUT_DIR/diff.patch"
+
+cat > "$OUT_DIR/README.md" <<EOF
+# PR $PR_NUMBER Review Context
+
+- Base: $BASE_REF
+- Head: $HEAD_REF
+
+Files:
+- summary.json: PR metadata, files, status checks, top-level comments/reviews.
+- comments.json: issue/PR conversation comments.
+- review-comments.json: inline review comments.
+- diff.stat: changed-file summary.
+- diff.patch: full diff against the base branch.
+
+Recommended review start:
+
+\`\`\`bash
+bun run typecheck
+bun run lint
+\`\`\`
+EOF
+
+echo "==> PR #$PR_NUMBER checked out"
+echo "Context written to $OUT_DIR"
+echo "Base: $BASE_REF"
+echo "Head: $HEAD_REF"

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+echo "==> Deltalytix Codex Cloud setup"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "==> Installing Bun"
+  curl -fsSL https://bun.sh/install | bash
+  export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+  export PATH="$BUN_INSTALL/bin:$PATH"
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  echo "==> Installing native libraries used by canvas/PDF/image tooling"
+  sudo apt-get update
+  sudo apt-get install -y \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
+    libpixman-1-dev \
+    pkg-config
+fi
+
+echo "==> Installing JS dependencies"
+bun install --frozen-lockfile
+
+if [ -f prisma/generated/prisma/client.ts ]; then
+  echo "==> Prisma client already present; skipping generation"
+else
+  echo "==> Generating Prisma client"
+  DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/deltalytix}" \
+  DIRECT_URL="${DIRECT_URL:-postgresql://postgres:postgres@localhost:5432/deltalytix}" \
+    bunx prisma generate
+fi
+
+echo "==> Setup complete"
+echo "Next: bun run codex:review-pr -- <pr-number>"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .cursor
 WARP.md
 .github/instructions/
+codex-pr-context/
 
 # dependencies
 /node_modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Codex Instructions
+
+## Project Defaults
+
+- Use Bun for package management and scripts.
+- Prefer `bun install --frozen-lockfile` after dependency changes are pulled.
+- Prefer `bun run typecheck` and `bun run lint` for broad verification.
+- Use `bun test` for unit tests.
+- Do not commit or print `.env` values. Configure secrets in the Codex Cloud environment instead.
+
+## PR Review Flow
+
+1. Bootstrap the environment with `bun run codex:setup`.
+2. Load a PR locally with `bun run codex:review-pr -- <number>`.
+3. Read `codex-pr-context/pr-<number>/summary.json`, `comments.json`, `review-comments.json`, `diff.stat`, and `diff.patch`.
+4. Review as a code reviewer first: findings before summary, ordered by severity, with file and line references.
+5. If follow-up changes are needed, create a branch on top of the PR head branch and open the follow-up PR against that head branch.
+6. After the follow-up PR is approved, merge it into the base PR branch, then re-check the base PR before merge.
+
+## Verification Notes
+
+- If repo-wide verification is blocked by missing external services or env vars, run focused checks for the files touched and clearly report the limitation.
+- The app expects browser/public env vars for full local builds. Use Codex Cloud secrets for real values; keep `.env.example` as the committed reference only.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "screenshot:dashboard": "node scripts/screenshot-dashboard.js"
+    "screenshot:dashboard": "node scripts/screenshot-dashboard.js",
+    "codex:setup": "bash .codex/setup.sh",
+    "codex:review-pr": "bash .codex/review-pr.sh"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.10",
@@ -179,6 +182,7 @@
     "tailwindcss": "^4.1.16",
     "ts-node": "^10.9.2",
     "tw-animate-css": "latest",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^4.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- add Codex-specific repo instructions for the repeatable PR review workflow
- add Codex Cloud setup and PR context helper scripts using Bun
- add a Vitest script/dependency so the existing dxfeed token test and repo-wide typecheck work in fresh environments
- ignore generated PR review context artifacts

## Verification
- bun run codex:setup
- bun run codex:review-pr -- 132
- bun run typecheck
- bun test lib/dxfeed-token.test.ts