### PR TITLE
Fix support chat image attachments (blob URL → data URL)

### DIFF
--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -14,6 +14,7 @@ import {
   PromptInputTextarea,
   PromptInputToolbar,
   PromptInputTools,
+  usePromptInputAttachments,
 } from '@/components/ai-elements/prompt-input';
 import {
   Actions,
@@ -118,6 +119,24 @@ const preprocessContent = (content: string) => {
   return { content: contentWithoutThink, think };
 };
 
+const ATTACHMENT_ONLY_PLACEHOLDER = 'Sent with attachments';
+
+function SupportPromptSubmit({
+  input,
+  status,
+}: {
+  input: string;
+  status: ReturnType<typeof useChat>['status'];
+}) {
+  const attachments = usePromptInputAttachments();
+  const canSend =
+    Boolean(input.trim()) || attachments.files.length > 0;
+
+  return (
+    <PromptInputSubmit disabled={!canSend} status={status} />
+  );
+}
+
 const ChatBotDemo = () => {
   const t = useI18n();
   const [input, setInput] = useState('');
@@ -171,17 +190,21 @@ const ChatBotDemo = () => {
   }, [messages.length, setMessages, t]);
 
   const handleSubmit = (message: PromptInputMessage) => {
-    const hasText = Boolean(message.text);
+    const hasText = Boolean(message.text?.trim());
     const hasAttachments = Boolean(message.files?.length);
 
     if (!(hasText || hasAttachments)) {
       return;
     }
 
-    sendMessage({
-      text: message.text || 'Sent with attachments',
-      files: message.files,
-    });
+    if (hasText) {
+      sendMessage({
+        text: message.text!,
+        ...(hasAttachments ? { files: message.files } : {}),
+      });
+    } else {
+      sendMessage({ files: message.files! });
+    }
     setInput('');
   };
 
@@ -232,11 +255,53 @@ const ChatBotDemo = () => {
 
                       {message.parts.map((part, i) => {
                         switch (part.type) {
+                          case 'file': {
+                            if (!part.mediaType?.startsWith('image/') || !part.url) {
+                              return null;
+                            }
+
+                            const isUser = message.role === 'user';
+
+                            return (
+                              <ChatMessage key={`${message.id}-${i}`} align={isUser ? 'end' : 'start'}>
+                                <MessageContent>
+                                  <Bubble
+                                    variant={isUser ? 'default' : 'muted'}
+                                    align={isUser ? 'end' : 'start'}
+                                  >
+                                    <BubbleContent>
+                                      <img
+                                        alt={part.filename || 'attachment'}
+                                        className="max-h-96 max-w-full rounded-lg object-contain"
+                                        src={part.url}
+                                      />
+                                    </BubbleContent>
+                                  </Bubble>
+                                </MessageContent>
+                              </ChatMessage>
+                            );
+                          }
                           case 'text': {
                             const { content: contentWithoutThink, think } = preprocessContent(
                               part.text,
                             );
                             const isUser = message.role === 'user';
+
+                            if (
+                              isUser &&
+                              !contentWithoutThink.trim() &&
+                              message.parts.some((p) => p.type === 'file')
+                            ) {
+                              return null;
+                            }
+
+                            if (
+                              isUser &&
+                              contentWithoutThink.trim() === ATTACHMENT_ONLY_PLACEHOLDER &&
+                              message.parts.some((p) => p.type === 'file')
+                            ) {
+                              return null;
+                            }
 
                             return (
                               <Fragment key={`${message.id}-${i}`}>
@@ -456,7 +521,7 @@ const ChatBotDemo = () => {
                 </PromptInputActionMenuContent>
               </PromptInputActionMenu>
             </PromptInputTools>
-            <PromptInputSubmit disabled={!input && !status} status={status} />
+            <SupportPromptSubmit input={input} status={status} />
           </PromptInputToolbar>
         </PromptInput>
       </div>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -436,7 +436,7 @@ const ChatBotDemo = () => {
           </CardContent>
         </Card>
 
-        <PromptInput onSubmit={handleSubmit} globalDrop multiple>
+        <PromptInput accept="image/*" onSubmit={handleSubmit} globalDrop multiple>
           <PromptInputBody>
             <PromptInputAttachments>
               {(attachment) => <PromptInputAttachment data={attachment} />}

--- a/app/api/ai/support/route.ts
+++ b/app/api/ai/support/route.ts
@@ -1,4 +1,5 @@
 import { createAgentUIStreamResponse, type UIMessage } from "ai";
+import { hasUnsupportedFileUrls } from "@/lib/ai/convert-file-ui-parts";
 import { supportAgent } from "@/lib/ai/support-agent";
 
 export const maxDuration = 30;
@@ -7,13 +8,36 @@ export async function POST(req: Request) {
   try {
     const { messages }: { messages: UIMessage[] } = await req.json();
 
-    if (messages[0]?.role === "assistant") {
-      messages.shift();
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      return new Response(JSON.stringify({ error: "No messages provided" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (hasUnsupportedFileUrls(messages)) {
+      return new Response(
+        JSON.stringify({
+          error: "Invalid file attachments",
+          message:
+            "Attachments must be uploaded as images. Please remove and re-attach your files.",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const uiMessages = [...messages];
+
+    if (uiMessages[0]?.role === "assistant") {
+      uiMessages.shift();
     }
 
     return createAgentUIStreamResponse({
       agent: supportAgent,
-      uiMessages: messages,
+      uiMessages: uiMessages,
       sendReasoning: true,
       onStepFinish: (step) => {
         console.log(

--- a/components/ai-elements/prompt-input.tsx
+++ b/components/ai-elements/prompt-input.tsx
@@ -410,6 +410,7 @@ export const PromptInput = ({
     const files = await convertFileUIPartsToDataURLs(rawFiles);
 
     onSubmit({ text: form.message.value, files }, event);
+    clear();
   };
 
   const ctx = useMemo<AttachmentsContext>(

--- a/components/ai-elements/prompt-input.tsx
+++ b/components/ai-elements/prompt-input.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { convertFileUIPartsToDataURLs } from "@/lib/ai/convert-file-ui-parts";
 import type { ChatStatus, FileUIPart } from "ai";
 import {
   ImageIcon,
@@ -401,14 +402,14 @@ export const PromptInput = ({
     }
   };
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
 
-    const files: FileUIPart[] = items.map(({ ...item }) => ({
-      ...item,
-    }));
+    const form = event.currentTarget;
+    const rawFiles: FileUIPart[] = items.map(({ id: _id, ...item }) => item);
+    const files = await convertFileUIPartsToDataURLs(rawFiles);
 
-    onSubmit({ text: event.currentTarget.message.value, files }, event);
+    onSubmit({ text: form.message.value, files }, event);
   };
 
   const ctx = useMemo<AttachmentsContext>(

--- a/lib/ai/convert-file-ui-parts.ts
+++ b/lib/ai/convert-file-ui-parts.ts
@@ -1,0 +1,47 @@
+import type { FileUIPart } from "ai";
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function blobUrlToDataUrl(blobUrl: string): Promise<string> {
+  const response = await fetch(blobUrl);
+  const blob = await response.blob();
+  return blobToDataUrl(blob);
+}
+
+/** Ensures file parts use data URLs so server-side model conversion succeeds. */
+export async function convertFileUIPartsToDataURLs(
+  files: FileUIPart[],
+): Promise<FileUIPart[]> {
+  return Promise.all(
+    files.map(async (file) => {
+      if (!file.url?.startsWith("blob:")) {
+        return file;
+      }
+
+      return {
+        ...file,
+        url: await blobUrlToDataUrl(file.url),
+      };
+    }),
+  );
+}
+
+export function hasUnsupportedFileUrls(
+  messages: Array<{ parts?: Array<{ type?: string; url?: string }> }>,
+): boolean {
+  return messages.some((message) =>
+    message.parts?.some(
+      (part) =>
+        part.type === "file" &&
+        typeof part.url === "string" &&
+        !part.url.startsWith("data:"),
+    ),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes support chat attachment failures caused by `blob:` URLs being sent to the API, and fixes the UI so images actually appear in the conversation and clear from the input after send.

## Root cause

1. **API:** `PromptInput` stored attachments as `URL.createObjectURL()` blob URLs. `useChat` passes `FileUIPart[]` through unchanged, so the server received unusable `blob:` references.
2. **UI:** The support chat renderer only handled `text` / tool parts — not `file` parts — so sent images never appeared in the thread.
3. **UX:** Attachments were not cleared after submit, and the send button stayed disabled for image-only messages (`disabled={!input && !status}`).

## Changes

- **`convertFileUIPartsToDataURLs`**: Converts blob URLs to data URLs at submit time in `PromptInput`
- **Server guard**: `/api/ai/support` returns `400` if any file part still has a non-`data:` URL
- **Support UI**: Restrict attachments to `image/*` (screenshots)
- **Clear attachments** after successful submit in `PromptInput`
- **Render `file` parts** as images in the support conversation
- **`SupportPromptSubmit`**: Enable send when text or attachments are present
- **Files-only sends**: Use `sendMessage({ files })` without placeholder text

## Testing

- `bun run typecheck` passes
- Rebased onto latest `beta`

## Note

Can merge independently of #260 (search hardening). If both land, the support route will have both file URL validation and full Zod request validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0a53-a520-7c6e-9e92-5c3089c8f7a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0a53-a520-7c6e-9e92-5c3089c8f7a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

