### PR TITLE
perf(landing): defer hero video load until in viewport

### DIFF
--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -2,24 +2,54 @@
 import { useI18n } from "@/locales/client";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useEffect, useRef, useState } from "react";
 import { useTheme } from "@/context/theme-provider";
 
 export default function Hero() {
   const t = useI18n();
   const { theme, effectiveTheme } = useTheme();
+  const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
   const [videoLoaded, setVideoLoaded] = useState(false);
   const [videoError, setVideoError] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const videoContainerRef = useRef<HTMLDivElement>(null);
+
+  const posterSrc =
+    effectiveTheme === "dark"
+      ? "/videos/demo_dark_poster.png"
+      : "/videos/demo_white_poster.png";
+
+  const videoSrc =
+    effectiveTheme === "dark"
+      ? "/videos/demo_dark.mp4"
+      : "/videos/demo_white.mp4";
+
+  useEffect(() => {
+    const container = videoContainerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setShouldLoadVideo(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "400px 0px", threshold: 0 }
+    );
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     setVideoLoaded(false);
     setVideoError(false);
 
-    if (videoRef.current) {
+    if (shouldLoadVideo && videoRef.current) {
       videoRef.current.load();
     }
-  }, [theme, effectiveTheme]);
+  }, [theme, effectiveTheme, shouldLoadVideo]);
 
   const handleVideoLoad = () => {
     setVideoLoaded(true);
@@ -28,6 +58,7 @@ export default function Hero() {
   const handleVideoError = () => {
     setVideoError(true);
   };
+
   return (
     <div className="container px-4 md:px-6 mx-auto">
       <div className="flex flex-col w-full gap-y-24">
@@ -59,15 +90,20 @@ export default function Hero() {
             </Link>
           </div>
         </div>
-        <div className="flex w-full items-center justify-center  relative  rounded-lg">
+        <div
+          ref={videoContainerRef}
+          className="flex w-full items-center justify-center  relative  rounded-lg"
+        >
           <div className="relative w-full h-full">
             <span className="absolute inset-[-12px] md:inset-[-24px] bg-[rgba(50,169,151,0.15)] dark:bg-[hsl(var(--chart-1)/0.15)] rounded-[14.5867px] -z-10 animate-pulse"></span>
             <span className="absolute inset-[-4px] md:inset-[-8px] bg-[rgba(50,169,151,0.25)] dark:bg-[hsl(var(--chart-1)/0.25)] rounded-[14.5867px] -z-20 animate-pulse"></span>
             <span className="absolute inset-0 shadow-[0_9.1167px_13.675px_-2.735px_rgba(0,0,0,0.1),0_3.64667px_5.47px_-3.64667px_rgba(0,0,0,0.1)] md:shadow-[0_18.2333px_27.35px_-5.47px_rgba(0,0,0,0.1),0_7.29333px_10.94px_-7.29333px_rgba(0,0,0,0.1)] dark:shadow-[0_9.1167px_13.675px_-2.735px_hsl(var(--chart-1)/0.1),0_3.64667px_5.47px_-3.64667px_hsl(var(--chart-1)/0.1)] md:dark:shadow-[0_18.2333px_27.35px_-5.47px_hsl(var(--chart-1)/0.1),0_7.29333px_10.94px_-7.29333px_hsl(var(--chart-1)/0.1)] rounded-[14.5867px] -z-30"></span>
             {!videoLoaded && !videoError && (
-              <div className="w-full aspect-video flex items-center justify-center bg-gray-100 dark:bg-black rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] dark:border-gray-800">
-                <Skeleton className="w-full aspect-video rounded-[14.5867px]" />
-              </div>
+              <img
+                src={posterSrc}
+                alt=""
+                className="w-full aspect-video rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] dark:border-gray-800 object-cover"
+              />
             )}
             {videoError && (
               <div className="w-full aspect-video flex items-center justify-center bg-gray-100 dark:bg-black rounded-lg">
@@ -76,28 +112,19 @@ export default function Hero() {
             )}
             <video
               ref={videoRef}
-              preload="metadata"
+              preload="none"
               loop
               muted
               autoPlay
               playsInline
               className={`w-full h-full rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] dark:border-gray-800 ${videoLoaded ? "block" : "hidden"}`}
-              poster={
-                effectiveTheme === "dark"
-                  ? "/videos/demo_dark_poster.png"
-                  : "/videos/demo_white_poster.png"
-              }
+              poster={posterSrc}
               onLoadedData={handleVideoLoad}
               onError={handleVideoError}
             >
-              <source
-                src={
-                  effectiveTheme === "dark"
-                    ? "/videos/demo_dark.mp4"
-                    : "/videos/demo_white.mp4"
-                }
-                type="video/mp4"
-              />
+              {shouldLoadVideo && (
+                <source src={videoSrc} type="video/mp4" />
+              )}
             </video>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hero autoplay video (`demo_dark.mp4` 7.7MB / `demo_white.mp4` 6.2MB) competed with LCP on initial page load.

**Changes:**
- `preload="none"` until the hero video container is near the viewport
- `IntersectionObserver` with `rootMargin: "400px 0px"` triggers video load
- Theme-aware poster image shown until video is ready
- `<source>` and `load()` only run when `shouldLoadVideo` is true

Bandwidth for the full MP4 is deferred until users scroll near the hero section.

Part of the landing performance investigation. Assess LCP/bandwidth improvement independently before merging the full combined PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efb56-bc67-7d78-a97e-5d0f24d27336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efb56-bc67-7d78-a97e-5d0f24d27336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

