### PR TITLE
Improve OG images and social metadata for SEO previews

### DIFF
--- a/app/[locale]/(landing)/layout.tsx
+++ b/app/[locale]/(landing)/layout.tsx
@@ -9,13 +9,17 @@ import { Metadata } from 'next';
 import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 
 type Locale = 'en' | 'fr';
+const TITLE_TEMPLATE = "%s | Deltalytix";
 
 export async function generateMetadata(props: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const params = await props.params;
   const copy = getSiteMetadataCopy(params.locale);
 
   return {
-    title: copy.title,
+    title: {
+      absolute: copy.title,
+      template: TITLE_TEMPLATE,
+    },
     description: copy.description,
     openGraph: {
       title: copy.title,
@@ -23,6 +27,7 @@ export async function generateMetadata(props: { params: Promise<{ locale: Locale
       locale: params.locale === "fr" ? "fr_FR" : "en_US",
     },
     twitter: {
+      card: "summary_large_image",
       title: copy.title,
       description: copy.description,
     },

--- a/app/[locale]/(landing)/layout.tsx
+++ b/app/[locale]/(landing)/layout.tsx
@@ -6,21 +6,26 @@ import { I18nProviderClient } from "@/locales/landing-client";
 import { ConsentBanner } from "@/components/consent-banner";
 
 import { Metadata } from 'next';
+import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 
 type Locale = 'en' | 'fr';
 
 export async function generateMetadata(props: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const params = await props.params;
-  const descriptions: Record<Locale, string> = {
-    en: 'Centralize and visualize your trading performance across multiple brokers. Track, analyze, and improve your trading journey with powerful analytics.',
-    fr: 'Centralisez et visualisez vos performances de trading à travers différents brokers. Suivez, analysez et améliorez votre parcours de trading avec des analyses puissantes.',
-  };
-
-  const description = descriptions[params.locale] || descriptions.en;
+  const copy = getSiteMetadataCopy(params.locale);
 
   return {
-    title: 'Deltalytix',
-    description,
+    title: copy.title,
+    description: copy.description,
+    openGraph: {
+      title: copy.title,
+      description: copy.description,
+      locale: params.locale === "fr" ? "fr_FR" : "en_US",
+    },
+    twitter: {
+      title: copy.title,
+      description: copy.description,
+    },
   };
 }
 

--- a/app/[locale]/(landing)/opengraph-image.tsx
+++ b/app/[locale]/(landing)/opengraph-image.tsx
@@ -1,0 +1,23 @@
+import { createMarketingOgImageResponse } from "@/lib/og/shared";
+import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const copy = getSiteMetadataCopy(locale);
+
+  return createMarketingOgImageResponse({
+    headline: copy.ogHeadline,
+    subheadline: copy.ogSubheadline,
+    cta: copy.ogCta,
+  });
+}

--- a/app/[locale]/(landing)/ref/[ref]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/opengraph-image.tsx
@@ -29,5 +29,6 @@ export default async function Image({
     ref,
     joinLabel: copy.joinLabel,
     tagline: copy.tagline,
+    cta: copy.cta,
   });
 }

--- a/app/[locale]/(landing)/ref/[ref]/page.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/page.tsx
@@ -2,14 +2,10 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { isValidReferralSlug } from "@/lib/referral-url";
 import { siteUrl } from "@/lib/site-url";
+import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 
 type PageProps = {
   params: Promise<{ locale: string; ref: string }>;
-};
-
-const SHARE_DESCRIPTIONS: Record<string, string> = {
-  en: "Centralize and visualize your trading performance across multiple brokers. Track, analyze, and improve your trading journey with powerful analytics.",
-  fr: "Centralisez et visualisez vos performances de trading à travers différents brokers. Suivez, analysez et améliorez votre parcours de trading avec des analyses puissantes.",
 };
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -19,18 +15,22 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {};
   }
 
-  const description = SHARE_DESCRIPTIONS[locale] ?? SHARE_DESCRIPTIONS.en;
+  const siteCopy = getSiteMetadataCopy(locale);
+  const title = locale === "fr"
+    ? `Rejoignez Deltalytix avec le code ${ref.toUpperCase()}`
+    : `Join Deltalytix with Referral Code ${ref.toUpperCase()}`;
+  const description = siteCopy.description;
   const url = siteUrl(`/${locale}/ref/${encodeURIComponent(ref)}`);
   const openGraphLocale = locale === "fr" ? "fr_FR" : "en_US";
 
   return {
-    title: "Deltalytix",
+    title,
     description,
     alternates: {
       canonical: url,
     },
     openGraph: {
-      title: "Deltalytix",
+      title,
       description,
       url,
       siteName: "Deltalytix",
@@ -39,7 +39,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: "summary_large_image",
-      title: "Deltalytix",
+      title,
       description,
       // twitter:image is also derived from opengraph-image.tsx.
     },

--- a/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
@@ -4,6 +4,8 @@ import type { ReactElement } from "react"
 import { getStaticParams as getLocaleStaticParams } from '@/locales/server'
 import { enUS, fr } from "date-fns/locale"
 import { formatDateOnly } from "@/lib/format-date-only"
+import { OgCtaButton, ogImageCacheHeaders } from "@/lib/og/shared"
+import { getUpdatesOgCopy } from "@/lib/og/site-metadata"
 
 export const alt = "Deltalytix Update"
 export const size = {
@@ -52,6 +54,8 @@ export default async function Image({
         const formattedDate = formatDateOnly(meta.date, dateFormat, {
             locale: dateLocale,
         })
+
+        const updatesCopy = getUpdatesOgCopy(locale)
 
         const element = (
             <div
@@ -114,11 +118,13 @@ export default async function Image({
                     </h1>
                 </div>
 
-                {/* Bottom section with date */}
+                {/* Bottom section with date and CTA */}
                 <div
                     style={{
                         display: "flex",
+                        width: "100%",
                         alignItems: "center",
+                        justifyContent: "space-between",
                     }}
                 >
                     <span
@@ -131,17 +137,14 @@ export default async function Image({
                     >
                         {formattedDate}
                     </span>
+                    <OgCtaButton label={updatesCopy.cta} accentColor="#14B8A6" />
                 </div>
             </div>
         ) as ReactElement
 
         return new ImageResponse(element, {
             ...size,
-            headers: {
-                "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
-                "CDN-Cache-Control": "public, max-age=3600",
-                "Vercel-CDN-Cache-Control": "public, max-age=3600",
-            },
+            headers: ogImageCacheHeaders,
         })
     } catch (e: unknown) {
         console.log(e instanceof Error ? e.message : "Unknown error")

--- a/app/[locale]/(landing)/updates/[slug]/page.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { getStaticParams as getLocaleStaticParams } from "@/locales/server";
 import { MdxSidebar } from "@/components/mdx-sidebar";
 import { UpdatesNavigation } from "@/components/updates-navigation";
 import { siteUrl } from "@/lib/site-url";
+import { truncateForSocialDescription } from "@/lib/og/site-metadata";
 
 type ParamsInput =
   | {
@@ -82,11 +83,12 @@ export async function generateMetadata({
         locale: dateLocale,
       });
       const shareTitleLabel = locale === "fr" ? "Changements" : "Changelog";
-      const shareTitle = `${shareTitleLabel} · ${formattedShareDate}`;
+      const shareTitle = `${shareTitleLabel} · ${formattedShareDate} | Deltalytix`;
+      const description = truncateForSocialDescription(meta.description);
 
       return {
         title: meta.title,
-        description: meta.description,
+        description,
         alternates: {
           canonical: url,
           languages: {
@@ -96,7 +98,7 @@ export async function generateMetadata({
         },
         openGraph: {
           title: shareTitle,
-          description: meta.description,
+          description,
           type: "article",
           publishedTime: meta.date,
           modifiedTime: meta.updatedAt || meta.date,
@@ -113,7 +115,7 @@ export async function generateMetadata({
         twitter: {
           card: "summary_large_image",
           title: shareTitle,
-          description: meta.description,
+          description,
           // twitter:image is also derived from opengraph-image.tsx.
         },
       };

--- a/app/[locale]/shared/[slug]/opengraph-image.tsx
+++ b/app/[locale]/shared/[slug]/opengraph-image.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from "next/og"
 import { getShared } from "@/server/shared"
 import type { ReactElement } from "react"
-import { Logo } from "@/components/logo"
+import { OgCtaButton, ogImageCacheHeaders } from "@/lib/og/shared"
+import { getSharedOgCopy } from "@/lib/og/site-metadata"
 
 export const alt = "Shared Trading Performance"
 export const size = {
@@ -14,9 +15,10 @@ export const contentType = "image/png"
 export const runtime = 'nodejs'
 export const revalidate = 3600 // 1 hour
 
-export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+export default async function Image({ params }: { params: Promise<{ slug: string; locale: string }> }) {
     try {
-        const { slug } = await params
+        const { slug, locale } = await params
+        const sharedCopy = getSharedOgCopy(locale)
         const sharedData = await getShared(slug)
         if (!sharedData) {
             return new Response("Shared data not found", { status: 404 })
@@ -662,6 +664,16 @@ export default async function Image({ params }: { params: Promise<{ slug: string
                 <div
                     style={{
                         position: "absolute",
+                        bottom: "32px",
+                        left: "32px",
+                        display: "flex",
+                    }}
+                >
+                    <OgCtaButton label={sharedCopy.cta} accentColor={primaryColor} />
+                </div>
+                <div
+                    style={{
+                        position: "absolute",
                         top: "0",
                         right: "0",
                         width: "200px",
@@ -679,11 +691,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
 
         return new ImageResponse(element, {
             ...size,
-            headers: {
-                "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
-                "CDN-Cache-Control": "public, max-age=3600", 
-                "Vercel-CDN-Cache-Control": "public, max-age=3600",
-            },
+            headers: ogImageCacheHeaders,
         })
     } catch (e: unknown) {
         console.log(e instanceof Error ? e.message : "Unknown error")

--- a/app/[locale]/shared/[slug]/page.tsx
+++ b/app/[locale]/shared/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: SharedPageProps): Promise<Met
     console.error("Error loading shared metadata:", error)
   }
 
-  const title = sharedData?.params.title || "Shared Trading Performance | Deltalytix"
+  const title = sharedData?.params.title || "Shared Trading Performance"
   const description = truncateForSocialDescription(
     sharedData?.params.description ||
       "View this shared Deltalytix trading performance dashboard.",

--- a/app/[locale]/shared/[slug]/page.tsx
+++ b/app/[locale]/shared/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getShared } from "@/server/shared"
 import { SharedPageClient } from "./shared-page-client"
 import { getRequestOrigin, siteUrl } from "@/lib/site-url"
 import { headers } from "next/headers"
+import { truncateForSocialDescription } from "@/lib/og/site-metadata"
 
 interface SharedPageProps {
   params: Promise<{
@@ -24,10 +25,11 @@ export async function generateMetadata({ params }: SharedPageProps): Promise<Met
     console.error("Error loading shared metadata:", error)
   }
 
-  const title = sharedData?.params.title || "Shared Trading Performance"
-  const description =
+  const title = sharedData?.params.title || "Shared Trading Performance | Deltalytix"
+  const description = truncateForSocialDescription(
     sharedData?.params.description ||
-    "View this shared Deltalytix trading performance dashboard."
+      "View this shared Deltalytix trading performance dashboard.",
+  )
   const url = siteUrl(`/${locale}/shared/${slug}`, origin)
 
   return {

--- a/app/[locale]/teams/(landing)/layout.tsx
+++ b/app/[locale]/teams/(landing)/layout.tsx
@@ -2,20 +2,30 @@
 import { AuthProfileButton } from "../components/auth-profile-button";
 import TeamNavbar from "../components/team-navbar";
 import { Metadata } from 'next';
+import { truncateForSocialDescription } from "@/lib/og/site-metadata";
 
 type Locale = 'en' | 'fr';
 
+const TEAM_TITLES: Record<Locale, string> = {
+  en: "Deltalytix Enterprise — Team Trading Analytics Platform",
+  fr: "Deltalytix Enterprise — Analyses de trading pour équipes",
+};
+
+const TEAM_DESCRIPTIONS: Record<Locale, string> = {
+  en:
+    "Enterprise trading analytics for fund managers and prop firms. Monitor traders, track performance, and make data-driven decisions.",
+  fr:
+    "Analyses de trading entreprise pour gestionnaires de fonds et prop firms. Suivez les traders et pilotez vos décisions.",
+};
+
 export async function generateMetadata(props: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const params = await props.params;
-  const descriptions: Record<Locale, string> = {
-    en: 'Enterprise trading analytics platform for fund managers and proprietary trading firms. Monitor multiple traders, track performance, and make data-driven decisions.',
-    fr: 'Plateforme d\'analyses de trading entreprise pour les gestionnaires de fonds et les firmes de trading propriétaire. Surveillez plusieurs traders, suivez les performances et prenez des décisions basées sur les données.',
-  };
-
-  const description = descriptions[params.locale] || descriptions.en;
+  const description = truncateForSocialDescription(
+    TEAM_DESCRIPTIONS[params.locale] || TEAM_DESCRIPTIONS.en,
+  );
 
   return {
-    title: 'Deltalytix Enterprise',
+    title: TEAM_TITLES[params.locale] || TEAM_TITLES.en,
     description,
   };
 }

--- a/app/[locale]/teams/layout.tsx
+++ b/app/[locale]/teams/layout.tsx
@@ -2,20 +2,30 @@
 import { ThemeProvider } from "@/context/theme-provider";
 import { Metadata } from 'next';
 import { I18nProviderClient } from "@/locales/client";
+import { truncateForSocialDescription } from "@/lib/og/site-metadata";
 
 type Locale = 'en' | 'fr';
 
+const TEAM_TITLES: Record<Locale, string> = {
+  en: "Deltalytix Teams — Trading Analytics for Fund Managers",
+  fr: "Deltalytix Teams — Analyses de trading pour équipes",
+};
+
+const TEAM_DESCRIPTIONS: Record<Locale, string> = {
+  en:
+    "Team trading analytics for fund managers, prop firms, and trading desks. Monitor traders, track performance, and make data-driven decisions.",
+  fr:
+    "Analyses de trading pour gestionnaires de fonds, prop firms et équipes. Suivez les traders et pilotez vos décisions.",
+};
+
 export async function generateMetadata(props: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const params = await props.params;
-  const descriptions: Record<Locale, string> = {
-    en: 'Teams trading analytics platform for fund managers, proprietary trading firms and trading teams. Monitor multiple traders, track performance, and make data-driven decisions.',
-    fr: 'Plateforme d\'analyses de trading pour les gestionnaires de fonds, les propfirms et les équipes de trading. Suivez les performances de vos traders et prenez des décisions basées sur les données.',
-  };
-
-  const description = descriptions[params.locale] || descriptions.en;
+  const description = truncateForSocialDescription(
+    TEAM_DESCRIPTIONS[params.locale] || TEAM_DESCRIPTIONS.en,
+  );
 
   return {
-    title: 'Deltalytix Teams',
+    title: TEAM_TITLES[params.locale] || TEAM_TITLES.en,
     description,
   };
 }

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,85 +1,12 @@
-import { ImageResponse } from "next/og";
-import { NextRequest } from "next/server";
-import type { ReactElement } from "react";
 import { getReferralOgCopy } from "@/lib/og/referral-copy";
+import { createMarketingOgImageResponse } from "@/lib/og/shared";
 import {
   createReferralOgImageResponse,
   referralOgSize,
 } from "@/lib/og/referral-opengraph";
+import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 import { isValidReferralSlug } from "@/lib/referral-url";
-
-function DefaultOgImage() {
-  return (
-    <div
-      style={{
-        display: "flex",
-        width: "100%",
-        height: "100%",
-        background: "#0f0f0f",
-        fontFamily: "system-ui, -apple-system, sans-serif",
-        position: "relative",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          top: -120,
-          right: -120,
-          width: 520,
-          height: 520,
-          background: "radial-gradient(circle, rgba(124, 58, 237, 0.45) 0%, rgba(15, 15, 15, 0) 70%)",
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: -80,
-          left: -80,
-          width: 360,
-          height: 360,
-          background: "radial-gradient(circle, rgba(59, 130, 246, 0.35) 0%, rgba(15, 15, 15, 0) 70%)",
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 14,
-        }}
-      >
-        <svg viewBox="0 0 255 255" xmlns="http://www.w3.org/2000/svg" style={{ width: 96, height: 96 }}>
-          <path fillRule="evenodd" clipRule="evenodd" d="M159 63L127.5 0V255H255L236.5 218H159V63Z" fill="#FFFFFF" />
-          <path fillRule="evenodd" clipRule="evenodd" d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z" fill="#FFFFFF" />
-        </svg>
-        <span
-          style={{
-            fontSize: 88,
-            fontWeight: 700,
-            color: "#FFFFFF",
-            letterSpacing: "-0.03em",
-          }}
-        >
-          Deltalytix
-        </span>
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          bottom: 0,
-          left: 0,
-          right: 0,
-          height: 3,
-          background: "linear-gradient(90deg, rgba(20, 184, 166, 0.8) 0%, rgba(124, 58, 237, 0.8) 50%, rgba(220, 38, 38, 0.8) 100%)",
-          display: "flex",
-        }}
-      />
-    </div>
-  ) as ReactElement;
-}
+import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -93,13 +20,16 @@ export async function GET(req: NextRequest) {
       ref: ref!,
       joinLabel: copy.joinLabel,
       tagline: copy.tagline,
+      cta: copy.cta,
     });
   }
 
-  return new ImageResponse(<DefaultOgImage />, {
-    ...referralOgSize,
-    headers: {
-      "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
-    },
+  const siteCopy = getSiteMetadataCopy(locale);
+  return createMarketingOgImageResponse({
+    headline: siteCopy.ogHeadline,
+    subheadline: siteCopy.ogSubheadline,
+    cta: siteCopy.ogCta,
   });
 }
+
+export { referralOgSize as size };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,13 +6,18 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import Script from "next/script";
 import { ScrollLockFix } from "@/components/scroll-lock-fix";
 import { getSiteOrigin, siteUrl } from "@/lib/site-url";
+import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 
 const inter = Inter({ subsets: ["latin"] });
 const metadataBase = new URL(getSiteOrigin());
+const defaultSiteCopy = getSiteMetadataCopy("en");
 
 export const metadata: Metadata = {
-  title: "Deltalytix",
-  description: "Next generation trading dashboard",
+  title: {
+    default: defaultSiteCopy.title,
+    template: "%s | Deltalytix",
+  },
+  description: defaultSiteCopy.description,
   metadataBase,
   alternates: {
     canonical: siteUrl("/"),
@@ -23,25 +28,17 @@ export const metadata: Metadata = {
   },
   // ---------- OPEN GRAPH ----------
   openGraph: {
-    title: "Deltalytix",
-    description:
-      "Deltalytix is a next generation trading dashboard that provides real-time insights and analytics for traders.",
-    images: [
-      {
-        url: "/opengraph-image.png",
-        width: 1200,
-        height: 630,
-        alt: "Deltalytix Open Graph Image",
-      },
-    ],
+    title: defaultSiteCopy.title,
+    description: defaultSiteCopy.description,
+    // og:image is injected automatically from colocated opengraph-image.tsx.
   },
 
   // ---------- TWITTER ----------
   twitter: {
     card: "summary_large_image",
-    title: "Deltalytix",
-    description: "Next generation trading dashboard",
-    images: ["/twitter-image.png"],
+    title: defaultSiteCopy.title,
+    description: defaultSiteCopy.description,
+    // twitter:image is derived from opengraph-image.tsx.
   },
 
   // ---------- ICONS ----------

--- a/app/opengraph-image.alt.txt
+++ b/app/opengraph-image.alt.txt
@@ -1,1 +1,1 @@
-Deltalytix is the next generation trading analytics tailored to Propfirm traders needs
+Deltalytix trading analytics dashboard — Get Started Free

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { createMarketingOgImageResponse } from "@/lib/og/shared";
+import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
+
+export const alt = "Deltalytix trading analytics dashboard — Get Started Free";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+
+export default function Image() {
+  const copy = getSiteMetadataCopy("en");
+
+  return createMarketingOgImageResponse({
+    headline: copy.ogHeadline,
+    subheadline: copy.ogSubheadline,
+    cta: copy.ogCta,
+  });
+}

--- a/app/twitter-image.alt.txt
+++ b/app/twitter-image.alt.txt
@@ -1,1 +1,1 @@
-Deltalytix is the next generation trading analytics tailored to Propfirm traders needs
+Deltalytix trading analytics dashboard — Get Started Free

--- a/lib/og/referral-copy.test.ts
+++ b/lib/og/referral-copy.test.ts
@@ -6,12 +6,14 @@ describe("getReferralOgCopy", () => {
     const copy = await getReferralOgCopy("fr");
     expect(copy.joinLabel).toBe("Rejoignez avec un code de parrainage");
     expect(copy.tagline).toBe("Journal de trading nouvelle génération");
+    expect(copy.cta).toBe("Inscrivez-vous avec le code →");
   });
 
   it("returns English copy for en locale", async () => {
     const copy = await getReferralOgCopy("en");
     expect(copy.joinLabel).toBe("Join with a referral code");
     expect(copy.tagline).toBe("Next generation trading dashboard");
+    expect(copy.cta).toBe("Sign Up with Code →");
   });
 
   it("falls back to English for unsupported locales", async () => {

--- a/lib/og/referral-copy.ts
+++ b/lib/og/referral-copy.ts
@@ -1,6 +1,7 @@
 type ReferralOgCopy = {
   joinLabel: string;
   tagline: string;
+  cta: string;
   alt: string;
 };
 

--- a/lib/og/referral-opengraph.tsx
+++ b/lib/og/referral-opengraph.tsx
@@ -1,7 +1,13 @@
 import { ImageResponse } from "next/og";
 import type { ReactElement } from "react";
+import {
+  BrandLockup,
+  OgCtaButton,
+  ogImageCacheHeaders,
+  ogImageSize,
+} from "@/lib/og/shared";
 
-export const referralOgSize = { width: 1200, height: 630 };
+export const referralOgSize = ogImageSize;
 
 function hslToHex(h: number, s: number, l: number): string {
   s /= 100;
@@ -53,58 +59,12 @@ export function generateReferralAccentColor(ref: string): string {
   return hslToHex(hue, saturation, lightness);
 }
 
-function LogoMark({ sizePx = 40 }: { sizePx?: number }) {
-  return (
-    <svg
-      viewBox="0 0 255 255"
-      xmlns="http://www.w3.org/2000/svg"
-      style={{ width: sizePx, height: sizePx }}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M159 63L127.5 0V255H255L236.5 218H159V63Z"
-        fill="#FFFFFF"
-      />
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z"
-        fill="#FFFFFF"
-      />
-    </svg>
-  );
-}
-
-function BrandLockup({ logoSize = 40, fontSize = 28 }: { logoSize?: number; fontSize?: number }) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 14,
-      }}
-    >
-      <LogoMark sizePx={logoSize} />
-      <span
-        style={{
-          fontSize,
-          fontWeight: 700,
-          color: "#FFFFFF",
-          letterSpacing: "-0.03em",
-        }}
-      >
-        Deltalytix
-      </span>
-    </div>
-  );
-}
-
 type ReferralOgImageProps = {
   ref: string;
   accentColor: string;
   joinLabel: string;
   tagline: string;
+  cta: string;
 };
 
 export function ReferralOgImage({
@@ -112,6 +72,7 @@ export function ReferralOgImage({
   accentColor,
   joinLabel,
   tagline,
+  cta,
 }: ReferralOgImageProps) {
   return (
     <div
@@ -209,6 +170,8 @@ export function ReferralOgImage({
         >
           {tagline}
         </p>
+
+        <OgCtaButton label={cta} accentColor={accentColor} />
       </div>
 
       <p
@@ -229,10 +192,12 @@ export function createReferralOgImageResponse({
   ref,
   joinLabel,
   tagline,
+  cta,
 }: {
   ref: string;
   joinLabel: string;
   tagline: string;
+  cta: string;
 }) {
   const accentColor = generateReferralAccentColor(ref);
 
@@ -242,14 +207,11 @@ export function createReferralOgImageResponse({
       accentColor={accentColor}
       joinLabel={joinLabel}
       tagline={tagline}
+      cta={cta}
     />,
     {
       ...referralOgSize,
-      headers: {
-        "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
-        "CDN-Cache-Control": "public, max-age=3600",
-        "Vercel-CDN-Cache-Control": "public, max-age=3600",
-      },
+      headers: ogImageCacheHeaders,
     },
   );
 }

--- a/lib/og/shared.tsx
+++ b/lib/og/shared.tsx
@@ -1,0 +1,217 @@
+import { ImageResponse } from "next/og";
+import type { ReactElement } from "react";
+
+export const ogImageSize = { width: 1200, height: 630 };
+
+export const ogImageCacheHeaders = {
+  "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600",
+  "CDN-Cache-Control": "public, max-age=3600",
+  "Vercel-CDN-Cache-Control": "public, max-age=3600",
+} as const;
+
+export function LogoMark({ sizePx = 40 }: { sizePx?: number }) {
+  return (
+    <svg
+      viewBox="0 0 255 255"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: sizePx, height: sizePx }}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M159 63L127.5 0V255H255L236.5 218H159V63Z"
+        fill="#FFFFFF"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z"
+        fill="#FFFFFF"
+      />
+    </svg>
+  );
+}
+
+export function BrandLockup({
+  logoSize = 40,
+  fontSize = 28,
+}: {
+  logoSize?: number;
+  fontSize?: number;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+      }}
+    >
+      <LogoMark sizePx={logoSize} />
+      <span
+        style={{
+          fontSize,
+          fontWeight: 700,
+          color: "#FFFFFF",
+          letterSpacing: "-0.03em",
+        }}
+      >
+        Deltalytix
+      </span>
+    </div>
+  );
+}
+
+export function OgCtaButton({
+  label,
+  accentColor = "#14B8A6",
+}: {
+  label: string;
+  accentColor?: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        alignSelf: "flex-start",
+        padding: "18px 32px",
+        borderRadius: 999,
+        background: accentColor,
+        boxShadow: `0 12px 40px ${accentColor}66`,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 28,
+          fontWeight: 700,
+          color: "#FFFFFF",
+          letterSpacing: "-0.01em",
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+type MarketingOgImageProps = {
+  headline: string;
+  subheadline: string;
+  cta: string;
+  accentColor?: string;
+};
+
+export function MarketingOgImage({
+  headline,
+  subheadline,
+  cta,
+  accentColor = "#14B8A6",
+}: MarketingOgImageProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        background: "#0a0a0a",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        position: "relative",
+        padding: "56px 72px",
+        flexDirection: "column",
+        justifyContent: "space-between",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -100,
+          right: -100,
+          width: 480,
+          height: 480,
+          background: `radial-gradient(circle, ${accentColor}55 0%, rgba(10, 10, 10, 0) 72%)`,
+          display: "flex",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: -60,
+          left: -60,
+          width: 320,
+          height: 320,
+          background: "radial-gradient(circle, rgba(59, 130, 246, 0.25) 0%, rgba(10, 10, 10, 0) 70%)",
+          display: "flex",
+        }}
+      />
+
+      <BrandLockup />
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 24,
+          maxWidth: 920,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 58,
+            fontWeight: 800,
+            color: "#FFFFFF",
+            lineHeight: 1.1,
+            letterSpacing: "-0.03em",
+          }}
+        >
+          {headline}
+        </p>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 30,
+            fontWeight: 500,
+            color: "#a1a1aa",
+            lineHeight: 1.35,
+            letterSpacing: "-0.01em",
+          }}
+        >
+          {subheadline}
+        </p>
+        <OgCtaButton label={cta} accentColor={accentColor} />
+      </div>
+
+      <p
+        style={{
+          margin: 0,
+          fontSize: 22,
+          fontWeight: 500,
+          color: "#71717a",
+        }}
+      >
+        deltalytix.app
+      </p>
+    </div>
+  ) as ReactElement;
+}
+
+export function createMarketingOgImageResponse({
+  headline,
+  subheadline,
+  cta,
+  accentColor,
+}: MarketingOgImageProps) {
+  return new ImageResponse(
+    <MarketingOgImage
+      headline={headline}
+      subheadline={subheadline}
+      cta={cta}
+      accentColor={accentColor}
+    />,
+    {
+      ...ogImageSize,
+      headers: ogImageCacheHeaders,
+    },
+  );
+}

--- a/lib/og/site-metadata.test.ts
+++ b/lib/og/site-metadata.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSiteMetadataCopy,
+  SOCIAL_DESCRIPTION_MAX_LENGTH,
+  truncateForSocialDescription,
+} from "./site-metadata";
+
+describe("site metadata copy", () => {
+  it("returns English copy with SEO-friendly title and description lengths", () => {
+    const copy = getSiteMetadataCopy("en");
+
+    expect(copy.title.length).toBeGreaterThanOrEqual(50);
+    expect(copy.title.length).toBeLessThanOrEqual(70);
+    expect(copy.description.length).toBeLessThanOrEqual(SOCIAL_DESCRIPTION_MAX_LENGTH);
+    expect(copy.ogCta).toContain("→");
+  });
+
+  it("returns French copy with SEO-friendly description length", () => {
+    const copy = getSiteMetadataCopy("fr");
+
+    expect(copy.description.length).toBeLessThanOrEqual(SOCIAL_DESCRIPTION_MAX_LENGTH);
+    expect(copy.ogCta).toContain("→");
+  });
+});
+
+describe("truncateForSocialDescription", () => {
+  it("keeps short descriptions unchanged", () => {
+    const text = "Short description.";
+    expect(truncateForSocialDescription(text)).toBe(text);
+  });
+
+  it("truncates long descriptions with an ellipsis", () => {
+    const text =
+      "Centralize and visualize your trading performance across multiple brokers. Track, analyze, and improve your trading journey with powerful analytics.";
+    const truncated = truncateForSocialDescription(text);
+
+    expect(truncated.length).toBeLessThanOrEqual(SOCIAL_DESCRIPTION_MAX_LENGTH);
+    expect(truncated.endsWith("…")).toBe(true);
+  });
+});

--- a/lib/og/site-metadata.ts
+++ b/lib/og/site-metadata.ts
@@ -1,0 +1,88 @@
+export const SOCIAL_DESCRIPTION_MAX_LENGTH = 125;
+
+export type OgLocale = "en" | "fr";
+
+export type SiteMetadataCopy = {
+  title: string;
+  description: string;
+  ogHeadline: string;
+  ogSubheadline: string;
+  ogCta: string;
+  ogAlt: string;
+};
+
+const SITE_METADATA: Record<OgLocale, SiteMetadataCopy> = {
+  en: {
+    title: "Deltalytix — Trading Analytics Dashboard for Futures Traders",
+    description:
+      "Deltalytix is a trading dashboard for futures traders. Store, explore, and understand your track-record across brokers.",
+    ogHeadline: "Master your trading journey",
+    ogSubheadline: "Real-time analytics, journaling, and performance insights for futures traders.",
+    ogCta: "Get Started Free →",
+    ogAlt: "Deltalytix trading analytics dashboard — Get Started Free",
+  },
+  fr: {
+    title: "Deltalytix — Tableau de bord de trading pour traders futures",
+    description:
+      "Deltalytix est un journal de trading pour traders futures. Centralisez, analysez et comprenez vos performances.",
+    ogHeadline: "Maîtrisez votre parcours de trading",
+    ogSubheadline:
+      "Analyses en temps réel, journal et insights de performance pour traders futures.",
+    ogCta: "Commencer gratuitement →",
+    ogAlt: "Tableau de bord Deltalytix — Commencer gratuitement",
+  },
+};
+
+const UPDATES_OG_COPY: Record<OgLocale, { cta: string; alt: string }> = {
+  en: {
+    cta: "Read the Changelog →",
+    alt: "Deltalytix product update — Read the Changelog",
+  },
+  fr: {
+    cta: "Lire les changements →",
+    alt: "Mise à jour Deltalytix — Lire les changements",
+  },
+};
+
+const SHARED_OG_COPY: Record<OgLocale, { cta: string; alt: string }> = {
+  en: {
+    cta: "View Performance →",
+    alt: "Shared Deltalytix trading performance — View Performance",
+  },
+  fr: {
+    cta: "Voir la performance →",
+    alt: "Performance de trading Deltalytix partagée — Voir la performance",
+  },
+};
+
+export function resolveOgLocale(locale: string | undefined): OgLocale {
+  return locale === "fr" ? "fr" : "en";
+}
+
+export function getSiteMetadataCopy(locale: string | undefined): SiteMetadataCopy {
+  return SITE_METADATA[resolveOgLocale(locale)];
+}
+
+export function getUpdatesOgCopy(locale: string | undefined) {
+  return UPDATES_OG_COPY[resolveOgLocale(locale)];
+}
+
+export function getSharedOgCopy(locale: string | undefined) {
+  return SHARED_OG_COPY[resolveOgLocale(locale)];
+}
+
+export function truncateForSocialDescription(
+  text: string,
+  maxLength = SOCIAL_DESCRIPTION_MAX_LENGTH,
+): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  const truncated = normalized.slice(0, maxLength - 1).trimEnd();
+  const lastSpace = truncated.lastIndexOf(" ");
+  const safe = lastSpace > maxLength * 0.6 ? truncated.slice(0, lastSpace) : truncated;
+
+  return `${safe}…`;
+}

--- a/locales/en/referral.ts
+++ b/locales/en/referral.ts
@@ -19,7 +19,8 @@ export default {
     og: {
       joinLabel: 'Join with a referral code',
       tagline: 'Next generation trading dashboard',
-      alt: 'Deltalytix Referral',
+      cta: 'Sign Up with Code →',
+      alt: 'Deltalytix referral — Sign Up with Code',
     },
     landing: {
       title: 'Referral Program',

--- a/locales/fr/referral.ts
+++ b/locales/fr/referral.ts
@@ -19,7 +19,8 @@ export default {
     og: {
       joinLabel: 'Rejoignez avec un code de parrainage',
       tagline: 'Journal de trading nouvelle génération',
-      alt: 'Parrainage Deltalytix',
+      cta: 'Inscrivez-vous avec le code →',
+      alt: 'Parrainage Deltalytix — Inscrivez-vous avec le code',
     },
     landing: {
       title: 'Programme de Parrainage',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes social preview audit issues across the site:

- **OG images missing CTA text** — all generated OG images now include a prominent call-to-action button (e.g. "Get Started Free →", "Read the Changelog →", "View Performance →").
- **Description too long (148 chars)** — centralized metadata copy with `truncateForSocialDescription()` capped at 125 characters; landing, referral, teams, updates, and shared pages updated.
- **Page title too short (10 chars)** — default title expanded to ~60 characters (e.g. "Deltalytix — Trading Analytics Dashboard for Futures Traders") with a `%s | Deltalytix` template for child pages.

## Review fixes

- Merged repair from `repair/pr-277-og-metadata`: localized landing layout now uses `title.absolute` to avoid double `| Deltalytix` on `/en` and `/fr`, and restores `twitter.card: summary_large_image`.
- Shared page fallback title no longer hardcodes `| Deltalytix`, preventing `… | Deltalytix | Deltalytix`.

## Changes

- Added `lib/og/shared.tsx` with reusable `MarketingOgImage`, `OgCtaButton`, and `BrandLockup` components.
- Added `lib/og/site-metadata.ts` for locale-aware titles, descriptions, and OG copy.
- Replaced static `/opengraph-image.png` references with dynamic `opengraph-image.tsx` routes at root and landing locale levels.
- Updated all OG generators: referral, updates, shared, and `/api/og`.
- Added unit tests for metadata lengths and description truncation.

## Test plan

- [x] `bunx vitest run lib/og/site-metadata.test.ts lib/og/referral-copy.test.ts`
- [x] `bun run typecheck`
- [x] `OPENAI_API_KEY=dummy bun run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a0c8572-5afa-48da-9f17-2dbd5b2a98db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a0c8572-5afa-48da-9f17-2dbd5b2a98db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

