### PR TITLE
feat(widgets): consolidate codex interface-polish across 27 dashboard widgets

### DIFF
--- a/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
@@ -1474,7 +1474,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                       className={cn(
                         "relative border-l-4 rounded-r-lg",
                         groupColorClass,
-                        "transition-all duration-200 hover:shadow-md"
+                        "transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-md motion-reduce:transition-none"
                       )}
                     >
                       {/* Group header with subtle styling */}
@@ -1529,7 +1529,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                     <div
                       className={cn(
                         "relative border-l-4 border-gray-200/50 bg-gray-50/30 dark:border-gray-700/30 dark:bg-gray-900/20 rounded-r-lg",
-                        "transition-all duration-200 hover:shadow-md"
+                        "transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-md motion-reduce:transition-none"
                       )}
                     >
                       {/* Ungrouped header */}

--- a/app/[locale]/dashboard/components/calendar/desktop-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/desktop-calendar.tsx
@@ -144,7 +144,7 @@ function EventBadge({ events, impactLevels }: { events: FinancialEvent[], impact
           className={cn(
             "h-4 px-1.5 text-[8px] sm:text-[9px] font-medium cursor-pointer relative z-0 w-auto justify-center items-center gap-1",
             badgeStyles[highestImportance as keyof typeof badgeStyles],
-            "transition-all duration-200 ease-in-out",
+            "transition-[background-color,color,border-color,box-shadow,transform] duration-200 ease-in-out motion-reduce:transition-none",
             "hover:scale-110 hover:shadow-md",
             "active:scale-95"
           )}
@@ -186,7 +186,7 @@ function RenewalBadge({ renewals }: { renewals: Account[] }) {
           className={cn(
             "h-4 px-1.5 text-[8px] sm:text-[9px] font-medium cursor-pointer relative z-0 w-auto justify-center items-center gap-1",
             "bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-800 dark:hover:bg-blue-900/30",
-            "transition-all duration-200 ease-in-out",
+            "transition-[background-color,color,border-color,box-shadow,transform] duration-200 ease-in-out motion-reduce:transition-none",
             "hover:scale-110 hover:shadow-md",
             "active:scale-95"
           )}
@@ -220,7 +220,7 @@ function RenewalBadge({ renewals }: { renewals: Account[] }) {
             {renewals.map((account, index) => (
               <div 
                 key={account.id} 
-                className="group relative p-3 sm:p-4 rounded-lg border bg-card hover:bg-muted/50 hover:border-border transition-all duration-200 hover:shadow-xs"
+                className="group relative p-3 sm:p-4 rounded-lg border bg-card hover:bg-muted/50 hover:border-border transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-xs motion-reduce:transition-none"
               >
                 <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 sm:gap-3">
                   {/* Account Info */}
@@ -597,7 +597,7 @@ export default function CalendarPnl({ calendarData, hideFiltersOnMobile = false 
                   <React.Fragment key={dateString}>
                     <div
                       className={cn(
-                        "h-full flex flex-col cursor-pointer transition-all rounded-none p-1",
+                        "h-full flex flex-col cursor-pointer transition-[background-color,color,box-shadow] motion-reduce:transition-none rounded-none p-1",
                         "ring-1 ring-border hover:ring-primary hover:z-10",
                         dayData && dayData.pnl >= 0
                           ? "bg-green-50 dark:bg-green-900/20"

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -181,7 +181,7 @@ export default function CommissionsPnLChart({
                   <Cell
                     key={`cell-${index}`}
                     fill={entry.color}
-                    className="transition-all duration-300 ease-in-out hover:opacity-80 dark:brightness-90"
+                    className="transition-opacity duration-300 ease-out hover:opacity-80 dark:brightness-90"
                   />
                 ))}
                 {/* Centered percentage labels */}

--- a/app/[locale]/dashboard/components/charts/daily-tick-target.tsx
+++ b/app/[locale]/dashboard/components/charts/daily-tick-target.tsx
@@ -264,8 +264,8 @@ export default function DailyTickTargetChart({ size = 'medium' }: DailyTickTarge
               </DialogTrigger>
               <DialogContent>
                 <DialogHeader>
-                  <DialogTitle>{t('widgets.dailyTickTarget.setTarget')}</DialogTitle>
-                  <DialogDescription>
+                  <DialogTitle className="text-balance">{t('widgets.dailyTickTarget.setTarget')}</DialogTitle>
+                  <DialogDescription className="text-pretty">
                     {t('widgets.dailyTickTarget.setTargetDescription')}
                   </DialogDescription>
                 </DialogHeader>
@@ -433,4 +433,4 @@ export default function DailyTickTargetChart({ size = 'medium' }: DailyTickTarge
       </CardContent>
     </Card>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/charts/equity-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/equity-chart.tsx
@@ -288,7 +288,7 @@ const OptimizedTooltip = React.memo(
               <span className="text-[0.70rem] uppercase text-muted-foreground">
                 {t("equity.tooltip.totalEquity")}
               </span>
-              <span className="font-bold text-foreground">
+              <span className="font-bold text-foreground tabular-nums">
                 {formatCurrency(data.equity || 0)}
               </span>
             </div>
@@ -342,7 +342,7 @@ const OptimizedTooltip = React.memo(
             <span className="text-[0.70rem] uppercase text-muted-foreground">
               {t("equity.tooltip.totalEquity")}
             </span>
-            <span className="font-bold text-foreground">
+            <span className="font-bold text-foreground tabular-nums">
               {formatCurrency(data.equity || 0)}
             </span>
           </div>
@@ -364,7 +364,7 @@ const OptimizedTooltip = React.memo(
                           generateAccountColor(account),
                       }}
                     />
-                    <span className="text-sm text-foreground">
+                    <span className="text-sm text-foreground tabular-nums">
                       {t("equity.tooltip.accountReset", { account })}
                     </span>
                   </div>
@@ -537,13 +537,13 @@ const AccountsLegend = React.memo(
                       style={{ backgroundColor: color}}
                         ></span>
                       </span>
-                      <span className="text-xs text-muted-foreground leading-tight">
+                      <span className="text-xs text-muted-foreground leading-tight tabular-nums">
                         {formatCurrency(equity)}
                       </span>
                       <div className="min-h-3.5 flex flex-col">
                         {hasPayout && (
                           <span
-                            className="text-xs leading-tight"
+                            className="text-xs leading-tight tabular-nums"
                             style={{ color: getPayoutColors(payoutStatus).fg }}
                           >
                             {t("equity.legend.payout")}:{" "}

--- a/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
@@ -241,7 +241,7 @@ export default function PNLChart({ size = "medium" }: PNLChartProps) {
                 dataKey="pnl"
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
               >
                 {chartData.map((entry, index) => (
                   <Cell

--- a/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
@@ -252,7 +252,7 @@ export default function PnLBySideChart({
                 dataKey="pnl"
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
               >
                 {chartData.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={getColor(entry.pnl)} />

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
@@ -700,7 +700,7 @@ export default function PnLPerContractDailyChart({
                   dataKey="averagePnl"
                   radius={[3, 3, 0, 0]}
                   maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-all duration-300 ease-in-out"
+                  className="transition-opacity duration-300 ease-out"
                 >
                   {chartData.map((entry, index) => (
                     <Cell

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
@@ -244,7 +244,7 @@ export default function PnLPerContractChart({
                 dataKey="averagePnl"
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
               >
                 {chartData.map((entry, index) => (
                   <Cell

--- a/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
@@ -247,7 +247,7 @@ export default function TimeOfDayTradeChart({
                 fill={chartConfig.avgPnl.color}
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
                 opacity={hourFilter.hour !== null ? 0.3 : 1}
               >
                 {chartData.map((entry) => (

--- a/app/[locale]/dashboard/components/charts/tick-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/tick-distribution.tsx
@@ -269,7 +269,7 @@ export default function TickDistributionChart({
                 fill={chartConfig.count.color}
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
                 opacity={tickFilter.value ? 0.3 : 1}
               >
                 {chartData.map((entry) => (

--- a/app/[locale]/dashboard/components/charts/time-in-position.tsx
+++ b/app/[locale]/dashboard/components/charts/time-in-position.tsx
@@ -221,7 +221,7 @@ export default function TimeInPositionChart({
                 dataKey="avgTimeInPosition"
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
               >
                 {chartData.map((entry, index) => (
                   <Cell

--- a/app/[locale]/dashboard/components/charts/time-range-performance.tsx
+++ b/app/[locale]/dashboard/components/charts/time-range-performance.tsx
@@ -280,7 +280,7 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
                 fill={chartConfig.avgPnl.color}
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === 'small' ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
                 opacity={timeRange.range ? 0.3 : 1}
               >
                 {chartData.map((entry) => (
@@ -297,4 +297,4 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
       </CardContent>
     </Card>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -145,7 +145,7 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
                   <Cell 
                     key={`cell-${index}`} 
                     fill={entry.color}
-                    className="transition-all duration-300 ease-in-out hover:opacity-80 dark:brightness-90"
+                    className="transition-opacity duration-300 ease-out hover:opacity-80 dark:brightness-90"
                   />
                 ))}
                 <Label
@@ -206,4 +206,4 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
       </CardContent>
     </Card>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
@@ -265,7 +265,7 @@ export default function WeekdayPNLChart({
                 dataKey="pnl"
                 radius={[3, 3, 0, 0]}
                 maxBarSize={size === "small" ? 25 : 40}
-                className="transition-all duration-300 ease-in-out"
+                className="transition-opacity duration-300 ease-out"
                 opacity={weekdayFilter.days && weekdayFilter.days.length > 0 ? 0.3 : 1}
               >
                 {weekdayData.map((entry) => (
@@ -273,7 +273,7 @@ export default function WeekdayPNLChart({
                     key={`cell-${entry.day}`}
                     fill={getColor(entry.pnl)}
                     className={cn(
-                      "transition-all duration-300 ease-in-out",
+                      "transition-[opacity,filter,box-shadow] duration-300 ease-out",
                       weekdayFilter.days && weekdayFilter.days.includes(entry.day) && "ring-2 ring-primary ring-offset-2"
                     )}
                   />

--- a/app/[locale]/dashboard/components/chat/chat.tsx
+++ b/app/[locale]/dashboard/components/chat/chat.tsx
@@ -87,7 +87,7 @@ const ResumeScrollButton = () => {
   }, [scrollToBottom]);
 
   return (
-    <AnimatePresence>
+    <AnimatePresence initial={false}>
       {!isAtBottom && (
         <motion.div
           className="absolute bottom-20 right-4 z-10"

--- a/app/[locale]/dashboard/components/filters/tag-widget.tsx
+++ b/app/[locale]/dashboard/components/filters/tag-widget.tsx
@@ -351,10 +351,10 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
                 </DialogTrigger>
                 <DialogContent className="sm:max-w-[425px]">
                   <DialogHeader>
-                    <DialogTitle>
+                    <DialogTitle className="text-balance">
                       {editingTag ? t('widgets.tags.editTag') : t('widgets.tags.addTag')}
                     </DialogTitle>
-                    <DialogDescription>
+                    <DialogDescription className="text-pretty">
                       {t('widgets.tags.description')}
                     </DialogDescription>
                   </DialogHeader>
@@ -587,4 +587,4 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
       </AlertDialog>
     </>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/mindset/mindset-widget.tsx
+++ b/app/[locale]/dashboard/components/mindset/mindset-widget.tsx
@@ -459,7 +459,7 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
         {/* Timeline with animation */}
         <div 
           className={cn(
-            "relative transition-all duration-300 ease-out-quart",
+            "relative transition-[width] duration-300 ease-out-quart motion-reduce:transition-none",
             isTimelineVisible ? "w-auto" : "w-0 overflow-hidden"
           )}
         >
@@ -546,4 +546,4 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
       </CardContent>
     </Card>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/statistics/average-position-time-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/average-position-time-card.tsx
@@ -24,7 +24,7 @@ export default function AveragePositionTimeCard({ size = 'medium' }: AveragePosi
       <Card className="h-full">
         <div className="flex items-center justify-center h-full gap-1.5">
           <Clock className="h-3 w-3 text-muted-foreground" />
-          <div className="font-medium text-sm">{averagePositionTime}</div>
+          <div className="font-medium text-sm tabular-nums">{averagePositionTime}</div>
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>

--- a/app/[locale]/dashboard/components/statistics/cumulative-pnl-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/cumulative-pnl-card.tsx
@@ -26,7 +26,7 @@ export default function CumulativePnlCard({ size = 'medium' }: CumulativePnlCard
         <div className="flex items-center gap-1.5">
           <PiggyBank className="h-4 w-4 text-muted-foreground" />
           <span className={cn(
-            "font-semibold text-base",
+            "font-semibold text-base tabular-nums",
             isPositive ? "text-green-500" : "text-red-500"
           )}>
             ${Math.abs(totalPnl).toFixed(2)}

--- a/app/[locale]/dashboard/components/statistics/long-short-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/long-short-card.tsx
@@ -40,12 +40,12 @@ export default function LongShortPerformanceCard({ size = 'medium' }: LongShortP
         <div className="flex items-center justify-center h-full gap-1.5">
           <div className="flex items-center gap-1">
             <ArrowUpFromLine className="h-3 w-3 text-green-500" />
-            <span className="font-medium text-sm">{longRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{longRate}%</span>
           </div>
           <span className="text-muted-foreground">/</span>
           <div className="flex items-center gap-1">
             <ArrowDownFromLine className="h-3 w-3 text-red-500" />
-            <span className="font-medium text-sm">{shortRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{shortRate}%</span>
           </div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>

--- a/app/[locale]/dashboard/components/statistics/profit-factor-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/profit-factor-card.tsx
@@ -23,7 +23,7 @@ export default function ProfitFactorCard({ size = 'medium' }: ProfitFactorCardPr
       <Card className="h-full">
         <div className="flex items-center justify-center h-full gap-1.5">
           <Scale className="h-3 w-3 text-blue-500" />
-          <div className="font-medium text-sm">{profitFactor.toFixed(2)}</div>
+          <div className="font-medium text-sm tabular-nums">{profitFactor.toFixed(2)}</div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/app/[locale]/dashboard/components/statistics/risk-reward-ratio-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/risk-reward-ratio-card.tsx
@@ -55,7 +55,7 @@ export default function RiskRewardRatioCard({ size = 'tiny' }: RiskRewardRatioCa
       <div className="flex flex-col items-center justify-center h-full gap-2 p-2">
         <div className="flex items-center gap-1.5">
           <Scale className="h-3 w-3 text-primary" />
-          <span className="font-medium text-sm">RR {riskRewardRatio}</span>
+          <span className="font-medium text-sm tabular-nums">RR {riskRewardRatio}</span>
           <TooltipProvider delayDuration={100}>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -79,7 +79,7 @@ export default function RiskRewardRatioCard({ size = 'tiny' }: RiskRewardRatioCa
               </div>
             </TooltipTrigger>
             <TooltipContent side="top" sideOffset={5}>
-              <div className="text-xs space-y-0.5">
+              <div className="text-xs space-y-0.5 tabular-nums">
                 <div className="text-green-500">Avg. Win: ${avgWin.toFixed(2)}</div>
                 <div className="text-red-500">Avg. Loss: ${avgLoss.toFixed(2)}</div>
               </div>
@@ -89,4 +89,4 @@ export default function RiskRewardRatioCard({ size = 'tiny' }: RiskRewardRatioCa
       </div>
     </Card>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/statistics/statistics-widget.tsx
+++ b/app/[locale]/dashboard/components/statistics/statistics-widget.tsx
@@ -223,25 +223,25 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
               {/* Profits */}
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs">{t('statistics.profitLoss.profits')}</span>
-                <span className="text-xs font-medium text font-mono">{formatCurrency(grossWin)}</span>
+                <span className="text-xs font-medium text font-mono tabular-nums">{formatCurrency(grossWin)}</span>
               </div>
               
               {/* Losses */}
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs">- {t('statistics.profitLoss.losses')}</span>
-                <span className="text-xs font-medium text-red-500 font-mono">{formatCurrency(grossLosses)}</span>
+                <span className="text-xs font-medium text-red-500 font-mono tabular-nums">{formatCurrency(grossLosses)}</span>
               </div>
               
               {/* Fees */}
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs">- {t('statistics.profitLoss.fees')}</span>
-                <span className="text-xs font-medium text-red-500 font-mono">{formatCurrency(cumulativeFees)}</span>
+                <span className="text-xs font-medium text-red-500 font-mono tabular-nums">{formatCurrency(cumulativeFees)}</span>
               </div>
               
               {/* Payouts */}
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs">- {t('statistics.profitLoss.payouts')} ({nbPayouts})</span>
-                <span className="text-xs font-medium text-red-500 font-mono">{formatCurrency(totalPayouts)}</span>
+                <span className="text-xs font-medium text-red-500 font-mono tabular-nums">{formatCurrency(totalPayouts)}</span>
               </div>
               
               {/* Divider */}
@@ -251,7 +251,7 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs font-medium">{t('statistics.profitLoss.net')}</span>
                 <span className={cn(
-                  "text-sm font-bold font-mono",
+                  "text-sm font-bold font-mono tabular-nums",
                   netPnlWithPayouts > 0 ? "text-green-500" : "text-red-500"
                 )}>
                   {formatCurrency(netPnlWithPayouts)}
@@ -269,7 +269,7 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
             <div className="flex-1 flex flex-col justify-center gap-1.5">
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs">{t('statistics.performance.winRate')}</span>
-                <span className="text-sm font-medium">{winRate}%</span>
+                <span className="text-sm font-medium tabular-nums">{winRate}%</span>
               </div>
               <div className="flex justify-between items-center">
                 <div className="flex items-center gap-1">
@@ -285,7 +285,7 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
                     </Tooltip>
                   </TooltipProvider>
                 </div>
-                <span className="text-sm font-medium text-green-500 font-mono">{formatCurrency(avgWinPerDay)}</span>
+                <span className="text-sm font-medium text-green-500 font-mono tabular-nums">{formatCurrency(avgWinPerDay)}</span>
               </div>
               {size !== 'tiny' && (
                 <div className="flex justify-between items-center">
@@ -302,7 +302,7 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
                       </Tooltip>
                     </TooltipProvider>
                   </div>
-                  <span className="text-sm font-medium text-red-500 font-mono">-{formatCurrency(avgLossPerDay)}</span>
+                  <span className="text-sm font-medium text-red-500 font-mono tabular-nums">-{formatCurrency(avgLossPerDay)}</span>
                 </div>
               )}
             </div>
@@ -317,16 +317,16 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
             <div className="flex-1 flex flex-col justify-center gap-1.5">
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs">{t('statistics.activity.totalTrades')}</span>
-                <span className="text-sm font-medium">{nbTrades}</span>
+                <span className="text-sm font-medium tabular-nums">{nbTrades}</span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-muted-foreground text-xs">{t('statistics.activity.winningTrades')}</span>
-                <span className="text-sm font-medium text-green-500">{nbWin}</span>
+                <span className="text-sm font-medium text-green-500 tabular-nums">{nbWin}</span>
               </div>
               {size !== 'tiny' && (
                 <div className="flex justify-between items-center">
                   <span className="text-muted-foreground text-xs">{t('statistics.activity.avgDuration')}</span>
-                  <span className="text-sm font-medium">{averagePositionTime}</span>
+                  <span className="text-sm font-medium tabular-nums">{averagePositionTime}</span>
                 </div>
               )}
             </div>
@@ -342,7 +342,7 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
               <div className="space-y-1">
                 <div className="flex justify-between items-center">
                   <span className="text-muted-foreground text-xs">{t('statistics.distribution.long')}</span>
-                  <span className="text-sm font-medium">{longRate}%</span>
+                  <span className="text-sm font-medium tabular-nums">{longRate}%</span>
                 </div>
                 <Progress value={longRate} className="h-1" />
               </div>
@@ -351,19 +351,19 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
                   <div className="space-y-1">
                     <div className="flex justify-between items-center">
                       <span className="text-muted-foreground text-xs">{t('statistics.distribution.short')}</span>
-                      <span className="text-sm font-medium">{shortRate}%</span>
+                      <span className="text-sm font-medium tabular-nums">{shortRate}%</span>
                     </div>
                     <Progress value={shortRate} className="h-1" />
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-muted-foreground text-xs">{t('statistics.distribution.winningStreak')}</span>
-                    <span className="text-sm font-medium">{winningStreak}</span>
+                    <span className="text-sm font-medium tabular-nums">{winningStreak}</span>
                   </div>
                 </>
               ) : (
                 <div className="flex justify-between items-center">
                   <span className="text-muted-foreground text-xs">{t('statistics.distribution.winningStreak')}</span>
-                  <span className="text-sm font-medium">{winningStreak}</span>
+                  <span className="text-sm font-medium tabular-nums">{winningStreak}</span>
                 </div>
               )}
             </div>
@@ -372,4 +372,4 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
       </CardContent>
     </Card>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/statistics/trade-performance-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/trade-performance-card.tsx
@@ -31,17 +31,17 @@ export default function TradePerformanceCard({ size = 'medium' }: TradePerforman
         <div className="flex items-center justify-center h-full gap-1.5">
           <div className="flex items-center gap-1">
             <TrendingUp className="h-3 w-3 text-green-500" />
-            <span className="font-medium text-sm">{winRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{winRate}%</span>
           </div>
           <span className="text-muted-foreground">/</span>
           <div className="flex items-center gap-1">
             <Minus className="h-3 w-3 text-yellow-500" />
-            <span className="font-medium text-sm">{beRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{beRate}%</span>
           </div>
           <span className="text-muted-foreground">/</span>
           <div className="flex items-center gap-1">
             <TrendingDown className="h-3 w-3 text-red-500" />
-            <span className="font-medium text-sm">{lossRate}%</span>
+            <span className="font-medium text-sm tabular-nums">{lossRate}%</span>
           </div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>

--- a/app/[locale]/dashboard/components/statistics/winning-streak-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/winning-streak-card.tsx
@@ -23,7 +23,7 @@ export default function WinningStreakCard({ size = 'medium' }: WinningStreakCard
       <Card className="h-full">
         <div className="flex items-center justify-center h-full gap-1.5">
           <Award className="h-3 w-3 text-yellow-500" />
-          <div className="font-medium text-sm">{winningStreak}</div>
+          <div className="font-medium text-sm tabular-nums">{winningStreak}</div>
           <TooltipProvider delayDuration={100}>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -1459,7 +1459,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                     <tr
                       data-state={row.getIsSelected() && "selected"}
                       className={cn(
-                        "border-b border-border transition-all duration-75 hover:bg-muted/40 group",
+                        "border-b border-border transition-colors duration-75 hover:bg-muted/40 group",
                         row.getIsSelected() && "bg-accent/50 hover:bg-accent data-[state=selected]:bg-muted",
                         row.getIsExpanded()
                           ? "bg-muted/60"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates the stacked `[codex]` widget polish PRs (#201–#227) onto current `beta`.

After review, the individual stacked PRs are **safe to land** as cosmetic UI polish only (CSS transitions, `tabular-nums`, `text-balance`/`text-pretty`, reduced-motion fallbacks, chat `AnimatePresence initial={false}`). The auth-bypass / self-host foundation from PR #133 is already on `beta`.

## Why a consolidation PR

- PR #201 is **CONFLICTING** with its stacked base (`cursor/dashboard-local-auth-bypass-5847`) because #133 landed to `beta` with a rebased history.
- Merging the stack tip directly would have been 19 commits behind `beta` (risking regressions in propfirm templates, ATAS date parsing, Tradovate fixes).
- This branch cherry-picks only the 27 widget-polish commits onto latest `beta`.

## Changes (27 files)

- Chart widgets: `transition-all` → property-specific transitions (`transition-opacity`, etc.)
- Stat cards: `tabular-nums` for stable number layout
- Dialogs: `text-balance` / `text-pretty` for wrapping
- Calendar / accounts / mindset / trade table: scoped transitions + `motion-reduce:transition-none`
- Chat: skip initial presence animation

## Validation

- `bun run typecheck` ✅
- `OPENAI_API_KEY=dummy bun run build` ✅

## Supersedes

Closes/supersedes stacked PRs #201–#227 once merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efb5c-b01a-7989-b013-a204f079aa0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efb5c-b01a-7989-b013-a204f079aa0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

