### PR TITLE
Add Phidias Prop Firm to DxFeed/Volumetrica propfirm sync

### DIFF
--- a/lib/dxfeed-propfirms.ts
+++ b/lib/dxfeed-propfirms.ts
@@ -53,6 +53,15 @@ export const DXFEED_PROP_FIRMS: DxFeedPropFirmDefinition[] = [
     tradingSubdomain: 'trading-volumetrica',
     enabled: true,
   },
+  {
+    id: 'phidiaspropfirm',
+    name: 'Phidias Prop Firm',
+    website: 'https://dxfeed.phidiaspropfirm.com',
+    domain: 'phidiaspropfirm.com',
+    historicalSubdomain: 'dxfeed',
+    tradingSubdomain: 'trading-volumetrica',
+    enabled: true,
+  },
   // More Volumetrica-based firms can be added once their domain pattern is confirmed.
 ]
 


### PR DESCRIPTION
## Summary

Adds **Phidias Prop Firm** as a supported prop firm for DxFeed/Volumetrica account sync.

The firm runs on the shared Volumetrica stack at `https://dxfeed.phidiaspropfirm.com/`, using the same `dxfeed` historical subdomain pattern as Phoenix Trader Funding:
- Historical REST: `dxfeed.phidiaspropfirm.com`
- Trading WSS: `trading-volumetrica.phidiaspropfirm.com`

## Changes

- `lib/dxfeed-propfirms.ts`: registered `phidiaspropfirm` (domain `phidiaspropfirm.com`) with the `dxfeed` historical subdomain and default `trading-volumetrica` trading subdomain, enabled in the connect dropdown.

https://claude.ai/code/session_01UvUxEr7JQvQQZWtPeS12di

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvUxEr7JQvQQZWtPeS12di)_