### PR TITLE
perf(landing): skip Supabase auth on public routes

### DIFF
--- a/app/[locale]/(landing)/components/calendar-preview.tsx
+++ b/app/[locale]/(landing)/components/calendar-preview.tsx
@@ -1,60 +1,254 @@
 'use client'
 
 import { useMemo } from "react"
-import { format } from "date-fns"
+import {
+  addDays,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  getDay,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { useI18n } from "@/locales/client"
+import { translateWeekday } from "@/lib/translation-utils"
 
-import DesktopCalendarPnl from "@/app/[locale]/dashboard/components/calendar/desktop-calendar"
-import { CalendarData } from "@/app/[locale]/dashboard/types/calendar"
+type CalendarDayEntry = {
+  pnl: number
+  tradeNumber: number
+}
 
-function buildDemoCalendarData(): CalendarData {
+type PreviewCalendarData = Record<string, CalendarDayEntry>
+
+const WEEKDAYS = [
+  'calendar.weekdays.sun',
+  'calendar.weekdays.mon',
+  'calendar.weekdays.tue',
+  'calendar.weekdays.wed',
+  'calendar.weekdays.thu',
+  'calendar.weekdays.fri',
+  'calendar.weekdays.sat',
+] as const
+
+function formatCurrency(value: number) {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+function getCalendarDays(monthStart: Date, monthEnd: Date) {
+  const startDate = startOfWeek(monthStart, { weekStartsOn: 0 })
+  const endDate = endOfWeek(monthEnd, { weekStartsOn: 0 })
+  const days = eachDayOfInterval({ start: startDate, end: endDate })
+
+  if (days.length === 42) return days
+
+  const lastDay = days[days.length - 1]
+  const additionalDays = eachDayOfInterval({
+    start: addDays(lastDay, 1),
+    end: addDays(startDate, 41),
+  })
+
+  return [...days, ...additionalDays].slice(0, 42)
+}
+
+function buildDemoCalendarData(): PreviewCalendarData {
   const today = new Date()
   const year = today.getFullYear()
   const month = today.getMonth()
 
   const entries = [
-    { day: 1, pnl: 120, trades: 1, longs: 1, shorts: 0 },
-    { day: 2, pnl: 620, trades: 4, longs: 2, shorts: 2 },
-    { day: 3, pnl: 80, trades: 2, longs: 1, shorts: 1 },
-    { day: 4, pnl: -240, trades: 3, longs: 1, shorts: 2 },
-    { day: 6, pnl: 380, trades: 2, longs: 2, shorts: 0 },
-    { day: 7, pnl: -60, trades: 1, longs: 0, shorts: 1 },
-    { day: 9, pnl: 980, trades: 5, longs: 3, shorts: 2 },
-    { day: 11, pnl: 210, trades: 2, longs: 1, shorts: 1 },
-    { day: 12, pnl: -120, trades: 2, longs: 1, shorts: 1 },
-    { day: 14, pnl: 320, trades: 1, longs: 1, shorts: 0 },
-    { day: 15, pnl: 540, trades: 3, longs: 2, shorts: 1 },
-    { day: 18, pnl: -320, trades: 4, longs: 1, shorts: 3 },
-    { day: 19, pnl: 90, trades: 1, longs: 0, shorts: 1 },
-    { day: 21, pnl: 760, trades: 3, longs: 2, shorts: 1 },
-    { day: 22, pnl: -45, trades: 1, longs: 0, shorts: 1 },
-    { day: 24, pnl: 150, trades: 2, longs: 1, shorts: 1 },
-    { day: 25, pnl: 70, trades: 1, longs: 1, shorts: 0 },
-    { day: 27, pnl: 420, trades: 3, longs: 2, shorts: 1 },
-    { day: 29, pnl: -95, trades: 1, longs: 0, shorts: 1 }
+    { day: 1, pnl: 120, trades: 1 },
+    { day: 2, pnl: 620, trades: 4 },
+    { day: 3, pnl: 80, trades: 2 },
+    { day: 4, pnl: -240, trades: 3 },
+    { day: 6, pnl: 380, trades: 2 },
+    { day: 7, pnl: -60, trades: 1 },
+    { day: 9, pnl: 980, trades: 5 },
+    { day: 11, pnl: 210, trades: 2 },
+    { day: 12, pnl: -120, trades: 2 },
+    { day: 14, pnl: 320, trades: 1 },
+    { day: 15, pnl: 540, trades: 3 },
+    { day: 18, pnl: -320, trades: 4 },
+    { day: 19, pnl: 90, trades: 1 },
+    { day: 21, pnl: 760, trades: 3 },
+    { day: 22, pnl: -45, trades: 1 },
+    { day: 24, pnl: 150, trades: 2 },
+    { day: 25, pnl: 70, trades: 1 },
+    { day: 27, pnl: 420, trades: 3 },
+    { day: 29, pnl: -95, trades: 1 },
   ]
 
-  return entries.reduce<CalendarData>((acc, { day, pnl, trades, longs, shorts }) => {
+  return entries.reduce<PreviewCalendarData>((acc, { day, pnl, trades }) => {
     const dateKey = format(new Date(year, month, day), "yyyy-MM-dd")
-
-    const tradeCount = Math.max(1, trades)
-    const tradeStubs = Array.from({ length: tradeCount }).map((_, idx) => ({
-      entryDate: new Date(year, month, day, 10 + idx * 2).toISOString(),
-      pnl: pnl / tradeCount,
-      commission: 2 + idx
-    }))
-
-    acc[dateKey] = {
-      pnl,
-      tradeNumber: trades,
-      longNumber: longs,
-      shortNumber: shorts,
-      // Minimal trade stubs so the preview shows intra-day stats without
-      // requiring full trade objects from the dashboard.
-      trades: tradeStubs as any[]
-    }
-
+    acc[dateKey] = { pnl, tradeNumber: trades }
     return acc
   }, {})
+}
+
+function LandingCalendarPreview({ calendarData }: { calendarData: PreviewCalendarData }) {
+  const t = useI18n()
+  const currentDate = useMemo(() => new Date(), [])
+
+  const monthStart = startOfMonth(currentDate)
+  const monthEnd = endOfMonth(currentDate)
+  const calendarDays = useMemo(
+    () => getCalendarDays(monthStart, monthEnd),
+    [monthStart, monthEnd]
+  )
+
+  const monthlyTotal = useMemo(() => {
+    return Object.entries(calendarData).reduce((total, [dateString, dayData]) => {
+      const date = new Date(dateString)
+      return isSameMonth(date, currentDate) ? total + dayData.pnl : total
+    }, 0)
+  }, [calendarData, currentDate])
+
+  const calculateWeeklyTotal = (index: number) => {
+    const startOfWeekIndex = index - 6
+    const weekDays = calendarDays.slice(startOfWeekIndex, index + 1)
+    return weekDays.reduce((total, day) => {
+      const dayData = calendarData[format(day, 'yyyy-MM-dd')]
+      return total + (dayData?.pnl ?? 0)
+    }, 0)
+  }
+
+  return (
+    <Card className="h-full flex flex-col border-0 shadow-none">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b shrink-0 p-3 sm:p-4 h-[56px]">
+        <div className="flex items-center gap-3">
+          <CardTitle className="text-base sm:text-lg font-semibold truncate capitalize">
+            {format(currentDate, 'MMMM yyyy')}
+          </CardTitle>
+          <div
+            className={cn(
+              "text-sm sm:text-base font-semibold truncate",
+              monthlyTotal >= 0
+                ? "text-green-600 dark:text-green-400"
+                : "text-red-600 dark:text-red-400"
+            )}
+          >
+            {formatCurrency(monthlyTotal)}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 min-h-0 p-1.5 sm:p-4">
+        <div className="grid grid-cols-8 gap-x-px mb-1">
+          {WEEKDAYS.map((day) => (
+            <div key={day} className="text-center font-medium text-[9px] sm:text-[11px] text-muted-foreground">
+              {translateWeekday(t, day)}
+            </div>
+          ))}
+          <div className="text-center font-medium text-[9px] sm:text-[11px] text-muted-foreground">
+            {t('calendar.weekdays.weekly')}
+          </div>
+        </div>
+        <div className="grid grid-cols-8 auto-rows-fr rounded-lg h-[calc(100%-20px)]">
+          {calendarDays.map((date, index) => {
+            const dateString = format(date, 'yyyy-MM-dd')
+            const dayData = calendarData[dateString]
+            const isLastDayOfWeek = getDay(date) === 6
+            const isCurrentMonth = isSameMonth(date, currentDate)
+
+            return (
+              <div key={dateString} className="contents">
+                <div
+                  className={cn(
+                    "h-full flex flex-col rounded-none p-1 ring-1 ring-border",
+                    dayData && dayData.pnl >= 0
+                      ? "bg-green-50 dark:bg-green-900/20"
+                      : dayData && dayData.pnl < 0
+                        ? "bg-red-50 dark:bg-red-900/20"
+                        : "bg-card",
+                    isToday(date) && "ring-blue-500 bg-blue-500/5 z-10",
+                    index === 0 && "rounded-tl-lg",
+                    index === 35 && "rounded-bl-lg",
+                  )}
+                >
+                  <div className="flex justify-between items-start gap-0.5">
+                    <span
+                      className={cn(
+                        "text-[9px] sm:text-[11px] font-medium min-w-[14px] text-center",
+                        isToday(date) && "text-primary font-semibold",
+                        !isCurrentMonth && "opacity-50"
+                      )}
+                    >
+                      {format(date, 'd')}
+                    </span>
+                  </div>
+                  <div className="flex-1 flex flex-col justify-end gap-0.5">
+                    {dayData ? (
+                      <div
+                        className={cn(
+                          "text-[9px] sm:text-[11px] font-semibold truncate text-center",
+                          dayData.pnl >= 0
+                            ? "text-green-600 dark:text-green-400"
+                            : "text-red-600 dark:text-red-400",
+                          !isCurrentMonth && "opacity-50"
+                        )}
+                      >
+                        {formatCurrency(dayData.pnl)}
+                      </div>
+                    ) : (
+                      <div
+                        className={cn(
+                          "text-[9px] sm:text-[11px] font-semibold invisible text-center",
+                          !isCurrentMonth && "opacity-50"
+                        )}
+                      >
+                        $0
+                      </div>
+                    )}
+                    <div
+                      className={cn(
+                        "text-[7px] sm:text-[9px] text-muted-foreground truncate text-center",
+                        !isCurrentMonth && "opacity-50"
+                      )}
+                    >
+                      {dayData
+                        ? `${dayData.tradeNumber} ${dayData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`
+                        : t('calendar.noTrades')}
+                    </div>
+                  </div>
+                </div>
+                {isLastDayOfWeek && (() => {
+                  const weeklyTotal = calculateWeeklyTotal(index)
+                  return (
+                    <div
+                      className={cn(
+                        "h-full flex items-center justify-center rounded-none ring-1 ring-border",
+                        index === 6 && "rounded-tr-lg",
+                        index === 41 && "rounded-br-lg"
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          "text-[9px] sm:text-[11px] font-semibold truncate px-0.5",
+                          weeklyTotal >= 0
+                            ? "text-green-600 dark:text-green-400"
+                            : "text-red-600 dark:text-red-400"
+                        )}
+                      >
+                        {formatCurrency(weeklyTotal)}
+                      </div>
+                    </div>
+                  )
+                })()}
+              </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
 }
 
 export function CalendarFeaturePreview() {
@@ -62,7 +256,7 @@ export function CalendarFeaturePreview() {
 
   return (
     <div className="h-full min-h-[380px] w-full overflow-hidden rounded-xl border bg-card shadow-sm pointer-events-none lg:min-h-[440px]">
-      <DesktopCalendarPnl calendarData={calendarData} hideFiltersOnMobile />
+      <LandingCalendarPreview calendarData={calendarData} />
     </div>
   )
 }

--- a/app/[locale]/(landing)/components/pnl-per-contract-preview.tsx
+++ b/app/[locale]/(landing)/components/pnl-per-contract-preview.tsx
@@ -1,7 +1,139 @@
 'use client'
 
 import { useMemo } from "react"
-import PnLPerContractChartEmbed from "@/app/[locale]/embed/components/pnl-per-contract"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { useI18n } from "@/locales/client"
+
+type TradeLike = {
+  instrument?: string
+  pnl: number
+  commission?: number
+  quantity: number
+}
+
+type ChartEntry = {
+  instrument: string
+  averagePnl: number
+}
+
+function formatCurrency(value: number) {
+  if (!isFinite(value) || isNaN(value)) {
+    return '$0'
+  }
+
+  const abs = Math.abs(value)
+  if (abs >= 1_000_000) return `${value < 0 ? '-' : ''}$${(abs / 1_000_000).toFixed(1)}M`
+  if (abs >= 1_000) return `${value < 0 ? '-' : ''}$${(abs / 1_000).toFixed(1)}k`
+  return `${value < 0 ? '-' : ''}$${abs.toFixed(0)}`
+}
+
+function aggregateTrades(trades: TradeLike[]): ChartEntry[] {
+  const groups: Record<string, { totalPnl: number; totalContracts: number }> = {}
+
+  trades.forEach((trade) => {
+    const instrument = trade.instrument || 'Unknown'
+    const netPnl = (isFinite(trade.pnl) ? trade.pnl : 0) - (isFinite(trade.commission || 0) ? (trade.commission || 0) : 0)
+    const quantity = isFinite(trade.quantity) ? trade.quantity : 0
+
+    if (!groups[instrument]) {
+      groups[instrument] = { totalPnl: 0, totalContracts: 0 }
+    }
+    groups[instrument].totalPnl += netPnl
+    groups[instrument].totalContracts += quantity
+  })
+
+  return Object.entries(groups)
+    .map(([instrument, data]) => ({
+      instrument,
+      averagePnl: data.totalContracts > 0 ? data.totalPnl / data.totalContracts : 0,
+    }))
+    .sort((a, b) => b.averagePnl - a.averagePnl)
+}
+
+function getBarColor(value: number, absMax: number) {
+  if (!isFinite(value) || isNaN(value)) {
+    return 'hsl(var(--chart-win) / 0.2)'
+  }
+
+  const ratio = absMax === 0 ? 0.2 : Math.max(0.2, Math.abs(value / absMax))
+  const base = value >= 0 ? '--chart-win' : '--chart-loss'
+  return `hsl(var(${base}) / ${ratio})`
+}
+
+function LandingPnlBarChart({ chartData }: { chartData: ChartEntry[] }) {
+  const t = useI18n()
+
+  const absMax = useMemo(() => {
+    const values = chartData.map((d) => d.averagePnl)
+    return Math.max(Math.abs(Math.max(0, ...values)), Math.abs(Math.min(0, ...values)), 1)
+  }, [chartData])
+
+  const xTicks = useMemo(() => {
+    const domainMax = absMax * 1.1
+    const domainMin = -absMax * 1.1
+    const tickCount = 5
+    return Array.from({ length: tickCount }, (_, i) => {
+      return domainMin + ((domainMax - domainMin) * i) / (tickCount - 1)
+    })
+  }, [absMax])
+
+  return (
+    <Card className="h-[500px] flex flex-col border-0 shadow-none">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b shrink-0 p-3 sm:p-4 h-[56px]">
+        <CardTitle className="line-clamp-1 text-base">{t('embed.pnlPerContract.title')}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex-1 min-h-0 p-2 sm:p-4">
+        <div className="flex h-full flex-col">
+          <div className="relative flex min-h-0 flex-1 flex-col justify-center gap-2 py-2">
+            {chartData.map((entry) => {
+              const widthPct = (Math.abs(entry.averagePnl) / (absMax * 1.1)) * 50
+              const isPositive = entry.averagePnl >= 0
+
+              return (
+                <div key={entry.instrument} className="grid grid-cols-[36px_1fr] items-center gap-2">
+                  <span className="truncate text-right text-[11px] font-medium text-muted-foreground">
+                    {entry.instrument}
+                  </span>
+                  <div className="relative h-6 rounded-sm bg-muted/30">
+                    <div className="absolute inset-y-0 left-1/2 w-px bg-border" />
+                    <div
+                      className={cn(
+                        "absolute top-1/2 h-[70%] -translate-y-1/2 rounded-[3px] transition-all duration-300",
+                        isPositive ? "left-1/2 rounded-l-none" : "right-1/2 rounded-r-none"
+                      )}
+                      style={{
+                        width: `${Math.max(widthPct, entry.averagePnl !== 0 ? 2 : 0)}%`,
+                        backgroundColor: getBarColor(entry.averagePnl, absMax),
+                      }}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          <div className="relative mt-1 grid grid-cols-[36px_1fr] gap-2">
+            <div />
+            <div className="relative h-5">
+              {xTicks.map((tick) => {
+                const position = ((tick + absMax * 1.1) / (absMax * 2.2)) * 100
+                return (
+                  <span
+                    key={tick}
+                    className="absolute -translate-x-1/2 text-[10px] text-muted-foreground"
+                    style={{ left: `${position}%` }}
+                  >
+                    {formatCurrency(tick)}
+                  </span>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
 
 export function PnlPerContractPreview() {
   const trades = useMemo(
@@ -26,9 +158,11 @@ export function PnlPerContractPreview() {
     []
   )
 
+  const chartData = useMemo(() => aggregateTrades(trades), [trades])
+
   return (
     <div className="h-full w-full rounded-xl border bg-card shadow-sm pointer-events-none">
-      <PnLPerContractChartEmbed trades={trades} />
+      <LandingPnlBarChart chartData={chartData} />
     </div>
   )
 }

--- a/app/[locale]/(landing)/components/section-skeletons.tsx
+++ b/app/[locale]/(landing)/components/section-skeletons.tsx
@@ -1,0 +1,60 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function FeaturesSectionSkeleton() {
+  const spans = [
+    "lg:col-span-3",
+    "lg:col-span-3",
+    "lg:col-span-4",
+    "lg:col-span-2",
+  ];
+
+  return (
+    <div className="container mx-auto px-4 py-16" aria-hidden>
+      <Skeleton className="h-10 w-64 mx-auto mb-4" />
+      <Skeleton className="h-6 w-96 max-w-full mx-auto mb-12" />
+      <div className="grid grid-cols-1 lg:grid-cols-6 gap-4">
+        {spans.map((span, index) => (
+          <Skeleton key={index} className={`h-[420px] rounded-xl ${span}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PricingSectionSkeleton() {
+  return (
+    <div className="container mx-auto px-4 py-16" aria-hidden>
+      <Skeleton className="h-10 w-48 mx-auto mb-4" />
+      <Skeleton className="h-6 w-80 max-w-full mx-auto mb-12" />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+        <Skeleton className="h-[480px] rounded-xl" />
+        <Skeleton className="h-[480px] rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+export function FAQSectionSkeleton() {
+  return (
+    <section className="py-16" aria-hidden>
+      <div className="container mx-auto px-4">
+        <Skeleton className="h-9 w-56 mx-auto mb-8" />
+        <div className="max-w-3xl mx-auto space-y-6">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton key={index} className="h-12 w-full" />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function OpenSourceSectionSkeleton() {
+  return (
+    <div className="px-4 mb-8 md:mb-16 lg:mb-32" aria-hidden>
+      <Skeleton className="h-10 w-72 mb-4" />
+      <Skeleton className="h-5 w-full max-w-[500px] mb-8" />
+      <Skeleton className="h-[400px] w-full rounded-xl" />
+    </div>
+  );
+}

--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -1,32 +1,11 @@
-import nextDynamic from "next/dynamic";
+import Features from "./components/features";
+import OpenSource from "./components/open-source";
+import PricingPage from "./pricing/page";
 import Partners from "./components/partners";
+import FAQ from "./components/faq";
 import { setStaticParamsLocale } from "next-international/server";
 import Hero from "./components/hero";
 import { getStaticParams } from "@/locales/server";
-import {
-  FAQSectionSkeleton,
-  FeaturesSectionSkeleton,
-  OpenSourceSectionSkeleton,
-  PricingSectionSkeleton,
-} from "./components/section-skeletons";
-
-const Features = nextDynamic(() => import("./components/features"), {
-  loading: () => <FeaturesSectionSkeleton />,
-});
-
-const PricingPage = nextDynamic(() => import("./pricing/page"), {
-  loading: () => <PricingSectionSkeleton />,
-});
-
-const FAQ = nextDynamic(() => import("./components/faq"), {
-  loading: () => <FAQSectionSkeleton />,
-});
-
-const OpenSource = nextDynamic(() => import("./components/open-source"), {
-  loading: () => <OpenSourceSectionSkeleton />,
-});
-
-export const dynamic = "force-static";
 
 export function generateStaticParams() {
   return getStaticParams();

--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -1,11 +1,32 @@
-import Features from "./components/features";
-import OpenSource from "./components/open-source";
-import PricingPage from "./pricing/page";
+import nextDynamic from "next/dynamic";
 import Partners from "./components/partners";
-import FAQ from "./components/faq";
 import { setStaticParamsLocale } from "next-international/server";
 import Hero from "./components/hero";
 import { getStaticParams } from "@/locales/server";
+import {
+  FAQSectionSkeleton,
+  FeaturesSectionSkeleton,
+  OpenSourceSectionSkeleton,
+  PricingSectionSkeleton,
+} from "./components/section-skeletons";
+
+const Features = nextDynamic(() => import("./components/features"), {
+  loading: () => <FeaturesSectionSkeleton />,
+});
+
+const PricingPage = nextDynamic(() => import("./pricing/page"), {
+  loading: () => <PricingSectionSkeleton />,
+});
+
+const FAQ = nextDynamic(() => import("./components/faq"), {
+  loading: () => <FAQSectionSkeleton />,
+});
+
+const OpenSource = nextDynamic(() => import("./components/open-source"), {
+  loading: () => <OpenSourceSectionSkeleton />,
+});
+
+export const dynamic = "force-static";
 
 export function generateStaticParams() {
   return getStaticParams();

--- a/proxy.ts
+++ b/proxy.ts
@@ -64,6 +64,51 @@ function isProtectedDashboardPath(pathname: string) {
   )
 }
 
+const PUBLIC_MARKETING_PATHS = new Set([
+  "/about",
+  "/pricing",
+  "/support",
+  "/updates",
+  "/terms",
+  "/privacy",
+  "/disclaimers",
+  "/propfirms",
+  "/referral",
+  "/newsletter",
+  "/maintenance",
+  "/authentication",
+])
+
+function isPublicRoute(pathname: string) {
+  if (isHomepage(pathname)) {
+    return true
+  }
+
+  const normalizedPathname = withoutLocale(pathname)
+
+  if (PUBLIC_MARKETING_PATHS.has(normalizedPathname)) {
+    return true
+  }
+
+  if (normalizedPathname === "/teams") {
+    return true
+  }
+
+  return false
+}
+
+function createUnauthenticatedSession(request: NextRequest) {
+  const response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  })
+
+  response.headers.set("x-auth-status", "unauthenticated")
+
+  return { response, user: null as User | null, error: null }
+}
+
 function acceptsMarkdown(request: NextRequest) {
   return request.headers
     .get("accept")
@@ -245,8 +290,10 @@ export default async function proxy(req: NextRequest) {
   }
 
 
-  // Then update session
-  const { response: authResponse, user, error } = await updateSession(req)
+  // Skip Supabase auth on public marketing routes to avoid unnecessary round-trips
+  const { response: authResponse, user, error } = isPublicRoute(pathname)
+    ? createUnauthenticatedSession(req)
+    : await updateSession(req)
 
   // Embed route check
   if (pathname.includes("/embed")) {
@@ -342,8 +389,7 @@ export default async function proxy(req: NextRequest) {
 
   // Authentication checks with better error handling
   if (!user || error) {
-    const isPublicRoute = !isProtectedDashboardPath(pathname)
-    if (!isPublicRoute) {
+    if (isProtectedDashboardPath(pathname)) {
       const encodedSearchParams = `${pathname.substring(1)}${req.nextUrl.search}`
       const authUrl = new URL("/authentication", req.url)
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -64,6 +64,9 @@ function isProtectedDashboardPath(pathname: string) {
   )
 }
 
+// Routes that skip Supabase auth for performance. Must NOT include /authentication:
+// logged-in users visiting /authentication?next=... must run updateSession() so the
+// proxy can redirect them to the dashboard (see AGENTS.md health check).
 const PUBLIC_MARKETING_PATHS = new Set([
   "/about",
   "/pricing",
@@ -76,7 +79,6 @@ const PUBLIC_MARKETING_PATHS = new Set([
   "/referral",
   "/newsletter",
   "/maintenance",
-  "/authentication",
 ])
 
 function isPublicRoute(pathname: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes an unnecessary Supabase `auth.getUser()` round-trip on public/marketing routes.

**Post-review fix:** `/authentication` is **not** in the skip list. That route must run `updateSession()` so logged-in users get redirected to `/dashboard` (see `AGENTS.md` health check). Including it in `PUBLIC_MARKETING_PATHS` was a regression.

Public routes now skip `updateSession()` entirely and set `x-auth-status: unauthenticated` without a network call. i18n middleware, geolocation, embed CSP handling, maintenance mode, agent discovery headers, and full auth for protected paths are unchanged.

**Public routes (auth skipped):** homepage (`/`, `/en`, …), `/about`, `/pricing`, `/support`, `/updates`, `/terms`, `/privacy`, `/disclaimers`, `/propfirms`, `/referral`, `/newsletter`, `/maintenance`, `/teams`

**Routes that always run session lookup:** `/authentication`, `/dashboard`, `/teams/dashboard`, `/admin`

Part of the landing performance investigation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efb56-bc67-7d78-a97e-5d0f24d27336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efb56-bc67-7d78-a97e-5d0f24d27336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

