### PR TITLE
[codex] Polish Trade Performance widget

### DIFF
--- a/app/[locale]/dashboard/components/statistics/trade-performance-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/trade-performance-card.tsx
@@ -31,17 +31,17 @@ export default function TradePerformanceCard({ size = 'medium' }: TradePerforman
         <div className="flex items-center justify-center h-full gap-1.5">
           <div className="flex items-center gap-1">
             <TrendingUp className="h-3 w-3 text-green-500" />
-            <span className="font-medium text-sm">{winRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{winRate}%</span>
           </div>
           <span className="text-muted-foreground">/</span>
           <div className="flex items-center gap-1">
             <Minus className="h-3 w-3 text-yellow-500" />
-            <span className="font-medium text-sm">{beRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{beRate}%</span>
           </div>
           <span className="text-muted-foreground">/</span>
           <div className="flex items-center gap-1">
             <TrendingDown className="h-3 w-3 text-red-500" />
-            <span className="font-medium text-sm">{lossRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{lossRate}%</span>
           </div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>


### PR DESCRIPTION
## What changed

Apply tabular numerals to the live win, breakeven, and loss rates.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Trade Performance widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors