### PR TITLE
Harmonize landing feature preview canvases

### DIFF
--- a/app/[locale]/(landing)/components/calendar-preview.tsx
+++ b/app/[locale]/(landing)/components/calendar-preview.tsx
@@ -41,6 +41,7 @@ function formatCurrency(value: number, locale: string) {
   return value.toLocaleString(locale === "fr" ? "fr-FR" : "en-US", {
     style: "currency",
     currency: "USD",
+    currencyDisplay: "narrowSymbol",
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });
@@ -128,7 +129,7 @@ function LandingCalendarPreview({
   };
 
   return (
-    <Card className="flex h-full flex-col border-0 bg-transparent shadow-none">
+    <Card className="flex h-full flex-col rounded-none border-0 shadow-none">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b shrink-0 p-3 sm:p-4 h-[56px]">
         <div className="flex items-center gap-3">
           <CardTitle className="text-base sm:text-lg font-semibold truncate capitalize">

--- a/app/[locale]/(landing)/components/features.tsx
+++ b/app/[locale]/(landing)/components/features.tsx
@@ -116,7 +116,7 @@ export default function Features() {
             <CardContent className="min-w-0 p-0">
               <div
                 className={cn(
-                  "relative flex w-full min-w-0 max-w-full items-center justify-center overflow-hidden rounded-sm bg-white dark:bg-black",
+                  "relative flex w-full min-w-0 max-w-full items-center justify-center overflow-hidden rounded-sm bg-[#ddddd8] dark:bg-[#20201e]",
                   feature.wrapperClass ?? "h-[300px]",
                 )}
               >


### PR DESCRIPTION
## Summary

- harmonize landing feature preview canvases with the warm neutral background used by the AI journaling demo
- keep the calendar preview on a true white/black surface with square edges so win/loss cell colors retain their intended contrast
- use the narrow USD symbol in the French calendar preview, removing the unnecessary `US` suffix

## Impact

The landing feature section now feels visually consistent across previews, while the calendar preserves clear green/red performance states and cleaner French currency labels.

## Validation

- `bun run typecheck`
- `git diff --check`
- visually verified the French landing calendar and feature previews on localhost

Production build intentionally skipped because this follow-up contains only visual and formatting changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and `Intl` formatting only on landing marketing components; no auth, data, or business logic changes.
> 
> **Overview**
> **Landing feature previews** now use the same warm neutral canvas (`#ddddd8` / `#20201e`) as the AI journaling demo instead of plain white/black, so the features section reads as one visual system.
> 
> **Calendar preview** tweaks stay local to that widget: the outer card drops the transparent treatment in favor of **square corners** (`rounded-none`), and French locale currency formatting uses **`currencyDisplay: "narrowSymbol"`** so USD amounts show a compact `$` without an extra `US` suffix on monthly, daily, and weekly totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447aff39441f6bd8643a9163cc20f1322329b312. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->