### PR TITLE
Fix support doc search for Tradovate/DxFeed multi-word queries

### DIFF
--- a/app/api/ai/support/route.ts
+++ b/app/api/ai/support/route.ts
@@ -1,7 +1,11 @@
 import { createAgentUIStreamResponse, type UIMessage } from "ai";
 import { hasUnsupportedFileUrls } from "@/lib/ai/convert-file-ui-parts";
 import { supportAgent } from "@/lib/ai/support-agent";
-import { supportChatRequestSchema } from "./schema";
+import {
+  hasUserMessage,
+  stripInitialAssistantGreeting,
+  supportChatRequestSchema,
+} from "./schema";
 
 export const maxDuration = 30;
 
@@ -23,13 +27,16 @@ export async function POST(req: Request) {
       );
     }
 
-    const messages = [...parsed.data.messages] as UIMessage[];
+    const messages = stripInitialAssistantGreeting(parsed.data.messages);
 
-    if (!messages || !Array.isArray(messages) || messages.length === 0) {
-      return new Response(JSON.stringify({ error: "No messages provided" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+    if (!hasUserMessage(messages)) {
+      return new Response(
+        JSON.stringify({ error: "No user messages provided" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     if (hasUnsupportedFileUrls(messages)) {
@@ -46,25 +53,9 @@ export async function POST(req: Request) {
       );
     }
 
-    const uiMessages = [...messages];
-
-    if (uiMessages[0]?.role === "assistant") {
-      uiMessages.shift();
-    }
-
-    if (messages.length === 0) {
-      return new Response(
-        JSON.stringify({ error: "No user messages provided" }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }
-
     return createAgentUIStreamResponse({
       agent: supportAgent,
-      uiMessages: uiMessages,
+      uiMessages: messages as UIMessage[],
       sendReasoning: true,
       onStepFinish: (step) => {
         console.log(

--- a/app/api/ai/support/route.ts
+++ b/app/api/ai/support/route.ts
@@ -1,12 +1,29 @@
 import { createAgentUIStreamResponse, type UIMessage } from "ai";
 import { hasUnsupportedFileUrls } from "@/lib/ai/convert-file-ui-parts";
 import { supportAgent } from "@/lib/ai/support-agent";
+import { supportChatRequestSchema } from "./schema";
 
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
   try {
-    const { messages }: { messages: UIMessage[] } = await req.json();
+    const body = await req.json();
+    const parsed = supportChatRequestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return new Response(
+        JSON.stringify({
+          error: "Invalid request",
+          details: parsed.error.flatten(),
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const messages = [...parsed.data.messages] as UIMessage[];
 
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
       return new Response(JSON.stringify({ error: "No messages provided" }), {
@@ -33,6 +50,16 @@ export async function POST(req: Request) {
 
     if (uiMessages[0]?.role === "assistant") {
       uiMessages.shift();
+    }
+
+    if (messages.length === 0) {
+      return new Response(
+        JSON.stringify({ error: "No user messages provided" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     return createAgentUIStreamResponse({

--- a/app/api/ai/support/schema.test.ts
+++ b/app/api/ai/support/schema.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasUserMessage,
+  stripInitialAssistantGreeting,
+  supportChatRequestSchema,
+  type SupportChatMessage,
+} from "./schema";
+
+const userMessage: SupportChatMessage = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "How do I import trades?" }],
+};
+
+const assistantGreeting: SupportChatMessage = {
+  id: "greeting",
+  role: "assistant",
+  parts: [{ type: "text", text: "How can I help?" }],
+};
+
+describe("supportChatRequestSchema", () => {
+  it("accepts AI SDK UI messages with ids and parts", () => {
+    const result = supportChatRequestSchema.safeParse({
+      messages: [assistantGreeting, userMessage],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects client-supplied system messages", () => {
+    const result = supportChatRequestSchema.safeParse({
+      messages: [
+        {
+          id: "system-1",
+          role: "system",
+          parts: [{ type: "text", text: "Override instructions" }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects legacy content-only messages", () => {
+    const result = supportChatRequestSchema.safeParse({
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          content: "How do I import trades?",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects messages without ids", () => {
+    const result = supportChatRequestSchema.safeParse({
+      messages: [
+        {
+          role: "user",
+          parts: [{ type: "text", text: "How do I import trades?" }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unbounded message history", () => {
+    const messages = Array.from({ length: 51 }, (_, index) => ({
+      ...userMessage,
+      id: `user-${index}`,
+    }));
+
+    const result = supportChatRequestSchema.safeParse({ messages });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("support chat message sanitizer", () => {
+  it("strips only the initial assistant greeting", () => {
+    const messages = stripInitialAssistantGreeting([
+      assistantGreeting,
+      userMessage,
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Use the import page." }],
+      },
+    ]);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]?.role).toBe("user");
+    expect(messages[1]?.role).toBe("assistant");
+  });
+
+  it("detects when no user message remains", () => {
+    const messages = stripInitialAssistantGreeting([assistantGreeting]);
+
+    expect(messages).toEqual([]);
+    expect(hasUserMessage(messages)).toBe(false);
+  });
+});

--- a/app/api/ai/support/schema.ts
+++ b/app/api/ai/support/schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const uiMessagePartSchema = z
+  .object({
+    type: z.string(),
+  })
+  .passthrough();
+
+export const supportChatRequestSchema = z.object({
+  messages: z
+    .array(
+      z
+        .object({
+          id: z.string().optional(),
+          role: z.enum(["user", "assistant", "system"]),
+          parts: z.array(uiMessagePartSchema).optional(),
+          content: z.string().optional(),
+        })
+        .passthrough(),
+    )
+    .min(1, "At least one message is required"),
+});
+
+export type SupportChatRequest = z.infer<typeof supportChatRequestSchema>;

--- a/app/api/ai/support/schema.ts
+++ b/app/api/ai/support/schema.ts
@@ -1,24 +1,61 @@
 import { z } from "zod";
 
+const MAX_SUPPORT_MESSAGES = 50;
+const MAX_MESSAGE_ID_LENGTH = 200;
+const MAX_MESSAGE_PARTS = 50;
+const MAX_PART_TYPE_LENGTH = 80;
+const MAX_TEXT_PART_LENGTH = 8_000;
+
 const uiMessagePartSchema = z
   .object({
-    type: z.string(),
+    type: z.string().min(1).max(MAX_PART_TYPE_LENGTH),
+    text: z.string().max(MAX_TEXT_PART_LENGTH).optional(),
   })
-  .passthrough();
+  .passthrough()
+  .superRefine((part, ctx) => {
+    if (part.type !== "text") return;
+
+    if (typeof part.text !== "string" || part.text.trim().length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["text"],
+        message: "Text message parts must include non-empty text",
+      });
+    }
+  });
+
+const supportChatMessageSchema = z
+  .object({
+    id: z.string().min(1).max(MAX_MESSAGE_ID_LENGTH),
+    role: z.enum(["user", "assistant"]),
+    parts: z
+      .array(uiMessagePartSchema)
+      .min(1, "Message parts are required")
+      .max(MAX_MESSAGE_PARTS, "Too many message parts"),
+    metadata: z.unknown().optional(),
+  })
+  .strict();
 
 export const supportChatRequestSchema = z.object({
   messages: z
-    .array(
-      z
-        .object({
-          id: z.string().optional(),
-          role: z.enum(["user", "assistant", "system"]),
-          parts: z.array(uiMessagePartSchema).optional(),
-          content: z.string().optional(),
-        })
-        .passthrough(),
-    )
-    .min(1, "At least one message is required"),
+    .array(supportChatMessageSchema)
+    .min(1, "At least one message is required")
+    .max(MAX_SUPPORT_MESSAGES, "Too many messages"),
 });
 
 export type SupportChatRequest = z.infer<typeof supportChatRequestSchema>;
+export type SupportChatMessage = SupportChatRequest["messages"][number];
+
+export function stripInitialAssistantGreeting(
+  messages: SupportChatRequest["messages"],
+): SupportChatRequest["messages"] {
+  if (messages[0]?.role === "assistant") {
+    return messages.slice(1);
+  }
+
+  return [...messages];
+}
+
+export function hasUserMessage(messages: SupportChatRequest["messages"]): boolean {
+  return messages.some((message) => message.role === "user");
+}

--- a/app/api/ai/support/tools/search-codebase.ts
+++ b/app/api/ai/support/tools/search-codebase.ts
@@ -19,6 +19,13 @@ export const searchCodebaseTool = tool({
   execute: async ({ query, locale }) => {
     const result = await searchCodebase(query, { locale });
 
+    console.log("[searchCodebase]", {
+      query,
+      locale,
+      matchCount: result.matchCount,
+      sampleFiles: result.matches.slice(0, 3).map((match) => match.file),
+    });
+
     if (result.matchCount === 0) {
       return {
         found: false,

--- a/app/api/ai/support/tools/search-codebase.ts
+++ b/app/api/ai/support/tools/search-codebase.ts
@@ -2,6 +2,9 @@ import { tool } from "ai";
 import { z } from "zod";
 import { searchCodebase } from "@/lib/ai/search-codebase";
 
+const shouldLogSupportSearchDebug =
+  process.env.NODE_ENV !== "production" && process.env.SUPPORT_SEARCH_DEBUG !== "0";
+
 export const searchCodebaseTool = tool({
   description:
     "Search Deltalytix product documentation, release notes, locale strings, and self-hosting guides in the repository. Use this before answering questions about features, imports, billing, dashboard behavior, or setup.",
@@ -19,12 +22,14 @@ export const searchCodebaseTool = tool({
   execute: async ({ query, locale }) => {
     const result = await searchCodebase(query, { locale });
 
-    console.log("[searchCodebase]", {
-      query,
-      locale,
-      matchCount: result.matchCount,
-      sampleFiles: result.matches.slice(0, 3).map((match) => match.file),
-    });
+    if (shouldLogSupportSearchDebug) {
+      console.log("[searchCodebase]", {
+        query,
+        locale,
+        matchCount: result.matchCount,
+        sampleFiles: result.matches.slice(0, 3).map((match) => match.file),
+      });
+    }
 
     if (result.matchCount === 0) {
       return {

--- a/lib/ai/search-codebase.ts
+++ b/lib/ai/search-codebase.ts
@@ -1,18 +1,36 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 
 const execFileAsync = promisify(execFile);
 
 const REPO_ROOT = process.cwd();
 
-const SEARCH_ROOTS = ["content", "locales"] as const;
+/** Product documentation and user-facing copy only — not full locale aggregates. */
+const CONTENT_ROOT = "content" as const;
+
+const LOCALE_DOC_FILES = [
+  "locales/en/support.ts",
+  "locales/fr/support.ts",
+  "locales/en/faq.ts",
+  "locales/fr/faq.ts",
+  "locales/en/chat.ts",
+  "locales/fr/chat.ts",
+  "locales/en/landing.ts",
+  "locales/fr/landing.ts",
+] as const;
 
 const ROOT_MARKDOWN_FILES = ["README.md", "SELF_HOSTING.md", "AGENTS.md"] as const;
 
 const MAX_RESULTS = 12;
 const MAX_SNIPPET_CHARS = 600;
+
+const SEARCHABLE_FILE_PATTERN = /\.(md|mdx|ts)$/i;
+
+/** Ripgrep is unavailable on Vercel serverless; use Node fs there and in production. */
+const PREFER_NODE_FS_SEARCH =
+  process.env.VERCEL === "1" || process.env.NODE_ENV === "production";
 
 export type CodebaseSearchMatch = {
   file: string;
@@ -32,10 +50,14 @@ function normalizeSnippet(text: string): string {
 
 function localeContentPath(locale?: string): string | undefined {
   if (locale === "en" || locale === "fr") {
-    return path.join("content", "updates", locale);
+    return path.join(CONTENT_ROOT, "updates", locale);
   }
 
   return undefined;
+}
+
+function isSearchableFile(relativePath: string): boolean {
+  return SEARCHABLE_FILE_PATTERN.test(relativePath);
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -47,10 +69,18 @@ async function fileExists(filePath: string): Promise<boolean> {
   }
 }
 
+function buildFallbackSearchPaths(): string[] {
+  return [CONTENT_ROOT, ...LOCALE_DOC_FILES, ...ROOT_MARKDOWN_FILES];
+}
+
 async function searchWithRipgrep(
   query: string,
   searchPaths: string[],
 ): Promise<CodebaseSearchMatch[] | null> {
+  if (PREFER_NODE_FS_SEARCH) {
+    return null;
+  }
+
   try {
     const { stdout } = await execFileAsync(
       "rg",
@@ -98,6 +128,7 @@ async function searchWithRipgrep(
       const lines = (event.data.lines as { text?: string } | undefined)?.text;
 
       if (!filePath || !lineNumber || !lines) continue;
+      if (!isSearchableFile(filePath)) continue;
 
       const key = `${filePath}:${lineNumber}`;
       if (seen.has(key)) continue;
@@ -115,6 +146,30 @@ async function searchWithRipgrep(
     return matches;
   } catch {
     return null;
+  }
+}
+
+async function searchFile(
+  relativePath: string,
+  pattern: RegExp,
+  matches: CodebaseSearchMatch[],
+): Promise<void> {
+  if (matches.length >= MAX_RESULTS) return;
+
+  const absolutePath = path.join(REPO_ROOT, relativePath);
+  const content = await readFile(absolutePath, "utf8");
+  const lines = content.split("\n");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!pattern.test(lines[index])) continue;
+
+    matches.push({
+      file: relativePath,
+      line: index + 1,
+      snippet: normalizeSnippet(lines[index]),
+    });
+
+    if (matches.length >= MAX_RESULTS) break;
   }
 }
 
@@ -145,45 +200,26 @@ async function searchWithNodeFs(
         continue;
       }
 
-      if (!/\.(md|mdx|ts)$/i.test(entry.name)) continue;
+      if (!isSearchableFile(relativePath)) continue;
 
-      const absolutePath = path.join(REPO_ROOT, relativePath);
-      const content = await readFile(absolutePath, "utf8");
-      const lines = content.split("\n");
-
-      for (let index = 0; index < lines.length; index += 1) {
-        if (!pattern.test(lines[index])) continue;
-
-        matches.push({
-          file: relativePath,
-          line: index + 1,
-          snippet: normalizeSnippet(lines[index]),
-        });
-
-        if (matches.length >= MAX_RESULTS) break;
-      }
+      await searchFile(relativePath, pattern, matches);
     }
   }
 
   for (const searchPath of searchPaths) {
+    if (matches.length >= MAX_RESULTS) break;
+
     const absolutePath = path.join(REPO_ROOT, searchPath);
-    const stats = await import("node:fs/promises").then((fs) => fs.stat(absolutePath));
 
-    if (stats.isFile()) {
-      const content = await readFile(absolutePath, "utf8");
-      const lines = content.split("\n");
-
-      for (let index = 0; index < lines.length; index += 1) {
-        if (!pattern.test(lines[index])) continue;
-
-        matches.push({
-          file: searchPath,
-          line: index + 1,
-          snippet: normalizeSnippet(lines[index]),
-        });
-
-        if (matches.length >= MAX_RESULTS) break;
+    try {
+      const fileStat = await stat(absolutePath);
+      if (fileStat.isFile()) {
+        if (isSearchableFile(searchPath)) {
+          await searchFile(searchPath, pattern, matches);
+        }
+        continue;
       }
+    } catch {
       continue;
     }
 
@@ -191,6 +227,25 @@ async function searchWithNodeFs(
   }
 
   return matches;
+}
+
+async function runSearch(
+  query: string,
+  searchPaths: string[],
+): Promise<CodebaseSearchMatch[]> {
+  const existingPaths: string[] = [];
+  for (const searchPath of searchPaths) {
+    if (await fileExists(path.join(REPO_ROOT, searchPath))) {
+      existingPaths.push(searchPath);
+    }
+  }
+
+  if (existingPaths.length === 0) {
+    return [];
+  }
+
+  const ripgrepMatches = await searchWithRipgrep(query, existingPaths);
+  return ripgrepMatches ?? (await searchWithNodeFs(query, existingPaths));
 }
 
 export async function searchCodebase(
@@ -203,35 +258,16 @@ export async function searchCodebase(
   }
 
   const localePath = localeContentPath(options?.locale);
-  const fallbackPaths = [...SEARCH_ROOTS, ...ROOT_MARKDOWN_FILES].filter(
-    (value, index, array) => array.indexOf(value) === index,
-  );
-
-  const existingLocalePaths: string[] = [];
-  if (localePath && (await fileExists(path.join(REPO_ROOT, localePath)))) {
-    existingLocalePaths.push(localePath);
-  }
-
-  const existingFallbackPaths: string[] = [];
-  for (const searchPath of fallbackPaths) {
-    if (await fileExists(path.join(REPO_ROOT, searchPath))) {
-      existingFallbackPaths.push(searchPath);
-    }
-  }
+  const fallbackPaths = buildFallbackSearchPaths();
 
   let matches: CodebaseSearchMatch[] = [];
 
-  if (existingLocalePaths.length > 0) {
-    const localeMatches = await searchWithRipgrep(trimmedQuery, existingLocalePaths);
-    matches =
-      localeMatches ?? (await searchWithNodeFs(trimmedQuery, existingLocalePaths));
+  if (localePath) {
+    matches = await runSearch(trimmedQuery, [localePath]);
   }
 
-  if (matches.length === 0 && existingFallbackPaths.length > 0) {
-    const fallbackMatches = await searchWithRipgrep(trimmedQuery, existingFallbackPaths);
-    matches =
-      fallbackMatches ??
-      (await searchWithNodeFs(trimmedQuery, existingFallbackPaths));
+  if (matches.length === 0) {
+    matches = await runSearch(trimmedQuery, fallbackPaths);
   }
 
   return {

--- a/lib/ai/search-codebase.ts
+++ b/lib/ai/search-codebase.ts
@@ -6,6 +6,21 @@ const REPO_ROOT = process.cwd();
 /** Product documentation and user-facing copy only — not full locale aggregates. */
 const CONTENT_ROOT = "content" as const;
 
+export const SUPPORT_SEARCH_TRACE_INCLUDES = [
+  "./content/**/*",
+  "./locales/en/support.ts",
+  "./locales/fr/support.ts",
+  "./locales/en/faq.ts",
+  "./locales/fr/faq.ts",
+  "./locales/en/chat.ts",
+  "./locales/fr/chat.ts",
+  "./locales/en/landing.ts",
+  "./locales/fr/landing.ts",
+  "./README.md",
+  "./SELF_HOSTING.md",
+  "./AGENTS.md",
+] as const;
+
 const LOCALE_DOC_FILES = [
   "locales/en/support.ts",
   "locales/fr/support.ts",
@@ -23,6 +38,44 @@ const MAX_RESULTS = 12;
 const MAX_SNIPPET_CHARS = 600;
 
 const SEARCHABLE_FILE_PATTERN = /\.(md|mdx|ts)$/i;
+
+const SEARCH_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "or",
+  "for",
+  "to",
+  "how",
+  "what",
+  "when",
+  "where",
+  "why",
+  "is",
+  "are",
+  "was",
+  "were",
+  "do",
+  "does",
+  "did",
+  "can",
+  "could",
+  "should",
+  "would",
+  "about",
+  "with",
+  "from",
+  "into",
+  "documentation",
+  "docs",
+  "guide",
+  "help",
+  "setup",
+  "instructions",
+  "information",
+  "details",
+]);
 
 export type CodebaseSearchMatch = {
   file: string;
@@ -65,20 +118,96 @@ function buildFallbackSearchPaths(): string[] {
   return [CONTENT_ROOT, ...LOCALE_DOC_FILES, ...ROOT_MARKDOWN_FILES];
 }
 
+function parseSearchTerms(query: string): string[] {
+  const rawTerms = query
+    .trim()
+    .split(/\s+/)
+    .map((term) => term.replace(/[^\p{L}\p{N}_-]/gu, ""))
+    .filter((term) => term.length >= 2);
+
+  const terms = [
+    ...new Set(rawTerms.filter((term) => !SEARCH_STOP_WORDS.has(term.toLowerCase()))),
+  ];
+
+  return terms.length > 0 ? terms : rawTerms.slice(0, 1);
+}
+
+function fileContainsAllTerms(content: string, terms: string[]): boolean {
+  const lowerContent = content.toLowerCase();
+  return terms.every((term) => lowerContent.includes(term.toLowerCase()));
+}
+
+function fileNameContainsAllTerms(relativePath: string, terms: string[]): boolean {
+  const slug = path
+    .basename(relativePath, path.extname(relativePath))
+    .toLowerCase()
+    .replace(/-/g, " ");
+  return terms.every((term) => slug.includes(term.toLowerCase()));
+}
+
+function fileMatchesTerms(relativePath: string, content: string, terms: string[]): boolean {
+  return (
+    fileContainsAllTerms(content, terms) || fileNameContainsAllTerms(relativePath, terms)
+  );
+}
+
+const GENERIC_SEARCH_TERMS = new Set([
+  "firm",
+  "sync",
+  "account",
+  "import",
+  "trade",
+  "trades",
+  "selection",
+  "support",
+  "connection",
+  "dashboard",
+]);
+
+function pickPrimarySearchTerm(terms: string[]): string {
+  const distinctiveTerms = terms.filter(
+    (term) => !GENERIC_SEARCH_TERMS.has(term.toLowerCase()),
+  );
+  return distinctiveTerms[0] ?? terms[0];
+}
+
+function lineMatchedTermCount(line: string, terms: string[]): number {
+  const lowerLine = line.toLowerCase();
+  return terms.filter((term) => lowerLine.includes(term.toLowerCase())).length;
+}
+
 async function searchFile(
   relativePath: string,
-  pattern: RegExp,
+  terms: string[],
   matches: CodebaseSearchMatch[],
 ): Promise<void> {
-  if (matches.length >= MAX_RESULTS) return;
+  if (matches.length >= MAX_RESULTS || terms.length === 0) return;
 
   const absolutePath = path.join(REPO_ROOT, relativePath);
-  const content = await readFile(absolutePath, "utf8");
+
+  let content: string;
+  try {
+    content = await readFile(absolutePath, "utf8");
+  } catch {
+    return;
+  }
+
+  if (!fileMatchesTerms(relativePath, content, terms)) {
+    return;
+  }
+
   const lines = content.split("\n");
+  const lineMatches: Array<{ index: number; score: number }> = [];
 
   for (let index = 0; index < lines.length; index += 1) {
-    if (!pattern.test(lines[index])) continue;
+    const score = lineMatchedTermCount(lines[index], terms);
+    if (score === 0) continue;
+    lineMatches.push({ index, score });
+  }
 
+  lineMatches.sort((left, right) => right.score - left.score);
+
+  for (const { index } of lineMatches) {
     matches.push({
       file: relativePath,
       line: index + 1,
@@ -90,10 +219,9 @@ async function searchFile(
 }
 
 async function searchFiles(
-  query: string,
+  terms: string[],
   searchPaths: string[],
 ): Promise<CodebaseSearchMatch[]> {
-  const pattern = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
   const matches: CodebaseSearchMatch[] = [];
 
   async function walk(dir: string): Promise<void> {
@@ -118,7 +246,7 @@ async function searchFiles(
 
       if (!isSearchableFile(relativePath)) continue;
 
-      await searchFile(relativePath, pattern, matches);
+      await searchFile(relativePath, terms, matches);
     }
   }
 
@@ -131,7 +259,7 @@ async function searchFiles(
       const fileStat = await stat(absolutePath);
       if (fileStat.isFile()) {
         if (isSearchableFile(searchPath)) {
-          await searchFile(searchPath, pattern, matches);
+          await searchFile(searchPath, terms, matches);
         }
         continue;
       }
@@ -157,10 +285,21 @@ async function runSearch(
   }
 
   if (existingPaths.length === 0) {
+    console.warn("[searchCodebase] No searchable paths found", {
+      cwd: REPO_ROOT,
+      requestedPaths: searchPaths,
+    });
     return [];
   }
 
-  return searchFiles(query, existingPaths);
+  const terms = parseSearchTerms(query);
+  let matches = await searchFiles(terms, existingPaths);
+
+  if (matches.length === 0 && terms.length > 1) {
+    matches = await searchFiles([pickPrimarySearchTerm(terms)], existingPaths);
+  }
+
+  return matches;
 }
 
 export async function searchCodebase(

--- a/lib/ai/search-codebase.ts
+++ b/lib/ai/search-codebase.ts
@@ -1,4 +1,5 @@
-import { access, readFile, stat } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { access, readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 const REPO_ROOT = process.cwd();
@@ -38,6 +39,10 @@ const MAX_RESULTS = 12;
 const MAX_SNIPPET_CHARS = 600;
 
 const SEARCHABLE_FILE_PATTERN = /\.(md|mdx|ts)$/i;
+
+function shouldLogSearchDebug(): boolean {
+  return process.env.NODE_ENV !== "production" && process.env.SUPPORT_SEARCH_DEBUG !== "0";
+}
 
 const SEARCH_STOP_WORDS = new Set([
   "a",
@@ -230,8 +235,18 @@ async function searchFiles(
     const absoluteDir = path.join(REPO_ROOT, dir);
     if (!(await fileExists(absoluteDir))) return;
 
-    const { readdir } = await import("node:fs/promises");
-    const entries = await readdir(absoluteDir, { withFileTypes: true });
+    let entries: Dirent[];
+    try {
+      entries = await readdir(absoluteDir, { withFileTypes: true });
+    } catch (error) {
+      if (shouldLogSearchDebug()) {
+        console.warn("[searchCodebase] Skipping unreadable directory", {
+          dir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return;
+    }
 
     for (const entry of entries) {
       if (matches.length >= MAX_RESULTS) break;

--- a/lib/ai/search-codebase.ts
+++ b/lib/ai/search-codebase.ts
@@ -1,9 +1,5 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { access, readFile, stat } from "node:fs/promises";
 import path from "node:path";
-
-const execFileAsync = promisify(execFile);
 
 const REPO_ROOT = process.cwd();
 
@@ -27,10 +23,6 @@ const MAX_RESULTS = 12;
 const MAX_SNIPPET_CHARS = 600;
 
 const SEARCHABLE_FILE_PATTERN = /\.(md|mdx|ts)$/i;
-
-/** Ripgrep is unavailable on Vercel serverless; use Node fs there and in production. */
-const PREFER_NODE_FS_SEARCH =
-  process.env.VERCEL === "1" || process.env.NODE_ENV === "production";
 
 export type CodebaseSearchMatch = {
   file: string;
@@ -73,82 +65,6 @@ function buildFallbackSearchPaths(): string[] {
   return [CONTENT_ROOT, ...LOCALE_DOC_FILES, ...ROOT_MARKDOWN_FILES];
 }
 
-async function searchWithRipgrep(
-  query: string,
-  searchPaths: string[],
-): Promise<CodebaseSearchMatch[] | null> {
-  if (PREFER_NODE_FS_SEARCH) {
-    return null;
-  }
-
-  try {
-    const { stdout } = await execFileAsync(
-      "rg",
-      [
-        "-i",
-        "--json",
-        "-m",
-        String(MAX_RESULTS),
-        "--context",
-        "1",
-        "--glob",
-        "*.md",
-        "--glob",
-        "*.mdx",
-        "--glob",
-        "*.ts",
-        query,
-        ...searchPaths,
-      ],
-      {
-        cwd: REPO_ROOT,
-        maxBuffer: 10 * 1024 * 1024,
-      },
-    );
-
-    const matches: CodebaseSearchMatch[] = [];
-    const seen = new Set<string>();
-
-    for (const line of stdout.split("\n")) {
-      if (!line.trim()) continue;
-
-      let event: { type?: string; data?: Record<string, unknown> };
-      try {
-        event = JSON.parse(line);
-      } catch {
-        continue;
-      }
-
-      if (event.type !== "match" || !event.data) continue;
-
-      const pathData = event.data.path as string | { text?: string } | undefined;
-      const filePath =
-        typeof pathData === "string" ? pathData : String(pathData?.text ?? "");
-      const lineNumber = Number(event.data.line_number ?? 0);
-      const lines = (event.data.lines as { text?: string } | undefined)?.text;
-
-      if (!filePath || !lineNumber || !lines) continue;
-      if (!isSearchableFile(filePath)) continue;
-
-      const key = `${filePath}:${lineNumber}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-
-      matches.push({
-        file: filePath,
-        line: lineNumber,
-        snippet: normalizeSnippet(lines),
-      });
-
-      if (matches.length >= MAX_RESULTS) break;
-    }
-
-    return matches;
-  } catch {
-    return null;
-  }
-}
-
 async function searchFile(
   relativePath: string,
   pattern: RegExp,
@@ -173,7 +89,7 @@ async function searchFile(
   }
 }
 
-async function searchWithNodeFs(
+async function searchFiles(
   query: string,
   searchPaths: string[],
 ): Promise<CodebaseSearchMatch[]> {
@@ -244,8 +160,7 @@ async function runSearch(
     return [];
   }
 
-  const ripgrepMatches = await searchWithRipgrep(query, existingPaths);
-  return ripgrepMatches ?? (await searchWithNodeFs(query, existingPaths));
+  return searchFiles(query, existingPaths);
 }
 
 export async function searchCodebase(

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next';
 import createMDX from '@next/mdx';
+import { SUPPORT_SEARCH_TRACE_INCLUDES } from './lib/ai/search-codebase';
 
 const nextConfig: NextConfig = {
   output: "standalone",
@@ -35,6 +36,8 @@ const nextConfig: NextConfig = {
     '/app/api/**': [  // For App Router API routes (your auth callback)
       '**/node_modules/.prisma/client/**',
     ],
+    // Runtime fs search in /api/ai/support — keep docs in the serverless bundle.
+    '/app/api/ai/support/route': [...SUPPORT_SEARCH_TRACE_INCLUDES],
   },
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,7 +37,7 @@ const nextConfig: NextConfig = {
       '**/node_modules/.prisma/client/**',
     ],
     // Runtime fs search in /api/ai/support — keep docs in the serverless bundle.
-    '/app/api/ai/support/route': [...SUPPORT_SEARCH_TRACE_INCLUDES],
+    '/api/ai/support': [...SUPPORT_SEARCH_TRACE_INCLUDES],
   },
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the support assistant failing to find Tradovate and DxFeed documentation on Vercel (reported while testing #260).

## Root cause

Vercel logs for the PR #260 preview (`dpl_ASYui7gr1ymhQcRbaGTeYYtAPqb4`) show `searchCodebase` being called from `/api/ai/support`, but the agent still escalated because searches returned zero matches.

The search implementation treated the full agent query as one literal regex. That only matches when every word appears **consecutively on the same line**, so natural phrases fail:

| Query | Before | After |
|---|---|---|
| `tradovate` | 12 matches | 12 matches |
| `dxfeed prop firm selection` | 0 | 5 (incl. `dxfeed-prop-firm-selection.mdx`) |
| `Tradovate sync documentation` | 0 | 12 |
| `how to connect Tradovate account` | 0 | 12 |

## Changes

- **Keyword search**: split queries into terms, filter stop words (`documentation`, `setup`, etc.), and match when all terms appear in file content or in the filename slug.
- **Fallback**: if a multi-term query still finds nothing, retry with the most distinctive keyword (e.g. `dxfeed`, not `selection`).
- **Resilience**: skip unreadable files instead of failing the whole tool call.
- **Vercel bundle**: explicitly trace `content/**`, locale doc files, and root guides into `/api/ai/support` (normalized route path).
- **Diagnostics**: log query, locale, match count, and sample files in non-production only.

## Cursor review follow-up (merged)

Addresses the blocking issues from the Cursor automation review:

- Fix `outputFileTracingIncludes` key: `/api/ai/support` instead of `/app/api/ai/support/route`
- Reject client-supplied `system` messages and tighten request schema (message/part limits, required `id` + `parts`)
- Require at least one `user` message after stripping the initial assistant greeting
- Gate `searchCodebase` debug logging behind non-production / `SUPPORT_SEARCH_DEBUG`
- Wrap `readdir` in try/catch so unreadable directories do not 500 the API
- Add focused schema unit tests

## Beta merge conflict resolution

Rebased onto latest `beta` and merged `hasUnsupportedFileUrls` file-attachment validation from beta with the hardened schema/route flow from this PR.

## Testing

- `bunx vitest run app/api/ai/support/schema.test.ts` passes (7 tests)
- `bun run typecheck` passes
- Local `searchCodebase()` spot checks for Tradovate/DxFeed queries above

Follow-up to #260.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0adf-54a4-7b04-b054-f8c1ab623704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0adf-54a4-7b04-b054-f8c1ab623704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

