### PR TITLE
[codex] Polish Chat widget

### DIFF
--- a/app/[locale]/dashboard/components/chat/chat.tsx
+++ b/app/[locale]/dashboard/components/chat/chat.tsx
@@ -87,7 +87,7 @@ const ResumeScrollButton = () => {
   }, [scrollToBottom]);
 
   return (
-    <AnimatePresence>
+    <AnimatePresence initial={false}>
       {!isAtBottom && (
         <motion.div
           className="absolute bottom-20 right-4 z-10"


### PR DESCRIPTION
## What changed

Disable the resume control's presence animation on initial render.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Chat widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors