### PR TITLE
fix: auto-run changelog workflow on beta → main PRs

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,0 +1,11 @@
+---
+description: Git branch and pull request workflow for this repository
+alwaysApply: true
+---
+
+# Git workflow
+
+- **Default integration branch:** `beta` (not `main`)
+- **Feature branches:** branch from `beta`; rebase onto `origin/beta` before opening a PR
+- **Pull requests:** always target **`beta`** as the base branch unless the user explicitly asks for a different base (e.g. a `beta → main` release PR)
+- **Do not** assume `main` is the PR base — `main` is production; day-to-day work merges into `beta` first

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,20 +1,19 @@
 name: Generate Changelog
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to generate changelog for (any branch → any branch)'
-        required: true
-        type: string
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
 
 concurrency:
-  group: generate-changelog-${{ inputs.pr_number }}
+  group: generate-changelog-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   generate-changelog:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.ref == 'beta' && github.event.pull_request.base.ref == 'main'
     permissions:
       contents: write
       pull-requests: write
@@ -27,12 +26,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          PR_NUMBER="${{ inputs.pr_number }}"
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::error::pr_number must be a numeric PR number, got: $PR_NUMBER"
-            exit 1
-          fi
-
+          PR_NUMBER="${{ github.event.pull_request.number }}"
           PR_JSON=$(gh pr view "$PR_NUMBER" --json number,baseRefName,headRefName,baseRefOid,headRefOid,url)
 
           BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
@@ -40,6 +34,11 @@ jobs:
           BASE_SHA=$(echo "$PR_JSON" | jq -r '.baseRefOid')
           HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
           PR_URL=$(echo "$PR_JSON" | jq -r '.url')
+
+          if [ "$BASE_REF" != "main" ] || [ "$HEAD_REF" != "beta" ]; then
+            echo "::error::PR #$PR_NUMBER is not a beta → main promotion (got $HEAD_REF → $BASE_REF)"
+            exit 1
+          fi
 
           {
             echo "number=$PR_NUMBER"
@@ -105,7 +104,7 @@ jobs:
           LAST_COMMIT_DATE=$(git log --format=%ai -1 "$HEAD_SHA" | cut -d' ' -f1)
 
           agent -p --force --trust \
-            "Analyze the changes in pull request #${PR_NUMBER} (${HEAD_REF} → ${BASE_REF}).
+            "Analyze the changes in this pull request from beta to main.
             
             Create changelog entries following the Deltalytix format:
             

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,27 +1,20 @@
 name: Generate Changelog
 
 on:
-  pull_request:
-    types: [opened, reopened]
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'Beta → main PR number to generate changelog for'
+        description: 'PR number to generate changelog for (any branch → any branch)'
         required: true
         type: string
 
 concurrency:
-  group: generate-changelog-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: generate-changelog-${{ inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
   generate-changelog:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.head.ref == 'beta' && github.event.pull_request.base.ref == 'main')
     permissions:
       contents: write
       pull-requests: write
@@ -34,28 +27,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ inputs.pr_number }}"
-            if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-              echo "::error::pr_number must be a numeric PR number, got: $PR_NUMBER"
-              exit 1
-            fi
-            PR_JSON=$(gh pr view "$PR_NUMBER" --json number,baseRefName,headRefName,baseRefOid,headRefOid,url)
-          else
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            PR_JSON=$(gh pr view "$PR_NUMBER" --json number,baseRefName,headRefName,baseRefOid,headRefOid,url)
+          PR_NUMBER="${{ inputs.pr_number }}"
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be a numeric PR number, got: $PR_NUMBER"
+            exit 1
           fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json number,baseRefName,headRefName,baseRefOid,headRefOid,url)
 
           BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
           HEAD_REF=$(echo "$PR_JSON" | jq -r '.headRefName')
           BASE_SHA=$(echo "$PR_JSON" | jq -r '.baseRefOid')
           HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
           PR_URL=$(echo "$PR_JSON" | jq -r '.url')
-
-          if [ "$BASE_REF" != "main" ] || [ "$HEAD_REF" != "beta" ]; then
-            echo "::error::PR #$PR_NUMBER is not a beta → main promotion (got $HEAD_REF → $BASE_REF)"
-            exit 1
-          fi
 
           {
             echo "number=$PR_NUMBER"
@@ -121,7 +105,7 @@ jobs:
           LAST_COMMIT_DATE=$(git log --format=%ai -1 "$HEAD_SHA" | cut -d' ' -f1)
 
           agent -p --force --trust \
-            "Analyze the changes in this pull request from beta to main. 
+            "Analyze the changes in pull request #${PR_NUMBER} (${HEAD_REF} → ${BASE_REF}).
             
             Create changelog entries following the Deltalytix format:
             

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .cursorrules
 .cursor/*
 !.cursor/environment.json
+!.cursor/rules/
+!.cursor/rules/**
 WARP.md
 .github/instructions/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ curl -s -o /dev/null -D - "http://localhost:3000/authentication?next=dashboard" 
 
 ## Before opening a PR
 
+Open PRs against **`beta`** (not `main`). `main` is production; feature work lands on `beta` first.
+
 1. `git fetch origin beta && git rebase origin/beta`
 2. `bun install`
 3. `bunx prisma db push` (with local `.env.local` loaded)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores automatic changelog generation for **beta → main** promotion PRs and removes manual dispatch.

## Changes

- **Auto-trigger**: Runs on `pull_request` `opened` / `reopened` targeting `main`
- **Scoped**: Job only runs when `head = beta` and `base = main`; other PRs are skipped
- **No dispatch**: Removed `workflow_dispatch` — no manual trigger
- **Docs**: `.cursor/rules/git-workflow.mdc` + `AGENTS.md` clarify PRs target `beta` (not `main`)

## Behavior

When a beta → main PR is opened or reopened:

1. Workflow checks out the PR head (`beta`)
2. Cursor CLI generates changelog MDX files (EN + FR)
3. Pushes `changelog/pr-<N>` and opens a follow-up PR targeting `beta`

Skips if a changelog branch or open changelog PR already exists.

## Model

Uses **`--model auto`** on the Cursor CLI `agent` command.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0856-f960-742c-aae9-581c25690d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0856-f960-742c-aae9-581c25690d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

