### PR TITLE
[codex] Polish Profit Factor widget

### DIFF
--- a/app/[locale]/dashboard/components/statistics/profit-factor-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/profit-factor-card.tsx
@@ -23,7 +23,7 @@ export default function ProfitFactorCard({ size = 'medium' }: ProfitFactorCardPr
       <Card className="h-full">
         <div className="flex items-center justify-center h-full gap-1.5">
           <Scale className="h-3 w-3 text-blue-500" />
-          <div className="font-medium text-sm">{profitFactor.toFixed(2)}</div>
+          <div className="font-medium text-sm tabular-nums">{profitFactor.toFixed(2)}</div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
## What changed

Apply tabular numerals to the live profit factor metric.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Profit Factor widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors