### PR TITLE
fix(landing): cover full viewport when mobile navbar is open on iOS Safari

### DIFF
--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -134,48 +134,23 @@ export default function Component() {
         }
     }, [isOpen])
 
-    // Lock/unlock body scroll when mobile menu is open (position:fixed works reliably on iOS Safari)
+    // Lock body scroll when mobile menu is open without changing scroll position
     useEffect(() => {
-        if (typeof window === 'undefined') return
+        if (typeof window === 'undefined' || !isOpen) return
 
         const { body, documentElement } = document
+        const previousBodyOverflow = body.style.overflow
+        const previousHtmlOverflow = documentElement.style.overflow
+        const previousBodyTouchAction = body.style.touchAction
 
-        if (isOpen) {
-            const scrollY = window.scrollY
-            body.dataset.mobileNavbarScrollY = String(scrollY)
-            body.style.position = 'fixed'
-            body.style.top = `-${scrollY}px`
-            body.style.left = '0'
-            body.style.right = '0'
-            body.style.width = '100%'
-            body.style.overflow = 'hidden'
-            documentElement.style.overflow = 'hidden'
-        } else {
-            const scrollY = Number(body.dataset.mobileNavbarScrollY ?? '0')
-            body.style.position = ''
-            body.style.top = ''
-            body.style.left = ''
-            body.style.right = ''
-            body.style.width = ''
-            body.style.overflow = ''
-            documentElement.style.overflow = ''
-            delete body.dataset.mobileNavbarScrollY
-            window.scrollTo(0, scrollY)
-        }
+        body.style.overflow = 'hidden'
+        documentElement.style.overflow = 'hidden'
+        body.style.touchAction = 'none'
 
         return () => {
-            const scrollY = Number(body.dataset.mobileNavbarScrollY ?? '0')
-            body.style.position = ''
-            body.style.top = ''
-            body.style.left = ''
-            body.style.right = ''
-            body.style.width = ''
-            body.style.overflow = ''
-            documentElement.style.overflow = ''
-            delete body.dataset.mobileNavbarScrollY
-            if (scrollY > 0) {
-                window.scrollTo(0, scrollY)
-            }
+            body.style.overflow = previousBodyOverflow
+            documentElement.style.overflow = previousHtmlOverflow
+            body.style.touchAction = previousBodyTouchAction
         }
     }, [isOpen])
 

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -134,16 +134,47 @@ export default function Component() {
         }
     }, [isOpen])
 
-    // Lock/unlock body scroll when mobile menu is open
+    // Lock/unlock body scroll when mobile menu is open (position:fixed works reliably on iOS Safari)
     useEffect(() => {
-        if (typeof window !== 'undefined') {
-            document.body.style.overflow = isOpen ? 'hidden' : ''
+        if (typeof window === 'undefined') return
+
+        const { body, documentElement } = document
+
+        if (isOpen) {
+            const scrollY = window.scrollY
+            body.dataset.mobileNavbarScrollY = String(scrollY)
+            body.style.position = 'fixed'
+            body.style.top = `-${scrollY}px`
+            body.style.left = '0'
+            body.style.right = '0'
+            body.style.width = '100%'
+            body.style.overflow = 'hidden'
+            documentElement.style.overflow = 'hidden'
+        } else {
+            const scrollY = Number(body.dataset.mobileNavbarScrollY ?? '0')
+            body.style.position = ''
+            body.style.top = ''
+            body.style.left = ''
+            body.style.right = ''
+            body.style.width = ''
+            body.style.overflow = ''
+            documentElement.style.overflow = ''
+            delete body.dataset.mobileNavbarScrollY
+            window.scrollTo(0, scrollY)
         }
-        
-        // Cleanup on unmount
+
         return () => {
-            if (typeof window !== 'undefined') {
-                document.body.style.overflow = ''
+            const scrollY = Number(body.dataset.mobileNavbarScrollY ?? '0')
+            body.style.position = ''
+            body.style.top = ''
+            body.style.left = ''
+            body.style.right = ''
+            body.style.width = ''
+            body.style.overflow = ''
+            documentElement.style.overflow = ''
+            delete body.dataset.mobileNavbarScrollY
+            if (scrollY > 0) {
+                window.scrollTo(0, scrollY)
             }
         }
     }, [isOpen])
@@ -432,7 +463,7 @@ export default function Component() {
 
             {isOpen && (
                 <motion.div
-                    className="fixed bg-background -top-[2px] right-0 left-0 bottom-0 h-screen z-50 px-2"
+                    className="mobile-nav-overlay fixed inset-0 z-50 flex flex-col bg-background px-2 overscroll-none"
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: 20 }}
@@ -482,11 +513,11 @@ export default function Component() {
                         </motion.button>
                     </motion.div>
 
-                    <div className="h-screen pb-[150px] overflow-auto">
+                    <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain pb-[calc(150px+env(safe-area-inset-bottom,0px))]">
                         <motion.ul
                             initial="hidden"
                             animate="show"
-                            className="px-3 pt-8 text-xl text-[#878787] space-y-8 mb-8 overflow-auto"
+                            className="px-3 pt-8 text-xl text-[#878787] space-y-8 mb-8"
                             variants={listVariant}
                         >
                             {links.map(({ path, title, children }, index) => {
@@ -730,9 +761,9 @@ export default function Component() {
                 </motion.div>
             )}
 
-            {/* Mobile navbar overlay */}
+            {/* Mobile navbar backdrop — covers area behind Safari bottom tab bar */}
             {isOpen && (
-                <div className="fixed inset-0 bg-background z-40" />
+                <div className="mobile-nav-overlay fixed inset-0 bg-background z-40" aria-hidden="true" />
             )}
         </>
     )

--- a/app/globals.css
+++ b/app/globals.css
@@ -417,6 +417,13 @@
 }
 
 @layer utilities {
+  /* Full-viewport overlay that respects iOS Safari dynamic toolbars (bottom tabs, address bar) */
+  .mobile-nav-overlay {
+    height: 100dvh;
+    min-height: 100dvh;
+    min-height: -webkit-fill-available;
+  }
+
   /* Mobile navbar overlay styles */
   body[data-mobile-navbar='open'] .max-w-screen-xl {
     opacity: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a mobile Safari regression where landing page content was visible at the bottom of the screen while the navbar menu was open, especially with the new bottom tab bar UI. Also fixes scroll position jumping to the top when opening the menu.

## Root cause

1. **Bottom bleed:** The mobile menu overlay used `h-screen` (`100vh`), which on iOS Safari is taller than the **visible** viewport when browser chrome (address bar / bottom tabs) is shown.
2. **Scroll jump:** The scroll lock used `position: fixed` on the body, which reset the page to the top when the menu opened.

## Changes

- Added a `.mobile-nav-overlay` utility using `100dvh` and `-webkit-fill-available` so the overlay tracks the dynamic visible viewport
- Restructured the mobile menu as a flex column with a scrollable content area and safe-area bottom padding
- Switched scroll lock to `overflow: hidden` + `touch-action: none` on `html`/`body`, preserving scroll position when opening/closing the menu

## Testing

- `OPENAI_API_KEY=dummy bun run build` — pass
- `bun run typecheck` — pass
- Puppeteer mobile viewport: overlay covers full height; scroll position preserved at 1200px when opening and closing menu
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0a7a-f3fc-704a-bc79-2c8966eb1ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0a7a-f3fc-704a-bc79-2c8966eb1ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

