### PR TITLE
fix(atas): format Excel date cells with UTC wall-clock components

### DIFF
--- a/app/[locale]/dashboard/components/import/atas/atas-file-upload.tsx
+++ b/app/[locale]/dashboard/components/import/atas/atas-file-upload.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/locales/client";
+import { formatAtasExcelDateCell } from "@/lib/atas-date";
 import { Step } from "../import-button";
 
 interface AtasFileUploadProps {
@@ -71,19 +72,9 @@ const normalizeAtasHeaderKey = (header: string): string =>
 const normalizeAtasHeader = (header: string): string =>
   ATAS_HEADER_MAPPINGS[normalizeAtasHeaderKey(header)] || header.trim();
 
-const formatAtasDateCell = (date: Date): string => {
-  const pad = (value: number) => value.toString().padStart(2, "0");
-
-  return [
-    date.getFullYear(),
-    pad(date.getMonth() + 1),
-    pad(date.getDate()),
-  ].join("-") + ` ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-};
-
 const formatAtasCell = (value: CellValue | null): string => {
   if (value == null) return "";
-  if (value instanceof Date) return formatAtasDateCell(value);
+  if (value instanceof Date) return formatAtasExcelDateCell(value);
 
   return String(value);
 };

--- a/lib/atas-date.test.ts
+++ b/lib/atas-date.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { formatAtasExcelDateCell } from "./atas-date";
+
+describe("formatAtasExcelDateCell", () => {
+  it("uses UTC wall-clock components instead of browser-local getters", () => {
+    const excelDate = new Date(Date.UTC(2024, 5, 15, 14, 30, 45));
+
+    expect(formatAtasExcelDateCell(excelDate)).toBe("2024-06-15 14:30:45");
+  });
+});

--- a/lib/atas-date.ts
+++ b/lib/atas-date.ts
@@ -1,0 +1,20 @@
+/**
+ * Format an Excel Date cell for ATAS import.
+ *
+ * read-excel-file exposes workbook datetimes as JS Date objects whose UTC
+ * components represent the wall-clock time from the file. Downstream
+ * parseAtasDate treats those components as local time in the user's profile
+ * timezone, so we must not use the browser's local getters here.
+ */
+export function formatAtasExcelDateCell(date: Date): string {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+
+  return (
+    [
+      date.getUTCFullYear(),
+      pad(date.getUTCMonth() + 1),
+      pad(date.getUTCDate()),
+    ].join("-") +
+    ` ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`formatAtasDateCell` formatted Excel `Date` cells using the browser's local timezone getters (`getFullYear`, `getHours`, etc.). Downstream `parseAtasDate` treats `YYYY-MM-DD HH:mm:ss` strings as wall-clock times in the user's profile timezone.

When the browser timezone differed from the profile timezone (or from what ATAS exported), open/close times could shift or land on the wrong day.

## Fix

- Extract `formatAtasExcelDateCell` to `lib/atas-date.ts`
- Use UTC getters so the string matches the Excel wall-clock convention already used when `parseAtasDate` receives a `Date` object directly
- Add unit test

## Bugbot reference

Identified during PR #198 final review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18d73592-7bc7-4447-95b9-d9bd254cce36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18d73592-7bc7-4447-95b9-d9bd254cce36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

