### PR TITLE
[codex] Polish Mindset widget

### DIFF
--- a/app/[locale]/dashboard/components/mindset/mindset-widget.tsx
+++ b/app/[locale]/dashboard/components/mindset/mindset-widget.tsx
@@ -459,7 +459,7 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
         {/* Timeline with animation */}
         <div 
           className={cn(
-            "relative transition-all duration-300 ease-out-quart",
+            "relative transition-[width] duration-300 ease-out-quart motion-reduce:transition-none",
             isTimelineVisible ? "w-auto" : "w-0 overflow-hidden"
           )}
         >
@@ -546,4 +546,4 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
       </CardContent>
     </Card>
   )
-} 
+}


### PR DESCRIPTION
## What changed

Restrict timeline animation to width and disable it under reduced-motion preferences.

## Why

This applies the installed interface-polish guidance while keeping the change isolated to the Mindset widget.

## Validation

- bun run typecheck passed for the complete 27-widget stack
- Next.js compilation and TypeScript build stages passed
- Full page-data collection remains blocked by the repository's missing native canvas.node
- ESLint remains baseline-red with pre-existing errors