### PR TITLE
Update landing navbar features and updates dropdown

### DIFF
--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useI18n } from "@/locales/landing-client";
+import { useCurrentLocale, useI18n } from "@/locales/landing-client";
+import { localizeLandingHref } from "@/lib/landing-nav-paths";
 import Link, { useLinkStatus } from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
@@ -26,6 +27,7 @@ function GetStartedLinkContent({ children }: { children: React.ReactNode }) {
 
 export default function Hero() {
   const t = useI18n();
+  const locale = useCurrentLocale();
   const { theme, effectiveTheme } = useTheme();
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
   const [videoLoaded, setVideoLoaded] = useState(false);
@@ -83,7 +85,7 @@ export default function Hero() {
       <div className="flex flex-col gap-14 md:gap-20">
         <div className="max-w-[900px]">
           <Link
-            href="/updates"
+            href={localizeLandingHref(locale, "/updates")}
             className="mb-7 inline-flex text-sm text-black/55 transition-colors hover:text-black dark:text-white/55 dark:hover:text-white"
           >
             {t("landing.updates")}

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -18,7 +18,6 @@ import {
   Layers,
   BarChart3,
   Calendar,
-  BookOpen,
   Database,
   LineChart,
   Menu,

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -784,7 +784,7 @@ export default function Component() {
               })}
 
               <motion.li
-                className="mt-auto border-t pt-8"
+                className="border-t border-black/10 pt-8 dark:border-white/10"
                 variants={itemVariant}
               >
                 <motion.div
@@ -792,7 +792,7 @@ export default function Component() {
                   transition={{ duration: 0.2 }}
                 >
                   <Link
-                    className="block w-full min-h-11 text-xl text-primary rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    className="block w-full text-xl text-primary rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                     href="/authentication"
                     onClick={closeMenu}
                   >
@@ -801,52 +801,45 @@ export default function Component() {
                 </motion.div>
               </motion.li>
 
-              <motion.li variants={itemVariant}>
-                <motion.div
-                  className="py-4 border-t"
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{
-                    duration: 0.3,
-                    ease: "easeOut",
-                    delay: 0.2,
-                  }}
-                >
-                  <Accordion collapsible type="single">
-                    <AccordionItem value="theme" className="border-none">
-                      <AccordionTrigger className="flex items-center justify-between w-full font-normal p-0 hover:no-underline">
-                        <span className="text-[#878787] flex items-center space-x-2">
-                          <div className="flex items-center justify-center w-5 h-5">
-                            <AnimatePresence mode="wait">
-                              <motion.div
-                                key={theme}
-                                initial={{
-                                  opacity: 0,
-                                  scale: 0.8,
-                                  rotate: -90,
-                                }}
-                                animate={{ opacity: 1, scale: 1, rotate: 0 }}
-                                exit={{ opacity: 0, scale: 0.8, rotate: 90 }}
-                                transition={{
-                                  duration: 0.4,
-                                  ease: "easeInOut",
-                                }}
-                                className="flex items-center justify-center"
-                              >
-                                <ThemeToggleIcon className="h-5 w-5" />
-                              </motion.div>
-                            </AnimatePresence>
-                          </div>
-                          <span>{t("landing.navbar.changeTheme")}</span>
-                        </span>
-                      </AccordionTrigger>
-                      <AccordionContent className="text-xl">
-                        <motion.ul
-                          className="space-y-8 ml-4 mt-6"
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ duration: 0.2 }}
-                        >
+              <motion.li
+                className="space-y-8 border-t border-black/10 pt-8 dark:border-white/10"
+                variants={itemVariant}
+              >
+                <Accordion collapsible type="single">
+                  <AccordionItem value="theme" className="border-none">
+                    <AccordionTrigger className="flex items-center justify-between w-full font-normal p-0 hover:no-underline">
+                      <span className="text-[#878787] flex items-center space-x-2">
+                        <div className="flex items-center justify-center w-5 h-5">
+                          <AnimatePresence mode="wait">
+                            <motion.div
+                              key={theme}
+                              initial={{
+                                opacity: 0,
+                                scale: 0.8,
+                                rotate: -90,
+                              }}
+                              animate={{ opacity: 1, scale: 1, rotate: 0 }}
+                              exit={{ opacity: 0, scale: 0.8, rotate: 90 }}
+                              transition={{
+                                duration: 0.4,
+                                ease: "easeInOut",
+                              }}
+                              className="flex items-center justify-center"
+                            >
+                              <ThemeToggleIcon className="h-5 w-5" />
+                            </motion.div>
+                          </AnimatePresence>
+                        </div>
+                        <span>{t("landing.navbar.changeTheme")}</span>
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="text-xl">
+                      <motion.ul
+                        className="space-y-8 ml-4 mt-6"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 0.2 }}
+                      >
                           <motion.li
                             initial={{ opacity: 0, x: -10 }}
                             animate={{ opacity: 1, x: 0 }}
@@ -977,55 +970,42 @@ export default function Component() {
                       </AccordionContent>
                     </AccordionItem>
                   </Accordion>
-                </motion.div>
-              </motion.li>
 
-              <motion.li variants={itemVariant}>
-                <motion.div
-                  className="pb-4"
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{
-                    duration: 0.3,
-                    ease: "easeOut",
-                    delay: 0.25,
-                  }}
-                >
-                  <Accordion collapsible type="single">
-                    <AccordionItem value="language" className="border-none">
-                      <AccordionTrigger className="flex items-center justify-between w-full font-normal p-0 hover:no-underline">
-                        <span className="text-[#878787] flex items-center space-x-2">
-                          <div className="flex items-center justify-center w-5 h-5">
-                            <AnimatePresence mode="wait">
-                              <motion.div
-                                key={locale}
-                                initial={{
-                                  opacity: 0,
-                                  scale: 0.8,
-                                  rotate: -90,
-                                }}
-                                animate={{ opacity: 1, scale: 1, rotate: 0 }}
-                                exit={{ opacity: 0, scale: 0.8, rotate: 90 }}
-                                transition={{
-                                  duration: 0.4,
-                                  ease: "easeInOut",
-                                }}
-                                className="flex items-center justify-center"
-                              >
-                                <Globe className="h-5 w-5" />
-                              </motion.div>
-                            </AnimatePresence>
-                          </div>
-                          <span>{t("landing.navbar.changeLanguage")}</span>
-                        </span>
-                      </AccordionTrigger>
-                      <AccordionContent className="text-xl">
-                        <motion.ul
-                          className="space-y-8 ml-4 mt-6"
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ duration: 0.2 }}
-                        >
+                <Accordion collapsible type="single">
+                  <AccordionItem value="language" className="border-none">
+                    <AccordionTrigger className="flex items-center justify-between w-full font-normal p-0 hover:no-underline">
+                      <span className="text-[#878787] flex items-center space-x-2">
+                        <div className="flex items-center justify-center w-5 h-5">
+                          <AnimatePresence mode="wait">
+                            <motion.div
+                              key={locale}
+                              initial={{
+                                opacity: 0,
+                                scale: 0.8,
+                                rotate: -90,
+                              }}
+                              animate={{ opacity: 1, scale: 1, rotate: 0 }}
+                              exit={{ opacity: 0, scale: 0.8, rotate: 90 }}
+                              transition={{
+                                duration: 0.4,
+                                ease: "easeInOut",
+                              }}
+                              className="flex items-center justify-center"
+                            >
+                              <Globe className="h-5 w-5" />
+                            </motion.div>
+                          </AnimatePresence>
+                        </div>
+                        <span>{t("landing.navbar.changeLanguage")}</span>
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="text-xl">
+                      <motion.ul
+                        className="space-y-8 ml-4 mt-6"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 0.2 }}
+                      >
                           {languages.map((language, languageIndex) => (
                             <motion.li
                               key={language.value}
@@ -1083,7 +1063,6 @@ export default function Component() {
                       </AccordionContent>
                     </AccordionItem>
                   </Accordion>
-                </motion.div>
               </motion.li>
             </motion.ul>
           </div>

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -384,7 +384,7 @@ export default function Component() {
       <header
         className={`max-w-7xl mx-auto fixed top-0 left-0 right-0 px-4 lg:px-6 h-14 flex items-center justify-between z-50  text-foreground transition-transform duration-300 ${isVisible ? "translate-y-0" : "-translate-y-full"}`}
       >
-        <Link href="/" className="flex items-center space-x-2">
+        <Link href={localize("/")} className="flex items-center space-x-2">
           <Logo className="w-6 h-6 fill-black dark:fill-white" />
           <span className="font-bold text-xl">Deltalytix</span>
         </Link>
@@ -407,7 +407,7 @@ export default function Component() {
                       <NavigationMenuLink asChild>
                         <Link
                           className="flex h-full w-full select-none flex-col justify-end rounded-md bg-linear-to-b from-muted/50 to-muted p-6 no-underline outline-hidden focus:shadow-md"
-                          href="/"
+                          href={localize("/")}
                         >
                           <Logo className="w-6 h-6" />
                           <div className="mb-2 mt-4 text-lg font-medium">
@@ -540,15 +540,17 @@ export default function Component() {
                     >
                       {t("landing.navbar.openSourceDescription")}
                     </ListItem>
-                    <ListItem
-                      href={process.env.NEXT_PUBLIC_DISCORD_INVITATION || ""}
-                      title={t("landing.navbar.joinCommunity")}
-                      icon={<Users className="h-4 w-4" />}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {t("landing.navbar.joinCommunityDescription")}
-                    </ListItem>
+                    {process.env.NEXT_PUBLIC_DISCORD_INVITATION && (
+                      <ListItem
+                        href={process.env.NEXT_PUBLIC_DISCORD_INVITATION}
+                        title={t("landing.navbar.joinCommunity")}
+                        icon={<Users className="h-4 w-4" />}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {t("landing.navbar.joinCommunityDescription")}
+                      </ListItem>
+                    )}
                   </ul>
                 </NavigationMenuContent>
               </NavigationMenuItem>
@@ -559,7 +561,9 @@ export default function Component() {
               className="h-14 rounded-none px-4 text-sm font-medium hover:text-accent-foreground"
               asChild
             >
-              <Link href="/authentication">{t("landing.navbar.signIn")}</Link>
+              <Link href={localize("/authentication")}>
+                {t("landing.navbar.signIn")}
+              </Link>
             </Button>
           </NavigationMenu>
         </div>
@@ -793,7 +797,7 @@ export default function Component() {
                 >
                   <Link
                     className="block w-full text-xl text-primary rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    href="/authentication"
+                    href={localize("/authentication")}
                     onClick={closeMenu}
                   >
                     {t("landing.navbar.signIn")}

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -43,7 +43,7 @@ import {
 import { useTheme } from "@/context/theme-provider";
 import { cn } from "@/lib/utils";
 import { useChangeLocale, useI18n } from "@/locales/landing-client";
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname } from "next/navigation";
 import {
   Popover,
   PopoverContent,
@@ -60,6 +60,11 @@ import {
 import { useCurrentLocale } from "@/locales/landing-client";
 import { LanguageSelector } from "@/components/ui/language-selector";
 import { GITHUB_REPO_URL } from "@/lib/github-repo";
+import {
+  getHashFromHref,
+  localizeLandingHref,
+  scrollToLandingHash,
+} from "@/lib/landing-nav-paths";
 import { YOUTUBE_CHANNEL_URL } from "@/lib/social-links";
 import { ThemeToggleIcon } from "@/components/theme-toggle-icon";
 
@@ -177,14 +182,37 @@ export default function Component() {
   const [isVisible, setIsVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
   const t = useI18n();
+  const locale = useCurrentLocale();
   const pathname = usePathname();
+
+  const closeMenu = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const localize = useCallback(
+    (path: string) => localizeLandingHref(locale, path),
+    [locale],
+  );
+
+  const handleNavClick = useCallback(
+    (href: string) => {
+      closeMenu();
+
+      const hash = getHashFromHref(href);
+      if (!hash) {
+        return;
+      }
+
+      const pathWithoutHash = href.slice(0, href.indexOf("#"));
+      if (pathWithoutHash === pathname) {
+        scrollToLandingHash(hash);
+      }
+    },
+    [closeMenu, pathname],
+  );
 
   const toggleMenu = () => {
     setIsOpen(!isOpen);
-  };
-
-  const closeMenu = () => {
-    setIsOpen(false);
   };
 
   // Add/remove data attribute when mobile menu visibility changes
@@ -208,16 +236,13 @@ export default function Component() {
     const { body, documentElement } = document;
     const previousBodyOverflow = body.style.overflow;
     const previousHtmlOverflow = documentElement.style.overflow;
-    const previousBodyTouchAction = body.style.touchAction;
 
     body.style.overflow = "hidden";
     documentElement.style.overflow = "hidden";
-    body.style.touchAction = "none";
 
     return () => {
       body.style.overflow = previousBodyOverflow;
       documentElement.style.overflow = previousHtmlOverflow;
-      body.style.touchAction = previousBodyTouchAction;
     };
   }, [isOpen]);
 
@@ -345,7 +370,7 @@ export default function Component() {
           title: t("landing.navbar.api"),
           icon: <Cpu className="h-4 w-4" />,
         },
-      ],
+      ].filter((child) => child.path.length > 0),
     },
   ];
 
@@ -398,28 +423,28 @@ export default function Component() {
                       </NavigationMenuLink>
                     </li>
                     <ListItem
-                      href="/#ai-journaling"
+                      href={localize("/#ai-journaling")}
                       title={t("landing.navbar.aiJournaling")}
                       icon={<Brain className="h-4 w-4" />}
                     >
                       {t("landing.navbar.aiJournalingDescription")}
                     </ListItem>
                     <ListItem
-                      href="/#performance-visualization"
+                      href={localize("/#performance-visualization")}
                       title={t("landing.navbar.performanceVisualization")}
                       icon={<LineChart className="h-4 w-4" />}
                     >
                       {t("landing.navbar.performanceVisualizationDescription")}
                     </ListItem>
                     <ListItem
-                      href="/#daily-performance"
+                      href={localize("/#daily-performance")}
                       title={t("landing.navbar.dailyPerformance")}
                       icon={<Calendar className="h-4 w-4" />}
                     >
                       {t("landing.navbar.dailyPerformanceDescription")}
                     </ListItem>
                     <ListItem
-                      href="/#performance-tracking"
+                      href={localize("/#performance-tracking")}
                       title={t("landing.navbar.performanceTracking")}
                       icon={<TrendingUp className="h-4 w-4" />}
                     >
@@ -427,7 +452,7 @@ export default function Component() {
                     </ListItem>
                     <div className="col-span-2">
                       <ListItem
-                        href="/#data-import"
+                        href={localize("/#data-import")}
                         title={t("landing.navbar.dataImport")}
                         icon={<Database className="h-4 w-4" />}
                       >
@@ -450,14 +475,14 @@ export default function Component() {
                 >
                   <ul className="grid gap-3 p-6 md:w-[500px] lg:w-[600px] list-none">
                     <ListItem
-                      href="#pricing"
+                      href={localize("#pricing")}
                       title={t("pricing.basic.name")}
                       icon={<Sun className="h-4 w-4" />}
                     >
                       {t("pricing.basic.description")}
                     </ListItem>
                     <ListItem
-                      href="#pricing"
+                      href={localize("#pricing")}
                       title={t("pricing.plus.name")}
                       icon={<Crown className="h-4 w-4" />}
                     >
@@ -479,7 +504,7 @@ export default function Component() {
                 >
                   <ul className="grid gap-3 p-4 md:w-[500px] lg:w-[600px] list-none">
                     <ListItem
-                      href="/updates"
+                      href={localize("/updates")}
                       title={t("landing.navbar.changelog")}
                       icon={<BarChart3 className="h-4 w-4" />}
                     >
@@ -657,10 +682,11 @@ export default function Component() {
               variants={listVariant}
             >
               {links.map(({ path, title, children }, index) => {
+                const localizedPath = path ? localize(path) : undefined;
                 const isActive =
                   path === "/updates"
                     ? pathname.includes("updates")
-                    : path === pathname;
+                    : localizedPath === pathname;
 
                 if (path) {
                   return (
@@ -670,9 +696,9 @@ export default function Component() {
                         transition={{ duration: 0.2 }}
                       >
                         <Link
-                          href={path}
+                          href={localizedPath!}
                           className={cn(isActive && "text-primary", "block")}
-                          onClick={closeMenu}
+                          onClick={() => handleNavClick(localizedPath!)}
                         >
                           {title}
                         </Link>
@@ -701,6 +727,9 @@ export default function Component() {
                               transition={{ duration: 0.2 }}
                             >
                               {children.map((child, childIndex) => {
+                                const href = child.external
+                                  ? child.path
+                                  : localize(child.path);
                                 const linkProps = child.external
                                   ? {
                                       target: "_blank" as const,
@@ -722,15 +751,26 @@ export default function Component() {
                                       whileHover={{ x: 4 }}
                                       transition={{ duration: 0.2 }}
                                     >
-                                      <Link
-                                        onClick={closeMenu}
-                                        href={child.path}
-                                        className="text-[#878787] flex items-center space-x-2"
-                                        {...linkProps}
-                                      >
-                                        <span>{child.icon}</span>
-                                        <span>{child.title}</span>
-                                      </Link>
+                                      {child.external ? (
+                                        <a
+                                          href={href}
+                                          onClick={closeMenu}
+                                          className="text-[#878787] flex items-center space-x-2"
+                                          {...linkProps}
+                                        >
+                                          <span>{child.icon}</span>
+                                          <span>{child.title}</span>
+                                        </a>
+                                      ) : (
+                                        <Link
+                                          onClick={() => handleNavClick(href)}
+                                          href={href}
+                                          className="text-[#878787] flex items-center space-x-2"
+                                        >
+                                          <span>{child.icon}</span>
+                                          <span>{child.title}</span>
+                                        </Link>
+                                      )}
                                     </motion.div>
                                   </motion.li>
                                 );
@@ -948,7 +988,7 @@ export default function Component() {
       {/* Mobile navbar backdrop — covers area behind Safari bottom tab bar */}
       {isOpen && (
         <div
-          className="mobile-nav-overlay fixed inset-0 bg-background z-40"
+          className="mobile-nav-overlay fixed inset-0 bg-background z-40 pointer-events-none"
           aria-hidden="true"
         />
       )}

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -27,6 +27,8 @@ import {
   Sun,
   Moon,
   Crown,
+  TrendingUp,
+  Brain,
 } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import {
@@ -58,6 +60,7 @@ import {
 import { useCurrentLocale } from "@/locales/landing-client";
 import { LanguageSelector } from "@/components/ui/language-selector";
 import { GITHUB_REPO_URL } from "@/lib/github-repo";
+import { YOUTUBE_CHANNEL_URL } from "@/lib/social-links";
 import { ThemeToggleIcon } from "@/components/theme-toggle-icon";
 
 const ListItem = React.forwardRef<
@@ -99,6 +102,20 @@ function GithubIcon({ className }: { className?: string }) {
       fill="currentColor"
     >
       <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+function YoutubeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      role="img"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
     </svg>
   );
 }
@@ -257,9 +274,9 @@ export default function Component() {
       title: t("landing.navbar.features"),
       children: [
         {
-          path: "/#data-import",
-          title: t("landing.navbar.dataImport"),
-          icon: <Database className="h-4 w-4" />,
+          path: "/#ai-journaling",
+          title: t("landing.navbar.aiJournaling"),
+          icon: <Brain className="h-4 w-4" />,
         },
         {
           path: "/#performance-visualization",
@@ -272,9 +289,14 @@ export default function Component() {
           icon: <Calendar className="h-4 w-4" />,
         },
         {
-          path: "/#ai-journaling",
-          title: t("landing.navbar.aiJournaling"),
-          icon: <BookOpen className="h-4 w-4" />,
+          path: "/#performance-tracking",
+          title: t("landing.navbar.performanceTracking"),
+          icon: <TrendingUp className="h-4 w-4" />,
+        },
+        {
+          path: "/#data-import",
+          title: t("landing.navbar.dataImport"),
+          icon: <Database className="h-4 w-4" />,
         },
       ],
     },
@@ -287,8 +309,14 @@ export default function Component() {
       children: [
         {
           path: "/updates",
-          title: t("landing.navbar.productUpdates"),
+          title: t("landing.navbar.changelog"),
           icon: <BarChart3 className="h-4 w-4" />,
+        },
+        {
+          path: YOUTUBE_CHANNEL_URL,
+          title: t("landing.navbar.youtube"),
+          icon: <YoutubeIcon className="h-4 w-4" />,
+          external: true,
         },
       ],
     },
@@ -299,16 +327,13 @@ export default function Component() {
           path: GITHUB_REPO_URL,
           title: t("landing.navbar.openSource"),
           icon: <GithubIcon className="h-4 w-4" />,
-        },
-        {
-          path: "https://www.youtube.com/@hugodemenez",
-          title: "YouTube",
-          icon: <FileText className="h-4 w-4" />,
+          external: true,
         },
         {
           path: process.env.NEXT_PUBLIC_DISCORD_INVITATION || "",
           title: t("landing.navbar.joinCommunity"),
           icon: <Users className="h-4 w-4" />,
+          external: true,
         },
         {
           path: "/docs",
@@ -356,7 +381,7 @@ export default function Component() {
                   onMouseLeave={() => setHoveredItem(null)}
                 >
                   <ul className="grid gap-3 p-6 md:w-[500px] lg:w-[600px] lg:grid-cols-[.75fr_1fr] list-none">
-                    <li className="row-span-3">
+                    <li className="row-span-5">
                       <NavigationMenuLink asChild>
                         <Link
                           className="flex h-full w-full select-none flex-col justify-end rounded-md bg-linear-to-b from-muted/50 to-muted p-6 no-underline outline-hidden focus:shadow-md"
@@ -373,11 +398,11 @@ export default function Component() {
                       </NavigationMenuLink>
                     </li>
                     <ListItem
-                      href="/#data-import"
-                      title={t("landing.navbar.dataImport")}
-                      icon={<Database className="h-4 w-4" />}
+                      href="/#ai-journaling"
+                      title={t("landing.navbar.aiJournaling")}
+                      icon={<Brain className="h-4 w-4" />}
                     >
-                      {t("landing.navbar.dataImportDescription")}
+                      {t("landing.navbar.aiJournalingDescription")}
                     </ListItem>
                     <ListItem
                       href="/#performance-visualization"
@@ -393,13 +418,20 @@ export default function Component() {
                     >
                       {t("landing.navbar.dailyPerformanceDescription")}
                     </ListItem>
+                    <ListItem
+                      href="/#performance-tracking"
+                      title={t("landing.navbar.performanceTracking")}
+                      icon={<TrendingUp className="h-4 w-4" />}
+                    >
+                      {t("landing.navbar.performanceTrackingDescription")}
+                    </ListItem>
                     <div className="col-span-2">
                       <ListItem
-                        href="/#ai-journaling"
-                        title={t("landing.navbar.aiJournaling")}
-                        icon={<BookOpen className="h-4 w-4" />}
+                        href="/#data-import"
+                        title={t("landing.navbar.dataImport")}
+                        icon={<Database className="h-4 w-4" />}
                       >
-                        {t("landing.navbar.aiJournalingDescription")}
+                        {t("landing.navbar.dataImportDescription")}
                       </ListItem>
                     </div>
                   </ul>
@@ -448,17 +480,19 @@ export default function Component() {
                   <ul className="grid gap-3 p-4 md:w-[500px] lg:w-[600px] list-none">
                     <ListItem
                       href="/updates"
-                      title={t("landing.navbar.productUpdates")}
+                      title={t("landing.navbar.changelog")}
                       icon={<BarChart3 className="h-4 w-4" />}
                     >
-                      {t("landing.navbar.productUpdatesDescription")}
+                      {t("landing.navbar.changelogDescription")}
                     </ListItem>
                     <ListItem
-                      href="/community"
-                      title={t("landing.navbar.community")}
-                      icon={<Users className="h-4 w-4" />}
+                      href={YOUTUBE_CHANNEL_URL}
+                      title={t("landing.navbar.youtube")}
+                      icon={<YoutubeIcon className="h-4 w-4" />}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
-                      {t("landing.navbar.communityDescription")}
+                      {t("landing.navbar.youtubeDescription")}
                     </ListItem>
                   </ul>
                 </NavigationMenuContent>
@@ -479,20 +513,17 @@ export default function Component() {
                       href={GITHUB_REPO_URL}
                       title={t("landing.navbar.openSource")}
                       icon={<GithubIcon className="h-4 w-4" />}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       {t("landing.navbar.openSourceDescription")}
-                    </ListItem>
-                    <ListItem
-                      href="https://www.youtube.com/@hugodemenez"
-                      title="YouTube"
-                      icon={<FileText className="h-4 w-4" />}
-                    >
-                      {t("landing.navbar.youtubeDescription")}
                     </ListItem>
                     <ListItem
                       href={process.env.NEXT_PUBLIC_DISCORD_INVITATION || ""}
                       title={t("landing.navbar.joinCommunity")}
                       icon={<Users className="h-4 w-4" />}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       {t("landing.navbar.joinCommunityDescription")}
                     </ListItem>
@@ -670,6 +701,13 @@ export default function Component() {
                               transition={{ duration: 0.2 }}
                             >
                               {children.map((child, childIndex) => {
+                                const linkProps = child.external
+                                  ? {
+                                      target: "_blank" as const,
+                                      rel: "noopener noreferrer",
+                                    }
+                                  : {};
+
                                 return (
                                   <motion.li
                                     key={child.path}
@@ -688,6 +726,7 @@ export default function Component() {
                                         onClick={closeMenu}
                                         href={child.path}
                                         className="text-[#878787] flex items-center space-x-2"
+                                        {...linkProps}
                                       >
                                         <span>{child.icon}</span>
                                         <span>{child.title}</span>

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -281,17 +281,14 @@ export default function Component() {
     // Add more languages here
   ];
 
-  const [themeOpen, setThemeOpen] = useState(false);
-  const [languageOpen, setLanguageOpen] = useState(false);
   const changeLocale = useChangeLocale();
   const handleThemeChange = (value: string) => {
     setTheme(value as "light" | "dark" | "system");
-    setThemeOpen(false);
   };
 
   const handleLanguageChange = (value: string) => {
     changeLocale(value as "en" | "fr");
-    setLanguageOpen(false);
+    closeMenu();
   };
 
   const links = [
@@ -568,43 +565,45 @@ export default function Component() {
         </div>
 
         <div className="flex items-center space-x-4">
-          <LanguageSelector />
-          <Popover modal>
-            <PopoverTrigger asChild>
-              <Button
-                variant="ghost"
-                className="hidden lg:inline-flex h-9 w-9 px-0"
-              >
-                <ThemeToggleIcon className="h-5 w-5" />
-                <span className="sr-only">
-                  {t("landing.navbar.toggleTheme")}
-                </span>
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-[200px] p-0" align="end">
-              <Command>
-                <CommandList>
-                  <CommandGroup>
-                    <CommandItem onSelect={() => handleThemeChange("light")}>
-                      <Sun className="mr-2 h-4 w-4" />
-                      <span>{t("landing.navbar.lightMode")}</span>
-                    </CommandItem>
-                    <CommandItem onSelect={() => handleThemeChange("dark")}>
-                      <Moon className="mr-2 h-4 w-4" />
-                      <span>{t("landing.navbar.darkMode")}</span>
-                    </CommandItem>
-                    <CommandItem onSelect={() => handleThemeChange("system")}>
-                      <Laptop className="mr-2 h-4 w-4" />
-                      <span>{t("landing.navbar.systemTheme")}</span>
-                    </CommandItem>
-                  </CommandGroup>
-                </CommandList>
-              </Command>
-            </PopoverContent>
-          </Popover>
+          <div className="hidden items-center space-x-4 lg:flex">
+            <LanguageSelector />
+            <Popover modal>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="hidden lg:inline-flex h-9 w-9 px-0"
+                >
+                  <ThemeToggleIcon className="h-5 w-5" />
+                  <span className="sr-only">
+                    {t("landing.navbar.toggleTheme")}
+                  </span>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[200px] p-0" align="end">
+                <Command>
+                  <CommandList>
+                    <CommandGroup>
+                      <CommandItem onSelect={() => handleThemeChange("light")}>
+                        <Sun className="mr-2 h-4 w-4" />
+                        <span>{t("landing.navbar.lightMode")}</span>
+                      </CommandItem>
+                      <CommandItem onSelect={() => handleThemeChange("dark")}>
+                        <Moon className="mr-2 h-4 w-4" />
+                        <span>{t("landing.navbar.darkMode")}</span>
+                      </CommandItem>
+                      <CommandItem onSelect={() => handleThemeChange("system")}>
+                        <Laptop className="mr-2 h-4 w-4" />
+                        <span>{t("landing.navbar.systemTheme")}</span>
+                      </CommandItem>
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </div>
           <button
             type="button"
-            className="ml-auto lg:hidden p-2"
+            className="p-2 lg:hidden"
             onClick={toggleMenu}
           >
             <svg
@@ -974,6 +973,112 @@ export default function Component() {
                               </button>
                             </motion.div>
                           </motion.li>
+                        </motion.ul>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </motion.div>
+              </motion.li>
+
+              <motion.li variants={itemVariant}>
+                <motion.div
+                  className="pb-4"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{
+                    duration: 0.3,
+                    ease: "easeOut",
+                    delay: 0.25,
+                  }}
+                >
+                  <Accordion collapsible type="single">
+                    <AccordionItem value="language" className="border-none">
+                      <AccordionTrigger className="flex items-center justify-between w-full font-normal p-0 hover:no-underline">
+                        <span className="text-[#878787] flex items-center space-x-2">
+                          <div className="flex items-center justify-center w-5 h-5">
+                            <AnimatePresence mode="wait">
+                              <motion.div
+                                key={locale}
+                                initial={{
+                                  opacity: 0,
+                                  scale: 0.8,
+                                  rotate: -90,
+                                }}
+                                animate={{ opacity: 1, scale: 1, rotate: 0 }}
+                                exit={{ opacity: 0, scale: 0.8, rotate: 90 }}
+                                transition={{
+                                  duration: 0.4,
+                                  ease: "easeInOut",
+                                }}
+                                className="flex items-center justify-center"
+                              >
+                                <Globe className="h-5 w-5" />
+                              </motion.div>
+                            </AnimatePresence>
+                          </div>
+                          <span>{t("landing.navbar.changeLanguage")}</span>
+                        </span>
+                      </AccordionTrigger>
+                      <AccordionContent className="text-xl">
+                        <motion.ul
+                          className="space-y-8 ml-4 mt-6"
+                          initial={{ opacity: 0 }}
+                          animate={{ opacity: 1 }}
+                          transition={{ duration: 0.2 }}
+                        >
+                          {languages.map((language, languageIndex) => (
+                            <motion.li
+                              key={language.value}
+                              initial={{ opacity: 0, x: -10 }}
+                              animate={{ opacity: 1, x: 0 }}
+                              transition={{
+                                duration: 0.2,
+                                delay: 0.05 + languageIndex * 0.05,
+                              }}
+                            >
+                              <motion.div
+                                whileHover={{ x: 4 }}
+                                transition={{ duration: 0.2 }}
+                              >
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    handleLanguageChange(language.value)
+                                  }
+                                  className={`flex items-center space-x-2 w-full text-left ${
+                                    locale === language.value
+                                      ? "text-primary"
+                                      : "text-[#878787]"
+                                  }`}
+                                >
+                                  <span className="text-base">
+                                    {language.value === "en" ? "🇬🇧" : "🇫🇷"}
+                                  </span>
+                                  <span>{language.label}</span>
+                                  {locale === language.value && (
+                                    <motion.div
+                                      initial={{ opacity: 0, scale: 0 }}
+                                      animate={{ opacity: 1, scale: 1 }}
+                                      transition={{ duration: 0.2 }}
+                                      className="ml-auto"
+                                    >
+                                      <svg
+                                        className="h-4 w-4"
+                                        fill="currentColor"
+                                        viewBox="0 0 20 20"
+                                      >
+                                        <path
+                                          fillRule="evenodd"
+                                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                          clipRule="evenodd"
+                                        />
+                                      </svg>
+                                    </motion.div>
+                                  )}
+                                </button>
+                              </motion.div>
+                            </motion.li>
+                          ))}
                         </motion.ul>
                       </AccordionContent>
                     </AccordionItem>

--- a/app/globals.css
+++ b/app/globals.css
@@ -422,6 +422,7 @@
     height: 100dvh;
     min-height: 100dvh;
     min-height: -webkit-fill-available;
+    touch-action: auto;
   }
 
   /* Mobile navbar overlay styles */

--- a/lib/landing-nav-paths.ts
+++ b/lib/landing-nav-paths.ts
@@ -1,0 +1,38 @@
+export function localizeLandingHref(locale: string, path: string): string {
+  if (!path || path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+
+  if (path.startsWith("/#")) {
+    return `/${locale}${path.slice(1)}`;
+  }
+
+  if (path.startsWith("#")) {
+    return `/${locale}${path}`;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `/${locale}${normalizedPath}`;
+}
+
+export function getHashFromHref(href: string): string | null {
+  const hashIndex = href.indexOf("#");
+  if (hashIndex === -1) {
+    return null;
+  }
+
+  return href.slice(hashIndex + 1);
+}
+
+export function scrollToLandingHash(hash: string) {
+  if (!hash) {
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    document.getElementById(hash)?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  });
+}

--- a/lib/social-links.ts
+++ b/lib/social-links.ts
@@ -1,0 +1,5 @@
+import { GITHUB_REPO_OWNER } from "@/lib/github-repo";
+
+export const YOUTUBE_CHANNEL_URL =
+  process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_URL ??
+  `https://www.youtube.com/@${GITHUB_REPO_OWNER}`;

--- a/locales/en/landing.ts
+++ b/locales/en/landing.ts
@@ -216,6 +216,7 @@ export default {
       performanceVisualization: "Performance Visualization",
       dailyPerformance: "Daily Performance",
       aiJournaling: "AI-Powered Journaling",
+      performanceTracking: "Track Your Performance",
       developers: "Developers",
       openSource: "Open Source",
       documentation: "Documentation",
@@ -231,6 +232,10 @@ export default {
       productUpdates: "Product Updates",
       productUpdatesDescription:
         "Stay up to date with our latest features and improvements.",
+      changelog: "Changelog",
+      changelogDescription:
+        "Browse release notes, improvements, and what's new in Deltalytix.",
+      youtube: "YouTube",
       dashboard: "Dashboard",
       signIn: "Sign in",
       elevateTrading:
@@ -242,6 +247,8 @@ export default {
         "Track your daily trading results with an intuitive calendar view.",
       aiJournalingDescription:
         "Improve your trading emotions with AI-assisted journaling.",
+      performanceTrackingDescription:
+        "Follow equity, daily results, and progress toward your targets.",
       openSourceDescription: "Explore our open-source projects and contribute.",
       youtubeDescription: "Watch tutorials and trading insights.",
       documentationDescription: "Comprehensive guides and API references.",

--- a/locales/fr/landing.ts
+++ b/locales/fr/landing.ts
@@ -233,7 +233,7 @@ export default {
       productUpdates: "Mises à jour du produit",
       productUpdatesDescription:
         "Restez informé de nos dernières fonctionnalités et améliorations.",
-      changelog: "Journal des modifications",
+      changelog: "Derniers changements",
       changelogDescription:
         "Parcourez les notes de version, améliorations et nouveautés de Deltalytix.",
       youtube: "YouTube",

--- a/locales/fr/landing.ts
+++ b/locales/fr/landing.ts
@@ -217,6 +217,7 @@ export default {
       performanceVisualization: "Visualisation des performances",
       dailyPerformance: "Performance quotidienne",
       aiJournaling: "Journal assisté par IA",
+      performanceTracking: "Suivi de performance",
       developers: "Développeurs",
       openSource: "Open Source",
       documentation: "Documentation",
@@ -232,6 +233,10 @@ export default {
       productUpdates: "Mises à jour du produit",
       productUpdatesDescription:
         "Restez informé de nos dernières fonctionnalités et améliorations.",
+      changelog: "Journal des modifications",
+      changelogDescription:
+        "Parcourez les notes de version, améliorations et nouveautés de Deltalytix.",
+      youtube: "YouTube",
       community: "Communauté",
       communityDescription:
         "Partagez vos idées, signalez des bugs et discutez des fonctionnalités.",
@@ -247,6 +252,8 @@ export default {
         "Suivez vos résultats quotidiens avec une vue calendrier intuitive.",
       aiJournalingDescription:
         "Améliorez vos émotions de trading avec un journal assisté par l'IA.",
+      performanceTrackingDescription:
+        "Suivez l'équité, les résultats quotidiens et votre progression vers vos objectifs.",
       openSourceDescription: "Explorez nos projets open-source et contribuez.",
       youtubeDescription: "Regardez des tutoriels et des analyses de trading.",
       documentationDescription: "Guides complets et références API.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings the landing page navbar in sync with the current site structure and fixes broken navigation.

### Updates menu (parent label unchanged)
- Renamed **Product Updates** → **Changelog** (still links to `/updates`)
- French label: **Derniers changements**
- Added **YouTube** channel link
- Removed the broken `/community` entry
- Moved YouTube out of the **Developers** menu to avoid duplication

### Features menu
- Added the missing **Track Your Performance** section (`/#performance-tracking`)
- Reordered links to match the on-page feature section order

### Link fixes (mobile + desktop)
- Removed `touch-action: none` on `body` while the mobile menu is open
- Localized all internal hrefs with the active locale
- Added same-page hash scrolling when already on the landing route
- Use native `<a>` tags for external mobile links

### Mobile menu polish
- Language selector moved from the header into the mobile menu, below **Change theme**
- Uses the same accordion pattern with animated Globe icon and selected-language checkmark
- Consistent `space-y-8` spacing across all items, with uniform `border-t pt-8` section breaks before sign-in and settings (theme + language grouped together)

## Test plan
- [x] `bun run typecheck` passes
- [ ] Mobile menu spacing is even between nav items, sign-in, theme, and language rows
- [ ] French locale shows "Derniers changements" in Updates dropdown
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f56e9-83b4-7d13-a50f-999b7509e79d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f56e9-83b4-7d13-a50f-999b7509e79d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

