### PR TITLE
Fix shared page: undefined slug in opengraph-image and getShared transaction timeout

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Deltalytix",
+  "install": "npm install && npx prisma generate",
+  "ports": [
+    {
+      "name": "next",
+      "port": 3000
+    }
+  ],
+  "terminals": [
+    {
+      "name": "next-dev",
+      "command": "npm run dev",
+      "description": "Next.js development server"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 
 # AI rules file
 .cursorrules
-.cursor
+.cursor/*
+!.cursor/environment.json
 WARP.md
 .github/instructions/
 

--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -26,6 +26,10 @@ interface PageProps {
   params: ParamsInput;
 }
 
+// These posts are static MDX content, so prerender them at build time. URLs
+// are resolved from the build-time site origin (siteUrl/getSiteOrigin, which
+// reads NEXT_PUBLIC_BASE_URL / VERCEL_URL), avoiding any request-time
+// dependency that would force dynamic rendering.
 export const dynamic = "force-static";
 export const dynamicParams = false;
 
@@ -92,20 +96,18 @@ export async function generateMetadata({
           url,
           siteName: "Deltalytix",
           locale: locale,
-          images: [
-            {
-              url: siteUrl(`/${locale}/updates/${slug}/opengraph-image`),
-              width: 1200,
-              height: 630,
-              alt: meta.title,
-            },
-          ],
+          // The og:image is injected automatically from the colocated
+          // opengraph-image.tsx route and resolved against metadataBase. We do
+          // not hardcode the URL: that route lives inside the (landing) route
+          // group, so Next.js publishes it at a hashed path
+          // (e.g. /opengraph-image-1uk6iz?<version>), and a hand-written
+          // `/opengraph-image` URL resolves to the not-found route instead.
         },
         twitter: {
           card: "summary_large_image",
           title: meta.title,
           description: meta.description,
-          images: [siteUrl(`/${locale}/updates/${slug}/opengraph-image`)],
+          // twitter:image is also derived from opengraph-image.tsx.
         },
       };
     } catch (postError) {
@@ -179,7 +181,7 @@ export default async function Page({ params }: PageProps) {
     author: {
       "@type": "Organization",
       name: "Deltalytix",
-      url: siteUrl(),
+      url: siteUrl("/"),
     },
     publisher: {
       "@type": "Organization",

--- a/app/[locale]/(landing)/updates/page.tsx
+++ b/app/[locale]/(landing)/updates/page.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+import { setStaticParamsLocale } from 'next-international/server'
 import { getI18n } from '@/locales/server'
+import { getStaticParams as getLocaleStaticParams } from '@/locales/server'
 import CompletedTimeline from '../components/completed-timeline'
 import { getAllPosts } from '@/lib/posts'
 import { getLatestVideoFromPlaylist } from '@/app/[locale]/admin/actions/youtube'
@@ -10,12 +12,20 @@ interface PageProps {
   }>
 }
 
+export const revalidate = 3600
+
+export function generateStaticParams() {
+  return getLocaleStaticParams()
+}
+
 export default async function UpdatesPage(props: PageProps) {
   const params = await props.params;
 
   const {
     locale
   } = params;
+
+  setStaticParamsLocale(locale)
 
   const t = await getI18n()
   const posts = await getAllPosts(locale)

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -47,6 +47,14 @@ const DXFEED_HISTORY_LOOKBACK_DAYS = Math.max(
   Number(process.env.DXFEED_HISTORY_LOOKBACK_DAYS ?? '364'),
 )
 
+// Retry configuration for the historical report API, which rate limits
+// requests with HTTP 429 ("Too many requests").
+const DXFEED_MAX_RETRIES = Math.max(0, Number(process.env.DXFEED_MAX_RETRIES ?? '3'))
+const DXFEED_RETRY_DELAY_MS = Math.max(
+  0,
+  Number(process.env.DXFEED_RETRY_DELAY_MS ?? '2000'),
+)
+
 const logger = {
   debug: (message: string, data?: any) => {
     if (IS_DEV) console.log(`[DXFEED-DEBUG] ${message}`, data ?? '')
@@ -83,6 +91,48 @@ function buildHistoricalAuthHeaders(accessToken: string): HeadersInit {
     // The report API expects the raw tradingRestReportToken, not a Bearer token.
     'Authorization': accessToken,
     'Accept': 'application/json',
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * `fetch` wrapper that retries on rate limiting (429). When the server sends a
+ * numeric `Retry-After` header we wait exactly that long; otherwise we fall
+ * back to a simple exponential backoff. Every 429 is logged with its full
+ * headers so we can learn DxFeed's actual rate-limit contract. Any other
+ * response is returned as-is.
+ */
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  options: { label?: string } = {},
+): Promise<Response> {
+  const label = options.label ? ` for ${options.label}` : ''
+
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(url, init)
+
+    if (response.status !== 429 || attempt >= DXFEED_MAX_RETRIES) {
+      return response
+    }
+
+    const retryAfter = response.headers.get('Retry-After')
+    const headers = Object.fromEntries(response.headers.entries())
+    logger.warn(
+      `Rate limited (429)${label} [attempt ${attempt + 1}/${DXFEED_MAX_RETRIES}]. ` +
+        `Retry-After=${retryAfter ?? 'none'}; headers=${JSON.stringify(headers)}`,
+    )
+
+    const retryAfterSeconds = Number(retryAfter)
+    const delayMs =
+      retryAfter && Number.isFinite(retryAfterSeconds)
+        ? retryAfterSeconds * 1000
+        : DXFEED_RETRY_DELAY_MS * 2 ** attempt
+
+    await sleep(delayMs)
   }
 }
 
@@ -266,9 +316,11 @@ export async function getDxFeedAccounts(
 
     logger.debug('Fetching accounts from:', url)
 
-    const response = await fetch(url, {
-      headers: buildHistoricalAuthHeaders(accessToken),
-    })
+    const response = await fetchWithRetry(
+      url,
+      { headers: buildHistoricalAuthHeaders(accessToken) },
+      { label: 'account list' },
+    )
 
     if (!response.ok) {
       const text = await response.text()
@@ -523,9 +575,11 @@ export async function getDxFeedTrades(
       tradesUrl.searchParams.set('startDt', startDt.toISOString())
       tradesUrl.searchParams.set('endDt', endDt.toISOString())
 
-      const response = await fetch(tradesUrl.toString(), {
-        headers: buildHistoricalAuthHeaders(accessToken),
-      })
+      const response = await fetchWithRetry(
+        tradesUrl.toString(),
+        { headers: buildHistoricalAuthHeaders(accessToken) },
+        { label: `account ${accountLabel}` },
+      )
 
       if (!response.ok) {
         const text = await response.text()

--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -330,7 +330,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
     tableConfig?.groupingGranularity || 0,
   );
   const [groupingMode, setGroupingMode] = useState<
-    "time" | "instrument" | "account"
+    "time" | "instrument" | "account" | "creationDate"
   >(tableConfig?.groupingMode || "time");
   const [selectedTrades, setSelectedTrades] = useState<string[]>([]);
   const [showPoints, setShowPoints] = useState(false);
@@ -409,7 +409,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
   };
 
   const handleGroupingModeChange = (
-    newMode: "time" | "instrument" | "account",
+    newMode: "time" | "instrument" | "account" | "creationDate",
   ) => {
     setGroupingMode(newMode);
     updateGroupingMode("trade-table", newMode);
@@ -516,7 +516,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           ? `instrument-${trade.instrument}`
           : groupingMode === "account"
             ? `account-${trade.accountNumber}`
-            : `${trade.instrument}-${roundedEntryDate.toISOString()}`;
+            : groupingMode === "creationDate"
+              ? `creationDate-${new Date(trade.createdAt).toDateString()}`
+              : `${trade.instrument}-${roundedEntryDate.toISOString()}`;
 
       const key = trade.groupId ? `${trade.groupId}` : autoGroupKey;
 
@@ -1335,9 +1337,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             {config?.groupTrades !== false && (
               <Select
                 value={groupingMode}
-                onValueChange={(value: "time" | "instrument" | "account") =>
-                  handleGroupingModeChange(value)
-                }
+                onValueChange={(
+                  value: "time" | "instrument" | "account" | "creationDate",
+                ) => handleGroupingModeChange(value)}
               >
                 <SelectTrigger className="w-full min-w-0 max-w-full xl:w-[180px] xl:max-w-[250px]">
                   <SelectValue
@@ -1354,6 +1356,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                   </SelectItem>
                   <SelectItem value="account">
                     {t("trade-table.groupingMode.account")}
+                  </SelectItem>
+                  <SelectItem value="creationDate">
+                    {t("trade-table.groupingMode.creationDate")}
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/app/[locale]/shared/[slug]/opengraph-image.tsx
+++ b/app/[locale]/shared/[slug]/opengraph-image.tsx
@@ -14,9 +14,10 @@ export const contentType = "image/png"
 export const runtime = 'nodejs'
 export const revalidate = 3600 // 1 hour
 
-export default async function Image({ params }: { params: { slug: string } }) {
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
     try {
-        const sharedData = await getShared(params.slug)
+        const { slug } = await params
+        const sharedData = await getShared(slug)
         if (!sharedData) {
             return new Response("Shared data not found", { status: 404 })
         }

--- a/content/updates/en/dxfeed-import-instant-dashboard-refresh.mdx
+++ b/content/updates/en/dxfeed-import-instant-dashboard-refresh.mdx
@@ -1,0 +1,13 @@
+---
+title: 'DxFeed import: dashboard refreshes right away'
+description: 'After a DxFeed sync or manual import, new trades show up on the dashboard without reloading the page.'
+date: '2026-06-01'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# DxFeed import: dashboard refreshes right away
+
+After a DxFeed sync finishes—whether you triggered it from the import dialog or it ran in the background—your **dashboard and trade table** now update immediately. You no longer need to refresh the browser to see the trades you just imported.
+
+The same fix applies across import paths, so scheduled syncs and on-demand imports both land on screen as soon as the save completes.

--- a/content/updates/en/dxfeed-phidias-swissfirmup-prop-firms.mdx
+++ b/content/updates/en/dxfeed-phidias-swissfirmup-prop-firms.mdx
@@ -1,0 +1,13 @@
+---
+title: 'DxFeed sync: Phidias Prop Firm and SwissFirmUp'
+description: 'Connect DxFeed accounts from Phidias Prop Firm and SwissFirmUp through the prop firm dropdown.'
+date: '2026-05-31'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# DxFeed sync: Phidias Prop Firm and SwissFirmUp
+
+**Phidias Prop Firm** and **SwissFirmUp** are now available in the **Prop firm** dropdown when you connect a DxFeed account. Pick your firm first, then sign in with the same email and password you use on their platform.
+
+Trades are pulled from each firm's own history server, so your import lands in the right place without manual CSV work. If you trade with either firm, open **Connect DxFeed Account** from account settings and select it from the list.

--- a/content/updates/en/dxfeed-sync-rate-limit-retry.mdx
+++ b/content/updates/en/dxfeed-sync-rate-limit-retry.mdx
@@ -1,0 +1,13 @@
+---
+title: 'DxFeed sync: automatic retry when rate limited'
+description: 'DxFeed imports wait and retry instead of failing when the history server returns too many requests.'
+date: '2026-06-01'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# DxFeed sync: automatic retry when rate limited
+
+DxFeed sync now handles **rate limiting** from the history server instead of stopping mid-import. When the API responds with a "too many requests" error, Deltalytix waits—using the server's suggested delay when available—and tries again automatically.
+
+This matters most during large historical imports or when syncing several accounts back to back. You should see fewer failed syncs that require starting over from scratch.

--- a/content/updates/en/trade-table-group-by-creation-date.mdx
+++ b/content/updates/en/trade-table-group-by-creation-date.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Trade table: group by creation date'
+description: 'Group trades by the day they were added to Deltalytix, separate from execution time.'
+date: '2026-06-01'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# Trade table: group by creation date
+
+The trade review table has a new **By creation date** option in the grouping dropdown, alongside time, instrument, and account. Trades are grouped by the day they were added to Deltalytix—not when they were executed on the market.
+
+This is handy when you want to review a recent import batch or see everything that landed in your journal on a given day. Your choice is saved with the rest of your table settings, so it sticks when you come back to the dashboard.

--- a/content/updates/en/updates-page-french-locale.mdx
+++ b/content/updates/en/updates-page-french-locale.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Updates page: French locale now sticks'
+description: 'The product updates page respects your language choice and keeps French (and other locales) applied.'
+date: '2026-05-31'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# Updates page: French locale now sticks
+
+Switching to **French** on the **Updates** page now actually applies—and stays applied as you browse. Before, the page could fall back to English even after you picked another language, especially when opening an update post or returning from a nested link.
+
+Your language choice is saved in a cookie that works across the whole site, so the updates list, timeline labels, and individual changelog posts all render in the locale you selected. The same fix applies to every supported language, not just French.

--- a/content/updates/fr/dxfeed-import-instant-dashboard-refresh.mdx
+++ b/content/updates/fr/dxfeed-import-instant-dashboard-refresh.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Import DxFeed : le dashboard se met à jour tout de suite'
+description: 'Après une sync DxFeed ou un import manuel, les nouveaux trades apparaissent sans recharger la page.'
+date: '2026-06-01'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# Import DxFeed : le dashboard se met à jour tout de suite
+
+Une fois une sync DxFeed terminée—que vous l'ayez lancée depuis la fenêtre d'import ou qu'elle ait tourné en arrière-plan—votre **dashboard et votre table de trades** se mettent à jour immédiatement. Plus besoin de rafraîchir le navigateur pour voir les trades que vous venez d'importer.
+
+La même correction s'applique à tous les chemins d'import, pour que les syncs planifiées et les imports à la demande s'affichent dès que l'enregistrement est terminé.

--- a/content/updates/fr/dxfeed-phidias-swissfirmup-prop-firms.mdx
+++ b/content/updates/fr/dxfeed-phidias-swissfirmup-prop-firms.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Sync DxFeed : Phidias Prop Firm et SwissFirmUp'
+description: 'Connectez des comptes DxFeed Phidias Prop Firm et SwissFirmUp via la liste des prop firms.'
+date: '2026-05-31'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# Sync DxFeed : Phidias Prop Firm et SwissFirmUp
+
+**Phidias Prop Firm** et **SwissFirmUp** sont desormais disponibles dans la liste **Prop firm** lorsque vous connectez un compte DxFeed. Choisissez d'abord votre firme, puis connectez-vous avec le meme email et mot de passe que sur leur plateforme.
+
+Les trades sont recuperes depuis le serveur d'historique de chaque firme, pour un import au bon endroit sans CSV manuel. Si vous tradez avec l'une de ces firmes, ouvrez **Connecter un compte DxFeed** depuis les parametres de compte et selectionnez-la dans la liste.

--- a/content/updates/fr/dxfeed-sync-rate-limit-retry.mdx
+++ b/content/updates/fr/dxfeed-sync-rate-limit-retry.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Sync DxFeed : nouvelle tentative automatique en cas de limite'
+description: 'Les imports DxFeed patientent et réessayent au lieu d''échouer quand le serveur d''historique limite les requêtes.'
+date: '2026-06-01'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# Sync DxFeed : nouvelle tentative automatique en cas de limite
+
+La sync DxFeed gère désormais les **limites de débit** du serveur d'historique au lieu de s'arrêter en plein import. Quand l'API renvoie une erreur « trop de requêtes », Deltalytix attend—en utilisant le délai suggéré par le serveur quand il est disponible—puis réessaie automatiquement.
+
+C'est surtout utile lors de gros imports historiques ou quand vous synchronisez plusieurs comptes d'affilée. Vous devriez voir moins de syncs échouées nécessitant de tout relancer depuis le début.

--- a/content/updates/fr/trade-table-group-by-creation-date.mdx
+++ b/content/updates/fr/trade-table-group-by-creation-date.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Table des trades : grouper par date de création'
+description: 'Regroupez les trades par jour d''ajout dans Deltalytix, distinct de l''heure d''exécution.'
+date: '2026-06-01'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# Table des trades : grouper par date de création
+
+La table de révision des trades propose une nouvelle option **Par date de création** dans le menu de groupement, aux côtés du temps, de l'instrument et du compte. Les trades sont regroupés par le jour où ils ont été ajoutés dans Deltalytix—pas par l'heure d'exécution sur le marché.
+
+Pratique pour passer en revue un import récent ou voir tout ce qui est arrivé dans votre journal un jour donné. Votre choix est enregistré avec le reste des réglages de la table, il reste donc actif quand vous revenez sur le dashboard.

--- a/content/updates/fr/updates-page-french-locale.mdx
+++ b/content/updates/fr/updates-page-french-locale.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Page Mises à jour : la langue française est conservée'
+description: 'La page des mises à jour respecte votre choix de langue et garde le français (et les autres locales) actifs.'
+date: '2026-05-31'
+status: completed
+completedDate: '2026-06-01'
+---
+
+# Page Mises à jour : la langue française est conservée
+
+Passer en **français** sur la page **Mises à jour** s'applique désormais correctement—et reste actif pendant votre navigation. Avant, la page pouvait revenir à l'anglais même après avoir choisi une autre langue, surtout en ouvrant un article ou en revenant d'un lien interne.
+
+Votre choix de langue est enregistré dans un cookie valable sur tout le site, pour que la liste des mises à jour, les libellés de la timeline et chaque article s'affichent dans la locale sélectionnée. La même correction s'applique à toutes les langues prises en charge, pas seulement le français.

--- a/lib/dxfeed-propfirms.ts
+++ b/lib/dxfeed-propfirms.ts
@@ -44,6 +44,24 @@ export const DXFEED_PROP_FIRMS: DxFeedPropFirmDefinition[] = [
     tradingSubdomain: 'trading-volumetrica',
     enabled: true,
   },
+  {
+    id: 'swissfirmup',
+    name: 'SwissFirmUp',
+    website: 'https://volumetrica.swissfirmup.com',
+    domain: 'swissfirmup.com',
+    historicalSubdomain: 'volumetrica',
+    tradingSubdomain: 'trading-volumetrica',
+    enabled: true,
+  },
+  {
+    id: 'phidiaspropfirm',
+    name: 'Phidias Prop Firm',
+    website: 'https://dxfeed.phidiaspropfirm.com',
+    domain: 'phidiaspropfirm.com',
+    historicalSubdomain: 'dxfeed',
+    tradingSubdomain: 'trading-volumetrica',
+    enabled: true,
+  },
   // More Volumetrica-based firms can be added once their domain pattern is confirmed.
 ]
 

--- a/lib/site-url.ts
+++ b/lib/site-url.ts
@@ -1,6 +1,8 @@
 const FALLBACK_SITE_HOST = "deltalytix.app";
 const FALLBACK_SITE_ORIGIN = `https://${FALLBACK_SITE_HOST}`;
-const TRUSTED_HOST_SUFFIXES = [`.${FALLBACK_SITE_HOST}`];
+// `.vercel.app` is trusted so preview deployments self-reference (OG/metadata
+// only). Trade-off: the app will reflect any *.vercel.app Host header.
+const TRUSTED_HOST_SUFFIXES = [`.${FALLBACK_SITE_HOST}`, ".vercel.app"];
 
 type HeaderLike = {
   get(name: string): string | null;

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1094,6 +1094,7 @@ export default {
       time: "By time",
       instrument: "By instrument",
       account: "By account",
+      creationDate: "By creation date",
     },
     groupTrades: "Group trades",
     ungroupTrades: "Ungroup trades",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1419,6 +1419,7 @@ export default {
       time: "Par heure",
       instrument: "Par instrument",
       account: "Par compte",
+      creationDate: "Par date de création",
     },
     groupTrades: "Grouper les trades",
     ungroupTrades: "Dégrouper les trades",

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,25 +3,10 @@ import createMDX from '@next/mdx';
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  async redirects() {
-    return [
-      {
-        source: '/updates',
-        destination: '/en/updates',
-        permanent: false,
-      },
-      {
-        source: '/updates/:slug',
-        destination: '/en/updates/:slug',
-        permanent: false,
-      },
-      {
-        source: '/shared/:slug',
-        destination: '/en/shared/:slug',
-        permanent: false,
-      },
-    ];
-  },
+  // NOTE: Do not add hardcoded /en redirects for localized routes (e.g. /updates
+  // -> /en/updates). next.config redirects run before middleware, so they force a
+  // single locale and prevent the i18n middleware from routing by the user's
+  // selected language. Locale routing is handled entirely by the i18n middleware.
   // cacheComponents: true, // Enable Cache Components (Next.js 16+)
   images: {
     remotePatterns: [

--- a/proxy.ts
+++ b/proxy.ts
@@ -15,7 +15,7 @@ const LOCALES = ["en", "fr", "de", "es", "it", "pt", "vi", "hi", "ja", "zh", "yo
 const I18nMiddleware = createI18nMiddleware({
   locales: LOCALES,
   defaultLocale: "en",
-  urlMappingStrategy: "rewrite",
+  urlMappingStrategy: "redirect",
 })
 
 const HOMEPAGE_PATHS = new Set([
@@ -206,6 +206,24 @@ export default async function proxy(req: NextRequest) {
   // Apply i18n middleware first
   const response = I18nMiddleware(req)
 
+  // next-international persists the locale in the Next-Locale cookie without an
+  // explicit path, so the browser scopes it to the directory of the request URL.
+  // When the language is switched from a nested route the change-locale helper
+  // navigates to e.g. /fr/updates, and the cookie ends up scoped to "/fr" - it is
+  // then never sent for the locale-less URLs the app actually uses (rewrite
+  // strategy), so the choice neither applies nor persists. Re-set it with an
+  // explicit path "/" using the resolved locale exposed via the X-Next-Locale
+  // header so the selection sticks across every route.
+  const resolvedLocale = response.headers.get("X-Next-Locale")
+  if (resolvedLocale) {
+    response.cookies.set("Next-Locale", resolvedLocale, {
+      path: "/",
+      maxAge: 60 * 60 * 24 * 365,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    })
+  }
+
 
   // Then update session
   const { response: authResponse, user, error } = await updateSession(req)
@@ -261,8 +279,13 @@ export default async function proxy(req: NextRequest) {
     
     return addAgentDiscoveryHeaders(response, req);
   }
-  // Merge responses - copy headers from auth response to i18n response
+  // Merge responses - copy headers from auth response to i18n response.
+  // Skip "set-cookie": overwriting it would clobber the Next-Locale cookie that
+  // the i18n middleware sets to persist the selected language. Auth cookies are
+  // merged separately below via the cookies API (which appends rather than
+  // replaces), so the locale cookie survives.
   authResponse.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") return
     response.headers.set(key, value)
   })
 

--- a/server/database.ts
+++ b/server/database.ts
@@ -122,10 +122,14 @@ export async function saveTradesAction(
       }
     }
 
-    try{
+    // Prefer updateTag: in a Server Action context (e.g. client-side import)
+    // it expires AND immediately refreshes the cache, so the caller reads its
+    // own writes without a separate refetch. updateTag throws when called from
+    // a Route Handler (e.g. /api/dxfeed/sync, /api/thor/store), so fall back to
+    // revalidateTag there — that's expected, not an error.
+    try {
       updateTag(`trades-${userId}`)
-    } catch (error) {
-      console.error('[saveTrades] Error updating tag:', error)
+    } catch {
       revalidateTag(`trades-${userId}`, { expire: 0 })
     }
 

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -91,85 +91,88 @@ export async function createShared(data: SharedParams): Promise<string> {
 
 export async function getShared(slug: string): Promise<{params: SharedParams, trades: Trade[], groups: GroupWithAccounts[]} | null> {
   try {
-    const result = await prisma.$transaction(async (tx) => {
-      const shared = await tx.shared.findUnique({
-        where: { slug },
-      })
-
-      if (!shared) {
-        return null
-      }
-
-      // Update view count
-      await tx.shared.update({
-        where: { slug },
-        data: {
-          viewCount: {
-            increment: 1,
-          },
-        },
-      })
-
-      // Parse the date range
-      const dateRange = shared.dateRange as unknown as DateRange
-      if (!dateRange?.from) {
-        throw new Error('Invalid date range: from date is required')
-      }
-      const fromDate = new Date(dateRange.from)
-      const toDate = dateRange.to ? new Date(dateRange.to) : undefined
-
-      // Parallel fetch of trades, tick details, and groups
-      const [trades, tickDetails, groups] = await Promise.all([
-        tx.trade.findMany({
-          where: {
-            userId: shared.userId,
-            ...(shared.accountNumbers.length > 0 && {
-              accountNumber: {
-                in: shared.accountNumbers,
-              },
-            }),
-            entryDate: {
-              gte: fromDate.toISOString(),
-              ...(toDate && { lte: toDate.toISOString() })
-            }
-          },
-          orderBy: {
-            entryDate: 'desc',
-          },
-        }),
-        tx.tickDetails.findMany(),
-        tx.group.findMany({
-          where: {
-            userId: shared.userId,
-          },
-          include: {
-            accounts: true,
-          },
-        })
-      ])
-
-      return {
-        params: {
-          userId: shared.userId,
-          title: shared.title || undefined,
-          description: shared.description || undefined,
-          isPublic: shared.isPublic,
-          accountNumbers: shared.accountNumbers,
-          dateRange: {
-            from: fromDate,
-            ...(toDate && { to: toDate })
-          },
-          desktop: shared.desktop as any[],
-          mobile: shared.mobile as any[],
-          expiresAt: shared.expiresAt || undefined,
-          tickDetails,
-        },
-        trades,
-        groups,
-      }
+    // Note: these reads are intentionally not wrapped in an interactive
+    // transaction. The heavy queries (trades and the full tickDetails table)
+    // can exceed the default 5s transaction timeout (P2028), and a public
+    // read-only view does not require cross-query snapshot isolation.
+    const shared = await prisma.shared.findUnique({
+      where: { slug },
     })
 
-    return result
+    if (!shared) {
+      return null
+    }
+
+    // Parse the date range
+    const dateRange = shared.dateRange as unknown as DateRange
+    if (!dateRange?.from) {
+      throw new Error('Invalid date range: from date is required')
+    }
+    const fromDate = new Date(dateRange.from)
+    const toDate = dateRange.to ? new Date(dateRange.to) : undefined
+
+    // Parallel fetch of trades, tick details, and groups
+    const [trades, tickDetails, groups] = await Promise.all([
+      prisma.trade.findMany({
+        where: {
+          userId: shared.userId,
+          ...(shared.accountNumbers.length > 0 && {
+            accountNumber: {
+              in: shared.accountNumbers,
+            },
+          }),
+          entryDate: {
+            gte: fromDate.toISOString(),
+            ...(toDate && { lte: toDate.toISOString() })
+          }
+        },
+        orderBy: {
+          entryDate: 'desc',
+        },
+      }),
+      prisma.tickDetails.findMany(),
+      prisma.group.findMany({
+        where: {
+          userId: shared.userId,
+        },
+        include: {
+          accounts: true,
+        },
+      })
+    ])
+
+    // Increment the view count without blocking the response or failing the
+    // fetch if it errors out.
+    prisma.shared.update({
+      where: { slug },
+      data: {
+        viewCount: {
+          increment: 1,
+        },
+      },
+    }).catch((error) => {
+      console.error('[getShared] Failed to increment view count:', error)
+    })
+
+    return {
+      params: {
+        userId: shared.userId,
+        title: shared.title || undefined,
+        description: shared.description || undefined,
+        isPublic: shared.isPublic,
+        accountNumbers: shared.accountNumbers,
+        dateRange: {
+          from: fromDate,
+          ...(toDate && { to: toDate })
+        },
+        desktop: shared.desktop as any[],
+        mobile: shared.mobile as any[],
+        expiresAt: shared.expiresAt || undefined,
+        tickDetails,
+      },
+      trades,
+      groups,
+    }
   } catch (error) {
     console.error('[getShared] Error:', error)
     return null

--- a/store/widgets/table-config-store.ts
+++ b/store/widgets/table-config-store.ts
@@ -18,7 +18,7 @@ export interface TableConfig {
   columnFilters: ColumnFiltersState
   pageSize: number
   groupingGranularity: number
-  groupingMode: 'time' | 'instrument' | 'account'
+  groupingMode: 'time' | 'instrument' | 'account' | 'creationDate'
 }
 
 interface TableConfigState {


### PR DESCRIPTION
## Summary

Fixes two errors on the shared trading performance page.

### 1. `opengraph-image` passed an undefined slug to Prisma

In Next.js 16, route segment `params` is a `Promise` that must be awaited. The shared OpenGraph image handler read `params.slug` directly off the un-awaited Promise, so `undefined` flowed into `prisma.shared.findUnique({ where: { slug: undefined } })`:

```
PrismaClientValidationError: Argument `where` of type SharedWhereUniqueInput
needs at least one of `id` or `slug` arguments.
```

Fixed by awaiting `params` (matching `page.tsx` and the `updates/[slug]` opengraph handler, which already do this correctly).

### 2. `getShared` transaction timeout (P2028)

The `getShared` reads were wrapped in an interactive transaction with the default 5s timeout. The trades query and the full `tickDetails.findMany()` read can exceed that budget:

```
PrismaClientKnownRequestError P2028: A batch query cannot be executed on an
expired transaction. The timeout for this transaction was 5000 ms, however
7461 ms passed since the start of the transaction.
```

A public read-only view doesn't require cross-query snapshot isolation, so the reads now run outside a transaction, and the `viewCount` increment is a non-blocking update that won't fail the fetch if it errors.

## Test plan
- [ ] Visit a shared page and confirm the OpenGraph image renders
- [ ] Confirm the shared page loads without the P2028 timeout error
- [ ] Confirm `viewCount` still increments

https://claude.ai/code/session_01LqSxqonQGYxviBTM64xsSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqSxqonQGYxviBTM64xsSS)_