### PR TITLE
Fix calendar vs table date mismatch (timezone bucketing)

### DIFF
--- a/app/[locale]/dashboard/components/calendar/daily-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { fr, enUS } from "date-fns/locale";
 import {
   Dialog,
@@ -71,10 +71,12 @@ export function CalendarModal({
   React.useEffect(() => {
     if (selectedDate) {
       setFormattedDate(
-        format(selectedDate, "MMMM d, yyyy", { locale: dateLocale }),
+        formatInTimeZone(selectedDate, timezone, "MMMM d, yyyy", {
+          locale: dateLocale,
+        }),
       );
     }
-  }, [selectedDate]);
+  }, [selectedDate, timezone, dateLocale]);
 
   if (!selectedDate) return null;
 

--- a/app/[locale]/dashboard/components/calendar/desktop-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/desktop-calendar.tsx
@@ -582,7 +582,7 @@ export default function CalendarPnl({ calendarData, hideFiltersOnMobile = false 
             </div>
             <div className="grid grid-cols-8 auto-rows-fr rounded-lg h-[calc(100%-20px)]">
               {calendarDays.map((date, index) => {
-                const dateString = format(date, 'yyyy-MM-dd')
+                const dateString = formatInTimeZone(date, timezone, 'yyyy-MM-dd')
                 const dayData = calendarData[dateString]
                 // Check if it's the last day of the week (Saturday for Sunday start, Sunday for Monday start)
                 const isLastDayOfWeek = weekStartsOnMonday ? getDay(date) === 0 : getDay(date) === 6
@@ -710,7 +710,7 @@ export default function CalendarPnl({ calendarData, hideFiltersOnMobile = false 
           if (!open) setSelectedDate(null)
         }}
         selectedDate={selectedDate}
-        dayData={selectedDate ? calendarData[format(selectedDate, 'yyyy-MM-dd', { locale: dateLocale })] : undefined}
+        dayData={selectedDate ? calendarData[formatInTimeZone(selectedDate, timezone, 'yyyy-MM-dd')] : undefined}
         isLoading={isLoading}
       />
       <WeeklyModal

--- a/app/[locale]/dashboard/components/calendar/weekly-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-calendar.tsx
@@ -2,6 +2,7 @@
 
 import React from "react"
 import { format, eachWeekOfInterval, getWeek, getMonth, getYear, addDays, startOfYear, endOfYear } from "date-fns"
+import { formatInTimeZone } from "date-fns-tz"
 import { fr, enUS } from 'date-fns/locale'
 import { cn } from "@/lib/utils"
 import { Trade } from "@/prisma/generated/prisma/browser"
@@ -35,6 +36,7 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
   const t = useI18n()
   const locale = useCurrentLocale()
   const dateLocale = locale === 'fr' ? fr : enUS
+  const timezone = useUserStore((state) => state.timezone)
 
   const yearStartDate = startOfYear(new Date(year, 0, 1));
   const yearEndDate = endOfYear(new Date(year, 0, 1));
@@ -50,7 +52,7 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
     for (let d = 0; d < 7; d++) {
       const day = new Date(weekStart)
       day.setDate(day.getDate() + d)
-      const key = format(day, 'yyyy-MM-dd', { locale: dateLocale })
+      const key = formatInTimeZone(day, timezone, 'yyyy-MM-dd')
       if (calendarData[key]) total += calendarData[key].pnl
     }
     return total
@@ -61,7 +63,7 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
     for (let d = 0; d < 7; d++) {
       const day = new Date(weekStart)
       day.setDate(day.getDate() + d)
-      const key = format(day, 'yyyy-MM-dd', { locale: dateLocale })
+      const key = formatInTimeZone(day, timezone, 'yyyy-MM-dd')
       if (calendarData[key]) {
         tradesByDay[key] = {
           trades: calendarData[key].trades,

--- a/context/data-provider.tsx
+++ b/context/data-provider.tsx
@@ -969,8 +969,8 @@ export const DataProvider: React.FC<{
   }, [formattedTrades, accounts, breakevenRange]);
 
   const calendarData = useMemo(
-    () => formatCalendarData(formattedTrades, accounts),
-    [formattedTrades, accounts]
+    () => formatCalendarData(formattedTrades, accounts, timezone),
+    [formattedTrades, accounts, timezone]
   );
 
 

--- a/lib/calendar-data.test.ts
+++ b/lib/calendar-data.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { formatCalendarData } from "./utils";
+import type { Trade } from "@/prisma/generated/prisma/browser";
+
+function makeTrade(entryDate: string): Trade {
+  return {
+    entryDate,
+    closeDate: entryDate,
+    pnl: 100,
+    commission: 0,
+    side: "long",
+    accountNumber: "A1",
+    instrument: "MNQ",
+    quantity: 1,
+  } as Trade;
+}
+
+describe("formatCalendarData", () => {
+  it("buckets trades by entry date in the user timezone", () => {
+    const trades = [makeTrade("2026-06-21T22:00:00.000Z")];
+
+    const calendarData = formatCalendarData(trades, [], "Europe/Paris");
+
+    expect(Object.keys(calendarData)).toEqual(["2026-06-22"]);
+    expect(calendarData["2026-06-22"].tradeNumber).toBe(1);
+  });
+
+  it("matches UTC day when timezone is UTC", () => {
+    const trades = [makeTrade("2026-06-21T22:00:00.000Z")];
+
+    const calendarData = formatCalendarData(trades, [], "UTC");
+
+    expect(Object.keys(calendarData)).toEqual(["2026-06-21"]);
+  });
+});

--- a/lib/pdf/statement.test.ts
+++ b/lib/pdf/statement.test.ts
@@ -19,9 +19,9 @@ describe('PDF statement chart data', () => {
 
     const chartData = computeChartData(trades, 'Europe/Paris')
 
-    expect(chartData.dailyPnl).toEqual([{ label: '2026-05-10', value: 90 }])
-    expect(chartData.weekdayPnl.find((point) => point.label === 'Sun')?.value).toBe(90)
-    expect(chartData.weekdayPnl.find((point) => point.label === 'Mon')?.value).toBe(0)
+    expect(chartData.dailyPnl).toEqual([{ label: '2026-05-11', value: 90 }])
+    expect(chartData.weekdayPnl.find((point) => point.label === 'Mon')?.value).toBe(90)
+    expect(chartData.weekdayPnl.find((point) => point.label === 'Sun')?.value).toBe(0)
   })
 
   it('classifies trade distribution using the configured breakeven range on net pnl', () => {

--- a/lib/pdf/statement.ts
+++ b/lib/pdf/statement.ts
@@ -133,15 +133,18 @@ function bucketByDay(
 }
 
 // Mirrors formatCalendarData in lib/utils: the live Daily P&L, Weekday P&L,
-// and calendar widgets bucket trades by entryDate formatted in UTC.
-function bucketByDashboardCalendarDay(trades: PdfTrade[]): Map<string, number> {
+// and calendar widgets bucket trades by entryDate in the user's timezone.
+function bucketByDashboardCalendarDay(
+  trades: PdfTrade[],
+  timezone: string,
+): Map<string, number> {
   const buckets = new Map<string, number>()
   for (const trade of trades) {
     const time = new Date(trade.entryDate).getTime()
     if (Number.isNaN(time)) {
       continue
     }
-    const day = formatInTimeZone(new Date(trade.entryDate), "UTC", "yyyy-MM-dd")
+    const day = formatInTimeZone(new Date(trade.entryDate), timezone, "yyyy-MM-dd")
     buckets.set(day, (buckets.get(day) ?? 0) + netPnl(trade))
   }
   return buckets
@@ -162,7 +165,7 @@ export function computeChartData(
   })
 
   // Daily net pnl by dashboard calendar bucket, chronological.
-  const dailyBuckets = bucketByDashboardCalendarDay(trades)
+  const dailyBuckets = bucketByDashboardCalendarDay(trades, timezone)
   const dailyDays = [...dailyBuckets.keys()].sort()
   const dailyPnl: PointSeries[] = dailyDays.map((day) => ({
     label: day,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -138,7 +138,11 @@ export function calculateStatistics(trades: Trade[], accounts: Account[] = [], b
   return statistics;
 }
 
-export function formatCalendarData(trades: Trade[], accounts: Account[] = []) {
+export function formatCalendarData(
+  trades: Trade[],
+  accounts: Account[] = [],
+  timezone: string,
+) {
   // // Create a map of accounts for quick lookup
   // const accountMap = new Map(accounts.map(account => [account.number, account]));
 
@@ -154,8 +158,11 @@ export function formatCalendarData(trades: Trade[], accounts: Account[] = []) {
   // });
 
   return trades.reduce((acc: any, trade: Trade) => {
-    // Parse the date and format it in UTC to ensure consistency across timezones
-    const date = formatInTimeZone(new Date(trade.entryDate), 'UTC', 'yyyy-MM-dd')
+    const date = formatInTimeZone(
+      new Date(trade.entryDate),
+      timezone,
+      "yyyy-MM-dd",
+    )
     
     if (!acc[date]) {
       acc[date] = { pnl: 0, tradeNumber: 0, longNumber: 0, shortNumber: 0, trades: [] }

--- a/scripts/verify-calendar-timezone.ts
+++ b/scripts/verify-calendar-timezone.ts
@@ -1,0 +1,223 @@
+/**
+ * Verifies calendar day bucketing matches trade table entry-date display
+ * for trades stored as UTC timestamps near midnight boundaries.
+ *
+ * Usage:
+ *   bun scripts/verify-calendar-timezone.ts           # logic-only checks
+ *   bun scripts/verify-calendar-timezone.ts --seed    # insert trades into local DB and re-check
+ */
+import "dotenv/config"
+import { randomUUID } from "crypto"
+import { formatInTimeZone } from "date-fns-tz"
+import { PrismaPg } from "@prisma/adapter-pg"
+import pg from "pg"
+
+import { loadEnvLocal } from "../lib/load-env-local.node"
+import { formatCalendarData } from "../lib/utils"
+import type { Trade } from "../prisma/generated/prisma/browser"
+import { PrismaClient } from "../prisma/generated/prisma/client"
+
+loadEnvLocal()
+
+const LOCAL_USER_ID = process.env.LOCAL_DASHBOARD_USER_ID || "local-dashboard-user"
+const LOCAL_ACCOUNT_NUMBER =
+  process.env.LOCAL_DASHBOARD_ACCOUNT_NUMBER || "LOCAL-SIM-001"
+
+const TIMEZONES = [
+  "UTC",
+  "Europe/Paris",
+  "America/New_York",
+  "Asia/Dubai",
+  "Australia/Sydney",
+] as const
+
+/** UTC timestamps that straddle calendar days in common trading timezones. */
+const EDGE_CASE_TRADES = [
+  {
+    label: "user-report (Paris late evening -> next local day)",
+    entryDate: "2026-06-21T22:00:00.000Z",
+  },
+  {
+    label: "US evening futures (NY still same UTC day)",
+    entryDate: "2026-06-22T03:30:00.000Z",
+  },
+  {
+    label: "Sydney morning (previous UTC day)",
+    entryDate: "2026-06-21T14:00:00.000Z",
+  },
+  {
+    label: "exact UTC midnight",
+    entryDate: "2026-06-22T00:00:00.000Z",
+  },
+  {
+    label: "one second before UTC midnight",
+    entryDate: "2026-06-21T23:59:59.000Z",
+  },
+] as const
+
+function tableEntryDate(trade: Trade, timezone: string): string {
+  return formatInTimeZone(new Date(trade.entryDate), timezone, "yyyy-MM-dd")
+}
+
+function utcCalendarDay(trade: Trade): string {
+  return formatInTimeZone(new Date(trade.entryDate), "UTC", "yyyy-MM-dd")
+}
+
+function calendarDayForTrade(
+  trade: Trade,
+  timezone: string,
+  calendarData: ReturnType<typeof formatCalendarData>,
+): string | null {
+  for (const [day, entry] of Object.entries(calendarData)) {
+    if (entry.trades.some((t) => t.entryDate === trade.entryDate)) {
+      return day
+    }
+  }
+  return null
+}
+
+function makeTrade(entryDate: string, instrument: string): Trade {
+  return {
+    id: randomUUID(),
+    entryDate,
+    closeDate: entryDate,
+    pnl: 100,
+    commission: 0,
+    side: "long",
+    accountNumber: LOCAL_ACCOUNT_NUMBER,
+    instrument,
+    quantity: 1,
+    userId: LOCAL_USER_ID,
+  } as Trade
+}
+
+function runLogicChecks(trades: Trade[]) {
+  console.log("\n=== Calendar vs table date alignment ===\n")
+
+  let mismatches = 0
+  let utcWouldMismatch = 0
+
+  for (const timezone of TIMEZONES) {
+    console.log(`Timezone: ${timezone}`)
+    const calendarData = formatCalendarData(trades, [], timezone)
+
+    for (const spec of EDGE_CASE_TRADES) {
+      const trade = trades.find((t) => t.entryDate === spec.entryDate)
+      if (!trade) continue
+
+      const tableDate = tableEntryDate(trade, timezone)
+      const calendarDate = calendarDayForTrade(trade, timezone, calendarData)
+      const oldUtcDay = utcCalendarDay(trade)
+      const ok = tableDate === calendarDate
+
+      if (!ok) mismatches++
+      if (oldUtcDay !== tableDate) utcWouldMismatch++
+
+      console.log(
+        `  ${ok ? "OK" : "MISMATCH"} | ${spec.label}`,
+      )
+      console.log(
+        `         stored: ${spec.entryDate}`,
+      )
+      console.log(
+        `         table: ${tableDate} | calendar: ${calendarDate ?? "—"} | old UTC bucket: ${oldUtcDay}`,
+      )
+    }
+    console.log("")
+  }
+
+  console.log("Summary:")
+  console.log(`  Mismatches (fixed calendar vs table): ${mismatches}`)
+  console.log(`  Cases where old UTC bucketing != table date: ${utcWouldMismatch}`)
+
+  if (mismatches > 0) {
+    process.exitCode = 1
+  }
+}
+
+async function seedEdgeCaseTrades(prisma: PrismaClient) {
+  const marker = "tz-edge-verify"
+
+  await prisma.trade.deleteMany({
+    where: {
+      userId: LOCAL_USER_ID,
+      tags: { has: marker },
+    },
+  })
+
+  const created: Trade[] = []
+
+  for (const spec of EDGE_CASE_TRADES) {
+    const trade = makeTrade(spec.entryDate, `MNQ-${marker}`)
+    await prisma.trade.create({
+      data: {
+        id: trade.id,
+        userId: LOCAL_USER_ID,
+        accountNumber: LOCAL_ACCOUNT_NUMBER,
+        instrument: trade.instrument,
+        quantity: 1,
+        entryPrice: "30400",
+        closePrice: "30450",
+        entryDate: trade.entryDate,
+        closeDate: trade.closeDate,
+        pnl: 50,
+        commission: 2,
+        side: "Long",
+        timeInPosition: 300,
+        tags: [marker, spec.label],
+      },
+    })
+    created.push(trade)
+  }
+
+  console.log(`\nSeeded ${created.length} timezone edge-case trades (tag: ${marker})`)
+  return created
+}
+
+async function loadSeededTrades(prisma: PrismaClient): Promise<Trade[]> {
+  const rows = await prisma.trade.findMany({
+    where: {
+      userId: LOCAL_USER_ID,
+      tags: { has: "tz-edge-verify" },
+    },
+    orderBy: { entryDate: "asc" },
+  })
+  return rows as Trade[]
+}
+
+async function main() {
+  const shouldSeed = process.argv.includes("--seed")
+  const inMemoryTrades = EDGE_CASE_TRADES.map((spec, index) =>
+    makeTrade(spec.entryDate, `MNQ-${index}`),
+  )
+
+  runLogicChecks(inMemoryTrades)
+
+  if (!shouldSeed) {
+    console.log("\nRun with --seed to insert edge-case trades into local Postgres and re-verify from DB.")
+    return
+  }
+
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required for --seed")
+  }
+
+  const pool = new pg.Pool({ connectionString: databaseUrl })
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) })
+
+  try {
+    await seedEdgeCaseTrades(prisma)
+    const dbTrades = await loadSeededTrades(prisma)
+    console.log(`\nLoaded ${dbTrades.length} trades from database`)
+    runLogicChecks(dbTrades)
+  } finally {
+    await prisma.$disconnect()
+    await pool.end()
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/verify-calendar-timezone.ts
+++ b/scripts/verify-calendar-timezone.ts
@@ -14,6 +14,7 @@ import pg from "pg"
 
 import { loadEnvLocal } from "../lib/load-env-local.node"
 import { formatCalendarData } from "../lib/utils"
+import type { CalendarData } from "../app/[locale]/dashboard/types/calendar"
 import type { Trade } from "../prisma/generated/prisma/browser"
 import { PrismaClient } from "../prisma/generated/prisma/client"
 
@@ -65,8 +66,7 @@ function utcCalendarDay(trade: Trade): string {
 
 function calendarDayForTrade(
   trade: Trade,
-  timezone: string,
-  calendarData: ReturnType<typeof formatCalendarData>,
+  calendarData: CalendarData,
 ): string | null {
   for (const [day, entry] of Object.entries(calendarData)) {
     if (entry.trades.some((t) => t.entryDate === trade.entryDate)) {
@@ -106,7 +106,7 @@ function runLogicChecks(trades: Trade[]) {
       if (!trade) continue
 
       const tableDate = tableEntryDate(trade, timezone)
-      const calendarDate = calendarDayForTrade(trade, timezone, calendarData)
+      const calendarDate = calendarDayForTrade(trade, calendarData)
       const oldUtcDay = utcCalendarDay(trade)
       const ok = tableDate === calendarDate
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users reported trades appearing on the wrong calendar day. For example, positions taken overnight showed on **June 21** in the calendar/agenda while the trade table correctly displayed **June 22** as the entry date.

## Root cause

Calendar day bucketing and table display used different timezones:

| Layer | Timezone used |
|-------|---------------|
| `formatCalendarData` (calendar buckets) | **UTC** (hardcoded) |
| Trade table "Date d'entrée" | **User timezone** |
| Desktop calendar cell lookup | **Browser local** (inconsistent) |

A trade like `2026-06-21T22:00:00Z` lands on June 21 in UTC but June 22 for users in Europe/Paris or similar offsets — exactly matching the reported screenshot.

## Fix

- Bucket `calendarData` using the user's configured timezone (same as the trade table)
- Align desktop and weekly calendar lookups to use `formatInTimeZone(..., timezone, ...)`
- Format the daily modal title in the user timezone
- Mirror the same bucketing in PDF statement daily P&L charts

## Tests

- Added `lib/calendar-data.test.ts` with regression cases for timezone-aware bucketing
- Updated `lib/pdf/statement.test.ts` expectations to match user-timezone bucketing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f03cd-6270-77ba-a039-756b250851c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f03cd-6270-77ba-a039-756b250851c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

