### PR TITLE
fix(cron): restore financial events sync by fixing playwright-core bundling

### DIFF
--- a/lib/browser-sandbox.ts
+++ b/lib/browser-sandbox.ts
@@ -24,9 +24,13 @@
  */
 
 import { Sandbox } from "@vercel/sandbox";
-import { chromium } from 'playwright-core';
 import { z } from 'zod/v3';
 import ms from 'ms';
+
+async function getChromium() {
+  const { chromium } = await import('playwright-core');
+  return chromium;
+}
 
 export async function retryWithBackoff<T>(fn: () => Promise<T>, retries = 3) {
   let delay = 1000;
@@ -155,6 +159,7 @@ export async function scrapeWithSandbox(
       const { sandbox, webSocketDebuggerUrl } = await createBrowserSandbox();
       
       try {
+        const chromium = await getChromium();
         const browser = await chromium.connectOverCDP(webSocketDebuggerUrl);
         const context = await browser.newContext({
           userAgent: options.userAgent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
@@ -200,6 +205,7 @@ export async function scrapeWithSandbox(
     // Fallback for development - use local Playwright
     console.log('Development mode: Using local Playwright browser...');
     try {
+      const chromium = await getChromium();
       const browser = await chromium.launch({
         headless: true
       });

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,8 @@ const buildWorkers =
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // playwright-core reads browsers.json at import time; keep it external + traced for cron scraping.
+  serverExternalPackages: ['playwright-core', '@vercel/sandbox'],
   allowedDevOrigins: ["13.36.171.174"],
   // NOTE: Do not add hardcoded /en redirects for localized routes (e.g. /updates
   // -> /en/updates). next.config redirects run before middleware, so they force a
@@ -52,6 +54,9 @@ const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
     '/app/api/**': [
       './prisma/generated/prisma/**',
+    ],
+    '/api/cron/investing': [
+      './node_modules/playwright-core/**',
     ],
     // Runtime fs search in /api/ai/support — keep docs in the serverless bundle.
     '/api/ai/support': [...SUPPORT_SEARCH_TRACE_INCLUDES],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Financial events stopped appearing in the dashboard (calendar, mindset/news widgets, AI news tool).

Investigation using Vercel runtime errors + local reproduction shows this is **not** a retrieval/query bug — `getUserData` and `getFinancialEvents` work when the database has rows. The data pipeline broke upstream.

## Root cause

Financial events are populated by the weekly Vercel cron:

- `GET /api/cron/investing?lang=fr&db=true`
- `GET /api/cron/investing?lang=en&db=true`

That route uses `scrapeWithSandbox()` → `playwright-core` to scrape Investing.com and upsert `FinancialEvent` rows.

**Production cron has been failing since at least May 25** with:

```
Error: Cannot find module '/var/task/node_modules/playwright-core/browsers.json'
```

Next.js/Turbopack bundles `playwright-core` into the serverless function but omits `browsers.json`, which Playwright reads at import time. The cron never completes, so the DB stops receiving events and the UI shows nothing.

## Verification

- **Vercel MCP** (`get_runtime_errors`): 4 error clusters on `/api/cron/investing`, last seen 2026-06-29 (Monday cron run).
- **Local DB**: started empty (0 rows). After running the cron handler locally, 348 `fr` events stored and `getFinancialEvents('fr')` returned them.
- **Scraping**: Investing.com HTML fetch + parser still works locally.

## Fix

1. Mark `playwright-core` and `@vercel/sandbox` as `serverExternalPackages`.
2. Add `outputFileTracingIncludes` for `/api/cron/investing` so `browsers.json` ships in the standalone bundle.
3. Lazy-load `playwright-core` via dynamic import to avoid eager module evaluation during bundling.

Verified: `browsers.json` is present in `.next/standalone/node_modules/playwright-core/` after build.

## Post-merge

After deploy, manually trigger both cron endpoints (or wait for Monday 05:00 UTC) to repopulate production `FinancialEvent` data for `fr` and `en`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d68-6e6c-71d2-b45a-13339cc50149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d68-6e6c-71d2-b45a-13339cc50149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

