### PR TITLE
Remove duplicate hero image from update detail pages

### DIFF
--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import { getAllPosts, getAdjacentPosts } from "@/lib/mdx";
 import { Badge } from "@/components/ui/badge";
-import Image from "next/image";
 import { enUS, fr } from "date-fns/locale";
 import { formatDateOnly } from "@/lib/format-date-only";
 import Script from "next/script";
@@ -248,20 +247,6 @@ export default async function Page({ params }: PageProps) {
             </Badge>
           </div>
         </div>
-
-        {meta.image && (
-          <div className="mb-8 rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-800">
-            <Image
-              src={meta.image}
-              alt={meta.title}
-              width={1200}
-              height={600}
-              className="w-full h-auto"
-              priority
-              itemProp="image"
-            />
-          </div>
-        )}
 
         <div
           className="prose prose-neutral dark:prose-invert max-w-none


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Update detail pages were showing each post image twice: once as a hero block above the article body, and again inside the MDX content (e.g. markdown `![]()` or video poster).

This removes the top-of-page hero render so images only appear where authors place them in the post content.

## What stays the same

- `meta.image` in frontmatter is unchanged and still powers:
  - Open Graph / social previews
  - JSON-LD structured data
  - Thumbnails on the updates listing page

## Test plan

- [ ] Open an update with an inline image (e.g. `/en/updates/import-from-mobile`) and confirm the image appears only once in the article body
- [ ] Open an update with a video poster (e.g. `/en/updates/faster-landing-page`) and confirm no duplicate still image above the content
- [ ] Confirm the updates index still shows post thumbnails
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0eb3-2b91-7914-99b6-ef4b807920f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0eb3-2b91-7914-99b6-ef4b807920f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

