### PR TITLE
[codex] Polish Prop Firm widget

### DIFF
--- a/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
@@ -1474,7 +1474,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                       className={cn(
                         "relative border-l-4 rounded-r-lg",
                         groupColorClass,
-                        "transition-all duration-200 hover:shadow-md"
+                        "transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-md motion-reduce:transition-none"
                       )}
                     >
                       {/* Group header with subtle styling */}
@@ -1529,7 +1529,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                     <div
                       className={cn(
                         "relative border-l-4 border-gray-200/50 bg-gray-50/30 dark:border-gray-700/30 dark:bg-gray-900/20 rounded-r-lg",
-                        "transition-all duration-200 hover:shadow-md"
+                        "transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-md motion-reduce:transition-none"
                       )}
                     >
                       {/* Ungrouped header */}


### PR DESCRIPTION
## What changed

Restrict account card animation to background, border, and shadow with reduced-motion support.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Prop Firm widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors