### PR TITLE
fix: apply breakeven range to PDF export trade distribution

### DIFF
--- a/app/[locale]/dashboard/components/share-button.tsx
+++ b/app/[locale]/dashboard/components/share-button.tsx
@@ -42,6 +42,7 @@ import { Switch } from "@/components/ui/switch"
 import { useTradesStore } from "../../../../store/trades-store"
 import { useUserStore } from "../../../../store/user-store"
 import { useData } from "@/context/data-provider"
+import { useBreakevenStore } from "@/store/widgets/breakeven-store"
 
 interface ShareButtonProps {
   variant?: "ghost" | "outline" | "secondary"
@@ -125,6 +126,7 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
     // from the data provider's globally-filtered `formattedTrades`. Use the same
     // source for the summary so the numbers always match the charts.
     const { formattedTrades, dateRange: globalDateRange, accountNumbers: globalAccountNumbers } = useData()
+    const breakevenRange = useBreakevenStore((state) => state.range)
     const [selectedAccounts, setSelectedAccounts] = useState<string[]>([])
     const [open, setOpen] = useState(false)
     const [comboboxOpen, setComboboxOpen] = useState(false)
@@ -407,6 +409,7 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
               }
             : null,
           accountNumbers: globalAccountNumbers,
+          breakevenRange,
           trades: filteredTrades.map((trade) => ({
             entryDate: trade.entryDate,
             closeDate: trade.closeDate ?? null,

--- a/app/api/dashboard-pdf/route.ts
+++ b/app/api/dashboard-pdf/route.ts
@@ -6,6 +6,7 @@ import enMessages from "@/locales/en"
 import frMessages from "@/locales/fr"
 import { StatementDocument, type StatementStrings } from "@/lib/pdf/statement-document"
 import type { ExportPdfPayload, PdfTrade } from "@/lib/pdf/statement"
+import { DEFAULT_BREAKEVEN_RANGE, type BreakevenRange } from "@/types/breakeven"
 
 // Generate the dashboard PDF on the server. Moving rendering off the client
 // avoids the mobile tab-reload/out-of-memory failures that html2canvas caused:
@@ -67,6 +68,19 @@ function buildStrings(t: (key: string) => string): StatementStrings {
   }
 }
 
+function sanitizeBreakevenRange(input: unknown): BreakevenRange {
+  if (!input || typeof input !== "object") {
+    return DEFAULT_BREAKEVEN_RANGE
+  }
+  const range = input as Record<string, unknown>
+  const min = Number(range.min)
+  const max = Number(range.max)
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min > max) {
+    return DEFAULT_BREAKEVEN_RANGE
+  }
+  return { min, max }
+}
+
 function sanitizeTrades(input: unknown): PdfTrade[] {
   if (!Array.isArray(input)) {
     return []
@@ -105,6 +119,7 @@ export async function POST(request: NextRequest) {
       title: typeof body.title === "string" ? body.title : "",
       dateRange: body.dateRange ?? null,
       accountNumbers: Array.isArray(body.accountNumbers) ? body.accountNumbers.map(String) : [],
+      breakevenRange: sanitizeBreakevenRange(body.breakevenRange),
       trades,
     }
 

--- a/lib/pdf/statement-document.tsx
+++ b/lib/pdf/statement-document.tsx
@@ -14,6 +14,7 @@ import {
 import { scaleLinear } from "d3-scale"
 import { arc as d3Arc, line as d3Line, pie as d3Pie } from "d3-shape"
 import type { PieArcDatum } from "d3-shape"
+import { DEFAULT_BREAKEVEN_RANGE } from "@/types/breakeven"
 import {
   computeChartData,
   computeSummary,
@@ -389,8 +390,9 @@ export function StatementDocument({
   strings: StatementStrings
   generatedAt: string
 }) {
-  const summary = computeSummary(payload.trades)
-  const charts = computeChartData(payload.trades, payload.timezone)
+  const breakevenRange = payload.breakevenRange ?? DEFAULT_BREAKEVEN_RANGE
+  const summary = computeSummary(payload.trades, breakevenRange)
+  const charts = computeChartData(payload.trades, payload.timezone, breakevenRange)
   const { dateRangeLabel, accountLabel } = resolveHeaderLabels(
     payload,
     strings.allTime,

--- a/lib/pdf/statement.test.ts
+++ b/lib/pdf/statement.test.ts
@@ -23,4 +23,46 @@ describe('PDF statement chart data', () => {
     expect(chartData.weekdayPnl.find((point) => point.label === 'Sun')?.value).toBe(90)
     expect(chartData.weekdayPnl.find((point) => point.label === 'Mon')?.value).toBe(0)
   })
+
+  it('classifies trade distribution using the configured breakeven range on net pnl', () => {
+    const trades: PdfTrade[] = [
+      {
+        entryDate: '2026-05-10T12:00:00.000Z',
+        closeDate: null,
+        pnl: 50,
+        commission: 10,
+        accountNumber: 'A1',
+        side: 'long',
+        quantity: 1,
+        instrument: 'ES',
+        timeInPosition: 60,
+      },
+      {
+        entryDate: '2026-05-11T12:00:00.000Z',
+        closeDate: null,
+        pnl: 15,
+        commission: 10,
+        accountNumber: 'A1',
+        side: 'long',
+        quantity: 1,
+        instrument: 'ES',
+        timeInPosition: 60,
+      },
+      {
+        entryDate: '2026-05-12T12:00:00.000Z',
+        closeDate: null,
+        pnl: -20,
+        commission: 0,
+        accountNumber: 'A1',
+        side: 'short',
+        quantity: 1,
+        instrument: 'ES',
+        timeInPosition: 60,
+      },
+    ]
+
+    const chartData = computeChartData(trades, 'UTC', { min: -5, max: 10 })
+
+    expect(chartData.distribution).toEqual({ win: 1, breakeven: 1, loss: 1 })
+  })
 })

--- a/lib/pdf/statement.ts
+++ b/lib/pdf/statement.ts
@@ -1,4 +1,9 @@
 import { formatInTimeZone } from "date-fns-tz"
+import {
+  type BreakevenRange,
+  DEFAULT_BREAKEVEN_RANGE,
+  classifyTradeOutcome,
+} from "@/types/breakeven"
 
 // Slim trade shape the client sends to the PDF route. It mirrors the fields the
 // dashboard's summary and charts actually read, so the server can reproduce the
@@ -24,6 +29,7 @@ export interface ExportPdfPayload {
   title: string
   dateRange: { from: string | null; to: string | null } | null
   accountNumbers: string[]
+  breakevenRange?: BreakevenRange
   trades: PdfTrade[]
 }
 
@@ -48,13 +54,36 @@ export interface StatementChartData {
 
 const netPnl = (trade: PdfTrade) => Number(trade.pnl || 0) - Number(trade.commission || 0)
 
-// Mirrors the existing client summary in share-button.tsx: winRate is based on
-// gross pnl > 0, gross is the sum of pnl, net subtracts commissions.
-export function computeSummary(trades: PdfTrade[]): SummaryMetrics {
+function computeTradeDistribution(
+  trades: PdfTrade[],
+  breakevenRange: BreakevenRange = DEFAULT_BREAKEVEN_RANGE,
+): { win: number; breakeven: number; loss: number } {
+  let win = 0
+  let loss = 0
+  let breakeven = 0
+  for (const trade of trades) {
+    const outcome = classifyTradeOutcome(netPnl(trade), breakevenRange)
+    if (outcome === "win") {
+      win += 1
+    } else if (outcome === "loss") {
+      loss += 1
+    } else {
+      breakeven += 1
+    }
+  }
+  return { win, breakeven, loss }
+}
+
+// Mirrors calculateStatistics in lib/utils: win rate and distribution use net
+// pnl with the user's configured breakeven range.
+export function computeSummary(
+  trades: PdfTrade[],
+  breakevenRange: BreakevenRange = DEFAULT_BREAKEVEN_RANGE,
+): SummaryMetrics {
   const totalGrossPnl = trades.reduce((sum, t) => sum + Number(t.pnl || 0), 0)
   const totalNetPnl = trades.reduce((sum, t) => sum + netPnl(t), 0)
-  const winningTrades = trades.filter((t) => Number(t.pnl || 0) > 0).length
-  const winRate = trades.length > 0 ? (winningTrades / trades.length) * 100 : 0
+  const { win } = computeTradeDistribution(trades, breakevenRange)
+  const winRate = trades.length > 0 ? (win / trades.length) * 100 : 0
   return {
     totalTrades: trades.length,
     winRate,
@@ -98,7 +127,11 @@ function bucketByDashboardCalendarDay(trades: PdfTrade[]): Map<string, number> {
   return buckets
 }
 
-export function computeChartData(trades: PdfTrade[], timezone: string): StatementChartData {
+export function computeChartData(
+  trades: PdfTrade[],
+  timezone: string,
+  breakevenRange: BreakevenRange = DEFAULT_BREAKEVEN_RANGE,
+): StatementChartData {
   // Equity: cumulative net pnl per day, in chronological order.
   const equityBuckets = bucketByDay(trades, "entryDate", timezone)
   const equityDays = [...equityBuckets.keys()].sort()
@@ -132,23 +165,9 @@ export function computeChartData(trades: PdfTrade[], timezone: string): Statemen
     return { label: weekdayLabels[i], value: count > 0 ? total / count : 0 }
   })
 
-  // Distribution by gross pnl, matching calculateStatistics in lib/utils (and
-  // the summary winRate), which bucket on trade.pnl rather than net.
-  let win = 0
-  let loss = 0
-  let breakeven = 0
-  for (const trade of trades) {
-    const pnl = Number(trade.pnl || 0)
-    if (pnl > 0) {
-      win += 1
-    } else if (pnl < 0) {
-      loss += 1
-    } else {
-      breakeven += 1
-    }
-  }
+  const distribution = computeTradeDistribution(trades, breakevenRange)
 
-  return { equity, dailyPnl, weekdayPnl, distribution: { win, breakeven, loss } }
+  return { equity, dailyPnl, weekdayPnl, distribution }
 }
 
 // Resolve a localized date-range / account label for the PDF header, mirroring

--- a/types/breakeven.ts
+++ b/types/breakeven.ts
@@ -7,3 +7,20 @@ export const DEFAULT_BREAKEVEN_RANGE: BreakevenRange = {
   min: 0,
   max: 0,
 }
+
+export type TradeOutcome = "win" | "loss" | "breakeven"
+
+export function classifyTradeOutcome(
+  netPnl: number,
+  range: BreakevenRange = DEFAULT_BREAKEVEN_RANGE,
+): TradeOutcome {
+  const beMin = range.min ?? 0
+  const beMax = range.max ?? 0
+  if (netPnl >= beMin && netPnl <= beMax) {
+    return "breakeven"
+  }
+  if (netPnl > beMax) {
+    return "win"
+  }
+  return "loss"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #153 added a configurable breakeven range for trade classification on the dashboard, but PDF export still classified trades using gross PnL with an exact-zero breakeven check. This caused the trade distribution chart and win rate in exported PDFs to disagree with what users see on the dashboard when a custom breakeven range is configured.

## Changes

- Pass `breakevenRange` from the share/export dialog through the `/api/dashboard-pdf` payload
- Classify PDF trade distribution and win rate using net PnL (`pnl - commission`) and the same breakeven range logic as `calculateStatistics`
- Add a shared `classifyTradeOutcome` helper in `types/breakeven.ts`
- Add a unit test covering range-based distribution bucketing

## Test plan

- [ ] Set a custom breakeven range in Settings (e.g. min: -5, max: 10)
- [ ] Confirm the dashboard trade distribution widget reflects the range
- [ ] Export a PDF and verify the trade distribution chart and win rate match the dashboard
- [ ] Export with the default range (0, 0) and confirm behavior is unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c25c08d-8895-4752-8423-7ae895041315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c25c08d-8895-4752-8423-7ae895041315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

