### PR TITLE
fix(landing): compute calendar preview monthly total from grid days

### DIFF
--- a/app/[locale]/(landing)/components/calendar-preview.tsx
+++ b/app/[locale]/(landing)/components/calendar-preview.tsx
@@ -18,6 +18,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 import { useCurrentLocale, useI18n } from "@/locales/landing-client"
 import { translateWeekday } from "@/lib/translation-utils"
+import { sumLandingCalendarMonthPnl } from "@/lib/landing-calendar-monthly-total"
 
 type CalendarDayEntry = {
   pnl: number
@@ -108,12 +109,10 @@ function LandingCalendarPreview({ calendarData }: { calendarData: PreviewCalenda
     [monthStart, monthEnd]
   )
 
-  const monthlyTotal = useMemo(() => {
-    return Object.entries(calendarData).reduce((total, [dateString, dayData]) => {
-      const date = new Date(dateString)
-      return isSameMonth(date, currentDate) ? total + dayData.pnl : total
-    }, 0)
-  }, [calendarData, currentDate])
+  const monthlyTotal = useMemo(
+    () => sumLandingCalendarMonthPnl(calendarDays, calendarData, currentDate),
+    [calendarDays, calendarData, currentDate],
+  )
 
   const calculateWeeklyTotal = (index: number) => {
     const startOfWeekIndex = index - 6

--- a/app/[locale]/(landing)/components/calendar-preview.tsx
+++ b/app/[locale]/(landing)/components/calendar-preview.tsx
@@ -110,8 +110,8 @@ function LandingCalendarPreview({ calendarData }: { calendarData: PreviewCalenda
   )
 
   const monthlyTotal = useMemo(
-    () => sumLandingCalendarMonthPnl(calendarDays, calendarData, currentDate),
-    [calendarDays, calendarData, currentDate],
+    () => sumLandingCalendarMonthPnl(calendarData, currentDate),
+    [calendarData, currentDate],
   )
 
   const calculateWeeklyTotal = (index: number) => {

--- a/lib/landing-calendar-monthly-total.test.ts
+++ b/lib/landing-calendar-monthly-total.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import {
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns"
+import { sumLandingCalendarMonthPnl } from "./landing-calendar-monthly-total"
+
+function getCalendarDays(monthStart: Date, monthEnd: Date) {
+  return eachDayOfInterval({
+    start: startOfWeek(monthStart, { weekStartsOn: 0 }),
+    end: endOfWeek(monthEnd, { weekStartsOn: 0 }),
+  })
+}
+
+describe("sumLandingCalendarMonthPnl", () => {
+  it("sums demo days for the visible month using local date keys", () => {
+    const currentDate = new Date(2026, 5, 15)
+    const monthStart = startOfMonth(currentDate)
+    const monthEnd = endOfMonth(currentDate)
+    const calendarDays = getCalendarDays(monthStart, monthEnd)
+
+    const calendarData = [1, 2, 3, 4].reduce<Record<string, { pnl: number }>>(
+      (acc, day) => {
+        const dateKey = format(new Date(2026, 5, day), "yyyy-MM-dd")
+        acc[dateKey] = { pnl: day * 100 }
+        return acc
+      },
+      {},
+    )
+
+    const expected = Object.values(calendarData).reduce(
+      (total, entry) => total + entry.pnl,
+      0,
+    )
+
+    expect(sumLandingCalendarMonthPnl(calendarDays, calendarData, currentDate)).toBe(
+      expected,
+    )
+  })
+
+  it("does not drop the first of the month in negative UTC offsets", () => {
+    const previousTz = process.env.TZ
+    process.env.TZ = "America/Los_Angeles"
+
+    try {
+      const currentDate = new Date(2026, 5, 15)
+      const calendarDays = getCalendarDays(
+        startOfMonth(currentDate),
+        endOfMonth(currentDate),
+      )
+      const calendarData = {
+        "2026-06-01": { pnl: 120 },
+        "2026-06-02": { pnl: 620 },
+      }
+
+      expect(
+        sumLandingCalendarMonthPnl(calendarDays, calendarData, currentDate),
+      ).toBe(740)
+    } finally {
+      process.env.TZ = previousTz
+    }
+  })
+})

--- a/lib/landing-calendar-monthly-total.test.ts
+++ b/lib/landing-calendar-monthly-total.test.ts
@@ -1,45 +1,19 @@
 import { describe, expect, it } from "vitest"
-import {
-  eachDayOfInterval,
-  endOfMonth,
-  endOfWeek,
-  format,
-  startOfMonth,
-  startOfWeek,
-} from "date-fns"
+import { format } from "date-fns"
 import { sumLandingCalendarMonthPnl } from "./landing-calendar-monthly-total"
 
-function getCalendarDays(monthStart: Date, monthEnd: Date) {
-  return eachDayOfInterval({
-    start: startOfWeek(monthStart, { weekStartsOn: 0 }),
-    end: endOfWeek(monthEnd, { weekStartsOn: 0 }),
-  })
-}
-
 describe("sumLandingCalendarMonthPnl", () => {
-  it("sums demo days for the visible month using local date keys", () => {
+  it("sums all calendar data for the month, not adjacent months", () => {
     const currentDate = new Date(2026, 5, 15)
-    const monthStart = startOfMonth(currentDate)
-    const monthEnd = endOfMonth(currentDate)
-    const calendarDays = getCalendarDays(monthStart, monthEnd)
+    const calendarData = {
+      "2026-05-31": { pnl: 999 },
+      "2026-06-01": { pnl: 120 },
+      "2026-06-15": { pnl: 540 },
+      "2026-06-30": { pnl: 95 },
+      "2026-07-01": { pnl: 888 },
+    }
 
-    const calendarData = [1, 2, 3, 4].reduce<Record<string, { pnl: number }>>(
-      (acc, day) => {
-        const dateKey = format(new Date(2026, 5, day), "yyyy-MM-dd")
-        acc[dateKey] = { pnl: day * 100 }
-        return acc
-      },
-      {},
-    )
-
-    const expected = Object.values(calendarData).reduce(
-      (total, entry) => total + entry.pnl,
-      0,
-    )
-
-    expect(sumLandingCalendarMonthPnl(calendarDays, calendarData, currentDate)).toBe(
-      expected,
-    )
+    expect(sumLandingCalendarMonthPnl(calendarData, currentDate)).toBe(755)
   })
 
   it("does not drop the first of the month in negative UTC offsets", () => {
@@ -48,20 +22,28 @@ describe("sumLandingCalendarMonthPnl", () => {
 
     try {
       const currentDate = new Date(2026, 5, 15)
-      const calendarDays = getCalendarDays(
-        startOfMonth(currentDate),
-        endOfMonth(currentDate),
-      )
       const calendarData = {
         "2026-06-01": { pnl: 120 },
         "2026-06-02": { pnl: 620 },
       }
 
-      expect(
-        sumLandingCalendarMonthPnl(calendarDays, calendarData, currentDate),
-      ).toBe(740)
+      expect(sumLandingCalendarMonthPnl(calendarData, currentDate)).toBe(740)
     } finally {
       process.env.TZ = previousTz
     }
+  })
+
+  it("includes month entries even when the grid would only show a subset", () => {
+    const currentDate = new Date(2026, 5, 15)
+    const calendarData = [1, 2, 29, 30].reduce<Record<string, { pnl: number }>>(
+      (acc, day) => {
+        const dateKey = format(new Date(2026, 5, day), "yyyy-MM-dd")
+        acc[dateKey] = { pnl: day * 100 }
+        return acc
+      },
+      {},
+    )
+
+    expect(sumLandingCalendarMonthPnl(calendarData, currentDate)).toBe(6200)
   })
 })

--- a/lib/landing-calendar-monthly-total.ts
+++ b/lib/landing-calendar-monthly-total.ts
@@ -1,17 +1,17 @@
-import { format, isSameMonth } from "date-fns"
+import { format } from "date-fns"
 
 type CalendarDayEntry = {
   pnl: number
 }
 
+/** Sum all P/L in calendarData for the given month (local yyyy-MM), independent of grid layout. */
 export function sumLandingCalendarMonthPnl(
-  calendarDays: Date[],
   calendarData: Record<string, CalendarDayEntry>,
   monthDate: Date,
 ): number {
-  return calendarDays.reduce((total, day) => {
-    if (!isSameMonth(day, monthDate)) return total
-    const dayData = calendarData[format(day, "yyyy-MM-dd")]
-    return total + (dayData?.pnl ?? 0)
+  const monthKey = format(monthDate, "yyyy-MM")
+
+  return Object.entries(calendarData).reduce((total, [dateKey, dayData]) => {
+    return dateKey.startsWith(monthKey) ? total + dayData.pnl : total
   }, 0)
 }

--- a/lib/landing-calendar-monthly-total.ts
+++ b/lib/landing-calendar-monthly-total.ts
@@ -1,0 +1,17 @@
+import { format, isSameMonth } from "date-fns"
+
+type CalendarDayEntry = {
+  pnl: number
+}
+
+export function sumLandingCalendarMonthPnl(
+  calendarDays: Date[],
+  calendarData: Record<string, CalendarDayEntry>,
+  monthDate: Date,
+): number {
+  return calendarDays.reduce((total, day) => {
+    if (!isSameMonth(day, monthDate)) return total
+    const dayData = calendarData[format(day, "yyyy-MM-dd")]
+    return total + (dayData?.pnl ?? 0)
+  }, 0)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a timezone mismatch in the landing page calendar preview where the monthly P/L header could disagree with the actual month total.

## Problem

- Demo day keys are built with local `format(new Date(year, month, day), "yyyy-MM-dd")`
- The monthly total previously parsed keys with `new Date(dateString)`, which treats `yyyy-MM-dd` as UTC
- In negative UTC offsets (e.g. `America/Los_Angeles`), `isSameMonth` could exclude the 1st of the month and undercount P/L

## Fix

- Sum monthly P/L from **all `calendarData` entries for the month** (source of truth), not by walking visible grid days
- Match month membership via local `yyyy-MM` key prefix — no `Date` parsing of date-only strings
- Add timezone regression tests

## Testing

- `bunx vitest run lib/landing-calendar-monthly-total.test.ts`
- Local self-host quickstart + dev server health checks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6136f221-25d0-4ad9-8cd8-57cb30cc1bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6136f221-25d0-4ad9-8cd8-57cb30cc1bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

