### PR TITLE
perf(landing): serve homepage from static edge cache

### DIFF
--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
-import { headers } from "next/headers";
 import nextDynamic from "next/dynamic";
 import Partners from "./components/partners";
 import { setStaticParamsLocale } from "next-international/server";
 import Hero from "./components/hero";
 import { getStaticParams } from "@/locales/server";
-import { getRequestOrigin, siteUrl } from "@/lib/site-url";
 import {
   FAQSectionSkeleton,
   FeaturesSectionSkeleton,
@@ -29,40 +26,10 @@ const OpenSource = nextDynamic(() => import("./components/open-source"), {
   loading: () => <OpenSourceSectionSkeleton />,
 });
 
+export const dynamic = "force-static";
+
 export function generateStaticParams() {
   return getStaticParams();
-}
-
-export async function generateMetadata({
-  searchParams,
-}: {
-  searchParams: Promise<{ ref?: string }>;
-}): Promise<Metadata> {
-  const { ref } = await searchParams;
-
-  if (!ref) {
-    return {};
-  }
-
-  const requestHeaders = await headers();
-  const origin = getRequestOrigin(requestHeaders);
-  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`, origin);
-
-  return {
-    openGraph: {
-      images: [
-        {
-          url: ogImageUrl,
-          width: 1200,
-          height: 630,
-          alt: "Deltalytix Open Graph Image",
-        },
-      ],
-    },
-    twitter: {
-      images: [ogImageUrl],
-    },
-  };
 }
 
 export default async function LandingPage({

--- a/app/[locale]/(landing)/ref/[ref]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/opengraph-image.tsx
@@ -1,0 +1,33 @@
+import { getReferralOgCopy } from "@/lib/og/referral-copy";
+import {
+  createReferralOgImageResponse,
+  referralOgSize,
+} from "@/lib/og/referral-opengraph";
+import { isValidReferralSlug } from "@/lib/referral-url";
+
+export const alt = "Deltalytix Referral";
+export const size = referralOgSize;
+export const contentType = "image/png";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ locale: string; ref: string }>;
+}) {
+  const { locale, ref } = await params;
+
+  if (!isValidReferralSlug(ref)) {
+    return new Response("Referral not found", { status: 404 });
+  }
+
+  const copy = await getReferralOgCopy(locale);
+
+  return createReferralOgImageResponse({
+    ref,
+    joinLabel: copy.joinLabel,
+    tagline: copy.tagline,
+  });
+}

--- a/app/[locale]/(landing)/ref/[ref]/page.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/page.tsx
@@ -1,12 +1,15 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { setStaticParamsLocale } from "next-international/server";
-import { getReferralOgCopy } from "@/lib/og/referral-copy";
 import { isValidReferralSlug } from "@/lib/referral-url";
 import { siteUrl } from "@/lib/site-url";
 
 type PageProps = {
   params: Promise<{ locale: string; ref: string }>;
+};
+
+const SHARE_DESCRIPTIONS: Record<string, string> = {
+  en: "Centralize and visualize your trading performance across multiple brokers. Track, analyze, and improve your trading journey with powerful analytics.",
+  fr: "Centralisez et visualisez vos performances de trading à travers différents brokers. Suivez, analysez et améliorez votre parcours de trading avec des analyses puissantes.",
 };
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -16,20 +19,19 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {};
   }
 
-  setStaticParamsLocale(locale);
-  const copy = await getReferralOgCopy(locale);
+  const description = SHARE_DESCRIPTIONS[locale] ?? SHARE_DESCRIPTIONS.en;
   const url = siteUrl(`/${locale}/ref/${encodeURIComponent(ref)}`);
   const openGraphLocale = locale === "fr" ? "fr_FR" : "en_US";
 
   return {
-    title: copy.joinLabel,
-    description: copy.tagline,
+    title: "Deltalytix",
+    description,
     alternates: {
       canonical: url,
     },
     openGraph: {
-      title: copy.joinLabel,
-      description: copy.tagline,
+      title: "Deltalytix",
+      description,
       url,
       siteName: "Deltalytix",
       locale: openGraphLocale,
@@ -37,8 +39,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: "summary_large_image",
-      title: copy.joinLabel,
-      description: copy.tagline,
+      title: "Deltalytix",
+      description,
       // twitter:image is also derived from opengraph-image.tsx.
     },
   };

--- a/app/[locale]/(landing)/ref/[ref]/page.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { siteUrl } from "@/lib/site-url";
+
+type PageProps = {
+  params: Promise<{ locale: string; ref: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { ref } = await params;
+  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`);
+
+  return {
+    openGraph: {
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: "Deltalytix Open Graph Image",
+        },
+      ],
+    },
+    twitter: {
+      images: [ogImageUrl],
+    },
+  };
+}
+
+export default async function ReferralLandingPage({ params }: PageProps) {
+  const { locale, ref } = await params;
+  redirect(`/${locale}?ref=${encodeURIComponent(ref)}`);
+}

--- a/app/[locale]/(landing)/ref/[ref]/page.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/page.tsx
@@ -1,37 +1,45 @@
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { setStaticParamsLocale } from "next-international/server";
+import { getReferralOgCopy } from "@/lib/og/referral-copy";
 import { isValidReferralSlug } from "@/lib/referral-url";
-import { getRequestOrigin, siteUrl } from "@/lib/site-url";
+import { siteUrl } from "@/lib/site-url";
 
 type PageProps = {
   params: Promise<{ locale: string; ref: string }>;
 };
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { ref } = await params;
+  const { locale, ref } = await params;
 
   if (!isValidReferralSlug(ref)) {
     return {};
   }
 
-  const requestHeaders = await headers();
-  const origin = getRequestOrigin(requestHeaders);
-  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`, origin);
+  setStaticParamsLocale(locale);
+  const copy = await getReferralOgCopy(locale);
+  const url = siteUrl(`/${locale}/ref/${encodeURIComponent(ref)}`);
+  const openGraphLocale = locale === "fr" ? "fr_FR" : "en_US";
 
   return {
+    title: copy.joinLabel,
+    description: copy.tagline,
+    alternates: {
+      canonical: url,
+    },
     openGraph: {
-      images: [
-        {
-          url: ogImageUrl,
-          width: 1200,
-          height: 630,
-          alt: "Deltalytix Open Graph Image",
-        },
-      ],
+      title: copy.joinLabel,
+      description: copy.tagline,
+      url,
+      siteName: "Deltalytix",
+      locale: openGraphLocale,
+      // og:image is injected automatically from colocated opengraph-image.tsx.
     },
     twitter: {
-      images: [ogImageUrl],
+      card: "summary_large_image",
+      title: copy.joinLabel,
+      description: copy.tagline,
+      // twitter:image is also derived from opengraph-image.tsx.
     },
   };
 }

--- a/app/[locale]/(landing)/ref/[ref]/page.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { siteUrl } from "@/lib/site-url";
+import { isValidReferralSlug } from "@/lib/referral-url";
+import { getRequestOrigin, siteUrl } from "@/lib/site-url";
 
 type PageProps = {
   params: Promise<{ locale: string; ref: string }>;
@@ -8,7 +10,14 @@ type PageProps = {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { ref } = await params;
-  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`);
+
+  if (!isValidReferralSlug(ref)) {
+    return {};
+  }
+
+  const requestHeaders = await headers();
+  const origin = getRequestOrigin(requestHeaders);
+  const ogImageUrl = siteUrl(`/api/og?ref=${encodeURIComponent(ref)}`, origin);
 
   return {
     openGraph: {
@@ -29,5 +38,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ReferralLandingPage({ params }: PageProps) {
   const { locale, ref } = await params;
+
+  if (!isValidReferralSlug(ref)) {
+    redirect(`/${locale}`);
+  }
+
   redirect(`/${locale}?ref=${encodeURIComponent(ref)}`);
 }

--- a/app/[locale]/dashboard/components/referral-button.tsx
+++ b/app/[locale]/dashboard/components/referral-button.tsx
@@ -17,6 +17,7 @@ import { toast } from 'sonner'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { buildReferralShareUrl } from '@/lib/referral-url'
+import { getSiteOrigin } from '@/lib/site-url'
 
 interface ReferralData {
   referral: {
@@ -71,11 +72,14 @@ export default function ReferralButton() {
     }
   }
 
+  const getShareOrigin = () =>
+    typeof window !== 'undefined' ? getSiteOrigin(window.location.origin) : getSiteOrigin()
+
   const copyReferralCode = async () => {
     if (!referralData?.referral.slug) return
 
     const referralUrl = buildReferralShareUrl(
-      window.location.origin,
+      getShareOrigin(),
       locale,
       referralData.referral.slug,
     )
@@ -158,7 +162,7 @@ export default function ReferralButton() {
                 <div className="flex-1 px-3 py-2 bg-muted rounded-md text-sm break-all">
                   {typeof window !== 'undefined'
                     ? buildReferralShareUrl(
-                        window.location.origin,
+                        getShareOrigin(),
                         locale,
                         referralData.referral.slug,
                       )

--- a/app/[locale]/dashboard/components/referral-button.tsx
+++ b/app/[locale]/dashboard/components/referral-button.tsx
@@ -16,6 +16,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { toast } from 'sonner'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
+import { buildReferralShareUrl } from '@/lib/referral-url'
 
 interface ReferralData {
   referral: {
@@ -73,7 +74,11 @@ export default function ReferralButton() {
   const copyReferralCode = async () => {
     if (!referralData?.referral.slug) return
 
-    const referralUrl = `${window.location.origin}?ref=${referralData.referral.slug}`
+    const referralUrl = buildReferralShareUrl(
+      window.location.origin,
+      locale,
+      referralData.referral.slug,
+    )
     
     try {
       await navigator.clipboard.writeText(referralUrl)
@@ -151,7 +156,13 @@ export default function ReferralButton() {
               </div>
               <div className="flex items-center gap-2">
                 <div className="flex-1 px-3 py-2 bg-muted rounded-md text-sm break-all">
-                  {typeof window !== 'undefined' ? `${window.location.origin}?ref=${referralData.referral.slug}` : referralData.referral.slug}
+                  {typeof window !== 'undefined'
+                    ? buildReferralShareUrl(
+                        window.location.origin,
+                        locale,
+                        referralData.referral.slug,
+                      )
+                    : referralData.referral.slug}
                 </div>
                 <Button
                   size="sm"

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,105 +1,12 @@
 import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
 import type { ReactElement } from "react";
-
-const size = { width: 1200, height: 630 };
-
-function hslToHex(h: number, s: number, l: number): string {
-  s /= 100;
-  l /= 100;
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const m = l - c / 2;
-  let r = 0;
-  let g = 0;
-  let b = 0;
-
-  if (h < 60) {
-    r = c;
-    g = x;
-  } else if (h < 120) {
-    r = x;
-    g = c;
-  } else if (h < 180) {
-    g = c;
-    b = x;
-  } else if (h < 240) {
-    g = x;
-    b = c;
-  } else if (h < 300) {
-    r = x;
-    b = c;
-  } else {
-    r = c;
-    b = x;
-  }
-
-  r = Math.round((r + m) * 255);
-  g = Math.round((g + m) * 255);
-  b = Math.round((b + m) * 255);
-
-  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
-}
-
-function generateColorFromString(str: string): string {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-
-  const hue = Math.abs(hash % 360);
-  const saturation = 60 + (Math.abs(hash >> 8) % 30);
-  const lightness = 50 + (Math.abs(hash >> 16) % 20);
-
-  return hslToHex(hue, saturation, lightness);
-}
-
-function LogoMark({ sizePx = 40 }: { sizePx?: number }) {
-  return (
-    <svg
-      viewBox="0 0 255 255"
-      xmlns="http://www.w3.org/2000/svg"
-      style={{ width: sizePx, height: sizePx }}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M159 63L127.5 0V255H255L236.5 218H159V63Z"
-        fill="#FFFFFF"
-      />
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z"
-        fill="#FFFFFF"
-      />
-    </svg>
-  );
-}
-
-function BrandLockup({ logoSize = 40, fontSize = 28 }: { logoSize?: number; fontSize?: number }) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 14,
-      }}
-    >
-      <LogoMark sizePx={logoSize} />
-      <span
-        style={{
-          fontSize,
-          fontWeight: 700,
-          color: "#FFFFFF",
-          letterSpacing: "-0.03em",
-        }}
-      >
-        Deltalytix
-      </span>
-    </div>
-  );
-}
+import { getReferralOgCopy } from "@/lib/og/referral-copy";
+import {
+  createReferralOgImageResponse,
+  referralOgSize,
+} from "@/lib/og/referral-opengraph";
+import { isValidReferralSlug } from "@/lib/referral-url";
 
 function DefaultOgImage() {
   return (
@@ -137,7 +44,28 @@ function DefaultOgImage() {
           display: "flex",
         }}
       />
-      <BrandLockup logoSize={96} fontSize={88} />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+        }}
+      >
+        <svg viewBox="0 0 255 255" xmlns="http://www.w3.org/2000/svg" style={{ width: 96, height: 96 }}>
+          <path fillRule="evenodd" clipRule="evenodd" d="M159 63L127.5 0V255H255L236.5 218H159V63Z" fill="#FFFFFF" />
+          <path fillRule="evenodd" clipRule="evenodd" d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z" fill="#FFFFFF" />
+        </svg>
+        <span
+          style={{
+            fontSize: 88,
+            fontWeight: 700,
+            color: "#FFFFFF",
+            letterSpacing: "-0.03em",
+          }}
+        >
+          Deltalytix
+        </span>
+      </div>
       <div
         style={{
           position: "absolute",
@@ -153,133 +81,23 @@ function DefaultOgImage() {
   ) as ReactElement;
 }
 
-function ReferralOgImage({ ref, accentColor }: { ref: string; accentColor: string }) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        width: "100%",
-        height: "100%",
-        background: "#0a0a0a",
-        fontFamily: "system-ui, -apple-system, sans-serif",
-        position: "relative",
-        padding: "56px 72px",
-        flexDirection: "column",
-        justifyContent: "space-between",
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          top: -100,
-          right: -100,
-          width: 480,
-          height: 480,
-          background: `radial-gradient(circle, ${accentColor}55 0%, rgba(10, 10, 10, 0) 72%)`,
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: -60,
-          left: -60,
-          width: 320,
-          height: 320,
-          background: "radial-gradient(circle, rgba(59, 130, 246, 0.25) 0%, rgba(10, 10, 10, 0) 70%)",
-          display: "flex",
-        }}
-      />
-
-      <BrandLockup />
-
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: 28,
-          maxWidth: 900,
-        }}
-      >
-        <p
-          style={{
-            margin: 0,
-            fontSize: 28,
-            fontWeight: 500,
-            color: "#a1a1aa",
-            letterSpacing: "-0.01em",
-          }}
-        >
-          Join with a referral code
-        </p>
-
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            alignSelf: "flex-start",
-            padding: "28px 40px",
-            borderRadius: 20,
-            border: `3px solid ${accentColor}`,
-            background: "rgba(255, 255, 255, 0.04)",
-            boxShadow: `0 0 60px ${accentColor}33`,
-          }}
-        >
-          <span
-            style={{
-              fontSize: 80,
-              fontWeight: 800,
-              color: "#FFFFFF",
-              letterSpacing: "0.12em",
-              textTransform: "uppercase",
-            }}
-          >
-            {ref}
-          </span>
-        </div>
-
-        <p
-          style={{
-            margin: 0,
-            fontSize: 34,
-            fontWeight: 600,
-            color: "#f4f4f5",
-            lineHeight: 1.3,
-            letterSpacing: "-0.02em",
-          }}
-        >
-          Next generation trading dashboard
-        </p>
-      </div>
-
-      <p
-        style={{
-          margin: 0,
-          fontSize: 22,
-          fontWeight: 500,
-          color: "#71717a",
-        }}
-      >
-        deltalytix.app
-      </p>
-    </div>
-  ) as ReactElement;
-}
-
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const ref = searchParams.get("ref");
-  const hasReferral = Boolean(ref && ref !== "Direct");
-  const accentColor = hasReferral ? generateColorFromString(ref!) : "#7c3aed";
+  const locale = searchParams.get("locale") ?? "en";
+  const hasReferral = Boolean(ref && ref !== "Direct" && isValidReferralSlug(ref));
 
-  const element = hasReferral ? (
-    <ReferralOgImage ref={ref!} accentColor={accentColor} />
-  ) : (
-    <DefaultOgImage />
-  );
+  if (hasReferral) {
+    const copy = await getReferralOgCopy(locale);
+    return createReferralOgImageResponse({
+      ref: ref!,
+      joinLabel: copy.joinLabel,
+      tagline: copy.tagline,
+    });
+  }
 
-  return new ImageResponse(element, {
-    ...size,
+  return new ImageResponse(<DefaultOgImage />, {
+    ...referralOgSize,
     headers: {
       "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
     },

--- a/lib/og/referral-copy.test.ts
+++ b/lib/og/referral-copy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getReferralOgCopy } from "./referral-copy";
+
+describe("getReferralOgCopy", () => {
+  it("returns French copy for fr locale", async () => {
+    const copy = await getReferralOgCopy("fr");
+    expect(copy.joinLabel).toBe("Rejoignez avec un code de parrainage");
+    expect(copy.tagline).toBe("Journal de trading nouvelle génération");
+  });
+
+  it("returns English copy for en locale", async () => {
+    const copy = await getReferralOgCopy("en");
+    expect(copy.joinLabel).toBe("Join with a referral code");
+    expect(copy.tagline).toBe("Next generation trading dashboard");
+  });
+
+  it("falls back to English for unsupported locales", async () => {
+    const copy = await getReferralOgCopy("de");
+    expect(copy.joinLabel).toBe("Join with a referral code");
+  });
+});

--- a/lib/og/referral-copy.ts
+++ b/lib/og/referral-copy.ts
@@ -1,0 +1,19 @@
+type ReferralOgCopy = {
+  joinLabel: string;
+  tagline: string;
+  alt: string;
+};
+
+const REFERRAL_OG_LOCALES = new Set(["en", "fr"]);
+
+export async function getReferralOgCopy(locale: string): Promise<ReferralOgCopy> {
+  const resolvedLocale = REFERRAL_OG_LOCALES.has(locale) ? locale : "en";
+
+  if (resolvedLocale === "fr") {
+    const { default: messages } = await import("../../locales/fr/referral");
+    return messages.referral.og;
+  }
+
+  const { default: messages } = await import("../../locales/en/referral");
+  return messages.referral.og;
+}

--- a/lib/og/referral-opengraph.tsx
+++ b/lib/og/referral-opengraph.tsx
@@ -1,0 +1,255 @@
+import { ImageResponse } from "next/og";
+import type { ReactElement } from "react";
+
+export const referralOgSize = { width: 1200, height: 630 };
+
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+
+  r = Math.round((r + m) * 255);
+  g = Math.round((g + m) * 255);
+  b = Math.round((b + m) * 255);
+
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+export function generateReferralAccentColor(ref: string): string {
+  let hash = 0;
+  for (let i = 0; i < ref.length; i++) {
+    hash = ref.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  const hue = Math.abs(hash % 360);
+  const saturation = 60 + (Math.abs(hash >> 8) % 30);
+  const lightness = 50 + (Math.abs(hash >> 16) % 20);
+
+  return hslToHex(hue, saturation, lightness);
+}
+
+function LogoMark({ sizePx = 40 }: { sizePx?: number }) {
+  return (
+    <svg
+      viewBox="0 0 255 255"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: sizePx, height: sizePx }}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M159 63L127.5 0V255H255L236.5 218H159V63Z"
+        fill="#FFFFFF"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z"
+        fill="#FFFFFF"
+      />
+    </svg>
+  );
+}
+
+function BrandLockup({ logoSize = 40, fontSize = 28 }: { logoSize?: number; fontSize?: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+      }}
+    >
+      <LogoMark sizePx={logoSize} />
+      <span
+        style={{
+          fontSize,
+          fontWeight: 700,
+          color: "#FFFFFF",
+          letterSpacing: "-0.03em",
+        }}
+      >
+        Deltalytix
+      </span>
+    </div>
+  );
+}
+
+type ReferralOgImageProps = {
+  ref: string;
+  accentColor: string;
+  joinLabel: string;
+  tagline: string;
+};
+
+export function ReferralOgImage({
+  ref,
+  accentColor,
+  joinLabel,
+  tagline,
+}: ReferralOgImageProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        background: "#0a0a0a",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        position: "relative",
+        padding: "56px 72px",
+        flexDirection: "column",
+        justifyContent: "space-between",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -100,
+          right: -100,
+          width: 480,
+          height: 480,
+          background: `radial-gradient(circle, ${accentColor}55 0%, rgba(10, 10, 10, 0) 72%)`,
+          display: "flex",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: -60,
+          left: -60,
+          width: 320,
+          height: 320,
+          background: "radial-gradient(circle, rgba(59, 130, 246, 0.25) 0%, rgba(10, 10, 10, 0) 70%)",
+          display: "flex",
+        }}
+      />
+
+      <BrandLockup />
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 28,
+          maxWidth: 900,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 28,
+            fontWeight: 500,
+            color: "#a1a1aa",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          {joinLabel}
+        </p>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            alignSelf: "flex-start",
+            padding: "28px 40px",
+            borderRadius: 20,
+            border: `3px solid ${accentColor}`,
+            background: "rgba(255, 255, 255, 0.04)",
+            boxShadow: `0 0 60px ${accentColor}33`,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 80,
+              fontWeight: 800,
+              color: "#FFFFFF",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+            }}
+          >
+            {ref}
+          </span>
+        </div>
+
+        <p
+          style={{
+            margin: 0,
+            fontSize: 34,
+            fontWeight: 600,
+            color: "#f4f4f5",
+            lineHeight: 1.3,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          {tagline}
+        </p>
+      </div>
+
+      <p
+        style={{
+          margin: 0,
+          fontSize: 22,
+          fontWeight: 500,
+          color: "#71717a",
+        }}
+      >
+        deltalytix.app
+      </p>
+    </div>
+  ) as ReactElement;
+}
+
+export function createReferralOgImageResponse({
+  ref,
+  joinLabel,
+  tagline,
+}: {
+  ref: string;
+  joinLabel: string;
+  tagline: string;
+}) {
+  const accentColor = generateReferralAccentColor(ref);
+
+  return new ImageResponse(
+    <ReferralOgImage
+      ref={ref}
+      accentColor={accentColor}
+      joinLabel={joinLabel}
+      tagline={tagline}
+    />,
+    {
+      ...referralOgSize,
+      headers: {
+        "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
+        "CDN-Cache-Control": "public, max-age=3600",
+        "Vercel-CDN-Cache-Control": "public, max-age=3600",
+      },
+    },
+  );
+}

--- a/lib/referral-url.test.ts
+++ b/lib/referral-url.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReferralShareUrl,
+  isValidReferralSlug,
+} from "./referral-url";
+
+describe("buildReferralShareUrl", () => {
+  it("builds the localized /ref/ share route", () => {
+    expect(
+      buildReferralShareUrl("https://www.deltalytix.app", "en", "abc123"),
+    ).toBe("https://www.deltalytix.app/en/ref/abc123");
+  });
+
+  it("strips trailing slashes from the origin", () => {
+    expect(
+      buildReferralShareUrl("https://www.deltalytix.app/", "fr", "xyz789"),
+    ).toBe("https://www.deltalytix.app/fr/ref/xyz789");
+  });
+
+  it("encodes slug segments for the URL path", () => {
+    expect(
+      buildReferralShareUrl("https://www.deltalytix.app", "en", "ab/c"),
+    ).toBe("https://www.deltalytix.app/en/ref/ab%2Fc");
+  });
+});
+
+describe("isValidReferralSlug", () => {
+  it("accepts lowercase alphanumeric slugs", () => {
+    expect(isValidReferralSlug("abc123")).toBe(true);
+  });
+
+  it("rejects invalid slug formats", () => {
+    expect(isValidReferralSlug("")).toBe(false);
+    expect(isValidReferralSlug("ABC123")).toBe(false);
+    expect(isValidReferralSlug("ab/c")).toBe(false);
+  });
+});

--- a/lib/referral-url.ts
+++ b/lib/referral-url.ts
@@ -1,7 +1,13 @@
+export const REFERRAL_SLUG_PATTERN = /^[a-z0-9]{1,32}$/;
+
+export function isValidReferralSlug(slug: string): boolean {
+  return REFERRAL_SLUG_PATTERN.test(slug);
+}
+
 export function buildReferralShareUrl(
   origin: string,
   locale: string,
   slug: string,
-) {
+): string {
   return `${origin.replace(/\/$/, "")}/${locale}/ref/${encodeURIComponent(slug)}`;
 }

--- a/lib/referral-url.ts
+++ b/lib/referral-url.ts
@@ -1,0 +1,7 @@
+export function buildReferralShareUrl(
+  origin: string,
+  locale: string,
+  slug: string,
+) {
+  return `${origin.replace(/\/$/, "")}/${locale}/ref/${encodeURIComponent(slug)}`;
+}

--- a/locales/en/referral.ts
+++ b/locales/en/referral.ts
@@ -16,6 +16,11 @@ export default {
     tier: 'Tier {level}',
     maxTierReached: 'Maximum tier reached!',
     howItWorks: 'How it works',
+    og: {
+      joinLabel: 'Join with a referral code',
+      tagline: 'Next generation trading dashboard',
+      alt: 'Deltalytix Referral',
+    },
     landing: {
       title: 'Referral Program',
       subtitle: 'Invite friends and earn rewards when they subscribe to Plus',

--- a/locales/fr/referral.ts
+++ b/locales/fr/referral.ts
@@ -16,6 +16,11 @@ export default {
     tier: 'Niveau {level}',
     maxTierReached: 'Niveau maximum atteint !',
     howItWorks: 'Comment ça marche',
+    og: {
+      joinLabel: 'Rejoignez avec un code de parrainage',
+      tagline: 'Journal de trading nouvelle génération',
+      alt: 'Parrainage Deltalytix',
+    },
     landing: {
       title: 'Programme de Parrainage',
       subtitle: 'Invitez des amis et gagnez des récompenses lorsqu\'ils s\'abonnent à Plus',

--- a/proxy.ts
+++ b/proxy.ts
@@ -96,6 +96,10 @@ function isPublicRoute(pathname: string) {
     return true
   }
 
+  if (normalizedPathname.startsWith("/ref/")) {
+    return true
+  }
+
   return false
 }
 
@@ -415,8 +419,10 @@ export default async function proxy(req: NextRequest) {
     }
   }
 
-  // Geolocation handling with better error handling
-  const skipGeoCookie = isPublicRoute(pathname)
+  // Skip geo cookies on cacheable landing/referral routes only (not all marketing pages).
+  const normalizedPathname = withoutLocale(pathname)
+  const skipGeoCookie =
+    isHomepage(pathname) || normalizedPathname.startsWith("/ref/")
 
   try {
     const geo = geolocation(req)

--- a/proxy.ts
+++ b/proxy.ts
@@ -416,17 +416,21 @@ export default async function proxy(req: NextRequest) {
   }
 
   // Geolocation handling with better error handling
+  const skipGeoCookie = isPublicRoute(pathname)
+
   try {
     const geo = geolocation(req)
 
     if (geo.country) {
       response.headers.set("x-user-country", geo.country)
-      response.cookies.set("user-country", geo.country, {
-        path: "/",
-        maxAge: 60 * 60 * 24, // 24 hours
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-      })
+      if (!skipGeoCookie) {
+        response.cookies.set("user-country", geo.country, {
+          path: "/",
+          maxAge: 60 * 60 * 24, // 24 hours
+          sameSite: "lax",
+          secure: process.env.NODE_ENV === "production",
+        })
+      }
     }
 
     if (geo.city) {
@@ -444,12 +448,14 @@ export default async function proxy(req: NextRequest) {
 
     if (country) {
       response.headers.set("x-user-country", country)
-      response.cookies.set("user-country", country, {
-        path: "/",
-        maxAge: 60 * 60 * 24,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-      })
+      if (!skipGeoCookie) {
+        response.cookies.set("user-country", country, {
+          path: "/",
+          maxAge: 60 * 60 * 24,
+          sameSite: "lax",
+          secure: process.env.NODE_ENV === "production",
+        })
+      }
     }
     if (city) response.headers.set("x-user-city", encodeURIComponent(city))
     if (region) response.headers.set("x-user-region", encodeURIComponent(region))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts the highest-impact latency fix from agent session `bc-019f04ef-1519-7e19-af7a-60f90cc6ec59` (full branch: `cursor/landing-page-performance-ec59`).

The landing page was dynamically server-rendered on every request because `generateMetadata` depended on `searchParams` and `headers()`. This PR makes the homepage **statically generated** so it can be served from the CDN edge.

## Changes

- Add `export const dynamic = "force-static"` to the landing page
- Move referral OG metadata to `/[locale]/ref/[ref]` (redirects to `?ref=` on the static homepage)
- Update referral share links in the dashboard to use the new `/ref/` URL
- Skip `user-country` cookie writes on homepage and `/ref/` routes only (keeps geo pricing on `/pricing`)
- Add colocated `opengraph-image.tsx` for referral routes (same pattern as `/updates/[slug]`) with localized French/English OG copy

## Review feedback addressed

- `/ref/` paths are now classified as public routes (skip Supabase auth round-trip)
- Referral OG metadata uses colocated opengraph route (no hardcoded `/api/og` URL)
- Geo cookie skip narrowed from all marketing routes to homepage + `/ref/` only
- Referral slug validation (`[a-z0-9]{1,32}`) before metadata/redirect
- Referral share URL generator uses canonical origin + `/ref/` route format

## Impact

Build output confirms `/[locale]` is now **SSG** (was dynamic SSR). Referral previews now resolve to `/[locale]/ref/[ref]/opengraph-image-...` with locale-specific copy.

## Test plan

- [x] `OPENAI_API_KEY=dummy bun run build` passes
- [x] Build shows `● /[locale]` as static (SSG)
- [x] Build shows `/[locale]/ref/[ref]/opengraph-image-...`
- [ ] Confirm `/fr/ref/<slug>` OG image shows French copy
- [ ] Confirm `/en/ref/<slug>` OG image shows English copy
- [ ] Confirm referral copy button generates `/en/ref/<slug>` URLs
- [ ] Confirm `/pricing` still sets `user-country` cookie for EUR/USD detection
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f051c-7693-7e36-8ba1-d0ec9113c8a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f051c-7693-7e36-8ba1-d0ec9113c8a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

