### PR TITLE
fix(ci): make changelog workflow recoverable via reopen and manual dispatch

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -12,6 +12,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: generate-changelog-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
 jobs:
   generate-changelog:
     runs-on: ubuntu-latest
@@ -32,6 +36,10 @@ jobs:
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ inputs.pr_number }}"
+            if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be a numeric PR number, got: $PR_NUMBER"
+              exit 1
+            fi
             PR_JSON=$(gh pr view "$PR_NUMBER" --json number,baseRefName,headRefName,baseRefOid,headRefOid,url)
           else
             PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -85,6 +93,7 @@ jobs:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
 
@@ -95,8 +104,14 @@ jobs:
             exit 0
           fi
 
-          if gh pr list --head "$BRANCH_NAME" --base "$HEAD_REF" --state open --json number --jq '.[0].number' | grep -q .; then
-            echo "An open changelog PR already exists for PR #${PR_NUMBER}. Skipping generation."
+          EXISTING_PR=$(gh pr list \
+            --head "${REPO_OWNER}:${BRANCH_NAME}" \
+            --base "$HEAD_REF" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "An open changelog PR already exists for PR #${PR_NUMBER} (#${EXISTING_PR}). Skipping generation."
             exit 0
           fi
 

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -2,26 +2,68 @@ name: Generate Changelog
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Beta → main PR number to generate changelog for'
+        required: true
+        type: string
 
 jobs:
   generate-changelog:
     runs-on: ubuntu-latest
-    # Only run if PR is from beta branch
-    if: github.event.pull_request.head.ref == 'beta' && github.event.pull_request.base.ref == 'main'
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.ref == 'beta' && github.event.pull_request.base.ref == 'main')
     permissions:
       contents: write
       pull-requests: write
 
     steps:
+      - name: Resolve PR context
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            PR_JSON=$(gh pr view "$PR_NUMBER" --json number,baseRefName,headRefName,baseRefOid,headRefOid,url)
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            PR_JSON=$(gh pr view "$PR_NUMBER" --json number,baseRefName,headRefName,baseRefOid,headRefOid,url)
+          fi
+
+          BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
+          HEAD_REF=$(echo "$PR_JSON" | jq -r '.headRefName')
+          BASE_SHA=$(echo "$PR_JSON" | jq -r '.baseRefOid')
+          HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
+          PR_URL=$(echo "$PR_JSON" | jq -r '.url')
+
+          if [ "$BASE_REF" != "main" ] || [ "$HEAD_REF" != "beta" ]; then
+            echo "::error::PR #$PR_NUMBER is not a beta → main promotion (got $HEAD_REF → $BASE_REF)"
+            exit 1
+          fi
+
+          {
+            echo "number=$PR_NUMBER"
+            echo "base_ref=$BASE_REF"
+            echo "head_ref=$HEAD_REF"
+            echo "base_sha=$BASE_SHA"
+            echo "head_sha=$HEAD_SHA"
+            echo "url=$PR_URL"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.pr.outputs.head_sha }}
 
       - name: Configure Git
         run: |
@@ -37,18 +79,32 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
-          # Create a new branch from the current HEAD (which is the PR head SHA)
-          BRANCH_NAME="changelog/pr-${{ github.event.pull_request.number }}"
+          set -euo pipefail
+
+          BRANCH_NAME="changelog/pr-${PR_NUMBER}"
+
+          if git ls-remote --exit-code origin "refs/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
+            echo "Changelog branch ${BRANCH_NAME} already exists. Skipping generation."
+            exit 0
+          fi
+
+          if gh pr list --head "$BRANCH_NAME" --base "$HEAD_REF" --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "An open changelog PR already exists for PR #${PR_NUMBER}. Skipping generation."
+            exit 0
+          fi
+
           git checkout -b "$BRANCH_NAME"
 
-          # Get the date range for the changelog
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           FIRST_COMMIT_DATE=$(git log --format=%ai -1 "$BASE_SHA" | cut -d' ' -f1)
           LAST_COMMIT_DATE=$(git log --format=%ai -1 "$HEAD_SHA" | cut -d' ' -f1)
 
-          # Generate changelog using Cursor CLI
           agent -p --force --trust \
             "Analyze the changes in this pull request from beta to main. 
             
@@ -84,29 +140,27 @@ jobs:
             
             Only create changelog files - do not modify any other files." --model auto
 
-          # Check if changelog files were created
           if [ -z "$(git status --porcelain content/updates/)" ]; then
             echo "No changelog entries generated. Exiting."
             exit 0
           fi
 
-          # Commit changelog entries
           git add content/updates/
-          git commit -m "docs: add changelog entries for PR #${{ github.event.pull_request.number }}"
+          git commit -m "docs: add changelog entries for PR #${PR_NUMBER}"
           git push origin "$BRANCH_NAME"
 
-          # Create pull request
           gh pr create \
-            --title "📝 Changelog entries for PR #${{ github.event.pull_request.number }}" \
-            --body "This PR contains changelog entries generated for [PR #${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}).
+            --title "📝 Changelog entries for PR #${PR_NUMBER}" \
+            --body "This PR contains changelog entries generated for [PR #${PR_NUMBER}](${PR_URL}).
             
             ## Generated by
             - Workflow: ${{ github.workflow }}
             - Run: ${{ github.run_id }}
-            - Base: ${{ github.event.pull_request.base.ref }}
-            - Head: ${{ github.event.pull_request.head.ref }}
+            - Event: ${{ github.event_name }}
+            - Base: ${BASE_REF}
+            - Head: ${HEAD_REF}
             
             ## Next Steps
             Review the changelog entries and merge this PR along with the main PR." \
-            --base "${{ github.event.pull_request.head.ref }}" \
+            --base "${HEAD_REF}" \
             --head "$BRANCH_NAME"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the **Generate Changelog** workflow easier to recover when the initial `opened` event is missed (as happened on PR #232).

**Targets `beta`** — follows the dev → prod flow (`beta` → `main`).

## Changes

- **Trigger on `reopened`** — closing and reopening a beta → main PR will re-run changelog generation
- **Add `workflow_dispatch`** — manually run from Actions with a `pr_number` input (e.g. `232`)
- **Resolve PR context in a dedicated step** — manual runs fetch PR metadata via `gh pr view` instead of relying on `github.event.pull_request`
- **Skip if changelog already exists** — avoids duplicate branches/PRs when re-triggering

## How to recover PR #232 after merge to beta

1. Merge this PR to `beta`
2. Go to **Actions → Generate Changelog → Run workflow** (select branch `beta`)
3. Enter `232` as the PR number

Alternatively, close and reopen PR #232 after this lands on `beta`.

When PR #232 eventually merges `beta` → `main`, this fix ships to prod too.

## Test plan

- [ ] Merge to `beta`
- [ ] Manually dispatch workflow (branch `beta`) with `pr_number: 232`
- [ ] Confirm a `changelog/pr-232` branch and companion PR are created targeting `beta`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8535edfe-bdd4-4ace-b81f-8ca9c8072158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8535edfe-bdd4-4ace-b81f-8ca9c8072158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

