### PR TITLE
fix(landing): loosen hero headline line-height on mobile

### DIFF
--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -91,7 +91,7 @@ export default function Hero() {
             {t("landing.updates")}
           </Link>
           <div>
-            <h1 className="max-w-[880px] text-balance text-[clamp(3rem,7.2vw,7.25rem)] font-normal leading-[0.92] tracking-[-0.06em]">
+            <h1 className="max-w-[880px] text-balance text-[clamp(3rem,7.2vw,7.25rem)] font-normal leading-[1.12] tracking-[-0.06em] sm:leading-[1.06] md:leading-[1] lg:leading-[0.96]">
               {t("landing.title")}
             </h1>
             <p className="mt-7 max-w-[660px] text-pretty text-lg leading-relaxed text-black/60 dark:text-white/60 md:text-xl">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes cramped hero headline text on mobile where wrapped lines overlapped — specifically the descender on "y" colliding with the ascender on "j" in "Master your trading journey."

## Changes

- Replace fixed `leading-[0.92]` with responsive line-height:
  - **Mobile:** `1.12` — comfortable spacing when the title wraps
  - **sm:** `1.06`
  - **md:** `1`
  - **lg:** `0.96` — preserves the tight display look on large screens where wrapping is less common

## Testing

- Visual check on mobile viewport for the landing hero headline
- Desktop hero should remain visually similar with only slightly looser leading at `lg`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5d35-e271-78a8-ace7-81a6ce8aef45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5d35-e271-78a8-ace7-81a6ce8aef45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

