### PR TITLE
[codex] Polish PnL per Contract widget

### DIFF
--- a/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
@@ -244,7 +244,7 @@ export default function PnLPerContractChart({
                 dataKey="averagePnl"
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
               >
                 {chartData.map((entry, index) => (
                   <Cell


### PR DESCRIPTION
## What changed

Replace the broad bar transition with an opacity-only transition.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the PnL per Contract widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors