### PR TITLE
Fix journal editor mobile zoom on focus

### DIFF
--- a/components/tiptap-editor.tsx
+++ b/components/tiptap-editor.tsx
@@ -358,7 +358,8 @@ export function TiptapEditor({
     editorProps: {
       attributes: {
         class: cn(
-          "prose prose-sm sm:prose lg:prose-sm xl:prose mx-auto focus:outline-none",
+          // text-lg on mobile prevents iOS Safari zoom-on-focus (same pattern as Input/chat)
+          "prose text-lg sm:text-sm sm:prose lg:prose-sm xl:prose mx-auto focus:outline-none",
           "h-full p-2",
           // Typography styles
           "[&_h1]:text-3xl [&_h1]:font-bold [&_h1]:leading-tight [&_h1]:mt-3 [&_h1]:mb-2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the journal widget zooming in on mobile when tapping the editor to write.

iOS Safari automatically zooms the page when focusing inputs with a font size below 16px. The journal uses `TiptapEditor`, which was styled with `prose-sm` (14px) on mobile. Chat inputs already avoid this with `text-lg` on small screens and `sm:text-sm` on larger ones.

## Changes

- Update `TiptapEditor` typography to use `text-lg sm:text-sm` on mobile, matching the existing `Input` and chat prompt patterns
- Keep smaller prose sizing on `sm+` breakpoints for desktop density

## Test plan

- [ ] Open the mindset/journal widget on a mobile device (or iOS Safari simulator)
- [ ] Tap into the journal editor and confirm the page does not zoom in
- [ ] Verify editor text still looks correct on desktop
- [ ] Confirm chat widget input behavior is unchanged (reference comparison)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f20-b64e-74d1-be72-39b646bc5546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f20-b64e-74d1-be72-39b646bc5546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

