### PR TITLE
fix(dashboard): virtualize trade table rows to prevent crash on Show All

### DIFF
--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useRef } from "react";
 import { useData } from "@/context/data-provider";
 import {
   ColumnDef,
@@ -100,6 +100,7 @@ import {
 import { EditableTimeCell } from "./editable-time-cell";
 import { EditableInstrumentCell } from "./editable-instrument-cell";
 import { BulkEditPanel } from "./bulk-edit-panel";
+import { TradeTableVirtualBody } from "./trade-table-virtual-body";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { DASHBOARD_COMPACT_BREAKPOINT } from "../../types/dashboard";
 
@@ -1256,6 +1257,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
   // Note: This only controls the Card header, not the table column headers
   const showHeader = config?.showHeader !== false;
   const isCompactScreen = useMediaQuery(`(max-width: ${DASHBOARD_COMPACT_BREAKPOINT}px)`);
+  const tableContainerRef = useRef<HTMLDivElement>(null);
 
   // Visible columns are used for rendering header/body/footer so hidden columns don't create gaps
   const visibleColumns = table.getVisibleLeafColumns();
@@ -1422,7 +1424,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
         </div>
       </CardHeader>
       )}
-      <CardContent className="flex-1 min-h-0 overflow-auto p-0">
+      <CardContent ref={tableContainerRef} className="flex-1 min-h-0 overflow-auto p-0">
         <div className="relative w-full min-w-max">
           <table
             className="w-full border-separate border-spacing-0 caption-bottom text-sm"
@@ -1452,54 +1454,11 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 ))}
               </thead>
 
-            <tbody className="bg-background [&_tr:last-child]:border-0">
-              {table.getRowModel().rows?.length ? (
-                table.getRowModel().rows.map((row, rowIndex) => (
-                  <React.Fragment key={row.id}>
-                    <tr
-                      data-state={row.getIsSelected() && "selected"}
-                      className={cn(
-                        "border-b border-border transition-colors duration-75 hover:bg-muted/40 group",
-                        row.getIsSelected() && "bg-accent/50 hover:bg-accent data-[state=selected]:bg-muted",
-                        row.getIsExpanded()
-                          ? "bg-muted/60"
-                          : row.getCanExpand()
-                            ? "bg-background"
-                            : "bg-muted/30",
-                        rowIndex % 2 === 1 &&
-                          !row.getIsSelected() &&
-                          "bg-muted/20",
-                      )}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <td
-                          key={cell.id}
-                          className={cn(
-                            "p-4 align-middle [&:has([role=checkbox])]:pr-0 whitespace-nowrap px-3 py-2 text-sm border-r border-border/50 last:border-r-0 first:border-l group-hover:border-border",
-                            row.getIsSelected() && "border-border",
-                          )}
-                          style={{ width: cell.column.getSize() }}
-                        >
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                          )}
-                        </td>
-                      ))}
-                    </tr>
-                  </React.Fragment>
-                ))
-              ) : (
-                <tr>
-                  <td
-                    colSpan={visibleColumns.length}
-                    className="p-4 align-middle [&:has([role=checkbox])]:pr-0 h-24 text-center"
-                  >
-                    No results.
-                  </td>
-                </tr>
-              )}
-            </tbody>
+            <TradeTableVirtualBody
+              table={table}
+              scrollElementRef={tableContainerRef}
+              columnCount={visibleColumns.length}
+            />
             <tfoot className="sticky bottom-0 z-10 bg-muted/90 backdrop-blur-xs border-t-2 border-border">
               <tr className="border-b transition-colors">
                 {visibleColumns.map((column, index) => {

--- a/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import React from "react";
+import { flexRender, Row, Table } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { cn } from "@/lib/utils";
+
+const ROW_HEIGHT_ESTIMATE = 44;
+const VIRTUAL_OVERSCAN = 10;
+
+interface TradeTableVirtualBodyProps<TData> {
+  table: Table<TData>;
+  scrollElementRef: React.RefObject<HTMLDivElement | null>;
+  columnCount: number;
+}
+
+function TradeTableBodyRow<TData>({
+  row,
+  rowIndex,
+}: {
+  row: Row<TData>;
+  rowIndex: number;
+}) {
+  return (
+    <tr
+      data-state={row.getIsSelected() && "selected"}
+      className={cn(
+        "border-b border-border transition-colors duration-75 hover:bg-muted/40 group",
+        row.getIsSelected() &&
+          "bg-accent/50 hover:bg-accent data-[state=selected]:bg-muted",
+        row.getIsExpanded()
+          ? "bg-muted/60"
+          : row.getCanExpand()
+            ? "bg-background"
+            : "bg-muted/30",
+        rowIndex % 2 === 1 && !row.getIsSelected() && "bg-muted/20",
+      )}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <td
+          key={cell.id}
+          className={cn(
+            "p-4 align-middle [&:has([role=checkbox])]:pr-0 whitespace-nowrap px-3 py-2 text-sm border-r border-border/50 last:border-r-0 first:border-l group-hover:border-border",
+            row.getIsSelected() && "border-border",
+          )}
+          style={{ width: cell.column.getSize() }}
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+export function TradeTableVirtualBody<TData>({
+  table,
+  scrollElementRef,
+  columnCount,
+}: TradeTableVirtualBodyProps<TData>) {
+  const { rows } = table.getRowModel();
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollElementRef.current,
+    estimateSize: () => ROW_HEIGHT_ESTIMATE,
+    overscan: VIRTUAL_OVERSCAN,
+  });
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+      : 0;
+
+  if (rows.length === 0) {
+    return (
+      <tbody className="bg-background [&_tr:last-child]:border-0">
+        <tr>
+          <td
+            colSpan={columnCount}
+            className="p-4 align-middle [&:has([role=checkbox])]:pr-0 h-24 text-center"
+          >
+            No results.
+          </td>
+        </tr>
+      </tbody>
+    );
+  }
+
+  return (
+    <tbody className="bg-background [&_tr:last-child]:border-0">
+      {paddingTop > 0 && (
+        <tr aria-hidden="true">
+          <td
+            colSpan={columnCount}
+            style={{ height: paddingTop, padding: 0, border: 0 }}
+          />
+        </tr>
+      )}
+      {virtualRows.map((virtualRow) => {
+        const row = rows[virtualRow.index];
+        return (
+          <TradeTableBodyRow key={row.id} row={row} rowIndex={virtualRow.index} />
+        );
+      })}
+      {paddingBottom > 0 && (
+        <tr aria-hidden="true">
+          <td
+            colSpan={columnCount}
+            style={{ height: paddingBottom, padding: 0, border: 0 }}
+          />
+        </tr>
+      )}
+    </tbody>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@tailwindcss/cli": "^4.1.16",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.14.4",
         "@tiptap/core": "^3.8.0",
         "@tiptap/extension-bubble-menu": "^3.8.0",
         "@tiptap/extension-collaboration": "^3.8.0",
@@ -893,7 +894,11 @@
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.4", "", { "dependencies": { "@tanstack/virtual-core": "3.17.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw=="],
+
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.2", "", {}, "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA=="],
 
     "@tiptap/core": ["@tiptap/core@3.26.1", "", { "peerDependencies": { "@tiptap/pm": "3.26.1" } }, "sha512-TX9PyPqBoix0qDLjtok/bddtdSy54QhzLVha405C07V+WySOpH3s/pWYkywehZQY0SQtcrcY4MNSCeQjCbA28A=="],
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@tailwindcss/cli": "^4.1.16",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.4",
     "@tiptap/core": "^3.8.0",
     "@tiptap/extension-bubble-menu": "^3.8.0",
     "@tiptap/extension-collaboration": "^3.8.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking **Show All** in Trade Review sets the page size to the full trade count (e.g. 1,500+), which mounts every row in the DOM at once and crashes or freezes the browser.

## Solution

Follow the [TanStack Table + TanStack Virtual](https://tanstack.com/table/latest/docs/framework/react/guide/virtualization) pattern: keep the full dataset in memory for sorting/filtering/pagination, but only render the rows visible in the scroll viewport.

### Implementation

- Add `@tanstack/react-virtual`
- New `TradeTableVirtualBody` component using the **spacer row** pattern (works with native `<table>` markup and sticky header/footer)
- Fixed 44px row height estimate, overscan of 10
- Scroll container is the existing `CardContent` overflow area

### What this enables

- **Show All** now scrolls through the full list without mounting thousands of DOM nodes
- Pagination still works — each page only virtualizes its current slice
- Expanded group rows remain supported (sub-rows are separate entries in the row model)

## Test plan

- [ ] Open Trade Review with 500+ trades
- [ ] Click **Show All** — table should scroll smoothly without crashing
- [ ] Verify prev/next pagination still works at smaller page sizes
- [ ] Expand a grouped row and confirm sub-trades render correctly while scrolling
- [ ] Confirm sorting and column visibility still behave as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0ada-3403-75a9-b947-d078f01b87a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0ada-3403-75a9-b947-d078f01b87a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

