### PR TITLE
📝 Changelog entries for PR #232

### DIFF
--- a/content/updates/en/atas-excel-wall-clock-dates.mdx
+++ b/content/updates/en/atas-excel-wall-clock-dates.mdx
@@ -1,0 +1,15 @@
+---
+title: 'ATAS Excel imports preserve wall-clock trade times'
+description: 'Excel date cells in ATAS workbooks now import using the time shown in the file, not your browser timezone.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# ATAS Excel imports preserve wall-clock trade times
+
+When ATAS exports open and close times as **Excel date cells** in a `.xlsx` journal, imports now read the **wall-clock time from the file** instead of shifting by your browser’s local timezone. Entry and exit times should match what you see in ATAS and line up with your **profile timezone** on charts, filters, and the trade table.
+
+The importer still expects the **Journal** or **Journal commercial** sheet and `.xlsx` workbooks. If something is wrong with the file, you get the same direct errors as before from **Dashboard → Import → ATAS**.
+
+If your export uses plain text dates instead of Excel cells, behavior is unchanged.

--- a/content/updates/en/custom-propfirm-account-templates.mdx
+++ b/content/updates/en/custom-propfirm-account-templates.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Save your own prop firm account templates'
+description: 'Reuse custom prop firm account settings across accounts without retyping balance, targets, and drawdown rules.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Save your own prop firm account templates
+
+You can now save your own **prop firm account templates** from the **Account Configuration** dialog on the **Accounts** tab. After you dial in balance, profit target, drawdown, consistency, and the rest of the configurator, use **Save as template** to store that setup under a name you choose.
+
+**My Templates** sits above the built-in prop firm presets in **Load Template**, so you can apply a saved layout to a new account in a couple of clicks. Templates live on **this device** (browser storage), which keeps quick experiments and personal firm setups handy without touching cloud sync.
+
+When a template is no longer useful, delete it from the template card. Built-in presets from the catalogue are unchanged—you still get FTMO, Earn2Trade, and the rest alongside your own list.

--- a/content/updates/en/journal-pdf-export.mdx
+++ b/content/updates/en/journal-pdf-export.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Export your trading journal to PDF'
+description: 'Download every saved journal entry from the Mindset widget as a formatted PDF table.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Export your trading journal to PDF
+
+The **Mindset** journaling widget now has an **Export all entries** action in the header. One click builds a PDF of every saved journal day—handy for coaching reviews, archiving, or sharing a read-only snapshot outside the app.
+
+Each row includes the **date**, your **mood** score, how many **news** items you tagged that day, and your **notes** as plain text. The file name includes today’s date so downloads stay easy to find. Labels follow your language (English or French).
+
+This is separate from **Share → Export PDF** on the dashboard, which exports performance charts and stats. Use the Mindset download when you want the journal itself.

--- a/content/updates/en/local-dashboard-auth-bypass-self-hosting.mdx
+++ b/content/updates/en/local-dashboard-auth-bypass-self-hosting.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Self-host Deltalytix with a local dashboard'
+description: 'Run the full app locally with Postgres, demo data, and dashboard access without Supabase sign-in.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Self-host Deltalytix with a local dashboard
+
+Self-hosting is now documented end to end. The **self-host quickstart** script spins up Postgres, applies the schema, seeds a demo account (**LOCAL-SIM-001**), and writes a `.env.local` you can use right away. **`SELF_HOSTING.md`** and **`AGENTS.md`** walk through Docker, env vars, and what to expect when you run the stack on your machine.
+
+With **local dashboard auth bypass** enabled, **`/dashboard`** loads without Supabase login and **`/authentication`** redirects you there instead. Trade **import** and save work in this mode, so you can exercise the full journal workflow offline or in a private deployment.
+
+Bypass mode is meant for **local development and self-hosted setups**, not production SaaS. Production refuses to start with bypass unless you explicitly opt in via the documented override.

--- a/content/updates/en/tradovate-token-status-fix.mdx
+++ b/content/updates/en/tradovate-token-status-fix.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Tradovate token status no longer shows false “expired”'
+description: 'Connection badges reflect whether a token exists, not a stale expiry snapshot from an old page load.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Tradovate token status no longer shows false “expired”
+
+On **Dashboard → Import → Tradovate sync**, the **Token Status** badge now reflects whether a token is actually stored—not whether an old `tokenExpiresAt` timestamp on the page has passed. Leaving the sync screen open for a while should no longer flip a healthy connection to **Expired** while the server still holds a valid token.
+
+When renewal really fails and the token is cleared, you still see **Expired** with **Reconnect** to sign in again. The table also refreshes when you return to the tab and after a failed sync, so status stays closer to what the backend knows.
+
+Demo and **Live** environment badges are unchanged; this fix is about trusting what you see before you hit sync.

--- a/content/updates/fr/atas-excel-wall-clock-dates.mdx
+++ b/content/updates/fr/atas-excel-wall-clock-dates.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Les imports ATAS Excel conservent l’heure affichée dans le fichier'
+description: 'Les cellules date Excel des classeurs ATAS utilisent l’heure du fichier, pas le fuseau du navigateur.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Les imports ATAS Excel conservent l’heure affichée dans le fichier
+
+Quand ATAS exporte les heures d’ouverture et de clôture en **cellules date Excel** dans un journal `.xlsx`, l’import lit désormais **l’heure telle qu’affichée dans le fichier** au lieu de la décaler selon le fuseau local du navigateur. Les horaires d’entrée et de sortie doivent correspondre à ATAS et à votre **fuseau horaire de profil** sur les graphiques, filtres et le tableau des trades.
+
+L’import attend toujours la feuille **Journal** ou **Journal commercial** et des fichiers `.xlsx`. En cas de problème, les mêmes messages explicites s’affichent depuis **Tableau de bord → Import → ATAS**.
+
+Si l’export utilise des dates en texte brut plutôt que des cellules Excel, le comportement est inchangé.

--- a/content/updates/fr/custom-propfirm-account-templates.mdx
+++ b/content/updates/fr/custom-propfirm-account-templates.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Enregistrez vos propres modèles de comptes prop firm'
+description: 'Réutilisez vos réglages de compte prop firm sans ressaisir solde, objectifs et règles de drawdown.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Enregistrez vos propres modèles de comptes prop firm
+
+Vous pouvez désormais enregistrer vos **modèles de compte prop firm** depuis la fenêtre **Configuration du compte** dans l’onglet **Comptes**. Une fois le solde, l’objectif de profit, le drawdown, la consistency et le reste du configurateur réglés, utilisez **Enregistrer comme modèle** pour garder cette configuration sous un nom de votre choix.
+
+**Mes modèles** apparaît au-dessus des préréglages intégrés dans **Charger un modèle**, pour appliquer une configuration enregistrée à un nouveau compte en quelques clics. Les modèles restent sur **cet appareil** (stockage navigateur), pratique pour vos essais et setups perso sans synchronisation cloud.
+
+Quand un modèle ne sert plus, supprimez-le depuis la carte du modèle. Les préréglages du catalogue (FTMO, Earn2Trade, etc.) sont inchangés.

--- a/content/updates/fr/journal-pdf-export.mdx
+++ b/content/updates/fr/journal-pdf-export.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Exportez votre journal de trading en PDF'
+description: 'Téléchargez toutes les entrées enregistrées du widget Mindset sous forme de tableau PDF.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Exportez votre journal de trading en PDF
+
+Le widget de journal **Mindset** propose désormais **Exporter toutes les entrées** dans l’en-tête. Un clic génère un PDF de chaque jour enregistré—pratique pour un coach, des archives ou un partage en lecture seule hors de l’app.
+
+Chaque ligne reprend la **date**, votre score d’**humeur**, le nombre d’**actualités** taguées ce jour-là et vos **notes** en texte brut. Le nom du fichier inclut la date du jour pour retrouver le téléchargement. Les libellés suivent votre langue (anglais ou français).
+
+C’est distinct de **Partager → Exporter PDF** sur le tableau de bord, qui exporte graphiques et stats de performance. Utilisez le téléchargement Mindset pour le journal lui-même.

--- a/content/updates/fr/local-dashboard-auth-bypass-self-hosting.mdx
+++ b/content/updates/fr/local-dashboard-auth-bypass-self-hosting.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Auto-hébergez Deltalytix avec un tableau de bord local'
+description: 'Lancez l’app en local avec Postgres, des données de démo et l’accès au tableau de bord sans connexion Supabase.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Auto-hébergez Deltalytix avec un tableau de bord local
+
+L’auto-hébergement est maintenant documenté de bout en bout. Le script **quickstart self-host** démarre Postgres, applique le schéma, injecte un compte de démo (**LOCAL-SIM-001**) et génère un `.env.local` prêt à l’emploi. **`SELF_HOSTING.md`** et **`AGENTS.md`** détaillent Docker, les variables d’environnement et le fonctionnement sur votre machine.
+
+Avec le **bypass d’auth locale** activé, **`/dashboard`** s’ouvre sans connexion Supabase et **`/authentication`** vous y redirige. L’**import** et l’enregistrement des trades fonctionnent dans ce mode, pour tester tout le journal en local ou sur un déploiement privé.
+
+Ce mode vise le **développement local et l’auto-hébergement**, pas la production SaaS. La production refuse le bypass sauf opt-in explicite documenté.

--- a/content/updates/fr/tradovate-token-status-fix.mdx
+++ b/content/updates/fr/tradovate-token-status-fix.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Le statut de token Tradovate n’affiche plus « expiré » à tort'
+description: 'Les badges reflètent la présence du token, pas une date d’expiration figée au chargement de la page.'
+date: '2026-06-08'
+status: completed
+completedDate: '2026-06-23'
+---
+
+# Le statut de token Tradovate n’affiche plus « expiré » à tort
+
+Dans **Tableau de bord → Import → Synchronisation Tradovate**, le badge **Statut du token** indique désormais si un token est réellement enregistré—et non si un ancien horodatage `tokenExpiresAt` affiché sur la page est dépassé. Laisser l’écran ouvert ne devrait plus passer une connexion saine en **Expiré** tant que le serveur conserve un token valide.
+
+Quand le renouvellement échoue vraiment et que le token est supprimé, vous voyez toujours **Expiré** avec **Reconnecter**. Le tableau se rafraîchit aussi au retour sur l’onglet et après un échec de sync, pour coller à l’état côté serveur.
+
+Les badges **Démo** et **Live** sont inchangés ; ce correctif concerne la confiance dans le statut avant de lancer une sync.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR contains changelog entries for [PR #232](https://github.com/hugodemenez/deltalytix/pull/232) (beta → main promotion).

## Entries (EN + FR)
- Custom prop firm account templates
- Self-hosting and local dashboard auth bypass
- Journal PDF export from Mindset widget
- Tradovate token status fix
- ATAS Excel wall-clock date import fix

## Next steps
Review and merge into `beta`, then merge PR #232 to `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8535edfe-bdd4-4ace-b81f-8ca9c8072158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8535edfe-bdd4-4ace-b81f-8ca9c8072158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

