### PR TITLE
Fix DxFeed token persistence

### DIFF
--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -11,15 +11,14 @@ import { getUserId } from '@/server/auth'
 import {
   coerceDxFeedHistoricalHostForSync,
   normalizeDxFeedHistoricalHost,
-  resolveDxFeedHistoricalHost,
 } from '@/lib/dxfeed-historical-host'
 import { DxFeedErrorCode } from '@/lib/dxfeed-errors'
 import {
-  isDxFeedTokenExpired,
-  resolveDxFeedTokenExpiresAt,
+  getDxFeedTokenExpiryFromProvider,
+  isDxFeedAccessTokenExpired,
 } from '@/lib/dxfeed-token'
+import { resolveDxFeedV2AuthUrl } from '@/lib/dxfeed-auth'
 import {
-  authPropfirmMatchesSelection,
   buildHistoricalHostForPropFirm,
   getDxFeedPropFirm,
 } from '@/lib/dxfeed-propfirms'
@@ -35,7 +34,7 @@ import type {
   DxFeedTradingAccount,
 } from './dxfeed-types'
 
-const DXFEED_AUTH_URL = process.env.DXFEED_AUTH_URL
+const DXFEED_AUTH_URL = resolveDxFeedV2AuthUrl(process.env.DXFEED_AUTH_URL)
 const DXFEED_PLATFORM_KEY = process.env.DXFEED_PLATFORM_KEY
 
 const IS_DEV = process.env.NODE_ENV === 'development' || process.env.DXFEED_DEBUG === 'true'
@@ -56,7 +55,7 @@ const DXFEED_RETRY_DELAY_MS = Math.max(
 )
 
 const logger = {
-  debug: (message: string, data?: any) => {
+  debug: (message: string, data?: unknown) => {
     if (IS_DEV) console.log(`[DXFEED-DEBUG] ${message}`, data ?? '')
   },
   info: (message: string) => {
@@ -168,8 +167,8 @@ function extractApiErrorMessage(payload: unknown): string | null {
 
 /**
  * Authenticate with DxFeed using username/password.
- * The auth response returns a token (body) and a host header
- * that must be used as the base URL for the Historical API.
+ * The documented v2 auth response returns a reusable report token, its exact
+ * expiration, and the Historical API host.
  */
 export async function authenticateDxFeed(
   login: string,
@@ -228,39 +227,52 @@ export async function authenticateDxFeed(
       }
     }
 
-    const data: DxFeedLoginResponse = await response.json()
+    const authResponse: DxFeedLoginResponse = await response.json()
+    const data = authResponse.data
 
-    if (data.status !== 'OK' || !data.token) {
+    if (!authResponse.success || !data?.tradingRestReportToken) {
       return {
         error: DxFeedErrorCode.AUTH_REJECTED,
-        errorParams: { reason: data.reason || 'Authentication failed' },
+        errorParams: { reason: authResponse.message || 'Authentication failed' },
       }
     }
 
-    if (!authPropfirmMatchesSelection(data.propfirmName, propFirm)) {
+    const tokenExpiresAt = getDxFeedTokenExpiryFromProvider(
+      data.tradingRestTokenExpiration,
+    )
+    if (!tokenExpiresAt) {
       return {
-        error: DxFeedErrorCode.AUTH_PROP_FIRM_MISMATCH,
-        errorParams: {
-          authPropfirm: data.propfirmName ?? '—',
-          selectedPropfirm: propFirm.name,
-        },
+        error: DxFeedErrorCode.AUTH_REJECTED,
+        errorParams: { reason: 'DxFeed did not return a valid report token expiration' },
       }
     }
 
-    const historicalHost = resolveDxFeedHistoricalHost(data, response.headers, { propFirmId: propFirm.id })
+    const historicalHost = normalizeDxFeedHistoricalHost(data.tradingRestReportHost)
 
     if (!historicalHost) {
-      logger.warn('Could not derive historical host from auth response (check prop firm mapping)')
+      logger.warn('DxFeed v2 auth response did not include the historical report host')
       return {
         error: DxFeedErrorCode.HISTORICAL_HOST_UNRESOLVED,
         errorParams: { propfirm: propFirm.name },
       }
     }
 
+    const expectedHistoricalHost = normalizeDxFeedHistoricalHost(
+      buildHistoricalHostForPropFirm(propFirm),
+    )
+    if (historicalHost !== expectedHistoricalHost) {
+      return {
+        error: DxFeedErrorCode.AUTH_PROP_FIRM_MISMATCH,
+        errorParams: {
+          authPropfirm: historicalHost,
+          selectedPropfirm: propFirm.name,
+        },
+      }
+    }
+
     logger.info(`Auth successful for ${propFirm.name}`)
 
-    const reportAccessToken = data.tradingRestReportToken || data.token
-    const tokenExpiresAt = resolveDxFeedTokenExpiresAt(reportAccessToken)
+    const reportAccessToken = data.tradingRestReportToken
 
     const accountsResult = historicalHost
       ? await getDxFeedAccounts(reportAccessToken, historicalHost)
@@ -280,7 +292,8 @@ export async function authenticateDxFeed(
       historicalHost,
       accountNumbers,
       propFirmId: propFirm.id,
-      propfirmName: data.propfirmName,
+      propfirmName: propFirm.name,
+      tokenExpirationSource: 'provider',
     }
 
     const storeResult = await storeDxFeedToken(JSON.stringify(credentials), login, {
@@ -508,7 +521,11 @@ export async function getDxFeedTrades(
     })
     syncAccountId = syncRow?.accountId ?? null
 
-    if (isDxFeedTokenExpired(syncRow?.tokenExpiresAt)) {
+    if (
+      isDxFeedAccessTokenExpired(accessToken, syncRow?.tokenExpiresAt, {
+        expirationIsAuthoritative: credentials.tokenExpirationSource === 'provider',
+      })
+    ) {
       if (syncAccountId) {
         await markDxFeedTokenExpired(resolvedUserId, syncAccountId)
       }
@@ -705,7 +722,7 @@ async function updateStoredCredentials(userId: string, oldTokenJson: string, new
 export async function storeDxFeedToken(
   tokenJson: string,
   accountId: string = 'default',
-  options?: { tokenExpiresAt?: Date },
+  options?: { tokenExpiresAt?: Date | null },
 ) {
   try {
     const supabase = await createClient()
@@ -769,7 +786,13 @@ export async function getDxFeedToken(accountId: string = 'default') {
       return { error: DxFeedErrorCode.NO_TOKEN_RECONNECT }
     }
 
-    if (isDxFeedTokenExpired(syncData.tokenExpiresAt)) {
+    const credentials = parseStoredCredentials(syncData.token)
+    if (
+      credentials &&
+      isDxFeedAccessTokenExpired(credentials.accessToken, syncData.tokenExpiresAt, {
+        expirationIsAuthoritative: credentials.tokenExpirationSource === 'provider',
+      })
+    ) {
       return { error: DxFeedErrorCode.TOKEN_EXPIRED }
     }
 
@@ -791,7 +814,11 @@ export async function removeDxFeedToken(accountId?: string) {
       return { error: 'User not authenticated' }
     }
 
-    const whereClause: any = {
+    const whereClause: {
+      userId: string
+      service: string
+      accountId?: string
+    } = {
       userId: user.id,
       service: 'dxfeed',
     }

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-types.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-types.ts
@@ -7,17 +7,23 @@ export interface DxFeedLoginRequest {
   connectOnlyTrading: boolean
 }
 
-export interface DxFeedLoginResponse {
-  status: string
-  token?: string
-  reason?: string
-  details?: string[]
-  tradingWss?: string
+export interface DxFeedLoginData {
+  dataEndpoint?: string
+  dataToken?: string
+  dataExchanges?: string[]
   tradingWssEndpoint?: string
+  tradingWssToken?: string
   tradingRestReportHost?: string
   tradingRestReportToken?: string
-  propfirmName?: string
+  tradingRestTokenExpiration?: number
   tradingApiVersion?: number
+}
+
+export interface DxFeedLoginResponse {
+  success: boolean
+  data?: DxFeedLoginData
+  statusCode?: number
+  message?: string
 }
 
 /**
@@ -31,8 +37,10 @@ export interface DxFeedStoredCredentials {
   accountNumbers?: string[]
   /** User-selected prop firm id (see lib/dxfeed-propfirms.ts) */
   propFirmId?: string
-  /** From auth propfirmName — used to re-resolve host if sync config changes */
+  /** Display name captured from the user-selected prop firm. */
   propfirmName?: string
+  /** Marks a stored expiration as provider-supplied rather than a legacy guessed TTL. */
+  tokenExpirationSource?: 'provider' | 'jwt'
 }
 
 export interface DxFeedTradingAccount {

--- a/app/api/dxfeed/synchronizations/route.ts
+++ b/app/api/dxfeed/synchronizations/route.ts
@@ -8,7 +8,7 @@ import {
 import { DxFeedErrorCode } from '@/lib/dxfeed-errors'
 import { coerceDxFeedHistoricalHostForSync } from '@/lib/dxfeed-historical-host'
 import { getDxFeedPropFirm } from '@/lib/dxfeed-propfirms'
-import { isDxFeedTokenExpired } from '@/lib/dxfeed-token'
+import { isDxFeedAccessTokenExpired } from '@/lib/dxfeed-token'
 
 export async function GET() {
   try {
@@ -28,8 +28,6 @@ export async function GET() {
         let apiUnauthorized = false
 
         if (token) {
-          tokenExpired = isDxFeedTokenExpired(tokenExpiresAt)
-
           try {
             const parsed = JSON.parse(token) as {
               accessToken?: string
@@ -37,7 +35,17 @@ export async function GET() {
               accountNumbers?: string[]
               propFirmId?: string
               propfirmName?: string
+              tokenExpirationSource?: 'provider' | 'jwt'
             }
+
+            tokenExpired = isDxFeedAccessTokenExpired(
+              parsed.accessToken ?? '',
+              tokenExpiresAt,
+              {
+                expirationIsAuthoritative:
+                  parsed.tokenExpirationSource === 'provider',
+              },
+            )
 
             const firm = getDxFeedPropFirm(parsed.propFirmId)
             propFirmName = firm?.name ?? parsed.propfirmName ?? null
@@ -74,7 +82,7 @@ export async function GET() {
               }
             }
           } catch {
-            /* ignore parse errors */
+            tokenExpired = isDxFeedAccessTokenExpired('', tokenExpiresAt)
           }
 
           if (apiUnauthorized) {

--- a/lib/dxfeed-auth.test.ts
+++ b/lib/dxfeed-auth.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { resolveDxFeedV2AuthUrl } from './dxfeed-auth'
+
+describe('resolveDxFeedV2AuthUrl', () => {
+  it('upgrades the legacy auth endpoint to v2', () => {
+    expect(
+      resolveDxFeedV2AuthUrl(
+        'https://authdxfeed.volumetricatrading.com/api/auth/token',
+      ),
+    ).toBe('https://authdxfeed.volumetricatrading.com/api/v2/auth/token')
+  })
+
+  it('keeps the documented v2 endpoint', () => {
+    expect(
+      resolveDxFeedV2AuthUrl(
+        'https://authdxfeed.volumetricatrading.com/api/v2/auth/token',
+      ),
+    ).toBe('https://authdxfeed.volumetricatrading.com/api/v2/auth/token')
+  })
+
+  it('rejects missing, malformed, or unexpected endpoints', () => {
+    expect(resolveDxFeedV2AuthUrl()).toBeNull()
+    expect(resolveDxFeedV2AuthUrl('not-a-url')).toBeNull()
+    expect(
+      resolveDxFeedV2AuthUrl('https://authdxfeed.volumetricatrading.com/api/other'),
+    ).toBeNull()
+  })
+})

--- a/lib/dxfeed-auth.ts
+++ b/lib/dxfeed-auth.ts
@@ -1,0 +1,22 @@
+const LEGACY_AUTH_PATH = '/api/auth/token'
+const V2_AUTH_PATH = '/api/v2/auth/token'
+
+/** Resolve the configured Volumetrica auth endpoint to the documented v2 API. */
+export function resolveDxFeedV2AuthUrl(configuredUrl?: string | null): string | null {
+  if (!configuredUrl) return null
+
+  try {
+    const url = new URL(configuredUrl)
+    const pathname = url.pathname.replace(/\/$/, '')
+    if (pathname !== LEGACY_AUTH_PATH && pathname !== V2_AUTH_PATH) {
+      return null
+    }
+
+    url.pathname = V2_AUTH_PATH
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return null
+  }
+}

--- a/lib/dxfeed-token.test.ts
+++ b/lib/dxfeed-token.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getDxFeedTokenExpiryFromProvider,
   getDxFeedTokenExpiryFromJwt,
+  isDxFeedAccessTokenExpired,
   isDxFeedTokenExpired,
   resolveDxFeedTokenExpiresAt,
 } from './dxfeed-token'
 
+function createJwt(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url')
+  return `${header}.${payload}.sig`
+}
+
 describe('dxfeed-token', () => {
   it('reads exp from JWT payload', () => {
-    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
     const exp = Math.floor(Date.now() / 1000) + 3600
-    const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url')
-    const token = `${header}.${payload}.sig`
+    const token = createJwt(exp)
 
     const expiry = getDxFeedTokenExpiryFromJwt(token)
     expect(expiry).not.toBeNull()
@@ -22,9 +28,51 @@ describe('dxfeed-token', () => {
     expect(isDxFeedTokenExpired(new Date(Date.now() + 60_000))).toBe(false)
   })
 
-  it('falls back to TTL when token is not a JWT', () => {
-    const connectedAt = new Date('2026-01-01T12:00:00Z')
-    const expiry = resolveDxFeedTokenExpiresAt('opaque-token', connectedAt)
-    expect(expiry.getTime()).toBeGreaterThan(connectedAt.getTime())
+  it('uses the provider-supplied Unix millisecond expiry', () => {
+    const expirationMs = Date.parse('2026-07-20T11:59:43.816Z')
+    expect(getDxFeedTokenExpiryFromProvider(expirationMs)?.getTime()).toBe(expirationMs)
+    expect(resolveDxFeedTokenExpiresAt('opaque-token', expirationMs)?.getTime()).toBe(
+      expirationMs,
+    )
+  })
+
+  it('does not invent an expiry for a legacy opaque token', () => {
+    expect(resolveDxFeedTokenExpiresAt('opaque-token')).toBeNull()
+  })
+
+  it('ignores guessed legacy TTL timestamps for opaque tokens', () => {
+    expect(
+      isDxFeedAccessTokenExpired(
+        'opaque-token',
+        new Date('2026-01-01T00:00:00Z'),
+        { now: new Date('2026-07-01T00:00:00Z') },
+      ),
+    ).toBe(false)
+  })
+
+  it('honors authoritative provider expiry for opaque tokens', () => {
+    expect(
+      isDxFeedAccessTokenExpired(
+        'opaque-token',
+        new Date('2026-01-01T00:00:00Z'),
+        {
+          expirationIsAuthoritative: true,
+          now: new Date('2026-07-01T00:00:00Z'),
+        },
+      ),
+    ).toBe(true)
+  })
+
+  it('honors explicit server invalidation for opaque tokens', () => {
+    expect(isDxFeedAccessTokenExpired('opaque-token', new Date(0))).toBe(true)
+  })
+
+  it('uses JWT exp as the authoritative expiry', () => {
+    const now = new Date('2026-07-01T00:00:00Z')
+    const expiredJwt = createJwt(Math.floor(now.getTime() / 1000) - 1)
+    const validJwt = createJwt(Math.floor(now.getTime() / 1000) + 3600)
+
+    expect(isDxFeedAccessTokenExpired(expiredJwt, null, { now })).toBe(true)
+    expect(isDxFeedAccessTokenExpired(validJwt, null, { now })).toBe(false)
   })
 })

--- a/lib/dxfeed-token.ts
+++ b/lib/dxfeed-token.ts
@@ -1,9 +1,7 @@
 /**
- * DxFeed report tokens may be JWTs with an `exp` claim, or opaque strings with no metadata.
- * When expiry is unknown, we apply DXFEED_TOKEN_TTL_HOURS from connect time (conservative default).
+ * DxFeed v2 returns the report token expiry separately in Unix milliseconds.
+ * Older report tokens may instead be JWTs, or opaque tokens with no metadata.
  */
-
-const DEFAULT_TOKEN_TTL_HOURS = 12
 
 function base64UrlDecode(segment: string): string {
   const padded = segment.replace(/-/g, '+').replace(/_/g, '/')
@@ -28,21 +26,25 @@ export function getDxFeedTokenExpiryFromJwt(token: string): Date | null {
   return null
 }
 
-export function getDxFeedTokenTtlHours(): number {
-  const raw = process.env.DXFEED_TOKEN_TTL_HOURS
-  if (raw == null || raw === '') return DEFAULT_TOKEN_TTL_HOURS
-  const hours = Number(raw)
-  return Number.isFinite(hours) && hours > 0 ? hours : DEFAULT_TOKEN_TTL_HOURS
-}
-
-export function resolveDxFeedTokenExpiresAt(accessToken: string, connectedAt = new Date()): Date {
-  const fromJwt = getDxFeedTokenExpiryFromJwt(accessToken)
-  if (fromJwt && fromJwt.getTime() > connectedAt.getTime()) {
-    return fromJwt
+export function getDxFeedTokenExpiryFromProvider(
+  expirationMs: number | null | undefined,
+): Date | null {
+  if (typeof expirationMs !== 'number' || !Number.isFinite(expirationMs) || expirationMs <= 0) {
+    return null
   }
 
-  const ttlMs = getDxFeedTokenTtlHours() * 60 * 60 * 1000
-  return new Date(connectedAt.getTime() + ttlMs)
+  const expiry = new Date(expirationMs)
+  return Number.isNaN(expiry.getTime()) ? null : expiry
+}
+
+export function resolveDxFeedTokenExpiresAt(
+  accessToken: string,
+  providerExpirationMs?: number | null,
+): Date | null {
+  return (
+    getDxFeedTokenExpiryFromProvider(providerExpirationMs) ??
+    getDxFeedTokenExpiryFromJwt(accessToken)
+  )
 }
 
 export function isDxFeedTokenExpired(
@@ -54,4 +56,32 @@ export function isDxFeedTokenExpired(
     tokenExpiresAt instanceof Date ? tokenExpiresAt : new Date(tokenExpiresAt)
   if (Number.isNaN(expiry.getTime())) return false
   return expiry.getTime() <= now.getTime()
+}
+
+/**
+ * Ignore guessed legacy TTL values for opaque tokens while honoring provider
+ * expiries, JWT claims, and the epoch-zero invalidation marker written after a
+ * real 401/403 response.
+ */
+export function isDxFeedAccessTokenExpired(
+  accessToken: string,
+  tokenExpiresAt: Date | string | null | undefined,
+  options: { expirationIsAuthoritative?: boolean; now?: Date } = {},
+): boolean {
+  const { expirationIsAuthoritative = false, now = new Date() } = options
+  const storedExpiry = tokenExpiresAt
+    ? tokenExpiresAt instanceof Date
+      ? tokenExpiresAt
+      : new Date(tokenExpiresAt)
+    : null
+
+  if (storedExpiry && !Number.isNaN(storedExpiry.getTime())) {
+    if (storedExpiry.getTime() === 0) return true
+    if (expirationIsAuthoritative) {
+      return storedExpiry.getTime() <= now.getTime()
+    }
+  }
+
+  const jwtExpiry = getDxFeedTokenExpiryFromJwt(accessToken)
+  return jwtExpiry ? jwtExpiry.getTime() <= now.getTime() : false
 }


### PR DESCRIPTION
## Summary

- switch DxFeed authentication to the documented v2 endpoint
- persist the dedicated reusable report token and provider-supplied expiration
- remove the guessed 12-hour expiry that forced near-daily reconnects
- keep existing opaque-token connections working until DxFeed actually rejects them
- preserve JWT expiry and explicit 401/403 invalidation behavior

## Root cause

Deltalytix treated opaque DxFeed tokens as expiring after a locally guessed 12-hour TTL. Volumetrica v2 instead returns a reusable `tradingRestReportToken` and an authoritative `tradingRestTokenExpiration` value.

## User impact

Users will no longer be asked to reconnect daily because of a Deltalytix fallback. New connections use Volumetrica's actual token lifetime, while legacy opaque-token rows ignore previously guessed timestamps and remain active until a genuine authorization failure.

## Validation

- `bun test lib/dxfeed-auth.test.ts lib/dxfeed-token.test.ts` — 11 passed
- targeted ESLint on all changed files — passed
- `bun run typecheck` — passed
- live demo validation — v2 auth succeeded, the same report token was reused across repeated account-list requests, and historical trade retrieval succeeded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches third-party auth, token persistence, and sync gating; behavior is covered by unit tests and preserves legacy opaque connections until real API failures.
> 
> **Overview**
> Fixes **near-daily DxFeed reconnect prompts** by aligning auth and expiry with Volumetrica’s documented **v2** API instead of a locally guessed 12-hour TTL.
> 
> **Authentication** now resolves `DXFEED_AUTH_URL` to `/api/v2/auth/token`, parses the `{ success, data }` response, and requires `tradingRestReportToken`, `tradingRestTokenExpiration`, and `tradingRestReportHost`. Prop-firm validation compares the **normalized historical host** from auth against the catalog-built host for the user’s selection (replacing auth `propfirmName` matching). Stored credentials add `tokenExpirationSource: 'provider'` and persist the provider expiry on connect.
> 
> **Token expiry** drops `DXFEED_TOKEN_TTL_HOURS` / connect-time guessing. New helper `isDxFeedAccessTokenExpired` treats provider timestamps as authoritative when flagged, still honors JWT `exp`, treats `tokenExpiresAt` epoch zero as explicit invalidation after 401/403, and **ignores legacy guessed TTL** on opaque tokens so existing rows stay usable until DxFeed actually rejects them. Sync, token fetch, and the synchronizations API route all use this logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf63bcbe37b883d135ae53205bc01655bacc384. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->