### PR TITLE
Speed up Get Started auth redirect and add navigation feedback

### DIFF
--- a/app/[locale]/(authentication)/authentication/loading.tsx
+++ b/app/[locale]/(authentication)/authentication/loading.tsx
@@ -1,9 +1,5 @@
-import { Loader2 } from "lucide-react"
+import { RouteLoadingSpinner } from "@/components/route-loading-spinner"
 
 export default function Loading() {
-  return (
-    <div className="h-screen flex items-center justify-center">
-      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-    </div>
-  )
+  return <RouteLoadingSpinner />
 }

--- a/app/[locale]/(authentication)/authentication/loading.tsx
+++ b/app/[locale]/(authentication)/authentication/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -1,9 +1,23 @@
 'use client'
 import { useI18n } from "@/locales/landing-client";
 import { Button } from "@/components/ui/button";
-import Link from "next/link";
+import Link, { useLinkStatus } from "next/link";
 import { useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { useTheme } from "@/context/theme-provider";
+
+function GetStartedLinkContent({ children }: { children: React.ReactNode }) {
+  const { pending } = useLinkStatus();
+
+  return (
+    <span className="relative inline-flex items-center justify-center font-medium text-sm text-white">
+      <span className={pending ? "invisible" : undefined}>{children}</span>
+      {pending && (
+        <Loader2 className="absolute h-4 w-4 animate-spin" aria-hidden />
+      )}
+    </span>
+  );
+}
 
 export default function Hero() {
   const t = useI18n();
@@ -87,9 +101,7 @@ export default function Hero() {
               href={"/dashboard"}
               className="flex justify-center items-center px-8 py-2.5 h-10 bg-[#2E9987] hover:bg-[#267a6d] dark:bg-[hsl(var(--chart-1))] dark:hover:bg-[hsl(var(--chart-1)/0.9)] shadow-[0_0_0_6px_rgba(50,169,151,0.1),0_0_0_2px_rgba(50,169,151,0.25),0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_-1px_rgba(0,0,0,0.1)] hover:shadow-[0_0_0_6px_rgba(50,169,151,0.2),0_0_0_2px_rgba(50,169,151,0.35),0_2px_4px_rgba(0,0,0,0.2),0_2px_3px_-1px_rgba(0,0,0,0.2)] dark:shadow-[0_0_0_6px_hsl(var(--chart-1)/0.1),0_0_0_2px_hsl(var(--chart-1)/0.25),0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_-1px_rgba(0,0,0,0.1)] dark:hover:shadow-[0_0_0_6px_hsl(var(--chart-1)/0.2),0_0_0_2px_hsl(var(--chart-1)/0.35),0_2px_4px_rgba(0,0,0,0.2),0_2px_3px_-1px_rgba(0,0,0,0.2)] rounded-xl transition-all duration-200"
             >
-              <span className="font-medium text-sm text-white">
-                {t("landing.cta")}
-              </span>
+              <GetStartedLinkContent>{t("landing.cta")}</GetStartedLinkContent>
             </Link>
           </div>
         </div>

--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -10,10 +10,16 @@ function GetStartedLinkContent({ children }: { children: React.ReactNode }) {
   const { pending } = useLinkStatus();
 
   return (
-    <span className="relative inline-flex items-center justify-center font-medium text-sm text-white">
+    <span
+      className="relative inline-flex items-center justify-center font-medium text-sm text-white"
+      aria-busy={pending}
+    >
       <span className={pending ? "invisible" : undefined}>{children}</span>
       {pending && (
-        <Loader2 className="absolute h-4 w-4 animate-spin" aria-hidden />
+        <>
+          <Loader2 className="absolute h-4 w-4 animate-spin" aria-hidden />
+          <span className="sr-only">Loading…</span>
+        </>
       )}
     </span>
   );
@@ -141,6 +147,7 @@ export default function Hero() {
               muted
               autoPlay
               playsInline
+              aria-label={t("landing.demoVideo")}
               className={`absolute inset-0 h-full w-full rounded-[14.5867px] border-[1.82333px] border-[#E5E7EB] object-cover transition-opacity duration-300 dark:border-gray-800 ${videoLoaded && !videoError ? "opacity-100" : "opacity-0"}`}
               onLoadedData={handleVideoLoad}
               onError={handleVideoError}

--- a/app/[locale]/dashboard/loading.tsx
+++ b/app/[locale]/dashboard/loading.tsx
@@ -1,9 +1,5 @@
-import { Loader2 } from "lucide-react"
+import { RouteLoadingSpinner } from "@/components/route-loading-spinner"
 
 export default function Loading() {
-  return (
-    <div className="h-screen flex items-center justify-center">
-      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-    </div>
-  )
+  return <RouteLoadingSpinner />
 }

--- a/app/[locale]/dashboard/loading.tsx
+++ b/app/[locale]/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/components/route-loading-spinner.tsx
+++ b/components/route-loading-spinner.tsx
@@ -1,0 +1,13 @@
+import { Loader2 } from "lucide-react"
+
+export function RouteLoadingSpinner() {
+  return (
+    <div className="flex h-screen items-center justify-center" role="status">
+      <Loader2
+        className="h-8 w-8 animate-spin text-foreground/60"
+        aria-hidden
+      />
+      <span className="sr-only">Loading…</span>
+    </div>
+  )
+}

--- a/locales/en/landing.ts
+++ b/locales/en/landing.ts
@@ -3,6 +3,7 @@ export default {
         title: 'Master your trading journey.',
         description: 'Deltalytix is a trading dashboard for futures traders to store, explore and understand their track-record.',
         cta: 'Get Started',
+        demoVideo: 'Product demo video',
         updates: 'Latest Product Updates →',
         partners: {
             title: 'Our Partners',

--- a/locales/fr/landing.ts
+++ b/locales/fr/landing.ts
@@ -3,6 +3,7 @@ export default {
         title: 'Votre journal de trading.',
         description: 'Deltalytix est un journal de trading web pour traders futures permettant de stocker, explorer et comprendre leur historique de trading.',
         cta: 'Commencer maintenant',
+        demoVideo: 'Vidéo de démonstration du produit',
         updates: 'Dernières mises à jour du produit →',
         partners: {
             title: 'Nos Partenaires',

--- a/proxy.ts
+++ b/proxy.ts
@@ -104,12 +104,11 @@ function isPublicRoute(pathname: string) {
 }
 
 function hasSupabaseAuthCookies(request: NextRequest) {
-  return request.cookies
-    .getAll()
-    .some(
-      (cookie) =>
-        cookie.name.startsWith("sb-") && cookie.name.includes("-auth-token"),
-    )
+  return request.cookies.getAll().some((cookie) => {
+    if (!cookie.name.startsWith("sb-")) return false
+    // Session token only — exclude PKCE verifier cookies (e.g. auth-token-code-verifier).
+    return /-auth-token(\.\d+)?$/.test(cookie.name)
+  })
 }
 
 function createUnauthenticatedSession(request: NextRequest) {
@@ -157,7 +156,10 @@ function addAgentDiscoveryHeaders(response: NextResponse, request: NextRequest) 
   return response
 }
 
-async function updateSession(request: NextRequest) {
+async function updateSession(
+  request: NextRequest,
+  options?: { requireServerAuth?: boolean },
+) {
   // Create a proper NextResponse first
   const response = NextResponse.next({
     request: {
@@ -212,9 +214,13 @@ async function updateSession(request: NextRequest) {
   let error: unknown = null
 
   try {
-    const authPromise =
-      typeof supabase.auth.getClaims === "function"
-        ? supabase.auth.getClaims().then((result) => {
+    const useServerAuth =
+      options?.requireServerAuth ||
+      typeof supabase.auth.getClaims !== "function"
+
+    const authPromise = useServerAuth
+      ? supabase.auth.getUser()
+      : supabase.auth.getClaims().then((result) => {
             const claims = result.data?.claims
             if (claims?.sub && !result.error) {
               return {
@@ -229,7 +235,6 @@ async function updateSession(request: NextRequest) {
             }
             return { data: { user: null }, error: result.error }
           })
-        : supabase.auth.getUser()
 
     const timeoutPromise = new Promise((_, reject) =>
       setTimeout(() => reject(new Error("Auth timeout")), 3000),
@@ -332,7 +337,9 @@ export default async function proxy(req: NextRequest) {
   // Skip Supabase auth on public marketing routes to avoid unnecessary round-trips
   const { response: authResponse, user, error } = isPublicRoute(pathname)
     ? createUnauthenticatedSession(req)
-    : await updateSession(req)
+    : await updateSession(req, {
+        requireServerAuth: pathname.includes("/admin"),
+      })
 
   // Embed route check
   if (pathname.includes("/embed")) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -103,6 +103,15 @@ function isPublicRoute(pathname: string) {
   return false
 }
 
+function hasSupabaseAuthCookies(request: NextRequest) {
+  return request.cookies
+    .getAll()
+    .some(
+      (cookie) =>
+        cookie.name.startsWith("sb-") && cookie.name.includes("-auth-token"),
+    )
+}
+
 function createUnauthenticatedSession(request: NextRequest) {
   const response = NextResponse.next({
     request: {
@@ -171,6 +180,11 @@ async function updateSession(request: NextRequest) {
     }
   }
 
+  // No Supabase session cookies — visitor cannot be authenticated; skip network call.
+  if (!hasSupabaseAuthCookies(request)) {
+    return createUnauthenticatedSession(request)
+  }
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -198,14 +212,33 @@ async function updateSession(request: NextRequest) {
   let error: unknown = null
 
   try {
-    // Add timeout to prevent hanging requests
-    const authPromise = supabase.auth.getUser()
-    const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject(new Error("Auth timeout")), 5000))
+    const authPromise =
+      typeof supabase.auth.getClaims === "function"
+        ? supabase.auth.getClaims().then((result) => {
+            const claims = result.data?.claims
+            if (claims?.sub && !result.error) {
+              return {
+                data: {
+                  user: {
+                    id: claims.sub,
+                    email: claims.email,
+                  } as User,
+                },
+                error: result.error,
+              }
+            }
+            return { data: { user: null }, error: result.error }
+          })
+        : supabase.auth.getUser()
 
-    const result = await Promise.race([
-      authPromise,
-      timeoutPromise,
-    ]) as Awaited<ReturnType<typeof supabase.auth.getUser>>
+    const timeoutPromise = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error("Auth timeout")), 3000),
+    )
+
+    const result = (await Promise.race([authPromise, timeoutPromise])) as {
+      data?: { user?: User | null }
+      error: unknown
+    }
     user = result.data?.user || null
     error = result.error
   } catch (authError: unknown) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking **Get started** on the landing page navigates to `/dashboard`, but the middleware (`proxy.ts`) blocked on a `supabase.auth.getUser()` network round-trip (with a 5s timeout) before either rendering the dashboard or redirecting to `/authentication?next=dashboard`. During that time the click showed no feedback at all, so the redirect felt broken/slow — especially for logged-out visitors who can never authenticate anyway.

## Changes

### Faster auth in the middleware (`proxy.ts`)

- **Fail-fast for logged-out visitors:** if the request carries no Supabase session cookies (`sb-*-auth-token`), skip the Supabase client and network call entirely and treat the request as unauthenticated. A cookie-less visitor clicking Get started now gets the 307 to `/authentication?next=dashboard` with zero auth latency. `/authentication` still runs the session check for visitors *with* cookies, preserving the logged-in → dashboard redirect.
- **Local JWT verification for logged-in visitors:** replaced `supabase.auth.getUser()` with `supabase.auth.getClaims()` (Supabase's current middleware recommendation), which verifies the JWT locally against cached JWKS when the project uses asymmetric signing keys instead of a round-trip per request. Falls back to `getUser()` if `getClaims` is unavailable. Header contract (`x-user-id`, `x-user-email`, `x-auth-status`) is unchanged.
- **`/admin` uses server-side auth:** admin routes call `getUser()` so revoked sessions are not accepted via local JWT claims alone.
- Cookie detection tightened to match only session tokens (`/-auth-token(\.\d+)?$/`), excluding PKCE verifier cookies.
- Auth timeout reduced from 5s to 3s.
- Local dashboard auth bypass logic is untouched.

### Immediate navigation feedback

- The Get started CTA now uses Next.js 16's `useLinkStatus()` to overlay a centered spinner while the navigation is pending, with no layout shift or change in the idle appearance. Includes `aria-busy` and an `sr-only` loading label for screen readers.
- Added shared `RouteLoadingSpinner` with `role="status"`, `sr-only` label, and `text-foreground/60` contrast; used by `/dashboard` and `/authentication` route loading states.
- Hero demo video given an `aria-label` (EN/FR i18n).

### Review feedback intentionally not applied

- **CTA design tokens (`bg-primary`):** the app's `--primary` token is neutral black/white, not the brand teal used by the landing CTA. Switching to `bg-primary` would change the button appearance; the existing `#2E9987` / `chart-1` dark styling is intentional brand styling.
- **10px updates badge contrast:** pre-existing styling outside this PR's scope.

## Verification

- `bun run typecheck` — pass
- `OPENAI_API_KEY=dummy bun run build` — pass
- Health checks against the dev server (local dashboard bypass):
  - `GET /dashboard` → `x-auth-status: authenticated`, `x-user-id: local-dashboard-user`
  - `GET /authentication?next=dashboard` → `307` with `location: /dashboard`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82e1c71b-2a89-4e48-97cd-8e514a1ddca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82e1c71b-2a89-4e48-97cd-8e514a1ddca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

