### PR TITLE
[codex] Polish Long/Short Performance widget

### DIFF
--- a/app/[locale]/dashboard/components/statistics/long-short-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/long-short-card.tsx
@@ -40,12 +40,12 @@ export default function LongShortPerformanceCard({ size = 'medium' }: LongShortP
         <div className="flex items-center justify-center h-full gap-1.5">
           <div className="flex items-center gap-1">
             <ArrowUpFromLine className="h-3 w-3 text-green-500" />
-            <span className="font-medium text-sm">{longRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{longRate}%</span>
           </div>
           <span className="text-muted-foreground">/</span>
           <div className="flex items-center gap-1">
             <ArrowDownFromLine className="h-3 w-3 text-red-500" />
-            <span className="font-medium text-sm">{shortRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{shortRate}%</span>
           </div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>


### PR DESCRIPTION
## What changed

Apply tabular numerals to the live long and short rates.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Long/Short Performance widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors