### PR TITLE
fix(tradovate): keep token badge valid based on presence, not stale expiry snapshot

### DIFF
--- a/app/[locale]/dashboard/components/import/tradovate/sync/tradovate-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/tradovate-credentials-manager.tsx
@@ -374,11 +374,13 @@ export function TradovateCredentialsManager() {
           </TableHeader>
           <TableBody>
             {accounts.map((account) => {
-              const isExpired =
-                !account.token ||
-                (account.tokenExpiresAt
-                  ? new Date(account.tokenExpiresAt).getTime() <= Date.now()
-                  : false);
+              // The badge reflects token presence rather than a frozen
+              // expiry timestamp. The token is kept alive in the DB by the
+              // renewal cron (which nulls it out if renewal fails), and the
+              // sync path re-reads the live DB, so comparing the page-load
+              // snapshot against Date.now() only produced false "expired"
+              // states while the page sat open.
+              const isExpired = !account.token;
 
               return (
                 <TableRow key={account.accountId}>


### PR DESCRIPTION
The token status badge compared a page-load snapshot of tokenExpiresAt
against Date.now() on every render, so it flipped to "expired" while the
page sat open even though the renewal cron kept the token valid in the DB
and sync still worked. Base the badge on token presence instead.