### PR TITLE
Refactor support assistant to ToolLoopAgent with codebase search

### DIFF
--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -293,11 +293,16 @@ const ChatBotDemo = () => {
                               </Fragment>
                             );
                           }
-                          case 'reasoning':
+                          case 'reasoning': {
+                            if (!part.text?.trim()) {
+                              return null;
+                            }
+
                             return (
                               <Reasoning
                                 key={`${message.id}-${i}`}
                                 className="w-full"
+                                disableAutoClose
                                 isStreaming={
                                   status === 'streaming' &&
                                   i === message.parts.length - 1 &&
@@ -308,6 +313,7 @@ const ChatBotDemo = () => {
                                 <ReasoningContent>{part.text}</ReasoningContent>
                               </Reasoning>
                             );
+                          }
                           case 'tool-searchCodebase': {
                             switch (part.state) {
                               case 'input-available':

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -9,13 +9,7 @@ import {
   PromptInputAttachment,
   PromptInputAttachments,
   PromptInputBody,
-  PromptInputButton,
   type PromptInputMessage,
-  PromptInputModelSelect,
-  PromptInputModelSelectContent,
-  PromptInputModelSelectItem,
-  PromptInputModelSelectTrigger,
-  PromptInputModelSelectValue,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputToolbar,
@@ -28,7 +22,7 @@ import {
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { Response } from '@/components/ai-elements/response';
-import { GlobeIcon, HeadsetIcon, RefreshCcwIcon } from 'lucide-react';
+import { HeadsetIcon, RefreshCcwIcon } from 'lucide-react';
 import { useI18n } from '@/locales/landing-client';
 import {
   Source,
@@ -93,17 +87,6 @@ type askForEmailFormToolUIPart = ToolUIPart<{
   };
 }>;
 
-const models = [
-  {
-    name: 'GPT 4o',
-    value: 'openai/gpt-4o',
-  },
-  {
-    name: 'Deepseek R1',
-    value: 'deepseek/deepseek-r1',
-  },
-];
-
 const getErrorMessage = (error: any, t: any) => {
   if (
     error?.message?.includes('Free credits temporarily have rate limits') ||
@@ -138,8 +121,6 @@ const preprocessContent = (content: string) => {
 const ChatBotDemo = () => {
   const t = useI18n();
   const [input, setInput] = useState('');
-  const [model, setModel] = useState<string>(models[0].value);
-  const [webSearch, setWebSearch] = useState(false);
   const { messages, sendMessage, status, setMessages } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/ai/support',
@@ -197,31 +178,15 @@ const ChatBotDemo = () => {
       return;
     }
 
-    sendMessage(
-      {
-        text: message.text || 'Sent with attachments',
-        files: message.files,
-      },
-      {
-        body: {
-          model,
-          webSearch,
-        },
-      },
-    );
+    sendMessage({
+      text: message.text || 'Sent with attachments',
+      files: message.files,
+    });
     setInput('');
   };
 
   const sendWithOptions = (text: string) => {
-    sendMessage(
-      { text },
-      {
-        body: {
-          model,
-          webSearch,
-        },
-      },
-    );
+    sendMessage({ text });
   };
 
   const isBusy = status === 'submitted' || status === 'streaming';
@@ -343,6 +308,21 @@ const ChatBotDemo = () => {
                                 <ReasoningContent>{part.text}</ReasoningContent>
                               </Reasoning>
                             );
+                          case 'tool-searchCodebase': {
+                            switch (part.state) {
+                              case 'input-available':
+                              case 'input-streaming':
+                                return (
+                                  <Marker key={`${message.id}-${i}`}>
+                                    <MarkerContent className="shimmer">
+                                      {t('support.tool.searchingDocs')}
+                                    </MarkerContent>
+                                  </Marker>
+                                );
+                              default:
+                                return null;
+                            }
+                          }
                           case 'tool-askForEmailForm': {
                             switch (part.state) {
                               case 'input-available':
@@ -469,25 +449,6 @@ const ChatBotDemo = () => {
                   <PromptInputActionAddAttachments />
                 </PromptInputActionMenuContent>
               </PromptInputActionMenu>
-              <PromptInputButton
-                variant={webSearch ? 'default' : 'ghost'}
-                onClick={() => setWebSearch(!webSearch)}
-              >
-                <GlobeIcon size={16} />
-                <span>{t('support.search')}</span>
-              </PromptInputButton>
-              <PromptInputModelSelect onValueChange={setModel} value={model}>
-                <PromptInputModelSelectTrigger>
-                  <PromptInputModelSelectValue />
-                </PromptInputModelSelectTrigger>
-                <PromptInputModelSelectContent>
-                  {models.map((item) => (
-                    <PromptInputModelSelectItem key={item.value} value={item.value}>
-                      {item.name}
-                    </PromptInputModelSelectItem>
-                  ))}
-                </PromptInputModelSelectContent>
-              </PromptInputModelSelect>
             </PromptInputTools>
             <PromptInputSubmit disabled={!input && !status} status={status} />
           </PromptInputToolbar>

--- a/app/api/ai/support/route.ts
+++ b/app/api/ai/support/route.ts
@@ -14,6 +14,7 @@ export async function POST(req: Request) {
     return createAgentUIStreamResponse({
       agent: supportAgent,
       uiMessages: messages,
+      sendReasoning: true,
       onStepFinish: (step) => {
         console.log(
           "[Support Agent] Step finished:",

--- a/app/api/ai/support/route.ts
+++ b/app/api/ai/support/route.ts
@@ -1,124 +1,49 @@
-import { convertToModelMessages, streamText, UIMessage } from "ai";
-import { askForEmailForm } from "./tools/ask-for-email-form";
+import { createAgentUIStreamResponse, type UIMessage } from "ai";
+import { supportAgent } from "@/lib/ai/support-agent";
 
-// Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
   try {
-    const {
-      messages,
-      model,
-      webSearch,
-    }: {
-      messages: UIMessage[];
-      model: string;
-      webSearch: boolean;
-    } = await req.json();
+    const { messages }: { messages: UIMessage[] } = await req.json();
 
-    // Remove first message if it's assistant message
-    if (messages[0].role === "assistant") {
+    if (messages[0]?.role === "assistant") {
       messages.shift();
     }
 
-    const modelMessages = await convertToModelMessages(messages);
-    const result = streamText({
-      model: webSearch ? "perplexity/sonar" : model,
-      system: `You are an AI chatbot support assistant for Deltalytix, a trading journaling platform. Your role is to gather information and direct users to the appropriate support channels.
-
-## CRITICAL LIMITATIONS
-- **NO DOCUMENTATION ACCESS**: You do not have access to Deltalytix documentation, user guides, or specific feature information
-- **NO HALLUCINATION**: Never provide specific details about Deltalytix features, interface elements, or usage instructions that you cannot verify
-- **IMMEDIATE ESCALATION**: For any questions about how to use Deltalytix, interface navigation, or feature explanations, immediately redirect to email support
-
-## RESPONSE STRATEGY
-1. **Context Gathering First**: Ask 1-2 clarifying questions to understand the user's specific issue before escalating
-2. **Basic Troubleshooting Only**: Help with general technical issues (browser problems, login issues, etc.)
-3. **Smart Escalation**: After gathering context, use askForEmailForm with a clear summary
-4. **Honest Limitations**: Clearly state when you don't have access to specific information
-5. **No Guessing**: Never provide information you're not certain about
-
-## WHAT YOU CAN HELP WITH
-- General technical troubleshooting (browser issues, connectivity problems)
-- Basic account access problems (login, password reset)
-- General questions about support process
-- Confirming that you'll escalate their issue to the right team
-
-## WHAT REQUIRES CONTEXT GATHERING + ESCALATION
-- How to use specific Deltalytix features
-- Interface navigation questions
-- Feature explanations or tutorials
-- Account-specific data or settings questions
-- Billing or subscription questions
-- Any question about Deltalytix functionality
-
-**Process**: Ask 1-2 clarifying questions to understand the specific issue, then escalate with context.
-
-## COMMUNICATION STYLE
-- Always identify yourself as an AI chatbot at the start of conversations
-- Be honest about your limitations and role as an information-gathering assistant
-- Acknowledge their question and ask clarifying questions to understand the context
-- Explain that you're gathering information to connect them with the right support person
-- Use askForEmailForm after understanding their specific issue
-- Be helpful but never guess or provide unverified information
-
-## TOOL USAGE
-- **askForEmailForm**: Use after gathering context for Deltalytix-specific questions. Always provide a clear summary of the user's issue and the context you've gathered.
-
-## CONTEXT GATHERING QUESTIONS
-Ask 1-2 targeted questions to understand:
-- What specific feature or functionality they're asking about
-- What they're trying to accomplish
-- Any error messages or unexpected behavior they're experiencing
-- Their current situation or what led to the question
-
-## ESCALATION CRITERIA
-Use askForEmailForm after gathering context when:
-- User asks "How do I..." questions about Deltalytix
-- User asks about specific features or interface elements
-- User needs guidance on using the platform
-- User asks about account-specific information
-- Any question you cannot answer with certainty
-
-## EXAMPLE FLOW
-1. User: "How do I add a trade?"
-2. You: "Hi! I'm an AI chatbot here to help gather information for our support team. I'd be happy to help you with adding trades. To make sure I connect you with the right support person, could you tell me:
-   - Are you seeing any specific error messages when trying to add a trade?
-   - What part of the process are you having trouble with?"
-3. User: [provides context]
-4. You: Use askForEmailForm with the gathered context
-
-## OPENING MESSAGE TEMPLATE
-When starting a conversation, always begin with:
-"Hi! I'm an AI chatbot here to help gather information for our support team. I don't have access to Deltalytix documentation, but I can help you with basic troubleshooting and connect you with the right support person. How can I help you today?"
-
-Remember: Always be transparent about being an AI chatbot and your role in gathering information for the support team.`,
-      messages: modelMessages,
-      tools: {
-        askForEmailForm,
-      },
-      temperature: 0.3,
+    return createAgentUIStreamResponse({
+      agent: supportAgent,
+      uiMessages: messages,
       onStepFinish: (step) => {
-        console.log("Step finished:", JSON.stringify(step, null, 2));
+        console.log(
+          "[Support Agent] Step finished:",
+          JSON.stringify(
+            {
+              finishReason: step.finishReason,
+              toolCalls: step.toolCalls?.map((toolCall) => toolCall.toolName),
+            },
+            null,
+            2,
+          ),
+        );
       },
     });
-
-    return result.toUIMessageStreamResponse({
-      sendSources: true,
-      sendReasoning: true,
-    });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Support API Error:", error);
 
-    // Handle rate limit errors specifically
-    if (error?.statusCode === 429 || error?.type === "rate_limit_exceeded") {
+    const apiError = error as {
+      statusCode?: number;
+      type?: string;
+    };
+
+    if (apiError?.statusCode === 429 || apiError?.type === "rate_limit_exceeded") {
       return new Response(
         JSON.stringify({
           error: "Rate limit exceeded",
           message:
             "We are experiencing high demand. Please try again in a few minutes or contact support directly.",
           type: "rate_limit_exceeded",
-          retryAfter: 300, // 5 minutes
+          retryAfter: 300,
         }),
         {
           status: 429,
@@ -130,8 +55,11 @@ Remember: Always be transparent about being an AI chatbot and your role in gathe
       );
     }
 
-    // Handle other AI/API errors
-    if (error?.statusCode >= 400 && error?.statusCode < 500) {
+    if (
+      apiError?.statusCode &&
+      apiError.statusCode >= 400 &&
+      apiError.statusCode < 500
+    ) {
       return new Response(
         JSON.stringify({
           error: "Service temporarily unavailable",
@@ -148,7 +76,6 @@ Remember: Always be transparent about being an AI chatbot and your role in gathe
       );
     }
 
-    // Handle server errors
     return new Response(
       JSON.stringify({
         error: "Internal server error",

--- a/app/api/ai/support/tools/search-codebase.ts
+++ b/app/api/ai/support/tools/search-codebase.ts
@@ -1,0 +1,39 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { searchCodebase } from "@/lib/ai/search-codebase";
+
+export const searchCodebaseTool = tool({
+  description:
+    "Search Deltalytix product documentation, release notes, locale strings, and self-hosting guides in the repository. Use this before answering questions about features, imports, billing, dashboard behavior, or setup.",
+  inputSchema: z.object({
+    query: z
+      .string()
+      .describe(
+        "Keywords or a short phrase describing what to look up, e.g. 'import CSV trades' or 'Tradovate sync'",
+      ),
+    locale: z
+      .enum(["en", "fr"])
+      .optional()
+      .describe("Prefer documentation in this language when available"),
+  }),
+  execute: async ({ query, locale }) => {
+    const result = await searchCodebase(query, { locale });
+
+    if (result.matchCount === 0) {
+      return {
+        found: false,
+        query: result.query,
+        message:
+          "No matching documentation was found. Ask a clarifying question or escalate to email support.",
+        matches: [],
+      };
+    }
+
+    return {
+      found: true,
+      query: result.query,
+      matchCount: result.matchCount,
+      matches: result.matches,
+    };
+  },
+});

--- a/components/ai-elements/reasoning.tsx
+++ b/components/ai-elements/reasoning.tsx
@@ -33,6 +33,7 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
   isStreaming?: boolean;
   open?: boolean;
   defaultOpen?: boolean;
+  disableAutoClose?: boolean;
   onOpenChange?: (open: boolean) => void;
   duration?: number;
 };
@@ -46,6 +47,7 @@ export const Reasoning = memo(
     isStreaming = false,
     open,
     defaultOpen = true,
+    disableAutoClose = false,
     onOpenChange,
     duration: durationProp,
     children,
@@ -78,7 +80,13 @@ export const Reasoning = memo(
 
     // Auto-open when streaming starts, auto-close when streaming ends (once only)
     useEffect(() => {
-      if (defaultOpen && !isStreaming && isOpen && !hasAutoClosed) {
+      if (
+        !disableAutoClose &&
+        defaultOpen &&
+        !isStreaming &&
+        isOpen &&
+        !hasAutoClosed
+      ) {
         // Add a small delay before closing to allow user to see the content
         const timer = setTimeout(() => {
           setIsOpen(false);
@@ -87,7 +95,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer);
       }
-    }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed]);
+    }, [isStreaming, isOpen, defaultOpen, disableAutoClose, setIsOpen, hasAutoClosed]);
 
     const handleOpenChange = (newOpen: boolean) => {
       setIsOpen(newOpen);

--- a/lib/ai/search-codebase.ts
+++ b/lib/ai/search-codebase.ts
@@ -1,0 +1,242 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+const REPO_ROOT = process.cwd();
+
+const SEARCH_ROOTS = ["content", "locales"] as const;
+
+const ROOT_MARKDOWN_FILES = ["README.md", "SELF_HOSTING.md", "AGENTS.md"] as const;
+
+const MAX_RESULTS = 12;
+const MAX_SNIPPET_CHARS = 600;
+
+export type CodebaseSearchMatch = {
+  file: string;
+  line: number;
+  snippet: string;
+};
+
+export type CodebaseSearchResult = {
+  query: string;
+  matchCount: number;
+  matches: CodebaseSearchMatch[];
+};
+
+function normalizeSnippet(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, MAX_SNIPPET_CHARS);
+}
+
+function localeContentPath(locale?: string): string | undefined {
+  if (locale === "en" || locale === "fr") {
+    return path.join("content", "updates", locale);
+  }
+
+  return undefined;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function searchWithRipgrep(
+  query: string,
+  searchPaths: string[],
+): Promise<CodebaseSearchMatch[] | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "rg",
+      [
+        "-i",
+        "--json",
+        "-m",
+        String(MAX_RESULTS),
+        "--context",
+        "1",
+        "--glob",
+        "*.md",
+        "--glob",
+        "*.mdx",
+        "--glob",
+        "*.ts",
+        query,
+        ...searchPaths,
+      ],
+      {
+        cwd: REPO_ROOT,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+
+    const matches: CodebaseSearchMatch[] = [];
+    const seen = new Set<string>();
+
+    for (const line of stdout.split("\n")) {
+      if (!line.trim()) continue;
+
+      let event: { type?: string; data?: Record<string, unknown> };
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (event.type !== "match" || !event.data) continue;
+
+      const pathData = event.data.path as string | { text?: string } | undefined;
+      const filePath =
+        typeof pathData === "string" ? pathData : String(pathData?.text ?? "");
+      const lineNumber = Number(event.data.line_number ?? 0);
+      const lines = (event.data.lines as { text?: string } | undefined)?.text;
+
+      if (!filePath || !lineNumber || !lines) continue;
+
+      const key = `${filePath}:${lineNumber}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      matches.push({
+        file: filePath,
+        line: lineNumber,
+        snippet: normalizeSnippet(lines),
+      });
+
+      if (matches.length >= MAX_RESULTS) break;
+    }
+
+    return matches;
+  } catch {
+    return null;
+  }
+}
+
+async function searchWithNodeFs(
+  query: string,
+  searchPaths: string[],
+): Promise<CodebaseSearchMatch[]> {
+  const pattern = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+  const matches: CodebaseSearchMatch[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    if (matches.length >= MAX_RESULTS) return;
+
+    const absoluteDir = path.join(REPO_ROOT, dir);
+    if (!(await fileExists(absoluteDir))) return;
+
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(absoluteDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (matches.length >= MAX_RESULTS) break;
+
+      const relativePath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === ".git") continue;
+        await walk(relativePath);
+        continue;
+      }
+
+      if (!/\.(md|mdx|ts)$/i.test(entry.name)) continue;
+
+      const absolutePath = path.join(REPO_ROOT, relativePath);
+      const content = await readFile(absolutePath, "utf8");
+      const lines = content.split("\n");
+
+      for (let index = 0; index < lines.length; index += 1) {
+        if (!pattern.test(lines[index])) continue;
+
+        matches.push({
+          file: relativePath,
+          line: index + 1,
+          snippet: normalizeSnippet(lines[index]),
+        });
+
+        if (matches.length >= MAX_RESULTS) break;
+      }
+    }
+  }
+
+  for (const searchPath of searchPaths) {
+    const absolutePath = path.join(REPO_ROOT, searchPath);
+    const stats = await import("node:fs/promises").then((fs) => fs.stat(absolutePath));
+
+    if (stats.isFile()) {
+      const content = await readFile(absolutePath, "utf8");
+      const lines = content.split("\n");
+
+      for (let index = 0; index < lines.length; index += 1) {
+        if (!pattern.test(lines[index])) continue;
+
+        matches.push({
+          file: searchPath,
+          line: index + 1,
+          snippet: normalizeSnippet(lines[index]),
+        });
+
+        if (matches.length >= MAX_RESULTS) break;
+      }
+      continue;
+    }
+
+    await walk(searchPath);
+  }
+
+  return matches;
+}
+
+export async function searchCodebase(
+  query: string,
+  options?: { locale?: "en" | "fr" },
+): Promise<CodebaseSearchResult> {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) {
+    return { query: trimmedQuery, matchCount: 0, matches: [] };
+  }
+
+  const localePath = localeContentPath(options?.locale);
+  const fallbackPaths = [...SEARCH_ROOTS, ...ROOT_MARKDOWN_FILES].filter(
+    (value, index, array) => array.indexOf(value) === index,
+  );
+
+  const existingLocalePaths: string[] = [];
+  if (localePath && (await fileExists(path.join(REPO_ROOT, localePath)))) {
+    existingLocalePaths.push(localePath);
+  }
+
+  const existingFallbackPaths: string[] = [];
+  for (const searchPath of fallbackPaths) {
+    if (await fileExists(path.join(REPO_ROOT, searchPath))) {
+      existingFallbackPaths.push(searchPath);
+    }
+  }
+
+  let matches: CodebaseSearchMatch[] = [];
+
+  if (existingLocalePaths.length > 0) {
+    const localeMatches = await searchWithRipgrep(trimmedQuery, existingLocalePaths);
+    matches =
+      localeMatches ?? (await searchWithNodeFs(trimmedQuery, existingLocalePaths));
+  }
+
+  if (matches.length === 0 && existingFallbackPaths.length > 0) {
+    const fallbackMatches = await searchWithRipgrep(trimmedQuery, existingFallbackPaths);
+    matches =
+      fallbackMatches ??
+      (await searchWithNodeFs(trimmedQuery, existingFallbackPaths));
+  }
+
+  return {
+    query: trimmedQuery,
+    matchCount: matches.length,
+    matches,
+  };
+}

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -34,8 +34,13 @@ Remember: search before you guess. Escalate when human support is the right path
 export const supportAgent = new ToolLoopAgent({
   model: SUPPORT_AGENT_MODEL,
   instructions: SUPPORT_AGENT_INSTRUCTIONS,
-  temperature: 0.3,
   stopWhen: stepCountIs(8),
+  providerOptions: {
+    openai: {
+      reasoningEffort: "low",
+      reasoningSummary: "auto",
+    },
+  },
   tools: {
     searchCodebase: searchCodebaseTool,
     askForEmailForm,

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -1,0 +1,45 @@
+import { ToolLoopAgent, stepCountIs } from "ai";
+import { askForEmailForm } from "@/app/api/ai/support/tools/ask-for-email-form";
+import { searchCodebaseTool } from "@/app/api/ai/support/tools/search-codebase";
+
+const SUPPORT_AGENT_MODEL = "openai/gpt-5-nano";
+
+const SUPPORT_AGENT_INSTRUCTIONS = `You are the Deltalytix support assistant — a trading journaling platform. Your role is to help users with product questions, troubleshooting, and routing complex issues to human support.
+
+## TOOL USAGE
+- **searchCodebase**: Use this FIRST when users ask about Deltalytix features, imports, dashboard behavior, integrations, self-hosting, or how-to questions. Search with focused keywords, then answer only from what you find.
+- **askForEmailForm**: Use when the issue needs human follow-up (billing, account-specific data, bugs you cannot resolve, or when documentation search returns nothing useful). Provide a clear summary in the user's language.
+
+## RESPONSE STRATEGY
+1. For product/how-to questions: search the codebase docs, then give a concise, accurate answer grounded in the search results.
+2. For general technical issues (browser, login): help with basic troubleshooting when possible.
+3. When uncertain or search finds nothing relevant: say so honestly, ask one clarifying question, or escalate with askForEmailForm.
+4. Never invent feature details, UI labels, or steps that are not supported by search results or well-known general troubleshooting.
+
+## COMMUNICATION STYLE
+- Identify yourself as an AI assistant at the start of new conversations.
+- Be concise, friendly, and actionable.
+- Use Markdown for steps and lists when helpful.
+- Match the user's language (English or French).
+
+## ESCALATION
+Use askForEmailForm when:
+- Billing or subscription questions
+- Account-specific data or settings
+- Persistent bugs after troubleshooting
+- Questions you cannot answer after searching documentation
+
+Remember: search before you guess. Escalate when human support is the right path.`;
+
+export const supportAgent = new ToolLoopAgent({
+  model: SUPPORT_AGENT_MODEL,
+  instructions: SUPPORT_AGENT_INSTRUCTIONS,
+  temperature: 0.3,
+  stopWhen: stepCountIs(8),
+  tools: {
+    searchCodebase: searchCodebaseTool,
+    askForEmailForm,
+  },
+});
+
+export { SUPPORT_AGENT_MODEL };

--- a/locales/en/support.ts
+++ b/locales/en/support.ts
@@ -44,6 +44,7 @@ export default {
     suggestionBug: "Report a bug or issue",
     suggestionHuman: "Talk to a human",
     tool: {
+      searchingDocs: "Searching product documentation...",
       preparingRequest: "Preparing your support request for our team...",
       requestError: "There was an error while preparing your support request.",
       requestErrorDetails: "Error details: {error}",

--- a/locales/fr/support.ts
+++ b/locales/fr/support.ts
@@ -47,6 +47,8 @@ export default {
     suggestionBug: "Signaler un bug ou un problème",
     suggestionHuman: "Parler à un humain",
     tool: {
+      searchingDocs:
+        "Recherche dans la documentation produit...",
       preparingRequest:
         "Préparation de votre demande de support pour notre équipe...",
       requestError:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the landing support assistant to use the AI SDK `ToolLoopAgent` pattern with a cheaper default model and an internal documentation search tool.

## Changes

- **Model**: Fixed to `openai/gpt-5-nano` (removed GPT-4o / DeepSeek model picker)
- **Removed web search toggle**: No more Perplexity/Sonar routing from the UI
- **Agent architecture**: `ToolLoopAgent` + `createAgentUIStreamResponse` in `/api/ai/support`
- **New `searchCodebase` tool**: Searches `content/`, `locales/`, and root guides (`README.md`, `SELF_HOSTING.md`, `AGENTS.md`) via ripgrep with a Node.js fallback
- **UI**: Shows a "Searching product documentation…" indicator while the tool runs
- **Reasoning visibility**: Enables `sendReasoning`, OpenAI `reasoningSummary`, keeps reasoning panels open, and hides empty reasoning blocks

## Motivation

The previous assistant explicitly could not access product documentation and relied on user escalation. The new agent can search in-repo docs before answering, while keeping `askForEmailForm` for human follow-up.

## Testing

- `bun run typecheck` passes
- Manual verification of `searchCodebase()` against product docs (e.g. Tradovate sync queries return `content/updates/en/*` matches)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0a53-a520-7c6e-9e92-5c3089c8f7a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0a53-a520-7c6e-9e92-5c3089c8f7a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

