### PR TITLE
fix(dxfeed): restore updateTag for instant reload on client-side import

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -122,10 +122,16 @@ export async function saveTradesAction(
       }
     }
 
-    // Use revalidateTag (not updateTag) so this works both from Server Actions
-    // and from Route Handlers (e.g. /api/dxfeed/sync, /api/thor/store).
-    // updateTag can only be called from within a Server Action.
-    revalidateTag(`trades-${userId}`, { expire: 0 })
+    // Prefer updateTag: in a Server Action context (e.g. client-side import)
+    // it expires AND immediately refreshes the cache, so the caller reads its
+    // own writes without a separate refetch. updateTag throws when called from
+    // a Route Handler (e.g. /api/dxfeed/sync, /api/thor/store), so fall back to
+    // revalidateTag there — that's expected, not an error.
+    try {
+      updateTag(`trades-${userId}`)
+    } catch {
+      revalidateTag(`trades-${userId}`, { expire: 0 })
+    }
 
     return {
       error: result.count === 0 ? 'NO_TRADES_ADDED' : false,


### PR DESCRIPTION
## Follow-up to #185

#185 fixed the `updateTag can only be called from within a Server Action` crash when saving trades from Route Handlers (`/api/dxfeed/sync`, `/api/thor/store`). However, it swapped `saveTradesAction` **wholesale** to `revalidateTag`, which regressed the Server Action path.

### Why this matters
- `updateTag` (Server Action only): expires **and immediately refreshes** the cache within the same request — so client-side imports (`import-button.tsx` → `saveTradesAction`) read their own writes and the UI reflects new trades instantly.
- `revalidateTag`: only marks the entry stale, refreshed on the **next** request — no instant reload.

### The fix
Restore `updateTag` as the primary path and fall back to `revalidateTag` **only** when `updateTag` throws (i.e. when invoked from a Route Handler). This keeps both contexts correct:

| Caller | Path | Behavior |
|---|---|---|
| Client import (Server Action) | `updateTag` | instant expire + refresh ✅ |
| `/api/dxfeed/sync`, `/api/thor/store` (Route Handler) | `updateTag` throws → `revalidateTag` fallback | cache invalidated, no crash ✅ |

No noisy error log — the throw in a Route Handler is expected, not a failure.

https://claude.ai/code/session_01TKsfr4sMiVjtM5trkPK6GK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKsfr4sMiVjtM5trkPK6GK)_