### PR TITLE
fix(updates): format changelog dates without timezone drift

### DIFF
--- a/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
@@ -2,6 +2,8 @@ import { ImageResponse } from "next/og"
 import { getPost, getAllPosts } from "@/lib/mdx"
 import type { ReactElement } from "react"
 import { getStaticParams as getLocaleStaticParams } from '@/locales/server'
+import { enUS, fr } from "date-fns/locale"
+import { formatDateOnly } from "@/lib/format-date-only"
 
 export const alt = "Deltalytix Update"
 export const size = {
@@ -45,12 +47,10 @@ export default async function Image({
 
         const { meta } = post
 
-        // Format the date
-        const date = new Date(meta.date)
-        const formattedDate = date.toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
+        const dateLocale = locale === "fr" ? fr : enUS
+        const dateFormat = locale === "fr" ? "d MMMM yyyy" : "MMMM d, yyyy"
+        const formattedDate = formatDateOnly(meta.date, dateFormat, {
+            locale: dateLocale,
         })
 
         const element = (

--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -4,8 +4,8 @@ import { Metadata } from "next";
 import { getAllPosts, getAdjacentPosts } from "@/lib/mdx";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
-import { format } from "date-fns";
 import { enUS, fr } from "date-fns/locale";
+import { formatDateOnly } from "@/lib/format-date-only";
 import Script from "next/script";
 import { setStaticParamsLocale } from "next-international/server";
 import { getStaticParams as getLocaleStaticParams } from "@/locales/server";
@@ -79,7 +79,7 @@ export async function generateMetadata({
       const url = siteUrl(`/${locale}/updates/${slug}`);
       const dateLocale = locale === "fr" ? fr : enUS;
       const shareDateFormat = locale === "fr" ? "d MMMM yyyy" : "MMMM d, yyyy";
-      const formattedShareDate = format(new Date(meta.date), shareDateFormat, {
+      const formattedShareDate = formatDateOnly(meta.date, shareDateFormat, {
         locale: dateLocale,
       });
       const shareTitleLabel = locale === "fr" ? "Changements" : "Changelog";
@@ -174,7 +174,11 @@ export default async function Page({ params }: PageProps) {
 
   const { previous, next } = adjacentPosts;
   const { meta, content } = post;
-  const formattedDate = format(new Date(meta.date), "MMMM d, yyyy");
+  const pageDateLocale = locale === "fr" ? fr : enUS;
+  const pageDateFormat = locale === "fr" ? "d MMMM yyyy" : "MMMM d, yyyy";
+  const formattedDate = formatDateOnly(meta.date, pageDateFormat, {
+    locale: pageDateLocale,
+  });
   const url = siteUrl(`/${locale}/updates/${slug}`);
 
   // Prepare JSON-LD structured data

--- a/lib/format-date-only.test.ts
+++ b/lib/format-date-only.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { enUS, fr } from "date-fns/locale";
-import { formatDateOnly } from "./format-date-only";
+import { formatDateOnly, toDateOnlyString } from "./format-date-only";
 
 describe("formatDateOnly", () => {
   it("formats YYYY-MM-DD without shifting the calendar day", () => {
@@ -15,6 +15,14 @@ describe("formatDateOnly", () => {
   it("ignores time portions on ISO strings", () => {
     expect(formatDateOnly("2026-06-24T00:00:00.000Z", "MMMM d, yyyy")).toBe(
       "June 24, 2026"
+    );
+  });
+
+  it("handles YAML Date objects from unquoted frontmatter", () => {
+    const yamlDate = new Date("2025-12-15T00:00:00.000Z");
+    expect(toDateOnlyString(yamlDate)).toBe("2025-12-15");
+    expect(formatDateOnly(yamlDate, "MMMM d, yyyy", { locale: enUS })).toBe(
+      "December 15, 2025"
     );
   });
 });

--- a/lib/format-date-only.test.ts
+++ b/lib/format-date-only.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { enUS, fr } from "date-fns/locale";
+import { formatDateOnly } from "./format-date-only";
+
+describe("formatDateOnly", () => {
+  it("formats YYYY-MM-DD without shifting the calendar day", () => {
+    expect(
+      formatDateOnly("2026-01-25", "MMMM d, yyyy", { locale: enUS })
+    ).toBe("January 25, 2026");
+    expect(
+      formatDateOnly("2026-01-25", "d MMMM yyyy", { locale: fr })
+    ).toBe("25 janvier 2026");
+  });
+
+  it("ignores time portions on ISO strings", () => {
+    expect(formatDateOnly("2026-06-24T00:00:00.000Z", "MMMM d, yyyy")).toBe(
+      "June 24, 2026"
+    );
+  });
+});

--- a/lib/format-date-only.ts
+++ b/lib/format-date-only.ts
@@ -1,17 +1,38 @@
 import { formatInTimeZone } from "date-fns-tz";
 import type { Locale } from "date-fns";
 
+type DateLike = string | Date | number;
+
+/** Normalize MDX frontmatter dates (string or YAML Date) to YYYY-MM-DD. */
+export function toDateOnlyString(value: DateLike): string {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return formatInTimeZone(value, "UTC", "yyyy-MM-dd");
+  }
+
+  const match = String(value).trim().match(/^(\d{4}-\d{2}-\d{2})/);
+  if (match) {
+    return match[1];
+  }
+
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return formatInTimeZone(parsed, "UTC", "yyyy-MM-dd");
+  }
+
+  throw new RangeError(`Invalid date-only value: ${String(value)}`);
+}
+
 /**
  * Format a date-only string (YYYY-MM-DD) for display.
  * Frontmatter dates are calendar dates, not timestamps — anchor at UTC noon so
  * the formatted day never shifts with build/runtime timezone.
  */
 export function formatDateOnly(
-  dateStr: string,
+  dateStr: DateLike,
   formatStr: string,
   options?: { locale?: Locale }
 ): string {
-  const dateOnly = dateStr.slice(0, 10);
+  const dateOnly = toDateOnlyString(dateStr);
   return formatInTimeZone(
     `${dateOnly}T12:00:00.000Z`,
     "UTC",

--- a/lib/format-date-only.ts
+++ b/lib/format-date-only.ts
@@ -1,0 +1,21 @@
+import { formatInTimeZone } from "date-fns-tz";
+import type { Locale } from "date-fns";
+
+/**
+ * Format a date-only string (YYYY-MM-DD) for display.
+ * Frontmatter dates are calendar dates, not timestamps — anchor at UTC noon so
+ * the formatted day never shifts with build/runtime timezone.
+ */
+export function formatDateOnly(
+  dateStr: string,
+  formatStr: string,
+  options?: { locale?: Locale }
+): string {
+  const dateOnly = dateStr.slice(0, 10);
+  return formatInTimeZone(
+    `${dateOnly}T12:00:00.000Z`,
+    "UTC",
+    formatStr,
+    options
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the medium-severity Bugbot finding on PR #249 (**Changelog share date shifts**).

Changelog/update posts store dates as calendar days in MDX frontmatter (`YYYY-MM-DD`). Formatting them with `new Date(meta.date)` + `date-fns` `format()` anchored at UTC midnight, so builds or requests west of UTC could show the **previous day** in OG/Twitter share titles (e.g. `Changelog · January 24, 2026` instead of January 25).

This adds `formatDateOnly()` which treats frontmatter dates as calendar days and formats them at UTC noon so the day never shifts with build region or viewer timezone.

## Changes

- **`lib/format-date-only.ts`** — shared helper for timezone-stable date-only formatting
- **`app/[locale]/(landing)/updates/[slug]/page.tsx`** — OG/Twitter share title + on-page date label
- **`app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx`** — OG image date (also localized for FR)
- **`lib/format-date-only.test.ts`** — regression tests

## Test plan

- [x] `bun test ./lib/format-date-only.test.ts`
- [x] `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0d80-aac0-7e0a-8417-ccebe2049ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0d80-aac0-7e0a-8417-ccebe2049ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

