### PR TITLE
[codex] Fix mobile dashboard filter toolbar button

### DIFF
--- a/app/[locale]/dashboard/components/filters/filter-command-menu.tsx
+++ b/app/[locale]/dashboard/components/filters/filter-command-menu.tsx
@@ -25,12 +25,14 @@ interface FilterCommandMenuProps {
   className?: string
   variant?: "navbar" | "toolbar"
   compactBreakpoint?: number
+  compact?: boolean
 }
 
 export function FilterCommandMenu({
   className,
   variant = "navbar",
   compactBreakpoint = 768,
+  compact = false,
 }: FilterCommandMenuProps) {
   const t = useI18n()
   const { isMobile, dateRange, setDateRange, setWeekdayFilter } = useData()
@@ -262,16 +264,21 @@ export function FilterCommandMenu({
   // Trigger on mobile: button that opens drawer
   const MobileTriggerButton = (
     <Button
-      variant="outline"
+      variant={compact ? "ghost" : "outline"}
       className={cn(
-        "justify-start text-left font-normal overflow-hidden",
+        "font-normal overflow-hidden",
+        compact
+          ? "h-10 w-10 shrink-0 rounded-full p-0"
+          : "justify-start text-left",
         variant === "toolbar" && "h-10 rounded-full max-w-full",
         className
       )}
       onClick={() => setOpen(true)}
     >
-      <Search className="h-4 w-4 mr-2" />
-      <span className="text-muted-foreground truncate">{t('filters.commandMenu.searchPlaceholderMobile')}</span>
+      <Search className={cn("h-4 w-4", !compact && "mr-2")} />
+      {!compact && (
+        <span className="text-muted-foreground truncate">{t('filters.commandMenu.searchPlaceholderMobile')}</span>
+      )}
     </Button>
   )
 
@@ -574,4 +581,3 @@ export function FilterCommandMenu({
     </Popover>
   )
 }
-

--- a/app/[locale]/dashboard/components/filters/filter-command-menu.tsx
+++ b/app/[locale]/dashboard/components/filters/filter-command-menu.tsx
@@ -274,6 +274,7 @@ export function FilterCommandMenu({
         className
       )}
       onClick={() => setOpen(true)}
+      aria-label={compact ? t('filters.commandMenu.searchPlaceholderMobile') : undefined}
     >
       <Search className={cn("h-4 w-4", !compact && "mr-2")} />
       {!compact && (

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -241,8 +241,9 @@ export function Toolbar({
 
             <FilterCommandMenu
               variant="toolbar"
-              className={cn(useCompactLayout ? "min-w-0 flex-1 basis-full sm:basis-44" : "w-auto")}
+              className={cn(useCompactLayout ? "w-10 p-0" : "w-auto")}
               compactBreakpoint={DASHBOARD_COMPACT_BREAKPOINT}
+              compact={useCompactLayout}
             />
 
             {isCustomizing && (
@@ -330,4 +331,4 @@ export function Toolbar({
       </ContextMenuContent>
     </ContextMenu>
   )
-} 
+}


### PR DESCRIPTION
## Summary

Fixes the mobile dashboard toolbar filter trigger so it matches the other compact toolbar buttons.

## What changed

- Added a compact mode to `FilterCommandMenu`.
- In compact toolbar mode, the filter trigger is now an icon-only `h-10 w-10` ghost button.
- Updated the dashboard toolbar to use compact filter mode on mobile/compact layouts.

## Why

The mobile toolbar was taller and visually inconsistent because the filter trigger rendered as a full-width outlined search button while the neighboring actions rendered as compact borderless icon buttons.

## Validation

- `sudo docker compose up --build -d app`
- `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/en/dashboard` returned `200`
- `curl -s -I http://localhost:3000/en/dashboard | grep -i x-auth-status` returned `x-auth-status: authenticated`
- `sudo docker compose ps` showed `deltalytix-app-1` up and `deltalytix-db-1` healthy
