### PR TITLE
[codex] Polish Cumulative PnL widget

### DIFF
--- a/app/[locale]/dashboard/components/statistics/cumulative-pnl-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/cumulative-pnl-card.tsx
@@ -26,7 +26,7 @@ export default function CumulativePnlCard({ size = 'medium' }: CumulativePnlCard
         <div className="flex items-center gap-1.5">
           <PiggyBank className="h-4 w-4 text-muted-foreground" />
           <span className={cn(
-            "font-semibold text-base",
+            "font-semibold text-base tabular-nums",
             isPositive ? "text-green-500" : "text-red-500"
           )}>
             ${Math.abs(totalPnl).toFixed(2)}


### PR DESCRIPTION
## What changed

Apply tabular numerals to the live currency metric.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Cumulative PnL widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors