### PR TITLE
fix(referral): set OG image from searchParams.ref on landing page

### DIFF
--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -1,8 +1,10 @@
+import type { Metadata } from "next";
 import nextDynamic from "next/dynamic";
 import Partners from "./components/partners";
 import { setStaticParamsLocale } from "next-international/server";
 import Hero from "./components/hero";
 import { getStaticParams } from "@/locales/server";
+import { siteUrl } from "@/lib/site-url";
 import {
   FAQSectionSkeleton,
   FeaturesSectionSkeleton,
@@ -26,10 +28,38 @@ const OpenSource = nextDynamic(() => import("./components/open-source"), {
   loading: () => <OpenSourceSectionSkeleton />,
 });
 
-export const dynamic = "force-static";
-
 export function generateStaticParams() {
   return getStaticParams();
+}
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>;
+}): Promise<Metadata> {
+  const { ref } = await searchParams;
+
+  if (!ref) {
+    return {};
+  }
+
+  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`);
+
+  return {
+    openGraph: {
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: "Deltalytix Open Graph Image",
+        },
+      ],
+    },
+    twitter: {
+      images: [ogImageUrl],
+    },
+  };
 }
 
 export default async function LandingPage({

--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import nextDynamic from "next/dynamic";
 import Partners from "./components/partners";
 import { setStaticParamsLocale } from "next-international/server";
 import Hero from "./components/hero";
 import { getStaticParams } from "@/locales/server";
-import { siteUrl } from "@/lib/site-url";
+import { getRequestOrigin, siteUrl } from "@/lib/site-url";
 import {
   FAQSectionSkeleton,
   FeaturesSectionSkeleton,
@@ -43,7 +44,9 @@ export async function generateMetadata({
     return {};
   }
 
-  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`);
+  const requestHeaders = await headers();
+  const origin = getRequestOrigin(requestHeaders);
+  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`, origin);
 
   return {
     openGraph: {

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,256 +1,287 @@
-// app/api/og/route.tsx
-import { createCanvas, loadImage } from 'canvas';
-import { NextRequest } from 'next/server';
-import sharp from 'sharp';
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+import type { ReactElement } from "react";
 
-// Convert HSL to RGB hex
+const size = { width: 1200, height: 630 };
+
 function hslToHex(h: number, s: number, l: number): string {
   s /= 100;
   l /= 100;
   const c = (1 - Math.abs(2 * l - 1)) * s;
   const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
   const m = l - c / 2;
-  let r = 0, g = 0, b = 0;
+  let r = 0;
+  let g = 0;
+  let b = 0;
 
-  if (0 <= h && h < 60) {
-    r = c; g = x; b = 0;
-  } else if (60 <= h && h < 120) {
-    r = x; g = c; b = 0;
-  } else if (120 <= h && h < 180) {
-    r = 0; g = c; b = x;
-  } else if (180 <= h && h < 240) {
-    r = 0; g = x; b = c;
-  } else if (240 <= h && h < 300) {
-    r = x; g = 0; b = c;
-  } else if (300 <= h && h < 360) {
-    r = c; g = 0; b = x;
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
   }
 
   r = Math.round((r + m) * 255);
   g = Math.round((g + m) * 255);
   b = Math.round((b + m) * 255);
 
-  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
 }
 
-// Generate a color from a string (referral code)
 function generateColorFromString(str: string): string {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
     hash = str.charCodeAt(i) + ((hash << 5) - hash);
   }
-  
-  // Generate vibrant colors (avoid too dark colors)
+
   const hue = Math.abs(hash % 360);
-  const saturation = 60 + (Math.abs(hash >> 8) % 30); // 60-90%
-  const lightness = 50 + (Math.abs(hash >> 16) % 20); // 50-70%
-  
+  const saturation = 60 + (Math.abs(hash >> 8) % 30);
+  const lightness = 50 + (Math.abs(hash >> 16) % 20);
+
   return hslToHex(hue, saturation, lightness);
+}
+
+function LogoMark({ sizePx = 40 }: { sizePx?: number }) {
+  return (
+    <svg
+      viewBox="0 0 255 255"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: sizePx, height: sizePx }}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M159 63L127.5 0V255H255L236.5 218H159V63Z"
+        fill="#FFFFFF"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z"
+        fill="#FFFFFF"
+      />
+    </svg>
+  );
+}
+
+function BrandLockup({ logoSize = 40, fontSize = 28 }: { logoSize?: number; fontSize?: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+      }}
+    >
+      <LogoMark sizePx={logoSize} />
+      <span
+        style={{
+          fontSize,
+          fontWeight: 700,
+          color: "#FFFFFF",
+          letterSpacing: "-0.03em",
+        }}
+      >
+        Deltalytix
+      </span>
+    </div>
+  );
+}
+
+function DefaultOgImage() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        background: "#0f0f0f",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        position: "relative",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -120,
+          right: -120,
+          width: 520,
+          height: 520,
+          background: "radial-gradient(circle, rgba(124, 58, 237, 0.45) 0%, rgba(15, 15, 15, 0) 70%)",
+          display: "flex",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: -80,
+          left: -80,
+          width: 360,
+          height: 360,
+          background: "radial-gradient(circle, rgba(59, 130, 246, 0.35) 0%, rgba(15, 15, 15, 0) 70%)",
+          display: "flex",
+        }}
+      />
+      <BrandLockup logoSize={96} fontSize={88} />
+      <div
+        style={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 3,
+          background: "linear-gradient(90deg, rgba(20, 184, 166, 0.8) 0%, rgba(124, 58, 237, 0.8) 50%, rgba(220, 38, 38, 0.8) 100%)",
+          display: "flex",
+        }}
+      />
+    </div>
+  ) as ReactElement;
+}
+
+function ReferralOgImage({ ref, accentColor }: { ref: string; accentColor: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        background: "#0a0a0a",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        position: "relative",
+        padding: "56px 72px",
+        flexDirection: "column",
+        justifyContent: "space-between",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -100,
+          right: -100,
+          width: 480,
+          height: 480,
+          background: `radial-gradient(circle, ${accentColor}55 0%, rgba(10, 10, 10, 0) 72%)`,
+          display: "flex",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: -60,
+          left: -60,
+          width: 320,
+          height: 320,
+          background: "radial-gradient(circle, rgba(59, 130, 246, 0.25) 0%, rgba(10, 10, 10, 0) 70%)",
+          display: "flex",
+        }}
+      />
+
+      <BrandLockup />
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 28,
+          maxWidth: 900,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 28,
+            fontWeight: 500,
+            color: "#a1a1aa",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          Join with a referral code
+        </p>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            alignSelf: "flex-start",
+            padding: "28px 40px",
+            borderRadius: 20,
+            border: `3px solid ${accentColor}`,
+            background: "rgba(255, 255, 255, 0.04)",
+            boxShadow: `0 0 60px ${accentColor}33`,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 80,
+              fontWeight: 800,
+              color: "#FFFFFF",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+            }}
+          >
+            {ref}
+          </span>
+        </div>
+
+        <p
+          style={{
+            margin: 0,
+            fontSize: 34,
+            fontWeight: 600,
+            color: "#f4f4f5",
+            lineHeight: 1.3,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          Next generation trading dashboard
+        </p>
+      </div>
+
+      <p
+        style={{
+          margin: 0,
+          fontSize: 22,
+          fontWeight: 500,
+          color: "#71717a",
+        }}
+      >
+        deltalytix.app
+      </p>
+    </div>
+  ) as ReactElement;
 }
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
-  const ref = searchParams.get('ref') ?? 'Direct';
+  const ref = searchParams.get("ref");
+  const hasReferral = Boolean(ref && ref !== "Direct");
+  const accentColor = hasReferral ? generateColorFromString(ref!) : "#7c3aed";
 
-  // Generate color from referral code if provided
-  const accentColor = ref && ref !== 'Direct' 
-    ? generateColorFromString(ref)
-    : '#7c3aed'; // Default purple
-
-  // Set canvas size (OG image standard size)
-  const width = 1200;
-  const height = 630;
-
-  const canvas = createCanvas(width, height);
-  const ctx = canvas.getContext('2d');
-
-  if (!ctx) {
-    return new Response('Failed to create canvas context', { status: 500 });
-  }
-
-  // Background
-  ctx.fillStyle = '#0f0f0f';
-  ctx.fillRect(0, 0, width, height);
-
-  // Gradient in top-right corner - uses generated color from referral code
-  const gradient = ctx.createRadialGradient(
-    width,
-    0,
-    0,
-    width,
-    0,
-    Math.max(width, height) * 0.6
+  const element = hasReferral ? (
+    <ReferralOgImage ref={ref!} accentColor={accentColor} />
+  ) : (
+    <DefaultOgImage />
   );
-  gradient.addColorStop(0, accentColor);
-  gradient.addColorStop(0.5, accentColor);
-  gradient.addColorStop(1, 'rgba(15, 15, 15, 0)');
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, width, height);
 
-  // Blue light in bottom-left corner
-  const bottomLeftGradient = ctx.createRadialGradient(
-    0,
-    height,
-    0,
-    0,
-    height,
-    Math.max(width, height) * 0.3
-  );
-  bottomLeftGradient.addColorStop(0, '#3b82f6');
-  bottomLeftGradient.addColorStop(0.5, '#2563eb');
-  bottomLeftGradient.addColorStop(1, 'rgba(15, 15, 15, 0)');
-  ctx.fillStyle = bottomLeftGradient;
-  ctx.fillRect(0, 0, width, height);
-
-  const generateNoiseArray = (length: number) => {
-    const noise = [Math.random() * 2 - 1];
-    for (let i = 1; i < length; i++) {
-      const nextValue = noise[i - 1] + (Math.random() * 0.4 - 0.2);
-      noise.push(Math.max(-1, Math.min(1, nextValue)));
-    }
-    return noise;
-  };
-
-  const noiseArray = generateNoiseArray(Math.ceil(width / 5) + 1);
-  const noiseArray2 = generateNoiseArray(Math.ceil(width / 5) + 1);
-
-  // Draw wavy lines at the bottom
-  const waveHeight = height * 0.15;
-  const waveY = height - waveHeight;
-
-  // Build a path along the teal wave, then down to the bottom to create a filled area
-  const waveGradient = ctx.createLinearGradient(0, waveY, 0, height);
-  waveGradient.addColorStop(0, 'rgba(20, 184, 166, 0.3)');
-  waveGradient.addColorStop(1, '#0a5a50');
-
-  // Create path for filled area beneath the teal wave
-  ctx.beginPath();
-  ctx.moveTo(0, waveY);
-  for (let x = 0; x <= width; x += 5) {
-    const noiseIndex = Math.floor(x / 5);
-    const y = waveY + Math.sin(x * 0.01 - 1) * 30 + noiseArray[noiseIndex] * 20;
-    ctx.lineTo(x, y);
-  }
-  ctx.lineTo(width, height);
-  ctx.lineTo(0, height);
-  ctx.closePath();
-  ctx.fillStyle = waveGradient;
-  ctx.fill();
-
-  const redWaveGradient = ctx.createLinearGradient(0, waveY - 20, 0, height);
-  redWaveGradient.addColorStop(0, 'rgba(220, 38, 38, 0.2)');
-  redWaveGradient.addColorStop(1, 'rgba(200, 50, 50, 0.1)');
-
-  // Create path for filled area beneath the red wave
-  ctx.beginPath();
-  ctx.moveTo(0, waveY - 20);
-  for (let x = 0; x <= width; x += 5) {
-    const noiseIndex = Math.floor(x / 5);
-    const y = waveY - 20 + Math.sin(x * 0.01 + 1) * 30 + noiseArray2[noiseIndex] * 20;
-    ctx.lineTo(x, y);
-  }
-  ctx.lineTo(width, height);
-  ctx.lineTo(0, height);
-  ctx.closePath();
-  ctx.fillStyle = redWaveGradient;
-  ctx.fill();
-
-  // Teal/green wave
-  ctx.strokeStyle = '#14b8a6';
-  ctx.lineWidth = 3;
-  ctx.beginPath();
-  for (let x = 0; x <= width; x += 5) {
-    const noiseIndex = Math.floor(x / 5);
-    const y = waveY + Math.sin(x * 0.01 - 1) * 30 + noiseArray[noiseIndex] * 20;
-    if (x === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  // Red/coral wave
-  ctx.strokeStyle = '#dc2626';
-  ctx.lineWidth = 3;
-  ctx.beginPath();
-  for (let x = 0; x <= width; x += 5) {
-    const noiseIndex = Math.floor(x / 5);
-    const y = waveY - 20 + Math.sin(x * 0.01 + 1) * 30 + noiseArray2[noiseIndex] * 20;
-    if (x === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  // Draw logo using SVG from Logo component
-  const logoSize = 240; // 2x the original triangle size for better visibility
-  const spacing = -40; // Negative spacing to make text overlap the logo
-
-  // Create SVG string from Logo component with white fill (matching dark mode styling)
-  const logoSvg = `
-    <svg viewBox="0 0 255 255" xmlns="http://www.w3.org/2000/svg" width="${logoSize}" height="${logoSize}">
-    <g fill="#ffffff" fill-rule="evenodd" clip-rule="evenodd">
-        <path d="M159 63L127.5 0V255H255L236.5 218H159V63Z" />
-        <path d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z" />
-      </g>
-    </svg>
-  `.trim();
-
-  // Convert SVG to PNG buffer using sharp
-  const logoBuffer = await sharp(Buffer.from(logoSvg))
-    .resize(logoSize, logoSize, {
-      fit: 'contain',
-      background: { r: 0, g: 0, b: 0, alpha: 0 } // Transparent background
-    })
-    .png()
-    .toBuffer();
-
-  // Load the image and draw it on canvas
-  const logoImage = await loadImage(logoBuffer);
-
-  // Set font to measure text width
-  ctx.font = 'bold 128px Inter, sans-serif';
-  const text = 'Deltalytix';
-  const textMetrics = ctx.measureText(text);
-  const textWidth = textMetrics.width;
-
-  // Calculate total width of logo + spacing + text
-  const totalWidth = logoSize + spacing + textWidth;
-
-  // Center horizontally: start position = (width - totalWidth) / 2
-  const logoX = (width - totalWidth) / 2;
-  const logoY = height / 2; // Center vertically
-
-  // Draw logo centered vertically
-  ctx.drawImage(logoImage, logoX, logoY - logoSize / 2, logoSize, logoSize);
-
-  // Draw text "Deltalytix" - positioned to the right of the logo and vertically centered
-  ctx.fillStyle = '#ffffff';
-  ctx.textAlign = 'left';
-  ctx.textBaseline = 'middle';
-  const textX = logoX + logoSize + spacing;
-  const textY = logoY; // Vertically centered with the logo
-  ctx.fillText(text, textX, textY);
-
-  // Add noise texture to the background
-  const imageData = ctx.getImageData(0, 0, width, height);
-  const data = imageData.data;
-  const noiseIntensity = 8; // Adjust for more/less noise (0-255)
-  
-  for (let i = 0; i < data.length; i += 4) {
-    // Add noise to RGB channels, keep alpha unchanged
-    const noise = (Math.random() - 0.5) * noiseIntensity;
-    data[i] = Math.max(0, Math.min(255, data[i] + noise));     // R
-    data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + noise)); // G
-    data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + noise)); // B
-  }
-  
-  ctx.putImageData(imageData, 0, 0);
-
-  // Convert canvas to buffer
-  const buffer = canvas.toBuffer('image/png');
-
-  return new Response(new Uint8Array(buffer), {
+  return new ImageResponse(element, {
+    ...size,
     headers: {
-      'Content-Type': 'image/png',
-      'Cache-Control': 'public, max-age=3600, immutable',
+      "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
     },
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Referral share links (`?ref=<slug>`) were still emitting the default `/opengraph-image.png` in OG/Twitter metadata because `searchParams` is only available to pages, not root layouts.

This moves referral OG image handling to the landing page `generateMetadata`, pointing `openGraph.images` and `twitter.images` at `/api/og?ref=...` when `ref` is present.

Also redesigns `/api/og` so referral images actually render the code and text correctly.

## Changes

- Add `generateMetadata` to `app/[locale]/(landing)/page.tsx` that reads `searchParams.ref`
- Override OG/Twitter images with `siteUrl('/api/og?ref=...')` when a referral slug is present
- Resolve OG image URL from `getRequestOrigin(headers())` so preview deployments reference their own `/api/og` (not production)
- Remove `force-static` from the landing page so `searchParams` can be evaluated at request time (required by Next.js)
- Rewrite `/api/og` with `ImageResponse` instead of `node-canvas:
  - Fixes missing font rendering (Inter was not registered, causing tofu boxes)
  - Displays the referral slug prominently in an accent-colored pill
  - Cleaner invite layout aligned with other OG images in the repo

## Verification

```bash
# Preview deployment should point og:image at its own origin, not deltalytix.app
curl -sL "https://<preview-host>/?ref=wm92x" | rg 'og:image'
# expect: https://<preview-host>/api/og?ref=wm92x

curl -sL "http://localhost:3000/?ref=testslug" | rg 'og:image'
# property="og:image" content="http://localhost:3000/api/og?ref=testslug"

curl -s "http://localhost:3000/api/og?ref=abc123" -o /tmp/og.png
# 200 image/png — referral code visible in output
```

- `OPENAI_API_KEY=dummy bun run build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efb99-6335-7e84-bd48-b1ab2635da89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efb99-6335-7e84-bd48-b1ab2635da89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

