### PR TITLE
Fix dark mode video poster flash on landing page

### DIFF
--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -14,18 +14,18 @@ export default function Hero() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const videoContainerRef = useRef<HTMLDivElement>(null);
 
-  const posterSrc =
-    effectiveTheme === "dark"
-      ? "/videos/demo_dark_poster.png"
-      : "/videos/demo_white_poster.png";
+  // Read from the DOM class (set by the blocking init-theme script) so the
+  // correct media is chosen before React state hydrates.
+  const resolvedTheme =
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+      ? "dark"
+      : effectiveTheme;
 
   const videoSrc =
-    effectiveTheme === "dark"
+    resolvedTheme === "dark"
       ? "/videos/demo_dark.mp4"
       : "/videos/demo_white.mp4";
-
-  const mediaAspectClass =
-    effectiveTheme === "dark" ? "aspect-[2120/1080]" : "aspect-[2108/1080]";
 
   useEffect(() => {
     const container = videoContainerRef.current;
@@ -97,17 +97,25 @@ export default function Hero() {
           ref={videoContainerRef}
           className="flex w-full items-center justify-center relative rounded-lg"
         >
-          <div className={`relative w-full ${mediaAspectClass} rounded-[14.5867px]`}>
+          <div className="relative w-full aspect-[2108/1080] dark:aspect-[2120/1080] rounded-[14.5867px]">
             <span className="absolute inset-[-12px] md:inset-[-24px] bg-[rgba(50,169,151,0.15)] dark:bg-[hsl(var(--chart-1)/0.15)] rounded-[14.5867px] -z-10 animate-pulse"></span>
             <span className="absolute inset-[-4px] md:inset-[-8px] bg-[rgba(50,169,151,0.25)] dark:bg-[hsl(var(--chart-1)/0.25)] rounded-[14.5867px] -z-20 animate-pulse"></span>
             <span className="absolute inset-0 shadow-[0_9.1167px_13.675px_-2.735px_rgba(0,0,0,0.1),0_3.64667px_5.47px_-3.64667px_rgba(0,0,0,0.1)] md:shadow-[0_18.2333px_27.35px_-5.47px_rgba(0,0,0,0.1),0_7.29333px_10.94px_-7.29333px_rgba(0,0,0,0.1)] dark:shadow-[0_9.1167px_13.675px_-2.735px_hsl(var(--chart-1)/0.1),0_3.64667px_5.47px_-3.64667px_hsl(var(--chart-1)/0.1)] md:dark:shadow-[0_18.2333px_27.35px_-5.47px_hsl(var(--chart-1)/0.1),0_7.29333px_10.94px_-7.29333px_hsl(var(--chart-1)/0.1)] rounded-[14.5867px] -z-30"></span>
             {!videoError && (
-              <img
-                src={posterSrc}
-                alt=""
-                aria-hidden={videoLoaded}
-                className={`absolute inset-0 h-full w-full rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] object-cover dark:border-gray-800 transition-opacity duration-300 ${videoLoaded ? "opacity-0" : "opacity-100"}`}
-              />
+              <>
+                <img
+                  src="/videos/demo_white_poster.png"
+                  alt=""
+                  aria-hidden={videoLoaded}
+                  className={`absolute inset-0 h-full w-full rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] object-cover dark:border-gray-800 transition-opacity duration-300 dark:hidden ${videoLoaded ? "opacity-0" : "opacity-100"}`}
+                />
+                <img
+                  src="/videos/demo_dark_poster.png"
+                  alt=""
+                  aria-hidden={videoLoaded}
+                  className={`absolute inset-0 hidden h-full w-full rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] object-cover dark:border-gray-800 transition-opacity duration-300 dark:block ${videoLoaded ? "opacity-0" : "opacity-100"}`}
+                />
+              </>
             )}
             {videoError && (
               <div className="absolute inset-0 flex items-center justify-center rounded-[14.5867px] bg-gray-100 dark:bg-black">
@@ -122,7 +130,6 @@ export default function Hero() {
               autoPlay
               playsInline
               className={`absolute inset-0 h-full w-full rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] object-cover transition-opacity duration-300 dark:border-gray-800 ${videoLoaded && !videoError ? "opacity-100" : "opacity-0"}`}
-              poster={posterSrc}
               onLoadedData={handleVideoLoad}
               onError={handleVideoError}
             >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the landing page in dark mode, the hero video briefly showed the white poster image before switching to the dark one.

## Root cause

The hero component chose poster/video assets from `effectiveTheme` in React state, which defaults to `'light'` until `ThemeProvider` hydrates. The blocking `init-theme` script already applies the `dark` class to `<html>` before paint, but JavaScript state lagged behind.

## Solution

- Render **both** poster images and toggle visibility with Tailwind `dark:hidden` / `hidden dark:block` (same pattern as the features section)
- Use CSS `dark:aspect-*` for aspect ratio instead of a JS conditional
- Resolve video source from the DOM `dark` class when available, so the correct `.mp4` is selected before React state catches up
- Remove the `poster` attribute from `<video>` since the overlay images handle the placeholder

## Testing

- [ ] Open landing page in dark mode — dark poster should appear immediately with no white flash
- [ ] Toggle between light/dark — poster and video should switch correctly
- [ ] Light mode unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0b36-2f44-7858-9876-31347efa69ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0b36-2f44-7858-9876-31347efa69ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

