### PR TITLE
[codex] Polish Trade Distribution widget

### DIFF
--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -145,7 +145,7 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
                   <Cell 
                     key={`cell-${index}`} 
                     fill={entry.color}
-                    className="transition-all duration-300 ease-in-out hover:opacity-80 dark:brightness-90"
+                    className="transition-opacity duration-300 ease-out hover:opacity-80 dark:brightness-90"
                   />
                 ))}
                 <Label
@@ -206,4 +206,4 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
       </CardContent>
     </Card>
   )
-} 
+}


### PR DESCRIPTION
## What changed

Replace broad cell transitions with an opacity-only hover transition.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Trade Distribution widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors