### PR TITLE
Fix Open Mailbox on iOS to open inbox instead of compose

### DIFF
--- a/app/[locale]/(authentication)/components/user-auth-form.tsx
+++ b/app/[locale]/(authentication)/components/user-auth-form.tsx
@@ -32,6 +32,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
 // Link removed; unauthenticated users can't reach settings
 import { useAuthPreferenceStore } from "@/store/auth-preference-store"
+import { openMailbox } from "@/lib/open-mailbox"
 
 const formSchema = z.object({
     email: z.string().email(),
@@ -324,39 +325,10 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
 
     function openMailClient() {
         const email = form.getValues('email')
-        const domain = email.split('@')[1]?.toLowerCase()
+        const result = openMailbox(email)
 
-        if (domain?.includes('gmail.com')) {
-            window.open('https://mail.google.com', '_blank', 'noopener,noreferrer')
-        } else if (
-            domain?.includes('outlook.com') || 
-            domain?.includes('hotmail.com') || 
-            domain?.includes('live.com') ||
-            domain?.includes('msn.com') ||
-            domain?.includes('office365.com')
-        ) {
-            window.open('https://outlook.live.com', '_blank', 'noopener,noreferrer')
-        } else if (
-            domain?.includes('proton.me') || 
-            domain?.includes('protonmail.com') || 
-            domain?.includes('pm.me')
-        ) {
-            window.open('https://mail.proton.me', '_blank', 'noopener,noreferrer')
-        } else if (
-            domain?.includes('icloud.com') || 
-            domain?.includes('me.com') || 
-            domain?.includes('mac.com')
-        ) {
-            window.open('https://www.icloud.com/mail', '_blank', 'noopener,noreferrer')
-        } else if (domain?.includes('yahoo.com')) {
-            window.open('https://mail.yahoo.com', '_blank', 'noopener,noreferrer')
-        } else if (domain?.includes('aol.com')) {
-            window.open('https://mail.aol.com', '_blank', 'noopener,noreferrer')
-        } else if (domain?.includes('zoho.com')) {
-            window.open('https://mail.zoho.com', '_blank', 'noopener,noreferrer')
-        } else {
-            // Default to mailto: for unknown domains
-            window.location.href = `mailto:${email}`
+        if (result === 'manual-check') {
+            toast.info(t('auth.openMailboxManualCheck'))
         }
     }
 

--- a/lib/open-mailbox.test.ts
+++ b/lib/open-mailbox.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, it } from "vitest"
-import { resolveMailboxTarget } from "./open-mailbox"
+import { detectPlatform, resolveMailboxTarget } from "./open-mailbox"
+
+describe("detectPlatform", () => {
+  it("detects iPhone Safari", () => {
+    expect(
+      detectPlatform(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+        "iPhone",
+        5,
+      ),
+    ).toBe("ios")
+  })
+
+  it("detects iPad in desktop mode", () => {
+    expect(
+      detectPlatform(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+        "MacIntel",
+        5,
+        true,
+      ),
+    ).toBe("ios")
+  })
+
+  it("detects iOS from userAgentData platform hint", () => {
+    expect(
+      detectPlatform(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        "MacIntel",
+        0,
+        false,
+        "iOS",
+      ),
+    ).toBe("ios")
+  })
+})
 
 describe("resolveMailboxTarget", () => {
   it("opens Apple Mail inbox on iOS for unknown domains", () => {
@@ -14,11 +49,17 @@ describe("resolveMailboxTarget", () => {
     })
   })
 
-  it("opens Gmail app with web fallback on iOS", () => {
+  it("opens Gmail app with Apple Mail fallback on iOS", () => {
     expect(resolveMailboxTarget("user@gmail.com", "ios")).toEqual({
       primary: "googlegmail://",
-      fallback: "https://mail.google.com/mail/u/0/#inbox",
-      openInNewTab: true,
+      fallback: "message://",
+    })
+  })
+
+  it("opens Proton app with Apple Mail fallback on iOS", () => {
+    expect(resolveMailboxTarget("user@proton.me", "ios")).toEqual({
+      primary: "protonmail://",
+      fallback: "message://",
     })
   })
 

--- a/lib/open-mailbox.test.ts
+++ b/lib/open-mailbox.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { resolveMailboxTarget } from "./open-mailbox"
+
+describe("resolveMailboxTarget", () => {
+  it("opens Apple Mail inbox on iOS for unknown domains", () => {
+    expect(resolveMailboxTarget("user@company.com", "ios")).toEqual({
+      primary: "message://",
+    })
+  })
+
+  it("opens Apple Mail inbox on iOS for iCloud addresses", () => {
+    expect(resolveMailboxTarget("user@icloud.com", "ios")).toEqual({
+      primary: "message://",
+    })
+  })
+
+  it("opens Gmail app with web fallback on iOS", () => {
+    expect(resolveMailboxTarget("user@gmail.com", "ios")).toEqual({
+      primary: "googlegmail://",
+      fallback: "https://mail.google.com/mail/u/0/#inbox",
+      openInNewTab: true,
+    })
+  })
+
+  it("opens Gmail web inbox on desktop", () => {
+    expect(resolveMailboxTarget("user@gmail.com", "desktop")).toEqual({
+      primary: "https://mail.google.com/mail/u/0/#inbox",
+      openInNewTab: true,
+    })
+  })
+
+  it("opens Outlook app with web fallback on Android", () => {
+    expect(resolveMailboxTarget("user@outlook.com", "android")).toEqual({
+      primary: "ms-outlook://",
+      fallback: "https://outlook.live.com/mail/0/inbox",
+      openInNewTab: true,
+    })
+  })
+
+  it("returns null on desktop for unknown domains instead of mailto", () => {
+    expect(resolveMailboxTarget("user@company.com", "desktop")).toBeNull()
+  })
+})

--- a/lib/open-mailbox.ts
+++ b/lib/open-mailbox.ts
@@ -16,15 +16,57 @@ export function detectPlatform(
   userAgent: string,
   platform: string,
   maxTouchPoints: number,
+  touchSupport = false,
+  uaPlatform?: string,
 ): Platform {
   const isIOS =
+    uaPlatform === "iOS" ||
     /iPad|iPhone|iPod/.test(userAgent) ||
-    (platform === "MacIntel" && maxTouchPoints > 1)
+    platform === "iPhone" ||
+    platform === "iPad" ||
+    platform === "iPod" ||
+    (platform === "MacIntel" && maxTouchPoints > 1) ||
+    (touchSupport && /Macintosh/.test(userAgent) && maxTouchPoints > 1)
 
   if (isIOS) return "ios"
-  if (/Android/i.test(userAgent)) return "android"
+
+  if (uaPlatform === "Android" || /Android/i.test(userAgent)) return "android"
+
   if (/Mac/.test(platform)) return "macos"
+
   return "desktop"
+}
+
+function resolveIOSMailboxTarget(domain: string): MailboxTarget {
+  if (domain === "gmail.com" || domain === "googlemail.com") {
+    return { primary: "googlegmail://", fallback: "message://" }
+  }
+
+  if (
+    domain.endsWith("outlook.com") ||
+    domain.endsWith("hotmail.com") ||
+    domain.endsWith("live.com") ||
+    domain.endsWith("msn.com") ||
+    domain.endsWith("office365.com") ||
+    domain.endsWith("outlook.fr") ||
+    domain.endsWith("outlook.de")
+  ) {
+    return { primary: "ms-outlook://", fallback: "message://" }
+  }
+
+  if (
+    domain.endsWith("proton.me") ||
+    domain.endsWith("protonmail.com") ||
+    domain.endsWith("pm.me")
+  ) {
+    return { primary: "protonmail://", fallback: "message://" }
+  }
+
+  if (domain.endsWith("yahoo.com") || domain.endsWith("yahoo.fr")) {
+    return { primary: "ymail://mail/", fallback: "message://" }
+  }
+
+  return { primary: "message://" }
 }
 
 export function resolveMailboxTarget(
@@ -34,8 +76,12 @@ export function resolveMailboxTarget(
   const domain = getEmailDomain(email)
   if (!domain) return null
 
-  const isMobileNative = platform === "ios" || platform === "android"
-  const opensNativeMail = platform === "ios" || platform === "macos"
+  if (platform === "ios") {
+    return resolveIOSMailboxTarget(domain)
+  }
+
+  const isMobileNative = platform === "android"
+  const opensNativeMail = platform === "macos"
 
   if (domain === "gmail.com" || domain === "googlemail.com") {
     if (isMobileNative) {
@@ -126,7 +172,7 @@ export function resolveMailboxTarget(
     }
   }
 
-  if (platform === "ios" || platform === "macos") {
+  if (platform === "macos") {
     return { primary: "message://" }
   }
 
@@ -149,31 +195,60 @@ function openUrl(url: string, newTab: boolean) {
   window.location.assign(url)
 }
 
+function openWithFallback(
+  primary: string,
+  fallback: string,
+  webFallbackInNewTab: boolean,
+) {
+  let leftPage = false
+  const markLeft = () => {
+    leftPage = true
+  }
+
+  window.addEventListener("pagehide", markLeft, { once: true })
+  window.addEventListener("blur", markLeft, { once: true })
+
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      markLeft()
+    }
+  }
+
+  document.addEventListener("visibilitychange", onVisibilityChange)
+  window.location.assign(primary)
+
+  window.setTimeout(() => {
+    document.removeEventListener("visibilitychange", onVisibilityChange)
+    if (!leftPage) {
+      openUrl(fallback, webFallbackInNewTab)
+    }
+  }, 1200)
+}
+
 export function openMailbox(email: string): MailboxOpenResult {
   if (typeof window === "undefined") return "manual-check"
+
+  const navigatorWithHints = navigator as Navigator & {
+    userAgentData?: { platform?: string }
+  }
 
   const platform = detectPlatform(
     navigator.userAgent,
     navigator.platform,
     navigator.maxTouchPoints,
+    "ontouchend" in document,
+    navigatorWithHints.userAgentData?.platform,
   )
   const target = resolveMailboxTarget(email, platform)
 
   if (!target) return "manual-check"
 
   if (target.fallback) {
-    const openedAt = Date.now()
-    openUrl(target.primary, false)
-
-    window.setTimeout(() => {
-      if (
-        document.visibilityState === "visible" &&
-        Date.now() - openedAt < 2000
-      ) {
-        openUrl(target.fallback!, Boolean(target.openInNewTab))
-      }
-    }, 750)
-
+    openWithFallback(
+      target.primary,
+      target.fallback,
+      Boolean(target.openInNewTab),
+    )
     return "opened"
   }
 

--- a/lib/open-mailbox.ts
+++ b/lib/open-mailbox.ts
@@ -1,0 +1,182 @@
+export type Platform = "ios" | "android" | "macos" | "desktop"
+
+export type MailboxTarget = {
+  primary: string
+  fallback?: string
+  openInNewTab?: boolean
+}
+
+export type MailboxOpenResult = "opened" | "manual-check"
+
+function getEmailDomain(email: string): string | undefined {
+  return email.split("@")[1]?.toLowerCase().trim()
+}
+
+export function detectPlatform(
+  userAgent: string,
+  platform: string,
+  maxTouchPoints: number,
+): Platform {
+  const isIOS =
+    /iPad|iPhone|iPod/.test(userAgent) ||
+    (platform === "MacIntel" && maxTouchPoints > 1)
+
+  if (isIOS) return "ios"
+  if (/Android/i.test(userAgent)) return "android"
+  if (/Mac/.test(platform)) return "macos"
+  return "desktop"
+}
+
+export function resolveMailboxTarget(
+  email: string,
+  platform: Platform,
+): MailboxTarget | null {
+  const domain = getEmailDomain(email)
+  if (!domain) return null
+
+  const isMobileNative = platform === "ios" || platform === "android"
+  const opensNativeMail = platform === "ios" || platform === "macos"
+
+  if (domain === "gmail.com" || domain === "googlemail.com") {
+    if (isMobileNative) {
+      return {
+        primary: "googlegmail://",
+        fallback: "https://mail.google.com/mail/u/0/#inbox",
+        openInNewTab: true,
+      }
+    }
+    return {
+      primary: "https://mail.google.com/mail/u/0/#inbox",
+      openInNewTab: true,
+    }
+  }
+
+  if (
+    domain.endsWith("outlook.com") ||
+    domain.endsWith("hotmail.com") ||
+    domain.endsWith("live.com") ||
+    domain.endsWith("msn.com") ||
+    domain.endsWith("office365.com") ||
+    domain.endsWith("outlook.fr") ||
+    domain.endsWith("outlook.de")
+  ) {
+    if (isMobileNative) {
+      return {
+        primary: "ms-outlook://",
+        fallback: "https://outlook.live.com/mail/0/inbox",
+        openInNewTab: true,
+      }
+    }
+    return {
+      primary: "https://outlook.live.com/mail/0/inbox",
+      openInNewTab: true,
+    }
+  }
+
+  if (
+    domain.endsWith("proton.me") ||
+    domain.endsWith("protonmail.com") ||
+    domain.endsWith("pm.me")
+  ) {
+    return {
+      primary: "https://mail.proton.me/inbox",
+      openInNewTab: true,
+    }
+  }
+
+  if (
+    domain.endsWith("icloud.com") ||
+    domain.endsWith("me.com") ||
+    domain.endsWith("mac.com")
+  ) {
+    if (opensNativeMail) {
+      return { primary: "message://" }
+    }
+    return {
+      primary: "https://www.icloud.com/mail",
+      openInNewTab: true,
+    }
+  }
+
+  if (domain.endsWith("yahoo.com") || domain.endsWith("yahoo.fr")) {
+    if (isMobileNative) {
+      return {
+        primary: "ymail://mail/",
+        fallback: "https://mail.yahoo.com/",
+        openInNewTab: true,
+      }
+    }
+    return {
+      primary: "https://mail.yahoo.com/",
+      openInNewTab: true,
+    }
+  }
+
+  if (domain.endsWith("aol.com")) {
+    return {
+      primary: "https://mail.aol.com/",
+      openInNewTab: true,
+    }
+  }
+
+  if (domain.includes("zoho.com")) {
+    return {
+      primary: "https://mail.zoho.com/",
+      openInNewTab: true,
+    }
+  }
+
+  if (platform === "ios" || platform === "macos") {
+    return { primary: "message://" }
+  }
+
+  if (platform === "android") {
+    return {
+      primary:
+        "intent:#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_EMAIL;end",
+    }
+  }
+
+  return null
+}
+
+function openUrl(url: string, newTab: boolean) {
+  if (newTab) {
+    window.open(url, "_blank", "noopener,noreferrer")
+    return
+  }
+
+  window.location.assign(url)
+}
+
+export function openMailbox(email: string): MailboxOpenResult {
+  if (typeof window === "undefined") return "manual-check"
+
+  const platform = detectPlatform(
+    navigator.userAgent,
+    navigator.platform,
+    navigator.maxTouchPoints,
+  )
+  const target = resolveMailboxTarget(email, platform)
+
+  if (!target) return "manual-check"
+
+  if (target.fallback) {
+    const openedAt = Date.now()
+    openUrl(target.primary, false)
+
+    window.setTimeout(() => {
+      if (
+        document.visibilityState === "visible" &&
+        Date.now() - openedAt < 2000
+      ) {
+        openUrl(target.fallback!, Boolean(target.openInNewTab))
+      }
+    }, 750)
+
+    return "opened"
+  }
+
+  openUrl(target.primary, Boolean(target.openInNewTab))
+  return "opened"
+}

--- a/locales/en/auth.ts
+++ b/locales/en/auth.ts
@@ -31,6 +31,7 @@ export default {
         signInWithDiscord: 'Discord',
         signInWithGoogle: 'Google',
         openMailbox: 'Open Mailbox',
+        openMailboxManualCheck: 'Check your inbox for the sign-in email from Deltalytix.',
         resendIn: 'Resend in',
         resendEmail: 'Resend Email',
         verificationCode: 'Verification Code',

--- a/locales/fr/auth.ts
+++ b/locales/fr/auth.ts
@@ -31,6 +31,7 @@ export default {
         signInWithDiscord: 'Discord',
         signInWithGoogle: 'Google',
         openMailbox: 'Ouvrir la Boîte Mail',
+        openMailboxManualCheck: 'Consultez votre boîte de réception pour l\'e-mail de connexion Deltalytix.',
         resendIn: 'Renvoyer dans',
         resendEmail: 'Renvoyer l\'Email',
         verificationCode: 'Code de Vérification',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The authentication "Open Mailbox" button used `mailto:` as a fallback for unknown email domains. On iOS, that opens Mail in **compose** mode and creates an unwanted draft.

This change introduces platform-aware mailbox routing:

- **iOS:** always opens native mail apps — never web inboxes
  - Gmail → `googlegmail://`
  - Outlook → `ms-outlook://`
  - Proton → `protonmail://`
  - Yahoo → `ymail://mail/`
  - Apple / custom domains → `message://` (Mail inbox)
  - If the provider app isn't installed, falls back to Apple Mail (`message://`), not a website
- **Improved iOS detection:** iPhone UA, iPad desktop mode (`MacIntel` + touch), and `navigator.userAgentData.platform`
- **Smarter fallback:** listens for `blur` / `pagehide` / `visibilitychange` so web/native fallbacks don't fire when an app already opened
- **Desktop:** opens known provider web inboxes; unknown domains show a toast instead of `mailto:`

## Test plan

- [x] Unit tests for `detectPlatform` and `resolveMailboxTarget`
- [x] `bun run typecheck` passes
- [ ] On iOS Safari, Gmail address → opens Gmail app (not mail.google.com)
- [ ] On iOS Safari, custom domain → opens Apple Mail inbox
- [ ] On iOS, unknown provider app → falls back to Apple Mail, not a website
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2a39-5f83-7d1e-a5e8-9180e751bf0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2a39-5f83-7d1e-a5e8-9180e751bf0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

