### PR TITLE
[codex] Polish Time of Day widget

### DIFF
--- a/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
@@ -247,7 +247,7 @@ export default function TimeOfDayTradeChart({
                 fill={chartConfig.avgPnl.color}
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
                 opacity={hourFilter.hour !== null ? 0.3 : 1}
               >
                 {chartData.map((entry) => (


### PR DESCRIPTION
## What changed

Replace the broad bar transition with an opacity-only transition.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Time of Day widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors