### PR TITLE
fix(landing): expand sign-in navbar hitbox to full row

### DIFF
--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -564,7 +564,7 @@ export default function Component() {
                             })}
 
                             <motion.li
-                                className="mt-auto border-t"
+                                className="mt-auto border-t pt-8"
                                 variants={itemVariant}
                             >
                                 <motion.div
@@ -572,7 +572,7 @@ export default function Component() {
                                     transition={{ duration: 0.2 }}
                                 >
                                     <Link
-                                        className="block w-full py-8 text-xl text-primary rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        className="block w-full min-h-11 text-xl text-primary rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                         href="/authentication"
                                         onClick={closeMenu}
                                     >

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -370,8 +370,12 @@ export default function Component() {
                             </NavigationMenuItem>
                         </NavigationMenuList>
                         <Separator orientation="vertical" className="h-6 mx-4" />
-                        <Button variant="ghost" className="text-sm font-medium hover:text-accent-foreground" asChild>
-                            <Link href={"/authentication"}>{t('landing.navbar.signIn')}</Link>
+                        <Button
+                            variant="ghost"
+                            className="h-14 rounded-none px-4 text-sm font-medium hover:text-accent-foreground"
+                            asChild
+                        >
+                            <Link href="/authentication">{t('landing.navbar.signIn')}</Link>
                         </Button>
                     </NavigationMenu>
                 </div>
@@ -560,16 +564,21 @@ export default function Component() {
                             })}
 
                             <motion.li
-                                className="mt-auto border-t pt-8"
+                                className="mt-auto border-t"
                                 variants={itemVariant}
                             >
-                                <Link
-                                    className="text-xl text-primary"
-                                    href="/authentication"
-                                    onClick={closeMenu}
+                                <motion.div
+                                    whileHover={{ x: 4 }}
+                                    transition={{ duration: 0.2 }}
                                 >
-                                    {t('landing.navbar.signIn')}
-                                </Link>
+                                    <Link
+                                        className="block w-full py-8 text-xl text-primary rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        href="/authentication"
+                                        onClick={closeMenu}
+                                    >
+                                        {t('landing.navbar.signIn')}
+                                    </Link>
+                                </motion.div>
                             </motion.li>
 
                             <motion.li variants={itemVariant}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands the sign-in control hit area in the landing navbar so users can click/tap anywhere on the row, not just the text label.

## Changes

- **Desktop:** Sign-in button uses `h-14` to match the navbar height, giving a full-height clickable target with existing `Button` focus styles.
- **Mobile:** Sign-in link uses `block w-full min-h-11` for a full-width tap target that meets the 44px minimum touch size without the oversized `py-8` padding that created excess whitespace. Restored `pt-8` on the list item to match the original section spacing above the divider.

## Accessibility

- Meets WCAG 2.5.5 target size guidance via `min-h-11` (44px) without padding bloat
- Preserves semantic `<Link>` elements with visible text labels
- Keyboard focus indicators on the mobile sign-in link

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0a58-3151-7602-a37e-749ead66673a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0a58-3151-7602-a37e-749ead66673a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

