### PR TITLE
fix(calendar): align grid day keys with user timezone

### DIFF
--- a/app/[locale]/dashboard/components/calendar/responsive-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/responsive-calendar.tsx
@@ -1,8 +1,14 @@
 'use client'
 
 import React, { useState, useEffect, useMemo } from "react"
-import { format, addMonths, subMonths, startOfMonth, endOfMonth, eachDayOfInterval, isSameMonth, isToday, startOfWeek, getDay, endOfWeek, addDays, isSameDay, getYear } from "date-fns"
-import { formatInTimeZone } from 'date-fns-tz'
+import { format, addMonths, subMonths, isSameMonth, getDay, getYear } from "date-fns"
+import {
+  calendarDateKeyFromZoned,
+  getCalendarGridDays,
+  isTodayInTimezone,
+  toUserZonedTime,
+  zonedMonthInterval,
+} from "@/lib/calendar-timezone"
 import { fr, enUS } from 'date-fns/locale'
 import { ChevronLeft, ChevronRight, Newspaper, Calendar, CalendarDays } from "lucide-react"
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
@@ -49,23 +55,6 @@ const WEEKDAYS_MONDAY_START = [
   'calendar.weekdays.sun'
 ] as const
 
-
-function getCalendarDays(monthStart: Date, monthEnd: Date, weekStartsOnMonday: boolean = false) {
-  const weekStartsOn = weekStartsOnMonday ? 1 : 0
-  const startDate = startOfWeek(monthStart, { weekStartsOn })
-  const endDate = endOfWeek(monthEnd, { weekStartsOn })
-  const days = eachDayOfInterval({ start: startDate, end: endDate })
-
-  if (days.length === 42) return days
-
-  const lastDay = days[days.length - 1]
-  const additionalDays = eachDayOfInterval({
-    start: addDays(lastDay, 1),
-    end: addDays(startDate, 41)
-  })
-
-  return [...days, ...additionalDays].slice(0, 42)
-}
 
 const formatCurrency = (value: number, options?: { minimumFractionDigits?: number; maximumFractionDigits?: number; signed?: boolean }) => {
   const formatted = value.toLocaleString('en-US', {
@@ -341,21 +330,18 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
   const dateLocale = locale === 'fr' ? fr : enUS
   const weekStartsOnMonday = locale === 'fr'
   const WEEKDAYS = weekStartsOnMonday ? WEEKDAYS_MONDAY_START : WEEKDAYS_SUNDAY_START
-  const [currentDate, setCurrentDate] = useState(new Date())
+  const [currentDate, setCurrentDate] = useState(() => toUserZonedTime(new Date(), timezone))
   const [isLoading, setIsLoading] = useState(false)
   const [monthEvents, setMonthEvents] = useState<FinancialEvent[]>([])
-  const [calendarDays, setCalendarDays] = useState<Date[]>([])
 
-  // Memoize monthStart and monthEnd calculations
-  const { monthStart, monthEnd } = React.useMemo(() => ({
-    monthStart: startOfMonth(currentDate),
-    monthEnd: endOfMonth(currentDate)
-  }), [currentDate])
-
-  // Update calendarDays when currentDate changes
   useEffect(() => {
-    setCalendarDays(getCalendarDays(monthStart, monthEnd, weekStartsOnMonday))
-  }, [currentDate, monthStart, monthEnd, weekStartsOnMonday])
+    setCurrentDate(toUserZonedTime(new Date(), timezone))
+  }, [timezone])
+
+  const calendarDays = useMemo(
+    () => getCalendarGridDays(currentDate, weekStartsOnMonday),
+    [currentDate, weekStartsOnMonday],
+  )
 
   // Use the calendar view store
   const {
@@ -377,16 +363,15 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
 
   // Update monthEvents when currentDate or financialEvents change
   useEffect(() => {
-    const monthStart = startOfMonth(currentDate)
-    const monthEnd = endOfMonth(currentDate)
+    const { startUtc, endUtc } = zonedMonthInterval(currentDate, timezone)
 
     const filteredEvents = userFinancialEvents.filter(event => {
       const eventDate = new Date(event.date)
-      return eventDate >= monthStart && eventDate <= monthEnd && event.lang === locale
+      return eventDate >= startUtc && eventDate <= endUtc && event.lang === locale
     })
 
     setMonthEvents(filteredEvents)
-  }, [currentDate, userFinancialEvents, locale])
+  }, [currentDate, userFinancialEvents, locale, timezone])
 
   const handlePrevMonth = React.useCallback(() => {
     setCurrentDate(subMonths(currentDate, 1))
@@ -414,9 +399,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
     monthEvents.forEach(event => {
       if (!event.date) return;
       try {
-        const eventDateObj = new Date(event.date);
-        eventDateObj.setHours(0, 0, 0, 0);
-        const dateKey = formatInTimeZone(eventDateObj, timezone, 'yyyy-MM-dd');
+        const dateKey = calendarDateKeyFromZoned(toUserZonedTime(new Date(event.date), timezone));
         if (!map.has(dateKey)) {
           map.set(dateKey, []);
         }
@@ -437,9 +420,9 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
     accounts.forEach(account => {
       if (hiddenAccountIds.has(account.id) || !account.nextPaymentDate) return;
       try {
-        const renewalDateObj = new Date(account.nextPaymentDate);
-        renewalDateObj.setHours(0, 0, 0, 0);
-        const dateKey = formatInTimeZone(renewalDateObj, timezone, 'yyyy-MM-dd');
+        const dateKey = calendarDateKeyFromZoned(
+          toUserZonedTime(new Date(account.nextPaymentDate), timezone),
+        );
         if (!map.has(dateKey)) {
           map.set(dateKey, []);
         }
@@ -517,9 +500,9 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
 
   // Memoize monthly and yearly totals
   const monthlyTotal = useMemo(() => {
+    const currentMonthKey = format(currentDate, 'yyyy-MM')
     return Object.entries(calendarData).reduce((total, [dateString, dayData]) => {
-      const date = new Date(dateString)
-      if (isSameMonth(date, currentDate)) {
+      if (dateString.startsWith(currentMonthKey)) {
         return total + dayData.pnl
       }
       return total
@@ -527,9 +510,9 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
   }, [calendarData, currentDate])
 
   const yearTotal = useMemo(() => {
+    const currentYear = format(currentDate, 'yyyy')
     return Object.entries(calendarData).reduce((total, [dateString, dayData]) => {
-      const date = new Date(dateString)
-      if (getYear(date) === getYear(currentDate)) {
+      if (dateString.startsWith(currentYear)) {
         return total + dayData.pnl
       }
       return total
@@ -540,10 +523,10 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
     const startOfWeekIndex = index - 6
     const weekDays = calendarDays.slice(startOfWeekIndex, index + 1)
     return weekDays.reduce((total, day) => {
-      const dayData = calendarData[formatInTimeZone(day, timezone, 'yyyy-MM-dd')]
+      const dayData = calendarData[calendarDateKeyFromZoned(day)]
       return total + (dayData ? dayData.pnl : 0)
     }, 0)
-  }, [timezone])
+  }, [])
 
   return (
     <Card className="h-full flex flex-col">
@@ -553,8 +536,8 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
         <div className="flex items-center justify-between sm:justify-start gap-2 sm:gap-3 min-w-0">
           <CardTitle className="text-sm sm:text-lg font-semibold truncate capitalize">
             {viewMode === 'daily'
-              ? formatInTimeZone(currentDate, timezone, 'MMMM yyyy', { locale: dateLocale })
-              : formatInTimeZone(currentDate, timezone, 'yyyy', { locale: dateLocale })}
+              ? format(currentDate, 'MMMM yyyy', { locale: dateLocale })
+              : format(currentDate, 'yyyy', { locale: dateLocale })}
           </CardTitle>
           <div className={cn(
             "text-xs sm:text-base font-semibold shrink-0",
@@ -609,7 +592,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
         {viewMode === 'daily' ? (
           <div
             role="grid"
-            aria-label={formatInTimeZone(currentDate, timezone, 'MMMM yyyy', { locale: dateLocale })}
+            aria-label={format(currentDate, 'MMMM yyyy', { locale: dateLocale })}
           >
             <div role="row" className="grid grid-cols-7 sm:grid-cols-8 gap-x-px mb-0.5 sm:mb-1">
               {WEEKDAYS.map((day) => (
@@ -624,7 +607,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
             </div>
             <div className="grid grid-cols-7 sm:grid-cols-8 auto-rows-fr rounded-lg h-[calc(100%-16px)] sm:h-[calc(100%-20px)]">
               {calendarDays.map((date, index) => {
-                const dateString = formatInTimeZone(date, timezone, 'yyyy-MM-dd')
+                const dateString = calendarDateKeyFromZoned(date)
                 const dayData = calendarData[dateString]
                 // Check if it's the last day of the week (Saturday for Sunday start, Sunday for Monday start)
                 const isLastDayOfWeek = weekStartsOnMonday ? getDay(date) === 0 : getDay(date) === 6
@@ -647,14 +630,14 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
                             ? "bg-red-50 dark:bg-red-900/20"
                             : "bg-card",
                         !isCurrentMonth && "",
-                        isToday(date) && "ring-blue-500 bg-blue-500/5 z-10",
+                        isTodayInTimezone(date, timezone) && "ring-blue-500 bg-blue-500/5 z-10",
                         index === 0 && "rounded-tl-lg",
                         index === 35 && "rounded-bl-lg",
                       )}
                     >
                       <button
                         type="button"
-                        aria-label={formatInTimeZone(date, timezone, 'EEEE, MMMM d, yyyy', { locale: dateLocale })}
+                        aria-label={format(date, 'EEEE, MMMM d, yyyy', { locale: dateLocale })}
                         className="absolute inset-0 cursor-pointer rounded-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                         onClick={() => setSelectedDate(date)}
                       />
@@ -662,7 +645,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
                         <div className="flex justify-between items-start gap-0">
                           <span className={cn(
                             "text-[10px] sm:text-[11px] font-medium min-w-[12px] sm:min-w-[14px] text-center leading-none",
-                            isToday(date) && "text-primary font-semibold",
+                            isTodayInTimezone(date, timezone) && "text-primary font-semibold",
                             !isCurrentMonth && "opacity-50"
                           )}>
                             {format(date, 'd')}
@@ -728,7 +711,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
                       return (
                         <button
                           type="button"
-                          aria-label={`${t('calendar.weekdays.weekly')}, ${formatInTimeZone(date, timezone, 'MMMM d, yyyy', { locale: dateLocale })}`}
+                          aria-label={`${t('calendar.weekdays.weekly')}, ${format(date, 'MMMM d, yyyy', { locale: dateLocale })}`}
                           className={cn(
                             "hidden sm:flex h-full w-full items-center justify-center rounded-none cursor-pointer",
                             "ring-1 ring-border hover:ring-primary hover:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
@@ -766,7 +749,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
           if (!open) setSelectedDate(null)
         }}
         selectedDate={selectedDate}
-        dayData={selectedDate ? calendarData[formatInTimeZone(selectedDate, timezone, 'yyyy-MM-dd')] : undefined}
+        dayData={selectedDate ? calendarData[calendarDateKeyFromZoned(selectedDate)] : undefined}
         isLoading={isLoading}
       />
       <WeeklyModal

--- a/app/[locale]/dashboard/components/calendar/weekly-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-calendar.tsx
@@ -1,13 +1,16 @@
 'use client'
 
 import React from "react"
-import { format, eachWeekOfInterval, getWeek, getMonth, getYear, addDays, startOfYear, endOfYear } from "date-fns"
-import { formatInTimeZone } from "date-fns-tz"
+import { format, eachWeekOfInterval, getWeek, getMonth, getYear, addDays, getDay } from "date-fns"
 import { fr, enUS } from 'date-fns/locale'
 import { cn } from "@/lib/utils"
 import { Trade } from "@/prisma/generated/prisma/browser"
 import { CalendarData } from "@/app/[locale]/dashboard/types/calendar"
 import { useI18n, useCurrentLocale } from "@/locales/client"
+import {
+  calendarDateKeyFromZoned,
+  zonedYearInterval,
+} from "@/lib/calendar-timezone"
 import {
   Accordion,
   AccordionContent,
@@ -152,21 +155,20 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
   const locale = useCurrentLocale()
   const dateLocale = locale === 'fr' ? fr : enUS
   const timezone = useUserStore((state) => state.timezone)
+  const weekStartsOnMonday = locale === 'fr'
 
-  const yearStartDate = startOfYear(new Date(year, 0, 1));
-  const yearEndDate = endOfYear(new Date(year, 0, 1));
+  const { startZoned: yearStartDate, endZoned: yearEndDate } = zonedYearInterval(year, timezone)
 
   const weeksToDisplay = eachWeekOfInterval(
     { start: yearStartDate, end: yearEndDate },
-    { weekStartsOn: 0 }
+    { weekStartsOn: weekStartsOnMonday ? 1 : 0 }
   );
 
   function getWeekPnl(weekStart: Date) {
     let total = 0
     for (let d = 0; d < 7; d++) {
-      const day = new Date(weekStart)
-      day.setDate(day.getDate() + d)
-      const key = formatInTimeZone(day, timezone, 'yyyy-MM-dd')
+      const day = addDays(weekStart, d)
+      const key = calendarDateKeyFromZoned(day)
       if (calendarData[key]) total += calendarData[key].pnl
     }
     return total
@@ -175,9 +177,8 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
   function getWeekTrades(weekStart: Date) {
     const tradesByDay: { [key: string]: { trades: Trade[], pnl: number } } = {}
     for (let d = 0; d < 7; d++) {
-      const day = new Date(weekStart)
-      day.setDate(day.getDate() + d)
-      const key = formatInTimeZone(day, timezone, 'yyyy-MM-dd')
+      const day = addDays(weekStart, d)
+      const key = calendarDateKeyFromZoned(day)
       if (calendarData[key]) {
         tradesByDay[key] = {
           trades: calendarData[key].trades,

--- a/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CalendarData } from "@/app/[locale]/dashboard/types/calendar"
 import { Charts } from "./charts"
 import { useI18n, useCurrentLocale } from "@/locales/client"
+import { calendarDateKeyFromZoned } from "@/lib/calendar-timezone"
 
 interface WeeklyModalProps {
   isOpen: boolean;
@@ -28,6 +29,7 @@ export function WeeklyModal({
   const t = useI18n()
   const locale = useCurrentLocale()
   const dateLocale = locale === 'fr' ? fr : enUS
+  const weekStartsOnMonday = locale === 'fr'
   const [activeTab, setActiveTab] = useState("charts")
 
   // Aggregate weekly data
@@ -35,13 +37,15 @@ export function WeeklyModal({
     if (!selectedDate) return { trades: [], tradeNumber: 0, pnl: 0, longNumber: 0, shortNumber: 0 }
 
     const trades: any[] = []
-    const weekStart = startOfWeek(selectedDate)
-    const weekEnd = endOfWeek(selectedDate)
+    const weekStartsOn = weekStartsOnMonday ? 1 : 0
+    const weekStart = startOfWeek(selectedDate, { weekStartsOn })
+    const weekEnd = endOfWeek(selectedDate, { weekStartsOn })
+    const weekStartKey = calendarDateKeyFromZoned(weekStart)
+    const weekEndKey = calendarDateKeyFromZoned(weekEnd)
 
     // Collect all trades for the week
     for (const [dateString, dayData] of Object.entries(calendarData)) {
-      const date = new Date(dateString)
-      if (date >= weekStart && date <= weekEnd && dayData.trades) {
+      if (dateString >= weekStartKey && dateString <= weekEndKey && dayData.trades) {
         trades.push(...(dayData.trades as any[]))
       }
     }
@@ -57,13 +61,14 @@ export function WeeklyModal({
       longNumber,
       shortNumber,
     }
-  }, [selectedDate, calendarData])
+  }, [selectedDate, calendarData, weekStartsOnMonday])
 
   if (!selectedDate || !isOpen) return null;
 
   // Get start and end of week
-  const weekStart = startOfWeek(selectedDate)
-  const weekEnd = endOfWeek(selectedDate)
+  const weekStartsOn = weekStartsOnMonday ? 1 : 0
+  const weekStart = startOfWeek(selectedDate, { weekStartsOn })
+  const weekEnd = endOfWeek(selectedDate, { weekStartsOn })
   const dateRange = `${format(weekStart, 'MMMM d', { locale: dateLocale })} - ${format(weekEnd, 'MMMM d, yyyy', { locale: dateLocale })}`
 
   return (

--- a/lib/calendar-timezone.test.ts
+++ b/lib/calendar-timezone.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { formatInTimeZone } from "date-fns-tz"
+import { fromZonedTime } from "date-fns-tz"
+
+import { formatCalendarData } from "./utils"
+import {
+  calendarDateKeyFromZoned,
+  getCalendarGridDays,
+  toUserZonedTime,
+} from "./calendar-timezone"
+import type { Trade } from "@/prisma/generated/prisma/browser"
+
+function makeTrade(entryDate: string): Trade {
+  return {
+    entryDate,
+    closeDate: entryDate,
+    pnl: 100,
+    commission: 0,
+    side: "long",
+    accountNumber: "A1",
+    instrument: "MNQ",
+    quantity: 1,
+  } as Trade
+}
+
+describe("calendar grid timezone alignment", () => {
+  it("maps Monday afternoon NY trades to the Monday grid cell", () => {
+    const timezone = "America/New_York"
+    const trade = makeTrade("2026-07-06T19:00:00.000Z") // Mon 3pm ET
+    const calendarData = formatCalendarData([trade], [], timezone)
+
+    const zonedRef = toUserZonedTime(new Date("2026-07-15T12:00:00.000Z"), timezone)
+    const days = getCalendarGridDays(zonedRef, true)
+    const mondayCell = days.find(
+      (day) => calendarDateKeyFromZoned(day) === "2026-07-06",
+    )
+
+    expect(mondayCell).toBeDefined()
+    expect(calendarData[calendarDateKeyFromZoned(mondayCell!)]?.tradeNumber).toBe(1)
+  })
+
+  it("does not shift grid keys when user TZ differs from a Paris-local midnight", () => {
+    const timezone = "America/New_York"
+    const trade = makeTrade("2026-07-06T19:00:00.000Z")
+    const calendarData = formatCalendarData([trade], [], timezone)
+
+    // Paris-local midnight on July 6 (old grid used browser-local midnights).
+    const parisLocalMidnight = fromZonedTime("2026-07-06T00:00:00", "Europe/Paris")
+    const buggyKey = formatInTimeZone(parisLocalMidnight, timezone, "yyyy-MM-dd")
+
+    const zonedRef = toUserZonedTime(new Date("2026-07-15T12:00:00.000Z"), timezone)
+    const mondayCell = getCalendarGridDays(zonedRef, true).find(
+      (day) => calendarDateKeyFromZoned(day) === "2026-07-06",
+    )
+
+    expect(buggyKey).toBe("2026-07-05")
+    expect(calendarData[buggyKey]).toBeUndefined()
+    expect(calendarData[calendarDateKeyFromZoned(mondayCell!)]?.tradeNumber).toBe(1)
+  })
+})

--- a/lib/calendar-timezone.ts
+++ b/lib/calendar-timezone.ts
@@ -1,0 +1,81 @@
+import {
+  addDays,
+  eachDayOfInterval,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns"
+import { fromZonedTime, toZonedTime } from "date-fns-tz"
+
+/** Wall-clock date in the user's timezone as a Date for date-fns local getters. */
+export function toUserZonedTime(date: Date, timezone: string): Date {
+  return toZonedTime(date, timezone)
+}
+
+/** yyyy-MM-dd for a calendar cell or trade bucket in the user's timezone. */
+export function calendarDateKey(date: Date, timezone: string): string {
+  return format(toUserZonedTime(date, timezone), "yyyy-MM-dd")
+}
+
+/** yyyy-MM-dd when `date` is already from {@link toUserZonedTime}. */
+export function calendarDateKeyFromZoned(zonedDate: Date): string {
+  return format(zonedDate, "yyyy-MM-dd")
+}
+
+export function isTodayInTimezone(date: Date, timezone: string): boolean {
+  return isSameDay(date, toUserZonedTime(new Date(), timezone))
+}
+
+export function getCalendarGridDays(
+  zonedMonthDate: Date,
+  weekStartsOnMonday: boolean,
+): Date[] {
+  const weekStartsOn = weekStartsOnMonday ? 1 : 0
+  const monthStart = startOfMonth(zonedMonthDate)
+  const monthEnd = endOfMonth(zonedMonthDate)
+  const startDate = startOfWeek(monthStart, { weekStartsOn })
+  const endDate = endOfWeek(monthEnd, { weekStartsOn })
+  const days = eachDayOfInterval({ start: startDate, end: endDate })
+
+  if (days.length === 42) return days
+
+  const lastDay = days[days.length - 1]
+  const additionalDays = eachDayOfInterval({
+    start: addDays(lastDay, 1),
+    end: addDays(startDate, 41),
+  })
+
+  return [...days, ...additionalDays].slice(0, 42)
+}
+
+export function zonedMonthInterval(
+  zonedMonthDate: Date,
+  timezone: string,
+): { startUtc: Date; endUtc: Date } {
+  const monthStart = startOfMonth(zonedMonthDate)
+  const monthEnd = endOfMonth(zonedMonthDate)
+  return {
+    startUtc: fromZonedTime(monthStart, timezone),
+    endUtc: fromZonedTime(endOfDay(monthEnd), timezone),
+  }
+}
+
+export function zonedYearInterval(
+  year: number,
+  timezone: string,
+): { startZoned: Date; endZoned: Date } {
+  return {
+    startZoned: toUserZonedTime(
+      fromZonedTime(`${year}-01-01T00:00:00`, timezone),
+      timezone,
+    ),
+    endZoned: toUserZonedTime(
+      fromZonedTime(`${year}-12-31T23:59:59`, timezone),
+      timezone,
+    ),
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

An American user reported that after switching to **America/New_York**, trades taken on **Monday afternoon** appeared on **Tuesday** in the calendar view. Switching back to **Europe/Paris** looked correct.

## Root cause

PR #284 unified the calendar widget, but the month grid was still built with `date-fns` in the **browser local timezone**, while trade buckets (`calendarData`) and cell lookups used the **configured user timezone**.

When those differ (e.g. user in Paris with browser in `Europe/Paris`, settings set to `America/New_York`):

| Layer | Timezone |
|-------|----------|
| Calendar grid cells | Browser local (Paris midnight) |
| Trade bucketing / lookup | User setting (`America/New_York`) |

A Paris-local Monday midnight maps to **Sunday** in New York, so Monday's NY trades were rendered on the **Tuesday** cell.

## Fix

- Add `lib/calendar-timezone.ts` helpers using `date-fns-tz` to build the grid in the user's timezone
- Update `responsive-calendar.tsx` to initialize/navigate months in user TZ and use consistent `yyyy-MM-dd` keys
- Align weekly calendar/modal week aggregation with the same date-key logic
- Add regression tests covering the Paris-browser / New-York-user mismatch

## Tests

- `bun test lib/calendar-timezone.test.ts lib/calendar-data.test.ts`
- `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f38a0-36b4-7586-b256-397cf1b4c1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f38a0-36b4-7586-b256-397cf1b4c1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

