### PR TITLE
[codex] Polish Trade Table Review widget

### DIFF
--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -1459,7 +1459,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                     <tr
                       data-state={row.getIsSelected() && "selected"}
                       className={cn(
-                        "border-b border-border transition-all duration-75 hover:bg-muted/40 group",
+                        "border-b border-border transition-colors duration-75 hover:bg-muted/40 group",
                         row.getIsSelected() && "bg-accent/50 hover:bg-accent data-[state=selected]:bg-muted",
                         row.getIsExpanded()
                           ? "bg-muted/60"


### PR DESCRIPTION
## What changed

Restrict table row hover animation to color properties.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Trade Table Review widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors