### PR TITLE
feat(trade-table): add "By creation date" grouping mode

### DIFF
--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -330,7 +330,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
     tableConfig?.groupingGranularity || 0,
   );
   const [groupingMode, setGroupingMode] = useState<
-    "time" | "instrument" | "account"
+    "time" | "instrument" | "account" | "creationDate"
   >(tableConfig?.groupingMode || "time");
   const [selectedTrades, setSelectedTrades] = useState<string[]>([]);
   const [showPoints, setShowPoints] = useState(false);
@@ -409,7 +409,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
   };
 
   const handleGroupingModeChange = (
-    newMode: "time" | "instrument" | "account",
+    newMode: "time" | "instrument" | "account" | "creationDate",
   ) => {
     setGroupingMode(newMode);
     updateGroupingMode("trade-table", newMode);
@@ -516,7 +516,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           ? `instrument-${trade.instrument}`
           : groupingMode === "account"
             ? `account-${trade.accountNumber}`
-            : `${trade.instrument}-${roundedEntryDate.toISOString()}`;
+            : groupingMode === "creationDate"
+              ? `creationDate-${new Date(trade.createdAt).toDateString()}`
+              : `${trade.instrument}-${roundedEntryDate.toISOString()}`;
 
       const key = trade.groupId ? `${trade.groupId}` : autoGroupKey;
 
@@ -1335,9 +1337,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             {config?.groupTrades !== false && (
               <Select
                 value={groupingMode}
-                onValueChange={(value: "time" | "instrument" | "account") =>
-                  handleGroupingModeChange(value)
-                }
+                onValueChange={(
+                  value: "time" | "instrument" | "account" | "creationDate",
+                ) => handleGroupingModeChange(value)}
               >
                 <SelectTrigger className="w-full min-w-0 max-w-full xl:w-[180px] xl:max-w-[250px]">
                   <SelectValue
@@ -1354,6 +1356,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                   </SelectItem>
                   <SelectItem value="account">
                     {t("trade-table.groupingMode.account")}
+                  </SelectItem>
+                  <SelectItem value="creationDate">
+                    {t("trade-table.groupingMode.creationDate")}
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1094,6 +1094,7 @@ export default {
       time: "By time",
       instrument: "By instrument",
       account: "By account",
+      creationDate: "By creation date",
     },
     groupTrades: "Group trades",
     ungroupTrades: "Ungroup trades",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1419,6 +1419,7 @@ export default {
       time: "Par heure",
       instrument: "Par instrument",
       account: "Par compte",
+      creationDate: "Par date de création",
     },
     groupTrades: "Grouper les trades",
     ungroupTrades: "Dégrouper les trades",

--- a/store/widgets/table-config-store.ts
+++ b/store/widgets/table-config-store.ts
@@ -18,7 +18,7 @@ export interface TableConfig {
   columnFilters: ColumnFiltersState
   pageSize: number
   groupingGranularity: number
-  groupingMode: 'time' | 'instrument' | 'account'
+  groupingMode: 'time' | 'instrument' | 'account' | 'creationDate'
 }
 
 interface TableConfigState {


### PR DESCRIPTION
## Summary

Adds a new **"By creation date"** option to the trade table's grouping-mode selector. This groups trades by the calendar date they were added to the database (`Trade.createdAt`), as opposed to the trade's entry/exit date.

This complements the existing grouping modes: **By time**, **By instrument**, and **By account**.

## Why

Requested: a way to group trades on the trade table by their creation date (when they were added to the DB). The `Trade` model already has a `createdAt DateTime @default(now())` field, so no schema/migration changes were needed.

## Changes

- **`store/widgets/table-config-store.ts`** — extended the `groupingMode` union type with `'creationDate'`.
- **`app/[locale]/dashboard/components/tables/trade-table-review.tsx`**:
  - Extended the `groupingMode` state and handler types.
  - Added a grouping branch that keys trades by `new Date(trade.createdAt).toDateString()` (calendar-day buckets).
  - Added the `creationDate` option to the grouping-mode `Select`.
- **`locales/en.ts` / `locales/fr.ts`** — added the `groupingMode.creationDate` label ("By creation date" / "Par date de création").

## Notes

- Grouping is by calendar day of `createdAt`. The time-granularity selector remains time-mode only, consistent with instrument/account modes.
- No database or API changes.

## Test plan

- [ ] On the trade table, open the grouping-mode selector and choose **By creation date**.
- [ ] Trades imported/added on the same day collapse into one group row.
- [ ] Switching back to time/instrument/account modes still works.
- [ ] Selection persists across reloads (stored via the zustand table-config store).

https://claude.ai/code/session_01FUkJTD91CbYKeutoU21x3e

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUkJTD91CbYKeutoU21x3e)_