### PR TITLE
Add skeleton loading to all dashboard charts

### DIFF
--- a/app/[locale]/dashboard/components/calendar/charts.tsx
+++ b/app/[locale]/dashboard/components/calendar/charts.tsx
@@ -53,11 +53,12 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
   const t = useI18n()
   const locale = useCurrentLocale()
   const { isLoading: globalIsLoading } = useData()
-  const showLoading = isLoading || (globalIsLoading && dayData === undefined)
+  const showLoading =
+    dayData === undefined && (isLoading === true || globalIsLoading)
   
   // Calculate data for charts
   const { accountPnL, equityChartData, chartData, totalPnL, calculateCommonDomain } = React.useMemo(() => {
-    if (!dayData?.trades?.length) {
+    if (showLoading || !dayData?.trades?.length) {
       return {
         accountPnL: {},
         equityChartData: [],
@@ -134,7 +135,7 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
       totalPnL,
       calculateCommonDomain
     };
-  }, [dayData?.trades, locale]);
+  }, [showLoading, dayData?.trades, locale]);
 
   if (showLoading) {
     return (
@@ -154,6 +155,7 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
               xDataKey="time"
               barDataKey="pnl"
               lineDataKey="balance"
+              loadingLabel={t("equity.loading")}
             />
           </CardContent>
         </Card>
@@ -174,6 +176,7 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
               yDataKey="value"
               showReferenceLine={true}
               marginVariant="calendar"
+              loadingLabel={t("equity.loading")}
             />
           </CardContent>
         </Card>

--- a/app/[locale]/dashboard/components/calendar/charts.tsx
+++ b/app/[locale]/dashboard/components/calendar/charts.tsx
@@ -14,12 +14,21 @@ import {
   ChartContainer,
 } from "@/components/ui/chart"
 import { CalendarEntry } from "@/app/[locale]/dashboard/types/calendar"
+import {
+  BarChartLoadingSkeleton,
+  ComposedChartLoadingSkeleton,
+  LOADING_MOCK_CALENDAR_DISTRIBUTION,
+  LOADING_MOCK_CALENDAR_EQUITY,
+} from "@/app/[locale]/dashboard/components/charts/chart-loading-skeleton"
 import { useTheme } from "@/context/theme-provider"
+import { useData } from "@/context/data-provider"
 import { useI18n, useCurrentLocale } from '@/locales/client'
+import { Skeleton } from "@/components/ui/skeleton"
 
 interface ChartsProps {
   dayData: CalendarEntry | undefined;
   isWeekly?: boolean;
+  isLoading?: boolean;
 }
 
 const chartConfig = {
@@ -38,11 +47,13 @@ const formatCurrency = (value: number | undefined | null) => {
   return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
 
-export function Charts({ dayData, isWeekly = false }: ChartsProps) {
+export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
   const { effectiveTheme } = useTheme()
   const isDarkMode = effectiveTheme === 'dark'
   const t = useI18n()
   const locale = useCurrentLocale()
+  const { isLoading: globalIsLoading } = useData()
+  const showLoading = isLoading || (globalIsLoading && dayData === undefined)
   
   // Calculate data for charts
   const { accountPnL, equityChartData, chartData, totalPnL, calculateCommonDomain } = React.useMemo(() => {
@@ -124,6 +135,51 @@ export function Charts({ dayData, isWeekly = false }: ChartsProps) {
       calculateCommonDomain
     };
   }, [dayData?.trades, locale]);
+
+  if (showLoading) {
+    return (
+      <div className="space-y-4">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-base md:text-lg">
+              {isWeekly ? t('calendar.charts.weeklyEquityVariation') : t('calendar.charts.equityVariation')}
+            </CardTitle>
+            <CardDescription className="text-xs md:text-sm">
+              <Skeleton className="h-4 w-36" />
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="h-[200px] md:h-[250px]">
+            <ComposedChartLoadingSkeleton
+              data={LOADING_MOCK_CALENDAR_EQUITY}
+              xDataKey="time"
+              barDataKey="pnl"
+              lineDataKey="balance"
+            />
+          </CardContent>
+        </Card>
+
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-base md:text-lg">
+              {isWeekly ? t('calendar.charts.weeklyPnlDistribution') : t('calendar.charts.dailyPnlDistribution')}
+            </CardTitle>
+            <CardDescription className="text-xs md:text-sm">
+              <Skeleton className="h-4 w-44" />
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="h-[250px] md:h-[300px] pb-8 md:pb-16">
+            <BarChartLoadingSkeleton
+              data={LOADING_MOCK_CALENDAR_DISTRIBUTION}
+              xDataKey="name"
+              yDataKey="value"
+              showReferenceLine={true}
+              marginVariant="calendar"
+            />
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
 
   if (!dayData?.trades?.length) {
     return (

--- a/app/[locale]/dashboard/components/calendar/daily-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-modal.tsx
@@ -130,7 +130,7 @@ export function CalendarModal({
             )}
             <DailyStats dayData={dayData} isWeekly={false} />
             {/* <DailyMood dayData={dayData} isWeekly={false} selectedDate={selectedDate} /> */}
-            <Charts dayData={dayData} />
+            <Charts dayData={dayData} isLoading={isLoading} />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
@@ -80,7 +80,7 @@ export function WeeklyModal({
             <TabsTrigger value="charts">{t('calendar.modal.charts')}</TabsTrigger>
           </TabsList>
           <TabsContent value="charts" className="grow overflow-auto p-6 pt-2">
-            <Charts dayData={weeklyData} isWeekly={true} />
+            <Charts dayData={weeklyData} isWeekly={true} isLoading={isLoading} />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import * as React from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
+
+const MUTED_BAR_FILL = "hsl(var(--muted-foreground) / 0.35)";
+
+export type ChartMarginVariant = "default" | "hourly" | "calendar";
+
+export function getChartMargins(
+  size: WidgetSize = "medium",
+  variant: ChartMarginVariant = "default",
+) {
+  if (variant === "hourly") {
+    return size === "small"
+      ? { left: 0, right: 4, top: 4, bottom: 20 }
+      : { left: 0, right: 8, top: 8, bottom: 24 };
+  }
+
+  if (variant === "calendar") {
+    return { left: 10, right: 16, top: 8, bottom: 35 };
+  }
+
+  if (size === "small") {
+    return { left: 10, right: 4, top: 4, bottom: 20 };
+  }
+
+  if (size === "large") {
+    return { left: 10, right: 12, top: 12, bottom: 28 };
+  }
+
+  return { left: 10, right: 8, top: 8, bottom: 24 };
+}
+
+export function getAxisDimensions(
+  size: WidgetSize = "medium",
+  yAxisWidth = 60,
+) {
+  return {
+    yAxisWidth,
+    xAxisHeight: size === "small" ? 20 : 24,
+  };
+}
+
+export function getSignedDomain(values: number[]) {
+  if (values.length === 0) {
+    return [0, 0] as [number, number];
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  return [Math.min(min * 1.1, 0), Math.max(max * 1.1, 0)] as [number, number];
+}
+
+interface ChartAxisSkeletonOverlayProps {
+  size?: WidgetSize;
+  margin: { left: number; right: number; top: number; bottom: number };
+  yAxisWidth?: number;
+  xAxisHeight?: number;
+  yTickCount?: number;
+  xTickCount?: number;
+}
+
+export function ChartAxisSkeletonOverlay({
+  size = "medium",
+  margin,
+  yAxisWidth = 60,
+  xAxisHeight = size === "small" ? 20 : 24,
+  yTickCount = 5,
+  xTickCount = 6,
+}: ChartAxisSkeletonOverlayProps) {
+  return (
+    <>
+      <div
+        className="pointer-events-none absolute flex flex-col justify-between pr-2"
+        style={{
+          left: `${margin.left}px`,
+          top: `${margin.top}px`,
+          bottom: `${margin.bottom + xAxisHeight}px`,
+          width: `${yAxisWidth}px`,
+        }}
+      >
+        {Array.from({ length: yTickCount }).map((_, i) => (
+          <Skeleton key={`y-${i}`} className="h-3 w-10" />
+        ))}
+      </div>
+      <div
+        className="pointer-events-none absolute flex items-center justify-between"
+        style={{
+          left: `${margin.left + yAxisWidth}px`,
+          right: `${margin.right}px`,
+          bottom: `${margin.bottom}px`,
+          height: `${xAxisHeight}px`,
+        }}
+      >
+        {Array.from({ length: xTickCount }).map((_, i) => (
+          <Skeleton
+            key={`x-${i}`}
+            className={cn(size === "small" ? "h-3 w-8" : "h-3.5 w-10")}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+interface BarChartLoadingSkeletonProps {
+  size?: WidgetSize;
+  data: Record<string, string | number>[];
+  xDataKey: string;
+  yDataKey: string;
+  marginVariant?: ChartMarginVariant;
+  yAxisWidth?: number;
+  showReferenceLine?: boolean;
+  maxBarSize?: number;
+  domain?: [number, number];
+  xTickCount?: number;
+}
+
+export function BarChartLoadingSkeleton({
+  size = "medium",
+  data,
+  xDataKey,
+  yDataKey,
+  marginVariant = "default",
+  yAxisWidth = 60,
+  showReferenceLine = false,
+  maxBarSize,
+  domain,
+  xTickCount = 6,
+}: BarChartLoadingSkeletonProps) {
+  const margin = getChartMargins(size, marginVariant);
+  const { xAxisHeight } = getAxisDimensions(size, yAxisWidth);
+  const values = data.map((row) => Number(row[yDataKey]));
+  const yDomain = domain ?? getSignedDomain(values);
+  const barSize = maxBarSize ?? (size === "small" ? 25 : 40);
+
+  return (
+    <div className={cn("w-full h-full animate-pulse relative")}>
+      <ChartAxisSkeletonOverlay
+        size={size}
+        margin={margin}
+        yAxisWidth={yAxisWidth}
+        xAxisHeight={xAxisHeight}
+        xTickCount={xTickCount}
+      />
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={margin}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            className="text-border dark:opacity-[0.12] opacity-[0.2]"
+          />
+          <XAxis
+            dataKey={xDataKey}
+            tickLine={false}
+            axisLine={false}
+            height={xAxisHeight}
+            tick={false}
+            minTickGap={size === "small" ? 30 : 50}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            width={yAxisWidth}
+            tickMargin={4}
+            tick={false}
+            domain={yDomain}
+          />
+          {showReferenceLine ? (
+            <ReferenceLine y={0} stroke="hsl(var(--border))" />
+          ) : null}
+          <Bar
+            dataKey={yDataKey}
+            radius={[3, 3, 0, 0]}
+            maxBarSize={barSize}
+            className="transition-none"
+            fill={MUTED_BAR_FILL}
+          >
+            {data.map((_, index) => (
+              <Cell key={`skeleton-cell-${index}`} fill={MUTED_BAR_FILL} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+interface LineChartLoadingSkeletonProps {
+  size?: WidgetSize;
+  data: Record<string, string | number>[];
+  xDataKey: string;
+  yDataKey: string;
+  showReferenceLine?: boolean;
+}
+
+export function LineChartLoadingSkeleton({
+  size = "medium",
+  data,
+  xDataKey,
+  yDataKey,
+  showReferenceLine = true,
+}: LineChartLoadingSkeletonProps) {
+  const margin = getChartMargins(size);
+  const { yAxisWidth, xAxisHeight } = getAxisDimensions(size);
+
+  return (
+    <div className={cn("w-full h-full animate-pulse relative")}>
+      <ChartAxisSkeletonOverlay
+        size={size}
+        margin={margin}
+        yAxisWidth={yAxisWidth}
+        xAxisHeight={xAxisHeight}
+      />
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={margin}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            className="text-border dark:opacity-[0.12] opacity-[0.2]"
+          />
+          <XAxis
+            dataKey={xDataKey}
+            tickLine={false}
+            axisLine={false}
+            height={xAxisHeight}
+            tick={false}
+            minTickGap={size === "small" ? 30 : 50}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            width={yAxisWidth}
+            tickMargin={4}
+            tick={false}
+          />
+          {showReferenceLine ? (
+            <ReferenceLine
+              y={0}
+              stroke="hsl(var(--muted-foreground))"
+              strokeDasharray="3 3"
+              strokeOpacity={0.5}
+            />
+          ) : null}
+          <Line
+            type="monotone"
+            dataKey={yDataKey}
+            stroke={MUTED_BAR_FILL}
+            strokeWidth={2}
+            dot={false}
+            className="transition-none"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+interface DonutChartLoadingSkeletonProps {
+  size?: WidgetSize;
+}
+
+export function DonutChartLoadingSkeleton({
+  size = "medium",
+}: DonutChartLoadingSkeletonProps) {
+  const mockData = [
+    { name: "a", value: 55 },
+    { name: "b", value: 10 },
+    { name: "c", value: 35 },
+  ];
+
+  return (
+    <div className={cn("w-full h-full animate-pulse relative flex flex-col")}>
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={mockData}
+              cx="50%"
+              cy="45%"
+              innerRadius={size === "small" ? "60%" : "65%"}
+              outerRadius={size === "small" ? "80%" : "85%"}
+              paddingAngle={2}
+              dataKey="value"
+              startAngle={90}
+              endAngle={-270}
+              stroke="hsl(var(--background))"
+              strokeWidth={1}
+            >
+              {mockData.map((_, index) => (
+                <Cell key={`skeleton-cell-${index}`} fill={MUTED_BAR_FILL} />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <div
+        className={cn(
+          "flex items-center justify-center gap-4 shrink-0",
+          size === "small" ? "pb-1" : "pb-2 pt-2",
+        )}
+      >
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton
+            key={`legend-${i}`}
+            className={cn(size === "small" ? "h-3 w-16" : "h-3.5 w-20")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ComposedChartLoadingSkeletonProps {
+  size?: WidgetSize;
+  data: Record<string, string | number>[];
+  xDataKey: string;
+  barDataKey: string;
+  lineDataKey: string;
+}
+
+export function ComposedChartLoadingSkeleton({
+  size = "medium",
+  data,
+  xDataKey,
+  barDataKey,
+  lineDataKey,
+}: ComposedChartLoadingSkeletonProps) {
+  const margin = { left: 10, right: 8, top: 8, bottom: 35 };
+  const { yAxisWidth, xAxisHeight } = getAxisDimensions(size);
+
+  return (
+    <div className={cn("w-full h-full animate-pulse relative")}>
+      <ChartAxisSkeletonOverlay
+        size={size}
+        margin={margin}
+        yAxisWidth={yAxisWidth}
+        xAxisHeight={xAxisHeight}
+        xTickCount={5}
+      />
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data} margin={margin}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            className="text-border dark:opacity-[0.12] opacity-[0.2]"
+          />
+          <XAxis
+            dataKey={xDataKey}
+            tickLine={false}
+            axisLine={false}
+            height={xAxisHeight}
+            tick={false}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            width={yAxisWidth}
+            tickMargin={4}
+            tick={false}
+          />
+          <ReferenceLine y={0} stroke="hsl(var(--border))" />
+          <Bar
+            dataKey={barDataKey}
+            radius={[3, 3, 0, 0]}
+            maxBarSize={size === "small" ? 20 : 30}
+            className="transition-none"
+            fill={MUTED_BAR_FILL}
+          >
+            {data.map((_, index) => (
+              <Cell key={`bar-${index}`} fill={MUTED_BAR_FILL} />
+            ))}
+          </Bar>
+          <Line
+            type="stepAfter"
+            dataKey={lineDataKey}
+            stroke={MUTED_BAR_FILL}
+            strokeWidth={2}
+            dot={false}
+            className="transition-none"
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export const LOADING_MOCK_DATE_PNL = [
+  { date: "2024-12-02", pnl: 120 },
+  { date: "2024-12-03", pnl: 240 },
+  { date: "2024-12-11", pnl: 180 },
+  { date: "2024-12-16", pnl: -90 },
+  { date: "2024-12-17", pnl: -30 },
+  { date: "2024-12-19", pnl: 310 },
+  { date: "2024-12-20", pnl: 150 },
+  { date: "2025-01-06", pnl: 220 },
+  { date: "2025-01-07", pnl: 420 },
+  { date: "2025-01-14", pnl: 95 },
+  { date: "2025-01-15", pnl: -60 },
+  { date: "2025-01-21", pnl: 280 },
+];
+
+export const LOADING_MOCK_AVERAGE_PNL = [
+  { instrument: "ES", averagePnl: 42.5 },
+  { instrument: "NQ", averagePnl: 18.2 },
+  { instrument: "CL", averagePnl: -12.4 },
+  { instrument: "GC", averagePnl: 31.8 },
+  { instrument: "YM", averagePnl: -8.6 },
+  { instrument: "RTY", averagePnl: 22.1 },
+];
+
+export const LOADING_MOCK_SIDE_PNL = [
+  { side: "Long", pnl: 85.4 },
+  { side: "Short", pnl: -24.6 },
+];
+
+export const LOADING_MOCK_HOURLY = Array.from({ length: 24 }, (_, hour) => ({
+  hour,
+  avgPnl: [12, -8, 5, 18, -3, 22, 45, 30, -15, 8, 12, 28, 35, -10, 6, 14, 20, -5, 40, 16, -12, 9, 25, 7][
+    hour
+  ],
+}));
+
+export const LOADING_MOCK_HOURLY_TIME = Array.from({ length: 24 }, (_, hour) => ({
+  hour,
+  avgTimeInPosition: [5, 8, 12, 15, 10, 18, 22, 30, 25, 14, 9, 20, 28, 16, 11, 19, 24, 13, 17, 21, 7, 10, 15, 6][
+    hour
+  ],
+}));
+
+export const LOADING_MOCK_HOURLY_QUANTITY = Array.from({ length: 24 }, (_, hour) => ({
+  hour,
+  totalQuantity: [2, 4, 1, 6, 3, 8, 5, 10, 7, 4, 2, 9, 12, 6, 3, 7, 11, 5, 8, 4, 2, 6, 9, 3][hour],
+}));
+
+export const LOADING_MOCK_WEEKDAY = [
+  { day: 0, pnl: 120 },
+  { day: 1, pnl: -45 },
+  { day: 2, pnl: 80 },
+  { day: 3, pnl: 210 },
+  { day: 4, pnl: -30 },
+  { day: 5, pnl: 55 },
+  { day: 6, pnl: 15 },
+];
+
+export const LOADING_MOCK_TIME_RANGE = [
+  { range: "0-5m", avgPnl: 12 },
+  { range: "5-15m", avgPnl: 28 },
+  { range: "15-30m", avgPnl: -8 },
+  { range: "30-60m", avgPnl: 45 },
+  { range: "1-2h", avgPnl: 18 },
+  { range: "2-4h", avgPnl: -22 },
+  { range: "4-8h", avgPnl: 35 },
+  { range: "8h+", avgPnl: 10 },
+];
+
+export const LOADING_MOCK_TICKS = [
+  { ticks: "-4", count: 3 },
+  { ticks: "-2", count: 8 },
+  { ticks: "0", count: 5 },
+  { ticks: "2", count: 12 },
+  { ticks: "4", count: 7 },
+  { ticks: "6", count: 4 },
+];
+
+export const LOADING_MOCK_EQUITY = [
+  { date: "2024-12-02", equity: 50000 },
+  { date: "2024-12-05", equity: 51200 },
+  { date: "2024-12-10", equity: 50800 },
+  { date: "2024-12-15", equity: 52500 },
+  { date: "2024-12-20", equity: 53100 },
+  { date: "2024-12-27", equity: 51800 },
+  { date: "2025-01-03", equity: 54200 },
+  { date: "2025-01-10", equity: 55600 },
+  { date: "2025-01-17", equity: 54900 },
+  { date: "2025-01-24", equity: 56800 },
+];
+
+export const LOADING_MOCK_CALENDAR_DISTRIBUTION = [
+  { name: "ACC-1", value: 420 },
+  { name: "ACC-2", value: -180 },
+  { name: "ACC-3", value: 95 },
+  { name: "ACC-4", value: 260 },
+];
+
+export const LOADING_MOCK_CALENDAR_EQUITY = [
+  { time: "09:30", balance: 50000, pnl: 120 },
+  { time: "10:15", balance: 50250, pnl: 250 },
+  { time: "11:00", balance: 49980, pnl: -270 },
+  { time: "13:30", balance: 50500, pnl: 520 },
+  { time: "14:45", balance: 50820, pnl: 320 },
+  { time: "15:30", balance: 50650, pnl: -170 },
+];

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -21,6 +21,31 @@ import { cn } from "@/lib/utils";
 import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 
 const MUTED_BAR_FILL = "hsl(var(--muted-foreground) / 0.35)";
+const DEFAULT_LOADING_LABEL = "Loading chart data...";
+
+interface ChartLoadingContainerProps {
+  children: React.ReactNode;
+  loadingLabel?: string;
+  className?: string;
+}
+
+function ChartLoadingContainer({
+  children,
+  loadingLabel = DEFAULT_LOADING_LABEL,
+  className,
+}: ChartLoadingContainerProps) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={loadingLabel}
+      className={cn("w-full h-full relative", className)}
+    >
+      <span className="sr-only">{loadingLabel}</span>
+      {children}
+    </div>
+  );
+}
 
 export type ChartMarginVariant = "default" | "hourly" | "calendar";
 
@@ -132,6 +157,7 @@ interface BarChartLoadingSkeletonProps {
   maxBarSize?: number;
   domain?: [number, number];
   xTickCount?: number;
+  loadingLabel?: string;
 }
 
 export function BarChartLoadingSkeleton({
@@ -145,6 +171,7 @@ export function BarChartLoadingSkeleton({
   maxBarSize,
   domain,
   xTickCount = 6,
+  loadingLabel,
 }: BarChartLoadingSkeletonProps) {
   const margin = getChartMargins(size, marginVariant);
   const { xAxisHeight } = getAxisDimensions(size, yAxisWidth);
@@ -153,7 +180,10 @@ export function BarChartLoadingSkeleton({
   const barSize = maxBarSize ?? (size === "small" ? 25 : 40);
 
   return (
-    <div className={cn("w-full h-full animate-pulse relative")}>
+    <ChartLoadingContainer
+      loadingLabel={loadingLabel}
+      className="animate-pulse"
+    >
       <ChartAxisSkeletonOverlay
         size={size}
         margin={margin}
@@ -199,7 +229,7 @@ export function BarChartLoadingSkeleton({
           </Bar>
         </BarChart>
       </ResponsiveContainer>
-    </div>
+    </ChartLoadingContainer>
   );
 }
 
@@ -209,6 +239,7 @@ interface LineChartLoadingSkeletonProps {
   xDataKey: string;
   yDataKey: string;
   showReferenceLine?: boolean;
+  loadingLabel?: string;
 }
 
 export function LineChartLoadingSkeleton({
@@ -217,12 +248,16 @@ export function LineChartLoadingSkeleton({
   xDataKey,
   yDataKey,
   showReferenceLine = true,
+  loadingLabel,
 }: LineChartLoadingSkeletonProps) {
   const margin = getChartMargins(size);
   const { yAxisWidth, xAxisHeight } = getAxisDimensions(size);
 
   return (
-    <div className={cn("w-full h-full animate-pulse relative")}>
+    <ChartLoadingContainer
+      loadingLabel={loadingLabel}
+      className="animate-pulse"
+    >
       <ChartAxisSkeletonOverlay
         size={size}
         margin={margin}
@@ -268,16 +303,18 @@ export function LineChartLoadingSkeleton({
           />
         </LineChart>
       </ResponsiveContainer>
-    </div>
+    </ChartLoadingContainer>
   );
 }
 
 interface DonutChartLoadingSkeletonProps {
   size?: WidgetSize;
+  loadingLabel?: string;
 }
 
 export function DonutChartLoadingSkeleton({
   size = "medium",
+  loadingLabel,
 }: DonutChartLoadingSkeletonProps) {
   const mockData = [
     { name: "a", value: 55 },
@@ -286,7 +323,10 @@ export function DonutChartLoadingSkeleton({
   ];
 
   return (
-    <div className={cn("w-full h-full animate-pulse relative flex flex-col")}>
+    <ChartLoadingContainer
+      loadingLabel={loadingLabel}
+      className="animate-pulse flex flex-col"
+    >
       <div className="flex-1 min-h-0">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
@@ -323,7 +363,7 @@ export function DonutChartLoadingSkeleton({
           />
         ))}
       </div>
-    </div>
+    </ChartLoadingContainer>
   );
 }
 
@@ -333,6 +373,7 @@ interface ComposedChartLoadingSkeletonProps {
   xDataKey: string;
   barDataKey: string;
   lineDataKey: string;
+  loadingLabel?: string;
 }
 
 export function ComposedChartLoadingSkeleton({
@@ -341,12 +382,16 @@ export function ComposedChartLoadingSkeleton({
   xDataKey,
   barDataKey,
   lineDataKey,
+  loadingLabel,
 }: ComposedChartLoadingSkeletonProps) {
-  const margin = { left: 10, right: 8, top: 8, bottom: 35 };
+  const margin = getChartMargins(size, "calendar");
   const { yAxisWidth, xAxisHeight } = getAxisDimensions(size);
 
   return (
-    <div className={cn("w-full h-full animate-pulse relative")}>
+    <ChartLoadingContainer
+      loadingLabel={loadingLabel}
+      className="animate-pulse"
+    >
       <ChartAxisSkeletonOverlay
         size={size}
         margin={margin}
@@ -396,7 +441,7 @@ export function ComposedChartLoadingSkeleton({
           />
         </ComposedChart>
       </ResponsiveContainer>
-    </div>
+    </ChartLoadingContainer>
   );
 }
 

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/tooltip";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
+import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton";
 
 interface CommissionsPnLChartProps {
   size?: WidgetSize;
@@ -46,7 +47,7 @@ const formatCurrency = (value: number) =>
 export default function CommissionsPnLChart({
   size = "medium",
 }: CommissionsPnLChartProps) {
-  const { formattedTrades: trades } = useData();
+  const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
 
 
@@ -161,6 +162,9 @@ export default function CommissionsPnLChart({
         )}
       >
         <div className="w-full h-full">
+          {isLoading ? (
+            <DonutChartLoadingSkeleton size={size} />
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
@@ -234,6 +238,7 @@ export default function CommissionsPnLChart({
               />
             </PieChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/contract-quantity.tsx
+++ b/app/[locale]/dashboard/components/charts/contract-quantity.tsx
@@ -23,6 +23,10 @@ import { Trade } from "@/prisma/generated/prisma/browser";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_HOURLY_QUANTITY,
+} from "./chart-loading-skeleton";
 
 interface ContractQuantityChartProps {
   size?: WidgetSize;
@@ -38,7 +42,7 @@ const chartConfig = {
 export default function ContractQuantityChart({
   size = "medium",
 }: ContractQuantityChartProps) {
-  const { formattedTrades: trades } = useData();
+  const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
 
   const chartData = React.useMemo(() => {
@@ -100,6 +104,19 @@ export default function ContractQuantityChart({
         <CardDescription>{t("contracts.description")}</CardDescription>
       </CardHeader>
       <CardContent className="px-2 sm:p-6">
+        {isLoading ? (
+          <div className="aspect-auto h-[350px] w-full">
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_HOURLY_QUANTITY}
+              xDataKey="hour"
+              yDataKey="totalQuantity"
+              marginVariant="hourly"
+              yAxisWidth={45}
+              xTickCount={8}
+            />
+          </div>
+        ) : (
         <ChartContainer
           config={chartConfig}
           className="aspect-auto h-[350px] w-full"
@@ -150,6 +167,7 @@ export default function ContractQuantityChart({
             </Bar>
           </BarChart>
         </ChartContainer>
+        )}
       </CardContent>
     </Card>
   );

--- a/app/[locale]/dashboard/components/charts/equity-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/equity-chart.tsx
@@ -50,6 +50,10 @@ import { useEquityChartStore } from "@/store/widgets/equity-chart-store";
 import { useEquityChartDataStore } from "@/store/widgets/equity-chart-data-store";
 import { Payout as PrismaPayout } from "@/prisma/generated/prisma/browser";
 import { AccountSelectionPopover } from "./account-selection-popover";
+import {
+  LineChartLoadingSkeleton,
+  LOADING_MOCK_EQUITY,
+} from "./chart-loading-skeleton";
 import { usePathname } from "next/navigation";
 
 interface EquityChartProps {
@@ -948,11 +952,13 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
         <div className="w-full h-full flex flex-col">
           <div className="flex-1 min-h-0">
             {isLoading ? (
-              <div className="w-full h-full flex items-center justify-center">
-                <div className="text-muted-foreground text-sm">
-                  {t("equity.loading")}
-                </div>
-              </div>
+              <LineChartLoadingSkeleton
+                size={size}
+                data={LOADING_MOCK_EQUITY}
+                xDataKey="date"
+                yDataKey="equity"
+                showReferenceLine={true}
+              />
             ) : (
               <ChartContainer config={chartConfig} className="w-full h-full">
                 <ResponsiveContainer width="100%" height="100%">

--- a/app/[locale]/dashboard/components/charts/equity-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/equity-chart.tsx
@@ -958,6 +958,7 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
                 xDataKey="date"
                 yDataKey="equity"
                 showReferenceLine={true}
+                loadingLabel={t("equity.loading")}
               />
             ) : (
               <ChartContainer config={chartConfig} className="w-full h-full">

--- a/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
@@ -27,6 +27,10 @@ import { useI18n, useCurrentLocale } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import { fr, enUS } from "date-fns/locale";
 import { useUserStore } from "@/store/user-store";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_DATE_PNL,
+} from "./chart-loading-skeleton";
 
 interface PNLChartProps {
   size?: WidgetSize;
@@ -102,7 +106,7 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
 };
 
 export default function PNLChart({ size = "medium" }: PNLChartProps) {
-  const { calendarData } = useData();
+  const { calendarData, isLoading } = useData();
   const t = useI18n();
   const locale = useCurrentLocale();
   const { timezone } = useUserStore();
@@ -195,63 +199,73 @@ export default function PNLChart({ size = "medium" }: PNLChartProps) {
         )}
       >
         <div className={cn("w-full h-full")}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData} margin={getChartMargins()}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="date"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                minTickGap={size === "small" ? 30 : 50}
-                tickFormatter={(value) => {
-                  const date = new Date(value + "T00:00:00Z");
-                  return formatInTimeZone(date, timezone, "MMM d", {
-                    locale: dateLocale,
-                  });
-                }}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={60}
-                tickMargin={4}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatCurrency}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="pnl"
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-              >
-                {chartData.map((entry, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={entry.pnl >= 0 ? positiveColor : negativeColor}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_DATE_PNL}
+              xDataKey="date"
+              yDataKey="pnl"
+              marginVariant="default"
+            />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} margin={getChartMargins()}>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
+                />
+                <XAxis
+                  dataKey="date"
+                  tickLine={false}
+                  axisLine={false}
+                  height={size === "small" ? 20 : 24}
+                  tickMargin={size === "small" ? 4 : 8}
+                  tick={{
+                    fontSize: size === "small" ? 9 : 11,
+                    fill: "currentColor",
+                  }}
+                  minTickGap={size === "small" ? 30 : 50}
+                  tickFormatter={(value) => {
+                    const date = new Date(value + "T00:00:00Z");
+                    return formatInTimeZone(date, timezone, "MMM d", {
+                      locale: dateLocale,
+                    });
+                  }}
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  width={60}
+                  tickMargin={4}
+                  tick={{
+                    fontSize: size === "small" ? 9 : 11,
+                    fill: "currentColor",
+                  }}
+                  tickFormatter={formatCurrency}
+                />
+                <Tooltip
+                  content={<CustomTooltip />}
+                  wrapperStyle={{
+                    fontSize: size === "small" ? "10px" : "12px",
+                    zIndex: 1000,
+                  }}
+                />
+                <Bar
+                  dataKey="pnl"
+                  radius={[3, 3, 0, 0]}
+                  maxBarSize={size === "small" ? 25 : 40}
+                  className="transition-opacity duration-300 ease-out"
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={entry.pnl >= 0 ? positiveColor : negativeColor}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
@@ -26,6 +26,10 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_SIDE_PNL,
+} from "./chart-loading-skeleton";
 
 interface PnLBySideChartProps {
   size?: WidgetSize;
@@ -91,7 +95,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 export default function PnLBySideChart({
   size = "medium",
 }: PnLBySideChartProps) {
-  const { formattedTrades: trades } = useData();
+  const { formattedTrades: trades, isLoading } = useData();
   const [showAverage, setShowAverage] = React.useState(true);
   const t = useI18n();
 
@@ -204,62 +208,76 @@ export default function PnLBySideChart({
         )}
       >
         <div className={cn("w-full h-full")}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === "small"
-                  ? { left: 10, right: 4, top: 4, bottom: 20 }
-                  : { left: 10, right: 8, top: 8, bottom: 24 }
-              }
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="side"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={60}
-                tickMargin={4}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatCurrency}
-                domain={[Math.min(minPnL * 1.1, 0), Math.max(maxPnL * 1.1, 0)]}
-              />
-              <ReferenceLine y={0} stroke="hsl(var(--border))" />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="pnl"
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_SIDE_PNL}
+              xDataKey="side"
+              yDataKey="pnl"
+              showReferenceLine
+              xTickCount={2}
+            />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={
+                  size === "small"
+                    ? { left: 10, right: 4, top: 4, bottom: 20 }
+                    : { left: 10, right: 8, top: 8, bottom: 24 }
+                }
               >
-                {chartData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={getColor(entry.pnl)} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
+                />
+                <XAxis
+                  dataKey="side"
+                  tickLine={false}
+                  axisLine={false}
+                  height={size === "small" ? 20 : 24}
+                  tickMargin={size === "small" ? 4 : 8}
+                  tick={{
+                    fontSize: size === "small" ? 9 : 11,
+                    fill: "currentColor",
+                  }}
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  width={60}
+                  tickMargin={4}
+                  tick={{
+                    fontSize: size === "small" ? 9 : 11,
+                    fill: "currentColor",
+                  }}
+                  tickFormatter={formatCurrency}
+                  domain={[
+                    Math.min(minPnL * 1.1, 0),
+                    Math.max(maxPnL * 1.1, 0),
+                  ]}
+                />
+                <ReferenceLine y={0} stroke="hsl(var(--border))" />
+                <Tooltip
+                  content={<CustomTooltip />}
+                  wrapperStyle={{
+                    fontSize: size === "small" ? "10px" : "12px",
+                    zIndex: 1000,
+                  }}
+                />
+                <Bar
+                  dataKey="pnl"
+                  radius={[3, 3, 0, 0]}
+                  maxBarSize={size === "small" ? 25 : 40}
+                  className="transition-opacity duration-300 ease-out"
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={getColor(entry.pnl)} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
@@ -25,6 +25,10 @@ import {
 } from "@/components/ui/tooltip";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_AVERAGE_PNL,
+} from "./chart-loading-skeleton";
 
 interface PnLPerContractChartProps {
   size?: WidgetSize;
@@ -89,7 +93,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 export default function PnLPerContractChart({
   size = "medium",
 }: PnLPerContractChartProps) {
-  const { formattedTrades: trades } = useData();
+  const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
 
   const chartData = React.useMemo(() => {
@@ -194,67 +198,80 @@ export default function PnLPerContractChart({
         )}
       >
         <div className={cn("w-full h-full")}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === "small"
-                  ? { left: 10, right: 4, top: 4, bottom: 20 }
-                  : { left: 10, right: 8, top: 8, bottom: 24 }
-              }
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="instrument"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                angle={size === "small" ? -45 : -45}
-                textAnchor="end"
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={60}
-                tickMargin={4}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatCurrency}
-                domain={[Math.min(minPnL * 1.1, 0), Math.max(maxPnL * 1.1, 0)]}
-              />
-              <ReferenceLine y={0} stroke="hsl(var(--border))" />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="averagePnl"
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_AVERAGE_PNL}
+              xDataKey="instrument"
+              yDataKey="averagePnl"
+              showReferenceLine
+            />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={
+                  size === "small"
+                    ? { left: 10, right: 4, top: 4, bottom: 20 }
+                    : { left: 10, right: 8, top: 8, bottom: 24 }
+                }
               >
-                {chartData.map((entry, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={getColor(entry.averagePnl)}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
+                />
+                <XAxis
+                  dataKey="instrument"
+                  tickLine={false}
+                  axisLine={false}
+                  height={size === "small" ? 20 : 24}
+                  tickMargin={size === "small" ? 4 : 8}
+                  tick={{
+                    fontSize: size === "small" ? 9 : 11,
+                    fill: "currentColor",
+                  }}
+                  angle={size === "small" ? -45 : -45}
+                  textAnchor="end"
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  width={60}
+                  tickMargin={4}
+                  tick={{
+                    fontSize: size === "small" ? 9 : 11,
+                    fill: "currentColor",
+                  }}
+                  tickFormatter={formatCurrency}
+                  domain={[
+                    Math.min(minPnL * 1.1, 0),
+                    Math.max(maxPnL * 1.1, 0),
+                  ]}
+                />
+                <ReferenceLine y={0} stroke="hsl(var(--border))" />
+                <Tooltip
+                  content={<CustomTooltip />}
+                  wrapperStyle={{
+                    fontSize: size === "small" ? "10px" : "12px",
+                    zIndex: 1000,
+                  }}
+                />
+                <Bar
+                  dataKey="averagePnl"
+                  radius={[3, 3, 0, 0]}
+                  maxBarSize={size === "small" ? 25 : 40}
+                  className="transition-opacity duration-300 ease-out"
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={getColor(entry.averagePnl)}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
@@ -28,6 +28,10 @@ import { useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import { Button } from "@/components/ui/button";
 import { useUserStore } from "../../../../../store/user-store";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_HOURLY,
+} from "./chart-loading-skeleton";
 
 interface TimeOfDayTradeChartProps {
   size?: WidgetSize;
@@ -46,7 +50,12 @@ const formatCurrency = (value: number) =>
 export default function TimeOfDayTradeChart({
   size = "medium",
 }: TimeOfDayTradeChartProps) {
-  const { formattedTrades: trades, hourFilter, setHourFilter } = useData();
+  const {
+    formattedTrades: trades,
+    hourFilter,
+    setHourFilter,
+    isLoading,
+  } = useData();
   const timezone = useUserStore((state) => state.timezone);
   const [activeHour, setActiveHour] = React.useState<number | null>(null);
   const t = useI18n();
@@ -194,6 +203,17 @@ export default function TimeOfDayTradeChart({
         )}
       >
         <div className="w-full h-full cursor-pointer" onClick={handleClick}>
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_HOURLY}
+              xDataKey="hour"
+              yDataKey="avgPnl"
+              marginVariant="hourly"
+              yAxisWidth={45}
+              xTickCount={8}
+            />
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={chartData}
@@ -266,6 +286,7 @@ export default function TimeOfDayTradeChart({
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/tick-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/tick-distribution.tsx
@@ -26,6 +26,10 @@ import {
 import { useI18n } from "@/locales/client";
 import { Button } from "@/components/ui/button";
 import { useTickDetailsStore } from "@/store/tick-details-store";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_TICKS,
+} from "./chart-loading-skeleton";
 
 interface TickDistributionProps {
   size?: WidgetSize;
@@ -97,7 +101,8 @@ const formatCount = (value: number) => {
 export default function TickDistributionChart({
   size = "medium",
 }: TickDistributionProps) {
-  const { formattedTrades: trades, tickFilter, setTickFilter } = useData();
+  const { formattedTrades: trades, tickFilter, setTickFilter, isLoading } =
+    useData();
   const tickDetails = useTickDetailsStore((state) => state.tickDetails);
   const t = useI18n();
 
@@ -201,6 +206,20 @@ export default function TickDistributionChart({
         )}
       >
         <div className={cn("w-full h-full")}>
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_TICKS}
+              xDataKey="ticks"
+              yDataKey="count"
+              yAxisWidth={45}
+              showReferenceLine={false}
+              domain={[
+                0,
+                Math.max(...LOADING_MOCK_TICKS.map((d) => d.count)) * 1.1,
+              ]}
+            />
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={chartData}
@@ -287,6 +306,7 @@ export default function TickDistributionChart({
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/time-in-position.tsx
+++ b/app/[locale]/dashboard/components/charts/time-in-position.tsx
@@ -26,6 +26,10 @@ import {
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_HOURLY_TIME,
+} from "./chart-loading-skeleton";
 
 interface TimeInPositionChartProps {
   size?: WidgetSize;
@@ -50,7 +54,7 @@ const formatTime = (minutes: number) => {
 export default function TimeInPositionChart({
   size = "medium",
 }: TimeInPositionChartProps) {
-  const { formattedTrades: trades } = useData();
+  const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
 
   const chartData = React.useMemo(() => {
@@ -169,6 +173,17 @@ export default function TimeInPositionChart({
         )}
       >
         <div className={cn("w-full h-full")}>
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_HOURLY_TIME}
+              xDataKey="hour"
+              yDataKey="avgTimeInPosition"
+              marginVariant="hourly"
+              yAxisWidth={45}
+              xTickCount={8}
+            />
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={chartData}
@@ -232,6 +247,7 @@ export default function TimeInPositionChart({
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/time-range-performance.tsx
+++ b/app/[locale]/dashboard/components/charts/time-range-performance.tsx
@@ -18,6 +18,10 @@ import { Trade } from "@/prisma/generated/prisma/browser"
 import { Button } from "@/components/ui/button"
 import { ChartConfig } from "@/components/ui/chart"
 import { getTimeRangeKey } from "@/lib/time-range"
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_TIME_RANGE,
+} from "./chart-loading-skeleton"
 
 interface TimeRangePerformanceChartProps {
   size?: WidgetSize
@@ -51,7 +55,7 @@ const chartConfig = {
 } satisfies ChartConfig
 
 export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRangePerformanceChartProps) {
-  const { formattedTrades: trades, timeRange, setTimeRange } = useData()
+  const { formattedTrades: trades, timeRange, setTimeRange, isLoading } = useData()
   const t = useI18n()
   const [activeRange, setActiveRange] = React.useState<string | null>(null)
 
@@ -218,6 +222,16 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
           className="w-full h-full cursor-pointer" 
           onClick={handleClick}
         >
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_TIME_RANGE}
+              xDataKey="range"
+              yDataKey="avgPnl"
+              yAxisWidth={45}
+              showReferenceLine
+            />
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={chartData}
@@ -293,6 +307,7 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useI18n } from "@/locales/client"
+import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton"
 
 interface TradeDistributionProps {
   size?: WidgetSize
@@ -66,7 +67,7 @@ const CustomTooltip = ({ active, payload }: TooltipProps) => {
 };
 
 export default function TradeDistributionChart({ size = 'medium' }: TradeDistributionProps) {
-  const { statistics: { nbWin, nbLoss, nbBe, nbTrades } } = useData()
+  const { statistics: { nbWin, nbLoss, nbBe, nbTrades }, isLoading } = useData()
   const t = useI18n()
 
   const chartData = React.useMemo(() => {
@@ -126,6 +127,9 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
         )}
       >
         <div className="w-full h-full">
+          {isLoading ? (
+            <DonutChartLoadingSkeleton size={size} />
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
@@ -202,6 +206,7 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
               />
             </PieChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
@@ -26,6 +26,10 @@ import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import { translateWeekdayPnL } from "@/lib/translation-utils";
 import { Button } from "@/components/ui/button";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_WEEKDAY,
+} from "./chart-loading-skeleton";
 
 const daysOfWeek = [0, 1, 2, 3, 4, 5, 6]; // Sunday = 0, Saturday = 6
 
@@ -46,7 +50,8 @@ const chartConfig = {
 export default function WeekdayPNLChart({
   size = "medium",
 }: WeekdayPNLChartProps) {
-  const { calendarData, weekdayFilter, setWeekdayFilter } = useData();
+  const { calendarData, weekdayFilter, setWeekdayFilter, isLoading } =
+    useData();
   const [darkMode, setDarkMode] = React.useState(false);
   const [activeDay, setActiveDay] = React.useState<number | null>(null);
   const t = useI18n();
@@ -215,6 +220,16 @@ export default function WeekdayPNLChart({
         )}
       >
         <div className="w-full h-full cursor-pointer" onClick={handleClick}>
+          {isLoading ? (
+            <BarChartLoadingSkeleton
+              size={size}
+              data={LOADING_MOCK_WEEKDAY}
+              xDataKey="day"
+              yDataKey="pnl"
+              yAxisWidth={45}
+              xTickCount={7}
+            />
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={weekdayData}
@@ -281,6 +296,7 @@ export default function WeekdayPNLChart({
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the chart-shaped skeleton loading pattern from the Net PNL per contract daily chart to all other dashboard Recharts widgets. During data fetch, charts now render muted mock series with axis tick skeleton overlays instead of blank charts or centered loading text.

## Changes

- **Shared utilities** (`chart-loading-skeleton.tsx`): reusable axis overlay, bar/line/donut/composed skeleton components, mock data presets, and accessible loading semantics (`role="status"`, `aria-busy`, `sr-only` label)
- **Bar charts**: pnl-per-contract, pnl-by-side, pnl-bar-chart, pnl-time-bar-chart, time-in-position, contract-quantity, weekday-pnl, time-range-performance, tick-distribution
- **Line chart**: equity-chart (replaces text-only loading state; keeps announced loading label)
- **Donut charts**: trade-distribution, commissions-pnl
- **Calendar modals**: daily/weekly modal charts with `useData()` fallback scoped to missing `dayData` only (cached modal charts stay visible during refresh)

## Pattern

Each chart checks `isLoading` from `useData()` (equity chart keeps its existing store/local loading path) and renders a skeleton that mirrors the loaded chart layout: grid, hidden axis ticks, skeleton tick overlays, and muted placeholder series.

## Review feedback addressed

1. **Accessibility** — shared skeleton wrappers announce loading to assistive tech; equity chart passes `t("equity.loading")`
2. **Calendar refresh** — skeletons only show when `dayData === undefined`; global/modal loading no longer blanks cached modal charts during `refreshTradesOnly`

## Verification

- `bun run typecheck` passes
- `OPENAI_API_KEY=dummy bun run build` passes

## Notes

- `pnl-per-contract-daily.tsx` remains the original inline reference implementation
- `daily-tick-target.tsx` is a progress widget (not Recharts) and was left unchanged
- `trade-progress-chart.tsx` (account card scoped) was out of scope for this pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f67303a-c797-42cc-9036-926d8bb012ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f67303a-c797-42cc-9036-926d8bb012ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

