### PR TITLE
[codex] Polish Average Position Time widget

### DIFF
--- a/app/[locale]/dashboard/components/statistics/average-position-time-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/average-position-time-card.tsx
@@ -24,7 +24,7 @@ export default function AveragePositionTimeCard({ size = 'medium' }: AveragePosi
       <Card className="h-full">
         <div className="flex items-center justify-center h-full gap-1.5">
           <Clock className="h-3 w-3 text-muted-foreground" />
-          <div className="font-medium text-sm">{averagePositionTime}</div>
+          <div className="font-medium text-sm tabular-nums">{averagePositionTime}</div>
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>


### PR DESCRIPTION
## What changed

Apply tabular numerals to the live duration metric.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Average Position Time widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors