### PR TITLE
fix(updates): use localized date-based share title for changelog OG metadata

### DIFF
--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -81,7 +81,8 @@ export async function generateMetadata({
       const formattedShareDate = format(new Date(meta.date), "MMMM d, yyyy", {
         locale: dateLocale,
       });
-      const shareTitle = `Changelog · ${formattedShareDate}`;
+      const shareTitleLabel = locale === "fr" ? "Changements" : "Changelog";
+      const shareTitle = `${shareTitleLabel} · ${formattedShareDate}`;
 
       return {
         title: meta.title,

--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -78,7 +78,8 @@ export async function generateMetadata({
 
       const url = siteUrl(`/${locale}/updates/${slug}`);
       const dateLocale = locale === "fr" ? fr : enUS;
-      const formattedShareDate = format(new Date(meta.date), "MMMM d, yyyy", {
+      const shareDateFormat = locale === "fr" ? "d MMMM yyyy" : "MMMM d, yyyy";
+      const formattedShareDate = format(new Date(meta.date), shareDateFormat, {
         locale: dateLocale,
       });
       const shareTitleLabel = locale === "fr" ? "Changements" : "Changelog";

--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { getAllPosts, getAdjacentPosts } from "@/lib/mdx";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { format } from "date-fns";
+import { enUS, fr } from "date-fns/locale";
 import Script from "next/script";
 import { setStaticParamsLocale } from "next-international/server";
 import { getStaticParams as getLocaleStaticParams } from "@/locales/server";
@@ -76,6 +77,11 @@ export async function generateMetadata({
       const { meta } = post;
 
       const url = siteUrl(`/${locale}/updates/${slug}`);
+      const dateLocale = locale === "fr" ? fr : enUS;
+      const formattedShareDate = format(new Date(meta.date), "MMMM d, yyyy", {
+        locale: dateLocale,
+      });
+      const shareTitle = `Changelog · ${formattedShareDate}`;
 
       return {
         title: meta.title,
@@ -88,7 +94,7 @@ export async function generateMetadata({
           },
         },
         openGraph: {
-          title: meta.title,
+          title: shareTitle,
           description: meta.description,
           type: "article",
           publishedTime: meta.date,
@@ -105,7 +111,7 @@ export async function generateMetadata({
         },
         twitter: {
           card: "summary_large_image",
-          title: meta.title,
+          title: shareTitle,
           description: meta.description,
           // twitter:image is also derived from opengraph-image.tsx.
         },


### PR DESCRIPTION
## Summary

Changelog link previews were repeating the full headline twice: once in the OG image and again as the share card title.

This change keeps the full `meta.title` as the document `<title>` (browser tabs, bookmarks, SEO) while setting `openGraph.title` and `twitter.title` to a contextual label with a locale-aware date (for example, **Changelog · June 8, 2026** in English and **Changements · 8 juin 2026** in French).

## Motivation

The colocated `opengraph-image.tsx` already renders the changelog headline prominently. Using the same text for the share card title made Slack/Twitter/iMessage previews feel redundant.

## Changes

- `app/[locale]/(landing)/updates/[slug]/page.tsx`
  - Add locale-aware share title label + date:
    - `en`: `Changelog · {formatted date}`
    - `fr`: `Changements · {formatted date}`
  - Keep document title as `meta.title`
  - Apply share title to Open Graph and Twitter metadata only