### PR TITLE
[codex] Polish Tags widget

### DIFF
--- a/app/[locale]/dashboard/components/filters/tag-widget.tsx
+++ b/app/[locale]/dashboard/components/filters/tag-widget.tsx
@@ -351,10 +351,10 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
                 </DialogTrigger>
                 <DialogContent className="sm:max-w-[425px]">
                   <DialogHeader>
-                    <DialogTitle>
+                    <DialogTitle className="text-balance">
                       {editingTag ? t('widgets.tags.editTag') : t('widgets.tags.addTag')}
                     </DialogTitle>
-                    <DialogDescription>
+                    <DialogDescription className="text-pretty">
                       {t('widgets.tags.description')}
                     </DialogDescription>
                   </DialogHeader>
@@ -587,4 +587,4 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
       </AlertDialog>
     </>
   )
-} 
+}


### PR DESCRIPTION
## What changed

Balance the tag dialog heading and apply pretty wrapping to its description.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Tags widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors