### PR TITLE
[codex] Polish Equity Chart widget

### DIFF
--- a/app/[locale]/dashboard/components/charts/equity-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/equity-chart.tsx
@@ -288,7 +288,7 @@ const OptimizedTooltip = React.memo(
               <span className="text-[0.70rem] uppercase text-muted-foreground">
                 {t("equity.tooltip.totalEquity")}
               </span>
-              <span className="font-bold text-foreground">
+              <span className="font-bold text-foreground tabular-nums">
                 {formatCurrency(data.equity || 0)}
               </span>
             </div>
@@ -342,7 +342,7 @@ const OptimizedTooltip = React.memo(
             <span className="text-[0.70rem] uppercase text-muted-foreground">
               {t("equity.tooltip.totalEquity")}
             </span>
-            <span className="font-bold text-foreground">
+            <span className="font-bold text-foreground tabular-nums">
               {formatCurrency(data.equity || 0)}
             </span>
           </div>
@@ -364,7 +364,7 @@ const OptimizedTooltip = React.memo(
                           generateAccountColor(account),
                       }}
                     />
-                    <span className="text-sm text-foreground">
+                    <span className="text-sm text-foreground tabular-nums">
                       {t("equity.tooltip.accountReset", { account })}
                     </span>
                   </div>
@@ -537,13 +537,13 @@ const AccountsLegend = React.memo(
                       style={{ backgroundColor: color}}
                         ></span>
                       </span>
-                      <span className="text-xs text-muted-foreground leading-tight">
+                      <span className="text-xs text-muted-foreground leading-tight tabular-nums">
                         {formatCurrency(equity)}
                       </span>
                       <div className="min-h-3.5 flex flex-col">
                         {hasPayout && (
                           <span
-                            className="text-xs leading-tight"
+                            className="text-xs leading-tight tabular-nums"
                             style={{ color: getPayoutColors(payoutStatus).fg }}
                           >
                             {t("equity.legend.payout")}:{" "}


### PR DESCRIPTION
## What changed

Apply tabular numerals to live equity, payout, and legend values.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Equity Chart widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors