### PR TITLE
perf(landing): lazy-load below-fold sections

### DIFF
--- a/app/[locale]/(landing)/components/section-skeletons.tsx
+++ b/app/[locale]/(landing)/components/section-skeletons.tsx
@@ -1,0 +1,60 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function FeaturesSectionSkeleton() {
+  const spans = [
+    "lg:col-span-3",
+    "lg:col-span-3",
+    "lg:col-span-4",
+    "lg:col-span-2",
+  ];
+
+  return (
+    <div className="container mx-auto px-4 py-16" aria-hidden>
+      <Skeleton className="h-10 w-64 mx-auto mb-4" />
+      <Skeleton className="h-6 w-96 max-w-full mx-auto mb-12" />
+      <div className="grid grid-cols-1 lg:grid-cols-6 gap-4">
+        {spans.map((span, index) => (
+          <Skeleton key={index} className={`h-[420px] rounded-xl ${span}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PricingSectionSkeleton() {
+  return (
+    <div className="container mx-auto px-4 py-16" aria-hidden>
+      <Skeleton className="h-10 w-48 mx-auto mb-4" />
+      <Skeleton className="h-6 w-80 max-w-full mx-auto mb-12" />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+        <Skeleton className="h-[480px] rounded-xl" />
+        <Skeleton className="h-[480px] rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+export function FAQSectionSkeleton() {
+  return (
+    <section className="py-16" aria-hidden>
+      <div className="container mx-auto px-4">
+        <Skeleton className="h-9 w-56 mx-auto mb-8" />
+        <div className="max-w-3xl mx-auto space-y-6">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton key={index} className="h-12 w-full" />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function OpenSourceSectionSkeleton() {
+  return (
+    <div className="px-4 mb-8 md:mb-16 lg:mb-32" aria-hidden>
+      <Skeleton className="h-10 w-72 mb-4" />
+      <Skeleton className="h-5 w-full max-w-[500px] mb-8" />
+      <Skeleton className="h-[400px] w-full rounded-xl" />
+    </div>
+  );
+}

--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -1,11 +1,32 @@
-import Features from "./components/features";
-import OpenSource from "./components/open-source";
-import PricingPage from "./pricing/page";
+import nextDynamic from "next/dynamic";
 import Partners from "./components/partners";
-import FAQ from "./components/faq";
 import { setStaticParamsLocale } from "next-international/server";
 import Hero from "./components/hero";
 import { getStaticParams } from "@/locales/server";
+import {
+  FAQSectionSkeleton,
+  FeaturesSectionSkeleton,
+  OpenSourceSectionSkeleton,
+  PricingSectionSkeleton,
+} from "./components/section-skeletons";
+
+const Features = nextDynamic(() => import("./components/features"), {
+  loading: () => <FeaturesSectionSkeleton />,
+});
+
+const PricingPage = nextDynamic(() => import("./pricing/page"), {
+  loading: () => <PricingSectionSkeleton />,
+});
+
+const FAQ = nextDynamic(() => import("./components/faq"), {
+  loading: () => <FAQSectionSkeleton />,
+});
+
+const OpenSource = nextDynamic(() => import("./components/open-source"), {
+  loading: () => <OpenSourceSectionSkeleton />,
+});
+
+export const dynamic = "force-static";
 
 export function generateStaticParams() {
   return getStaticParams();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Defers JavaScript for below-the-fold landing sections using `next/dynamic` with lightweight skeleton fallbacks.

**Synchronous (above fold):** Hero, Partners  
**Lazy loaded:** Features, Pricing, FAQ, OpenSource

This splits the initial JS bundle so visitors get interactive Hero/Partners faster while Features/Pricing/FAQ/OpenSource chunks load on demand.

Adds `section-skeletons.tsx` with pulse placeholders matching each section layout.

Part of the landing performance investigation. Assess TTI improvement independently before merging the full combined PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efb56-bc67-7d78-a97e-5d0f24d27336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efb56-bc67-7d78-a97e-5d0f24d27336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

