### PR TITLE
[codex] Polish Winning Streak widget

### DIFF
--- a/app/[locale]/dashboard/components/statistics/winning-streak-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/winning-streak-card.tsx
@@ -23,7 +23,7 @@ export default function WinningStreakCard({ size = 'medium' }: WinningStreakCard
       <Card className="h-full">
         <div className="flex items-center justify-center h-full gap-1.5">
           <Award className="h-3 w-3 text-yellow-500" />
-          <div className="font-medium text-sm">{winningStreak}</div>
+          <div className="font-medium text-sm tabular-nums">{winningStreak}</div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
## What changed

Apply tabular numerals to the live streak metric.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Winning Streak widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors