### PR TITLE
Fix Safari bottom chrome when mobile menu is open

### DIFF
--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -378,8 +378,13 @@ export default function Component() {
       />
 
       <span
-        key={`safari-theme-${effectiveTheme}`}
+        key={`safari-theme-top-${effectiveTheme}`}
         className="landing-safari-theme-sampler"
+        aria-hidden="true"
+      />
+      <span
+        key={`safari-theme-bottom-${effectiveTheme}`}
+        className="landing-safari-theme-sampler-bottom"
         aria-hidden="true"
       />
 

--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -382,11 +382,6 @@ export default function Component() {
         className="landing-safari-theme-sampler"
         aria-hidden="true"
       />
-      <span
-        key={`safari-theme-bottom-${effectiveTheme}`}
-        className="landing-safari-theme-sampler-bottom"
-        aria-hidden="true"
-      />
 
       <span
         className={`fixed top-0 left-0 right-0 z-50 bg-background pt-safe min-h-nav-safe transition-transform duration-300 ${isVisible ? "translate-y-0" : "-translate-y-full"}`}
@@ -639,6 +634,7 @@ export default function Component() {
 
       {isOpen && (
         <motion.div
+          key={`mobile-nav-menu-${effectiveTheme}`}
           className="mobile-nav-overlay fixed inset-0 z-50 flex flex-col bg-background px-2 overscroll-none"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -1088,6 +1084,7 @@ export default function Component() {
       {/* Mobile navbar backdrop — covers area behind Safari bottom tab bar */}
       {isOpen && (
         <div
+          key={`mobile-nav-backdrop-${effectiveTheme}`}
           className="mobile-nav-overlay fixed inset-0 bg-background z-40 pointer-events-none"
           aria-hidden="true"
         />

--- a/app/[locale]/(landing)/layout.tsx
+++ b/app/[locale]/(landing)/layout.tsx
@@ -54,7 +54,7 @@ export default async function RootLayout(
     <ThemeProvider>
       <I18nProviderClient locale={locale}>
         <ConsentBanner />
-        <div className="min-h-screen bg-[oklch(0.97_0_0)] text-[oklch(0.17_0_0)] [--background:0_0%_96.1%] [--card:0_0%_100%] [--foreground:0_0%_9%] dark:bg-[oklch(0.17_0_0)] dark:text-[oklch(0.93_0_0)] dark:[--background:0_0%_6.7%] dark:[--card:0_0%_0%] dark:[--foreground:0_0%_93%]">
+        <div className="min-h-dvh bg-[oklch(0.97_0_0)] text-[oklch(0.17_0_0)] [--background:0_0%_96.1%] [--card:0_0%_100%] [--foreground:0_0%_9%] dark:bg-[oklch(0.17_0_0)] dark:text-[oklch(0.93_0_0)] dark:[--background:0_0%_6.7%] dark:[--card:0_0%_0%] dark:[--foreground:0_0%_93%]">
           <Toaster />
           <Navbar />
           <div className="pt-nav-content">{children}</div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -422,33 +422,44 @@
    * Use the system media query here so the correct color is available before
    * the client theme script adds the light/dark class.
    */
-  .landing-safari-theme-sampler {
+  .landing-safari-theme-sampler,
+  .landing-safari-theme-sampler-bottom {
     background-color: hsl(0 0% 96.1%);
   }
 
-  .dark .landing-safari-theme-sampler {
+  .dark .landing-safari-theme-sampler,
+  .dark .landing-safari-theme-sampler-bottom {
     background-color: hsl(0 0% 6.7%);
   }
 
   @media (prefers-color-scheme: dark) {
-    :root:not(.light) .landing-safari-theme-sampler {
+    :root:not(.light) .landing-safari-theme-sampler,
+    :root:not(.light) .landing-safari-theme-sampler-bottom {
       background-color: hsl(0 0% 6.7%);
     }
   }
 
   /*
-   * Keep an untransformed fixed element at the viewport edge for Safari's
-   * browser-chrome sampler. The animated navbar backdrop is not reliably
-   * sampled while its transform changes.
+   * Keep untransformed fixed elements at the viewport edges for Safari's
+   * browser-chrome sampler. Animated overlays are not reliably re-sampled
+   * when the theme changes.
    */
-  .landing-safari-theme-sampler {
+  .landing-safari-theme-sampler,
+  .landing-safari-theme-sampler-bottom {
     position: fixed;
-    top: 0;
     left: 0;
     z-index: 60;
     width: 100%;
     height: 8px;
     pointer-events: none;
+  }
+
+  .landing-safari-theme-sampler {
+    top: 0;
+  }
+
+  .landing-safari-theme-sampler-bottom {
+    bottom: 0;
   }
 
   /* iOS safe-area helpers for fixed nav chrome */

--- a/app/globals.css
+++ b/app/globals.css
@@ -422,44 +422,33 @@
    * Use the system media query here so the correct color is available before
    * the client theme script adds the light/dark class.
    */
-  .landing-safari-theme-sampler,
-  .landing-safari-theme-sampler-bottom {
+  .landing-safari-theme-sampler {
     background-color: hsl(0 0% 96.1%);
   }
 
-  .dark .landing-safari-theme-sampler,
-  .dark .landing-safari-theme-sampler-bottom {
+  .dark .landing-safari-theme-sampler {
     background-color: hsl(0 0% 6.7%);
   }
 
   @media (prefers-color-scheme: dark) {
-    :root:not(.light) .landing-safari-theme-sampler,
-    :root:not(.light) .landing-safari-theme-sampler-bottom {
+    :root:not(.light) .landing-safari-theme-sampler {
       background-color: hsl(0 0% 6.7%);
     }
   }
 
   /*
-   * Keep untransformed fixed elements at the viewport edges for Safari's
+   * Keep an untransformed fixed element at the top viewport edge for Safari's
    * browser-chrome sampler. Animated overlays are not reliably re-sampled
    * when the theme changes.
    */
-  .landing-safari-theme-sampler,
-  .landing-safari-theme-sampler-bottom {
+  .landing-safari-theme-sampler {
     position: fixed;
+    top: 0;
     left: 0;
     z-index: 60;
     width: 100%;
     height: 8px;
     pointer-events: none;
-  }
-
-  .landing-safari-theme-sampler {
-    top: 0;
-  }
-
-  .landing-safari-theme-sampler-bottom {
-    bottom: 0;
   }
 
   /* iOS safe-area helpers for fixed nav chrome */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Follow-up to #305. When the mobile navbar menu is open and the user changes system theme, Safari can keep a stale color in the bottom browser chrome until the menu closes.

An earlier attempt added a fixed 8px bottom sampling strip, but that prevented page content from extending naturally under Safari's floating tab bar.

## Root cause

Safari 26 samples fixed elements at the viewport edges for browser chrome tinting. The conditional mobile menu overlay is not re-sampled when the theme changes. A permanent bottom strip fixes tinting but interferes with normal Safari layout.

## Fix

- Remove the bottom sampling strip
- Re-key the mobile menu overlay and backdrop on `effectiveTheme` so they remount when the theme changes, forcing Safari to re-sample while the menu stays open
- Use `min-h-dvh` on the landing shell so content fills the dynamic viewport behind Safari's floating controls

The top-only Safari sampler from #305 is unchanged.

## Testing

- `bun run typecheck`
- Manual verification on Safari 26: content should extend under the tab bar, and theme changes with the menu open should update bottom chrome without closing the menu
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5b1a-44b7-7b86-bb07-c756e9509df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5b1a-44b7-7b86-bb07-c756e9509df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

