### PR TITLE
fix(dxfeed): use revalidateTag in saveTradesAction for route handlers

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -122,12 +122,10 @@ export async function saveTradesAction(
       }
     }
 
-    try{
-      updateTag(`trades-${userId}`)
-    } catch (error) {
-      console.error('[saveTrades] Error updating tag:', error)
-      revalidateTag(`trades-${userId}`, { expire: 0 })
-    }
+    // Use revalidateTag (not updateTag) so this works both from Server Actions
+    // and from Route Handlers (e.g. /api/dxfeed/sync, /api/thor/store).
+    // updateTag can only be called from within a Server Action.
+    revalidateTag(`trades-${userId}`, { expire: 0 })
 
     return {
       error: result.count === 0 ? 'NO_TRADES_ADDED' : false,


### PR DESCRIPTION
saveTradesAction is reachable from Route Handlers (/api/dxfeed/sync and
/api/thor/store), where updateTag throws because it can only be called
from within a Server Action. Replace updateTag with revalidateTag, which
works in both Server Action and Route Handler contexts, matching the
pattern already used elsewhere in the codebase.