### PR TITLE
Fix DxFeed reconnect status for legacy credentials

### DIFF
--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -163,6 +163,7 @@ export async function authenticateDxFeed(
   login: string,
   password: string,
   propFirmId: string,
+  existingAccountId?: string,
 ): Promise<DxFeedActionResult> {
   try {
     if (!DXFEED_AUTH_URL || !DXFEED_PLATFORM_KEY) {
@@ -285,9 +286,12 @@ export async function authenticateDxFeed(
       tokenExpirationSource: 'provider',
     }
 
-    const storeResult = await storeDxFeedToken(JSON.stringify(credentials), login, {
-      tokenExpiresAt,
-    })
+    const synchronizationAccountId = existingAccountId?.trim() || login
+    const storeResult = await storeDxFeedToken(
+      JSON.stringify(credentials),
+      synchronizationAccountId,
+      { tokenExpiresAt },
+    )
     if (storeResult.error) {
       logger.warn('Failed to store token')
     }

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -19,13 +19,18 @@ import {
 } from '@/lib/dxfeed-token'
 import { resolveDxFeedV2AuthUrl } from '@/lib/dxfeed-auth'
 import {
+  parseDxFeedStoredCredentials,
+  resolveDxFeedPropFirmFromStoredCredentials,
+  withResolvedDxFeedPropFirmId,
+  type DxFeedStoredCredentials,
+} from '@/lib/dxfeed-stored-credentials'
+import {
   buildHistoricalHostForPropFirm,
   getDxFeedPropFirm,
 } from '@/lib/dxfeed-propfirms'
 import type {
   DxFeedLoginRequest,
   DxFeedLoginResponse,
-  DxFeedStoredCredentials,
   DxFeedAccountListResponse,
   DxFeedTradesResponse,
   DxFeedReportTrade,
@@ -67,22 +72,6 @@ const logger = {
   error: (message: string, error?: unknown) => {
     console.error(`[DXFEED] ${message}`, error instanceof Error ? error.message : '')
   },
-}
-
-/**
- * Parse the JSON stored in the Synchronization.token field
- * back into { accessToken, historicalHost }.
- */
-function parseStoredCredentials(tokenField: string): DxFeedStoredCredentials | null {
-  try {
-    const parsed = JSON.parse(tokenField)
-    if (parsed.accessToken && parsed.historicalHost) {
-      return parsed as DxFeedStoredCredentials
-    }
-    return null
-  } catch {
-    return null
-  }
 }
 
 function buildHistoricalAuthHeaders(accessToken: string): HeadersInit {
@@ -483,19 +472,23 @@ export async function getDxFeedTrades(
   options?: { userId?: string },
 ): Promise<DxFeedTradesResult> {
   try {
-    const credentials = parseStoredCredentials(initialTokenJson)
+    const credentials = parseDxFeedStoredCredentials(initialTokenJson)
     if (!credentials) {
       return { error: DxFeedErrorCode.INVALID_STORED_CREDENTIALS }
     }
 
-    const propFirm = getDxFeedPropFirm(credentials.propFirmId)
+    const propFirm = resolveDxFeedPropFirmFromStoredCredentials(credentials)
     if (!propFirm) {
       return { error: DxFeedErrorCode.MISSING_PROP_FIRM_RECONNECT }
     }
 
-    const { accessToken } = credentials
+    const migratedCredentials = withResolvedDxFeedPropFirmId(credentials, propFirm)
+    const { accessToken } = migratedCredentials
     // Prefer host from connect; remap mistaken trading WSS hosts; fall back to catalog.
-    const historicalHost = coerceDxFeedHistoricalHostForSync(credentials.historicalHost, propFirm)
+    const historicalHost = coerceDxFeedHistoricalHostForSync(
+      migratedCredentials.historicalHost,
+      propFirm,
+    )
 
     let userId = options?.userId ?? null
     let syncAccountId: string | null = null
@@ -512,7 +505,6 @@ export async function getDxFeedTrades(
     }
     const resolvedUserId = userId
 
-    let storedTokenJson = initialTokenJson
     const baseUrl = historicalHost.endsWith('/') ? historicalHost.slice(0, -1) : historicalHost
 
     const syncRow = await prisma.synchronization.findFirst({
@@ -521,9 +513,21 @@ export async function getDxFeedTrades(
     })
     syncAccountId = syncRow?.accountId ?? null
 
+    let storedTokenJson = initialTokenJson
+    const migratedTokenJson = JSON.stringify(migratedCredentials)
+    if (migratedTokenJson !== initialTokenJson) {
+      const migrated = await updateStoredCredentials(
+        resolvedUserId,
+        initialTokenJson,
+        migratedTokenJson,
+      )
+      if (migrated) storedTokenJson = migratedTokenJson
+    }
+
     if (
       isDxFeedAccessTokenExpired(accessToken, syncRow?.tokenExpiresAt, {
-        expirationIsAuthoritative: credentials.tokenExpirationSource === 'provider',
+        expirationIsAuthoritative:
+          migratedCredentials.tokenExpirationSource === 'provider',
       })
     ) {
       if (syncAccountId) {
@@ -549,13 +553,17 @@ export async function getDxFeedTrades(
     )
     if (accountNumbers.length > 0) {
       const updatedCreds: DxFeedStoredCredentials = {
-        ...credentials,
+        ...migratedCredentials,
         historicalHost,
         accountNumbers,
       }
       const updatedJson = JSON.stringify(updatedCreds)
-      await updateStoredCredentials(resolvedUserId, storedTokenJson, updatedJson)
-      storedTokenJson = updatedJson
+      const updated = await updateStoredCredentials(
+        resolvedUserId,
+        storedTokenJson,
+        updatedJson,
+      )
+      if (updated) storedTokenJson = updatedJson
     }
 
     const syncStats = {
@@ -567,7 +575,7 @@ export async function getDxFeedTrades(
     }
 
     if (accounts.length === 0) {
-      const cachedAccounts = credentials.accountNumbers?.length ?? 0
+      const cachedAccounts = migratedCredentials.accountNumbers?.length ?? 0
       if (cachedAccounts > 0) {
         return {
           error: DxFeedErrorCode.SYNC_ACCOUNTS_UNAVAILABLE,
@@ -706,8 +714,12 @@ async function updateLastSyncedAt(userId: string, storedTokenJson: string) {
   })
 }
 
-async function updateStoredCredentials(userId: string, oldTokenJson: string, newTokenJson: string) {
-  await prisma.synchronization.updateMany({
+async function updateStoredCredentials(
+  userId: string,
+  oldTokenJson: string,
+  newTokenJson: string,
+): Promise<boolean> {
+  const result = await prisma.synchronization.updateMany({
     where: {
       userId,
       service: 'dxfeed',
@@ -717,6 +729,7 @@ async function updateStoredCredentials(userId: string, oldTokenJson: string, new
       token: newTokenJson,
     },
   })
+  return result.count > 0
 }
 
 export async function storeDxFeedToken(
@@ -786,7 +799,7 @@ export async function getDxFeedToken(accountId: string = 'default') {
       return { error: DxFeedErrorCode.NO_TOKEN_RECONNECT }
     }
 
-    const credentials = parseStoredCredentials(syncData.token)
+    const credentials = parseDxFeedStoredCredentials(syncData.token)
     if (
       credentials &&
       isDxFeedAccessTokenExpired(credentials.accessToken, syncData.tokenExpiresAt, {

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-credentials-manager.tsx
@@ -321,7 +321,8 @@ export function DxFeedCredentialsManager() {
         <Accordion type="multiple" className="rounded-lg border divide-y">
           {accounts.map((connection) => {
             const tradingAccountCount = connection.accountNumbers.length
-            const isConnected = connection.hasToken && !connection.tokenExpired
+            const isConnected =
+              connection.hasToken && !connection.tokenExpired && !connection.needsReconnect
 
             return (
               <AccordionItem
@@ -340,12 +341,16 @@ export function DxFeedCredentialsManager() {
                           className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium leading-none ${
                             isConnected
                               ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                              : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                              : connection.needsReconnect
+                                ? 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200'
+                                : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
                           }`}
                         >
                           {isConnected
                             ? t('dxfeedSync.multiAccount.connected')
-                            : t('dxfeedSync.multiAccount.expired')}
+                            : connection.needsReconnect
+                              ? t('dxfeedSync.multiAccount.reconnectRequired')
+                              : t('dxfeedSync.multiAccount.expired')}
                         </span>
                       </div>
                       <p

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-credentials-manager.tsx
@@ -39,8 +39,14 @@ import { cn } from '@/lib/utils'
 import { getDxFeedErrorToastContent } from '@/lib/dxfeed-client-messages'
 import { showToastWithCopy } from '@/lib/toast-copy'
 import { authenticateDxFeed, updateDxFeedDailySyncTimeAction } from './actions'
-import { useDxFeedSyncContext } from '@/context/dxfeed-sync-context'
-import { getEnabledDxFeedPropFirms } from '@/lib/dxfeed-propfirms'
+import {
+  useDxFeedSyncContext,
+  type DxFeedSyncAccount,
+} from '@/context/dxfeed-sync-context'
+import {
+  getDxFeedPropFirmByAuthName,
+  getEnabledDxFeedPropFirms,
+} from '@/lib/dxfeed-propfirms'
 
 const DXFEED_PROP_FIRM_OPTIONS = getEnabledDxFeedPropFirms()
 const DEFAULT_PROP_FIRM_ID = DXFEED_PROP_FIRM_OPTIONS[0]?.id ?? ''
@@ -57,6 +63,7 @@ export function DxFeedCredentialsManager() {
 
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [reconnectingAccountId, setReconnectingAccountId] = useState<string | null>(null)
   const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false)
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null)
   const [syncingId, setSyncingId] = useState<string | null>(null)
@@ -82,6 +89,41 @@ export function DxFeedCredentialsManager() {
 
   const closeActionsMenu = useCallback(() => {
     setActionsMenuAccountId(null)
+  }, [])
+
+  const resetConnectionDialog = useCallback(() => {
+    setReconnectingAccountId(null)
+    setLoginEmail('')
+    setLoginPassword('')
+    setSelectedPropFirmId(DEFAULT_PROP_FIRM_ID)
+    setPropFirmOpen(false)
+    setPropFirmSearch('')
+  }, [])
+
+  const handleConnectionDialogOpenChange = useCallback(
+    (open: boolean) => {
+      setIsAddDialogOpen(open)
+      if (!open) resetConnectionDialog()
+    },
+    [resetConnectionDialog],
+  )
+
+  const openNewConnectionDialog = useCallback(() => {
+    resetConnectionDialog()
+    setIsAddDialogOpen(true)
+  }, [resetConnectionDialog])
+
+  const openReconnectDialog = useCallback((connection: DxFeedSyncAccount) => {
+    const propFirm = getDxFeedPropFirmByAuthName(connection.propFirmName)
+    setReconnectingAccountId(connection.accountId)
+    setLoginEmail(connection.accountId)
+    setLoginPassword('')
+    setSelectedPropFirmId(
+      propFirm?.enabled ? propFirm.id : DEFAULT_PROP_FIRM_ID,
+    )
+    setPropFirmOpen(false)
+    setPropFirmSearch('')
+    setIsAddDialogOpen(true)
   }, [])
 
   const handleRemoveConnection = useCallback(
@@ -110,7 +152,12 @@ export function DxFeedCredentialsManager() {
 
     try {
       setIsLoading(true)
-      const result = await authenticateDxFeed(loginEmail, loginPassword, selectedPropFirmId)
+      const result = await authenticateDxFeed(
+        loginEmail,
+        loginPassword,
+        selectedPropFirmId,
+        reconnectingAccountId ?? undefined,
+      )
 
       if (result.error) {
         const { title, description } = getDxFeedErrorToastContent(
@@ -128,9 +175,7 @@ export function DxFeedCredentialsManager() {
       showToastWithCopy('success', t('dxfeedSync.connected'), {
         copyLabel: t('common.copy'),
       })
-      setIsAddDialogOpen(false)
-      setLoginEmail('')
-      setLoginPassword('')
+      handleConnectionDialogOpenChange(false)
       await loadAccounts()
     } catch (error) {
       console.error('DxFeed connect error:', error)
@@ -141,7 +186,15 @@ export function DxFeedCredentialsManager() {
     } finally {
       setIsLoading(false)
     }
-  }, [loginEmail, loginPassword, selectedPropFirmId, t, loadAccounts])
+  }, [
+    loginEmail,
+    loginPassword,
+    selectedPropFirmId,
+    reconnectingAccountId,
+    t,
+    loadAccounts,
+    handleConnectionDialogOpenChange,
+  ])
 
   function formatDate(dateString: string) {
     return new Date(dateString).toLocaleString()
@@ -150,8 +203,10 @@ export function DxFeedCredentialsManager() {
   const handleReloadAccounts = useCallback(async () => {
     try {
       setIsReloading(true)
-      await loadAccounts()
-      toast.success(t('dxfeedSync.multiAccount.accountsReloaded'))
+      const loaded = await loadAccounts()
+      if (loaded) {
+        toast.success(t('dxfeedSync.multiAccount.accountsReloaded'))
+      }
     } catch (error) {
       toast.error(t('dxfeedSync.multiAccount.reloadError'), {
         description: t('dxfeedSync.errors.hintContactSupport'),
@@ -276,6 +331,7 @@ export function DxFeedCredentialsManager() {
             variant="ghost"
             disabled={isReloading}
             className="h-8 w-8 p-0 shrink-0"
+            aria-label={t('dxfeedSync.multiAccount.reloadAccounts')}
           >
             {isReloading ? (
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -298,7 +354,7 @@ export function DxFeedCredentialsManager() {
             <span className="truncate">{t('dxfeedSync.multiAccount.syncAll')}</span>
           </Button>
           <Button
-            onClick={() => setIsAddDialogOpen(true)}
+            onClick={openNewConnectionDialog}
             disabled={isLoading}
             size="sm"
             className="h-8 flex-1 sm:flex-none"
@@ -338,7 +394,7 @@ export function DxFeedCredentialsManager() {
                           {connection.propFirmName ?? '—'}
                         </p>
                         <span
-                          className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium leading-none ${
+                          className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium leading-none ${
                             isConnected
                               ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
                               : connection.needsReconnect
@@ -359,7 +415,7 @@ export function DxFeedCredentialsManager() {
                       >
                         {connection.accountId}
                       </p>
-                      <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
                         <span>
                           {t('dxfeedSync.multiAccount.lastSync')}:{' '}
                           <span className="text-foreground/75">
@@ -377,7 +433,7 @@ export function DxFeedCredentialsManager() {
                                 type="button"
                                 variant="link"
                                 size="sm"
-                                className="h-auto p-0 text-[11px] font-normal"
+                                className="-mx-1 h-auto min-h-6 px-1 py-1 text-xs font-normal"
                                 onClick={() =>
                                   handleSetDailySyncTime(
                                     connection.accountId,
@@ -393,7 +449,7 @@ export function DxFeedCredentialsManager() {
                               type="button"
                               variant="link"
                               size="sm"
-                              className="h-auto p-0 text-[11px] font-normal"
+                              className="-mx-1 h-auto min-h-6 px-1 py-1 text-xs font-normal"
                               onClick={() =>
                                 handleSetDailySyncTime(
                                   connection.accountId,
@@ -412,7 +468,7 @@ export function DxFeedCredentialsManager() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => setIsAddDialogOpen(true)}
+                          onClick={() => openReconnectDialog(connection)}
                           className="h-7 px-2 text-xs"
                         >
                           {t('dxfeedSync.multiAccount.reconnect')}
@@ -429,6 +485,9 @@ export function DxFeedCredentialsManager() {
                         disabled={syncingId !== null || !isConnected}
                         className="h-7 w-7 p-0 shrink-0"
                         title={t('dxfeedSync.multiAccount.syncAll')}
+                        aria-label={t('dxfeedSync.multiAccount.syncAccount', {
+                          accountId: connection.accountId,
+                        })}
                       >
                         {syncingId === connection.accountId ? (
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -444,7 +503,14 @@ export function DxFeedCredentialsManager() {
                         }
                       >
                         <PopoverTrigger asChild>
-                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0 shrink-0"
+                            aria-label={t('dxfeedSync.multiAccount.accountActions', {
+                              accountId: connection.accountId,
+                            })}
+                          >
                             <MoreVertical className="h-3.5 w-3.5" />
                           </Button>
                         </PopoverTrigger>
@@ -494,7 +560,7 @@ export function DxFeedCredentialsManager() {
                       {t('dxfeedSync.multiAccount.noTradingAccounts')}
                     </p>
                   )}
-                  <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">
+                  <p className="mt-1.5 text-xs leading-snug text-muted-foreground">
                     {t('dxfeedSync.multiAccount.syncImportsAllAccounts')}
                   </p>
                 </AccordionContent>
@@ -505,11 +571,21 @@ export function DxFeedCredentialsManager() {
       )}
 
       {/* Add Account Dialog */}
-      <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+      <Dialog open={isAddDialogOpen} onOpenChange={handleConnectionDialogOpenChange}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t('dxfeedSync.addAccount.title')}</DialogTitle>
-            <DialogDescription>{t('dxfeedSync.addAccount.description')}</DialogDescription>
+            <DialogTitle>
+              {reconnectingAccountId
+                ? t('dxfeedSync.addAccount.reconnectTitle')
+                : t('dxfeedSync.addAccount.title')}
+            </DialogTitle>
+            <DialogDescription>
+              {reconnectingAccountId
+                ? t('dxfeedSync.addAccount.reconnectDescription', {
+                    accountId: reconnectingAccountId,
+                  })
+                : t('dxfeedSync.addAccount.description')}
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 mt-4">
             {DXFEED_PROP_FIRM_OPTIONS.length === 0 ? (
@@ -600,6 +676,7 @@ export function DxFeedCredentialsManager() {
                 value={loginEmail}
                 onChange={(e) => setLoginEmail(e.target.value)}
                 placeholder={t('dxfeedSync.addAccount.emailPlaceholder')}
+                readOnly={reconnectingAccountId !== null}
               />
             </div>
             <div className="space-y-2">
@@ -613,7 +690,10 @@ export function DxFeedCredentialsManager() {
               />
             </div>
             <div className="flex justify-end space-x-2">
-              <Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
+              <Button
+                variant="outline"
+                onClick={() => handleConnectionDialogOpenChange(false)}
+              >
                 {t('common.cancel')}
               </Button>
               <Button
@@ -630,7 +710,9 @@ export function DxFeedCredentialsManager() {
                     {t('dxfeedSync.addAccount.connecting')}
                   </>
                 ) : (
-                  t('dxfeedSync.addAccount.connect')
+                  reconnectingAccountId
+                    ? t('dxfeedSync.multiAccount.reconnect')
+                    : t('dxfeedSync.addAccount.connect')
                 )}
               </Button>
             </div>

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-types.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-types.ts
@@ -26,23 +26,6 @@ export interface DxFeedLoginResponse {
   message?: string
 }
 
-/**
- * Stored as JSON in the Synchronization.token field.
- * Contains both the access token and the historical API host
- * returned by the auth endpoint.
- */
-export interface DxFeedStoredCredentials {
-  accessToken: string
-  historicalHost: string
-  accountNumbers?: string[]
-  /** User-selected prop firm id (see lib/dxfeed-propfirms.ts) */
-  propFirmId?: string
-  /** Display name captured from the user-selected prop firm. */
-  propfirmName?: string
-  /** Marks a stored expiration as provider-supplied rather than a legacy guessed TTL. */
-  tokenExpirationSource?: 'provider' | 'jwt'
-}
-
 export interface DxFeedTradingAccount {
   accountId: number
   accountReference: string | null

--- a/app/api/dxfeed/synchronizations/route.ts
+++ b/app/api/dxfeed/synchronizations/route.ts
@@ -7,7 +7,11 @@ import {
 } from '@/app/[locale]/dashboard/components/import/dxfeed/sync/actions'
 import { DxFeedErrorCode } from '@/lib/dxfeed-errors'
 import { coerceDxFeedHistoricalHostForSync } from '@/lib/dxfeed-historical-host'
-import { getDxFeedPropFirm } from '@/lib/dxfeed-propfirms'
+import {
+  isDxFeedStoredCredentialsOutdated,
+  parseDxFeedStoredCredentials,
+  resolveDxFeedPropFirmFromStoredCredentials,
+} from '@/lib/dxfeed-stored-credentials'
 import { isDxFeedAccessTokenExpired } from '@/lib/dxfeed-token'
 
 export async function GET() {
@@ -26,20 +30,15 @@ export async function GET() {
         let propFirmName: string | null = null
         let tokenExpired = false
         let apiUnauthorized = false
+        let needsReconnect = false
 
         if (token) {
-          try {
-            const parsed = JSON.parse(token) as {
-              accessToken?: string
-              historicalHost?: string
-              accountNumbers?: string[]
-              propFirmId?: string
-              propfirmName?: string
-              tokenExpirationSource?: 'provider' | 'jwt'
-            }
-
+          const parsed = parseDxFeedStoredCredentials(token)
+          if (!parsed) {
+            needsReconnect = true
+          } else {
             tokenExpired = isDxFeedAccessTokenExpired(
-              parsed.accessToken ?? '',
+              parsed.accessToken,
               tokenExpiresAt,
               {
                 expirationIsAuthoritative:
@@ -47,8 +46,9 @@ export async function GET() {
               },
             )
 
-            const firm = getDxFeedPropFirm(parsed.propFirmId)
+            const firm = resolveDxFeedPropFirmFromStoredCredentials(parsed)
             propFirmName = firm?.name ?? parsed.propfirmName ?? null
+            needsReconnect = isDxFeedStoredCredentialsOutdated(parsed)
 
             if (Array.isArray(parsed.accountNumbers)) {
               accountNumbers = parsed.accountNumbers
@@ -56,9 +56,8 @@ export async function GET() {
 
             if (
               !tokenExpired &&
+              !needsReconnect &&
               accountNumbers.length === 0 &&
-              typeof parsed.accessToken === 'string' &&
-              typeof parsed.historicalHost === 'string' &&
               firm
             ) {
               const historicalHost = coerceDxFeedHistoricalHostForSync(
@@ -81,8 +80,6 @@ export async function GET() {
                 )
               }
             }
-          } catch {
-            tokenExpired = isDxFeedAccessTokenExpired('', tokenExpiresAt)
           }
 
           if (apiUnauthorized) {
@@ -90,13 +87,14 @@ export async function GET() {
           }
         }
 
-        const connectionActive = !!token && !tokenExpired
+        const connectionActive = !!token && !tokenExpired && !needsReconnect
 
         return {
           ...rest,
           tokenExpiresAt,
           hasToken: connectionActive,
           tokenExpired: !!token && tokenExpired,
+          needsReconnect,
           propFirmName,
           accountNumbers,
         }

--- a/context/dxfeed-sync-context.tsx
+++ b/context/dxfeed-sync-context.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner'
 import { useI18n } from '@/locales/client'
 import { DxFeedErrorCode } from '@/lib/dxfeed-errors'
 import { formatDxFeedError, getDxFeedErrorToastContent } from '@/lib/dxfeed-client-messages'
-import { runToastWithCopy, showToastWithCopy } from '@/lib/toast-copy'
+import { runToastWithCopy } from '@/lib/toast-copy'
 import type { DxFeedSyncStats } from '@/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-types'
 
 interface DxFeedSyncApiPayload {
@@ -16,6 +16,32 @@ interface DxFeedSyncApiPayload {
   savedCount?: number
   tradesCount?: number
   syncStats?: DxFeedSyncStats
+}
+
+interface DxFeedSynchronizationPayload {
+  id?: string
+  userId?: string
+  service?: string
+  accountId?: string
+  hasToken?: boolean
+  tokenExpired?: boolean
+  needsReconnect?: boolean
+  propFirmName?: string | null
+  accountNumbers?: unknown
+  lastSyncedAt?: string | Date | null
+  tokenExpiresAt?: string | Date | null
+  dailySyncTime?: string | Date | null
+  createdAt?: string | Date | null
+  updatedAt?: string | Date | null
+}
+
+function normalizeSynchronizationDate(
+  value: string | Date | null | undefined,
+  fallback: Date | null,
+): Date | null {
+  if (!value) return fallback
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? fallback : date
 }
 
 function buildSyncLabel(account: DxFeedSyncAccount, t: unknown): string {
@@ -114,7 +140,7 @@ interface DxFeedSyncContextType {
   performSyncForAllAccounts: () => Promise<void>
   isAutoSyncing: boolean
   accounts: DxFeedSyncAccount[]
-  loadAccounts: () => Promise<void>
+  loadAccounts: () => Promise<boolean>
   deleteAccount: (accountId: string) => Promise<void>
   syncInterval: number
   setSyncInterval: (interval: number) => void
@@ -135,26 +161,28 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
   const { refreshTradesOnly } = useData()
 
   const normalizeSynchronization = useCallback(
-    (sync: any): DxFeedSyncAccount => ({
-      id: sync.id,
-      userId: sync.userId,
-      service: sync.service,
-      accountId: sync.accountId,
+    (sync: DxFeedSynchronizationPayload): DxFeedSyncAccount => ({
+      id: sync.id ?? '',
+      userId: sync.userId ?? '',
+      service: sync.service ?? 'dxfeed',
+      accountId: sync.accountId ?? '',
       hasToken: !!sync.hasToken,
       tokenExpired: !!sync.tokenExpired,
       needsReconnect: !!sync.needsReconnect,
       propFirmName: sync.propFirmName ?? null,
-      accountNumbers: Array.isArray(sync.accountNumbers) ? sync.accountNumbers : [],
-      lastSyncedAt: sync?.lastSyncedAt ? new Date(sync.lastSyncedAt) : new Date(),
-      tokenExpiresAt: sync?.tokenExpiresAt ? new Date(sync.tokenExpiresAt) : null,
-      dailySyncTime: sync?.dailySyncTime ? new Date(sync.dailySyncTime) : null,
-      createdAt: sync?.createdAt ? new Date(sync.createdAt) : new Date(),
-      updatedAt: sync?.updatedAt ? new Date(sync.updatedAt) : new Date(),
+      accountNumbers: Array.isArray(sync.accountNumbers)
+        ? sync.accountNumbers.filter((value): value is string => typeof value === 'string')
+        : [],
+      lastSyncedAt: normalizeSynchronizationDate(sync.lastSyncedAt, new Date())!,
+      tokenExpiresAt: normalizeSynchronizationDate(sync.tokenExpiresAt, null),
+      dailySyncTime: normalizeSynchronizationDate(sync.dailySyncTime, null),
+      createdAt: normalizeSynchronizationDate(sync.createdAt, new Date())!,
+      updatedAt: normalizeSynchronizationDate(sync.updatedAt, new Date())!,
     }),
     [],
   )
 
-  const loadAccounts = useCallback(async () => {
+  const loadAccounts = useCallback(async function loadDxFeedAccounts(): Promise<boolean> {
     try {
       const response = await fetch('/api/dxfeed/synchronizations', {
         method: 'GET',
@@ -168,12 +196,19 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
       const result = await response.json()
       const data = Array.isArray(result.data) ? result.data : []
       setAccounts(data.map(normalizeSynchronization))
+      return true
     } catch (error) {
       console.warn('Failed to load DxFeed accounts:', error)
-      showToastWithCopy('error', formatDxFeedError(t, 'LOAD_SYNCHRONIZATIONS_FAILED'), {
+      toast.error(formatDxFeedError(t, 'LOAD_SYNCHRONIZATIONS_FAILED'), {
         description: t('dxfeedSync.errors.hintContactSupport'),
-        copyLabel: t('common.copy'),
+        action: {
+          label: t('common.retry'),
+          onClick: () => {
+            void loadDxFeedAccounts()
+          },
+        },
       })
+      return false
     }
   }, [normalizeSynchronization, t])
 
@@ -283,7 +318,10 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
       const validAccounts = accounts.filter(
         (acc) => acc.hasToken && !acc.tokenExpired && !acc.needsReconnect,
       )
-      if (validAccounts.length === 0) return
+      if (validAccounts.length === 0) {
+        toast.info(t('dxfeedSync.multiAccount.noActiveAccountsToSync'))
+        return
+      }
 
       for (const account of validAccounts) {
         await performSyncForAccount(account.accountId)
@@ -295,7 +333,7 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
       isAutoSyncingRef.current = false
       setIsAutoSyncing(false)
     }
-  }, [accounts, performSyncForAccount])
+  }, [accounts, performSyncForAccount, t])
 
   const checkAndPerformSyncs = useCallback(async () => {
     if (!enableAutoSync || isAutoSyncingRef.current) return

--- a/context/dxfeed-sync-context.tsx
+++ b/context/dxfeed-sync-context.tsx
@@ -98,6 +98,8 @@ export interface DxFeedSyncAccount {
   hasToken: boolean
   /** True when saved credentials exist but the DxFeed session is no longer valid */
   tokenExpired?: boolean
+  /** True when the saved credentials cannot be mapped to a supported prop firm. */
+  needsReconnect?: boolean
   propFirmName?: string | null
   accountNumbers: string[]
   lastSyncedAt: Date
@@ -140,6 +142,7 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
       accountId: sync.accountId,
       hasToken: !!sync.hasToken,
       tokenExpired: !!sync.tokenExpired,
+      needsReconnect: !!sync.needsReconnect,
       propFirmName: sync.propFirmName ?? null,
       accountNumbers: Array.isArray(sync.accountNumbers) ? sync.accountNumbers : [],
       lastSyncedAt: sync?.lastSyncedAt ? new Date(sync.lastSyncedAt) : new Date(),
@@ -190,7 +193,7 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
         return { success: false, message: t('dxfeedSync.sync.accountNotFound') }
       }
 
-      if (account.tokenExpired || !account.hasToken) {
+      if (account.tokenExpired || account.needsReconnect || !account.hasToken) {
         return { success: false, message: t('dxfeedSync.sync.tokenMissing') }
       }
 
@@ -241,7 +244,12 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
                 e instanceof Error && 'errorParams' in e
                   ? (e as Error & { errorParams?: Record<string, string | number> }).errorParams
                   : undefined
-              if (code === DxFeedErrorCode.TOKEN_EXPIRED) {
+              if (
+                code === DxFeedErrorCode.TOKEN_EXPIRED ||
+                code === DxFeedErrorCode.MISSING_PROP_FIRM_RECONNECT ||
+                code === DxFeedErrorCode.NO_TOKEN_RECONNECT ||
+                code === DxFeedErrorCode.INVALID_STORED_CREDENTIALS
+              ) {
                 void loadAccounts()
               }
               return getDxFeedErrorToastContent(t, code, params)
@@ -272,7 +280,9 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
     setIsAutoSyncing(true)
 
     try {
-      const validAccounts = accounts.filter((acc) => acc.hasToken && !acc.tokenExpired)
+      const validAccounts = accounts.filter(
+        (acc) => acc.hasToken && !acc.tokenExpired && !acc.needsReconnect,
+      )
       if (validAccounts.length === 0) return
 
       for (const account of validAccounts) {
@@ -297,7 +307,7 @@ export function DxFeedSyncContextProvider({ children }: { children: ReactNode })
       const now = Date.now()
 
       for (const account of accounts) {
-        if (!account.hasToken) continue
+        if (!account.hasToken || account.needsReconnect) continue
 
         const lastSyncTime = new Date(account.lastSyncedAt).getTime()
         const minutesSinceLastSync = (now - lastSyncTime) / (1000 * 60)

--- a/lib/dxfeed-stored-credentials.test.ts
+++ b/lib/dxfeed-stored-credentials.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDxFeedPropFirmByHistoricalHost,
+  isDxFeedStoredCredentialsOutdated,
+  parseDxFeedStoredCredentials,
+  resolveDxFeedPropFirmFromStoredCredentials,
+  withResolvedDxFeedPropFirmId,
+} from "./dxfeed-stored-credentials";
+
+describe("dxfeed-stored-credentials", () => {
+  it("parses valid stored credentials and rejects malformed values", () => {
+    expect(
+      parseDxFeedStoredCredentials(
+        JSON.stringify({
+          accessToken: "token",
+          historicalHost: "https://volumetrica.miltraders.com",
+        }),
+      ),
+    ).toEqual({
+      accessToken: "token",
+      historicalHost: "https://volumetrica.miltraders.com",
+    });
+    expect(parseDxFeedStoredCredentials("{")).toBeNull();
+    expect(
+      parseDxFeedStoredCredentials(JSON.stringify({ accessToken: "token" })),
+    ).toBeNull();
+  });
+
+  it("resolves a prop firm from id, legacy auth name, or historical host", () => {
+    expect(
+      resolveDxFeedPropFirmFromStoredCredentials({
+        accessToken: "token",
+        historicalHost: "https://unknown.example.com",
+        propFirmId: "miltraders",
+      })?.id,
+    ).toBe("miltraders");
+    expect(
+      resolveDxFeedPropFirmFromStoredCredentials({
+        accessToken: "token",
+        historicalHost: "https://unknown.example.com",
+        propfirmName: "Phoenix Trader Funding",
+      })?.id,
+    ).toBe("phoenixtraderfunding");
+    expect(
+      resolveDxFeedPropFirmFromStoredCredentials({
+        accessToken: "token",
+        historicalHost: "https://volumetrica.swissfirmup.com",
+      })?.id,
+    ).toBe("swissfirmup");
+  });
+
+  it("matches complete host boundaries and marks unknown hosts outdated", () => {
+    expect(
+      getDxFeedPropFirmByHistoricalHost(
+        "https://volumetrica.miltraders.com.evil.test",
+      ),
+    ).toBeUndefined();
+    expect(
+      isDxFeedStoredCredentialsOutdated({
+        accessToken: "token",
+        historicalHost: "https://unknown.example.com",
+      }),
+    ).toBe(true);
+  });
+
+  it("adds the resolved firm without dropping token metadata or cached accounts", () => {
+    const migrated = withResolvedDxFeedPropFirmId(
+      {
+        accessToken: "token",
+        historicalHost: "https://volumetrica.miltraders.com",
+        accountNumbers: ["account-1"],
+        tokenExpirationSource: "provider",
+      },
+      getDxFeedPropFirmByHistoricalHost("https://volumetrica.miltraders.com")!,
+    );
+
+    expect(migrated).toMatchObject({
+      propFirmId: "miltraders",
+      propfirmName: "Miltraders",
+      accountNumbers: ["account-1"],
+      tokenExpirationSource: "provider",
+    });
+  });
+});

--- a/lib/dxfeed-stored-credentials.ts
+++ b/lib/dxfeed-stored-credentials.ts
@@ -1,0 +1,88 @@
+import { normalizeDxFeedHistoricalHost } from "@/lib/dxfeed-historical-host";
+import {
+  DXFEED_PROP_FIRMS,
+  getDxFeedPropFirm,
+  getDxFeedPropFirmByAuthName,
+  type DxFeedPropFirmDefinition,
+} from "@/lib/dxfeed-propfirms";
+
+export interface DxFeedStoredCredentials {
+  accessToken: string;
+  historicalHost: string;
+  accountNumbers?: string[];
+  /** User-selected prop firm id (see lib/dxfeed-propfirms.ts). */
+  propFirmId?: string;
+  /** Display name captured from the selected prop firm or a legacy auth response. */
+  propfirmName?: string;
+  /** Marks a stored expiration as provider-supplied rather than a legacy guessed TTL. */
+  tokenExpirationSource?: "provider" | "jwt";
+}
+
+export function parseDxFeedStoredCredentials(
+  tokenField: string | null | undefined,
+): DxFeedStoredCredentials | null {
+  if (!tokenField) return null;
+
+  try {
+    const parsed = JSON.parse(tokenField) as Partial<DxFeedStoredCredentials>;
+    if (
+      typeof parsed.accessToken === "string" &&
+      parsed.accessToken.length > 0 &&
+      typeof parsed.historicalHost === "string" &&
+      parsed.historicalHost.length > 0
+    ) {
+      return parsed as DxFeedStoredCredentials;
+    }
+  } catch {
+    // Invalid stored JSON requires reconnecting the account.
+  }
+
+  return null;
+}
+
+export function getDxFeedPropFirmByHistoricalHost(
+  historicalHost?: string | null,
+): DxFeedPropFirmDefinition | undefined {
+  const normalized = normalizeDxFeedHistoricalHost(historicalHost);
+  if (!normalized) return undefined;
+
+  try {
+    const hostname = new URL(normalized).hostname.toLowerCase();
+    return DXFEED_PROP_FIRMS.find((firm) => {
+      const domain = firm.domain.toLowerCase();
+      return hostname === domain || hostname.endsWith(`.${domain}`);
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve legacy credentials using the strongest available prop-firm signal. */
+export function resolveDxFeedPropFirmFromStoredCredentials(
+  credentials: DxFeedStoredCredentials,
+): DxFeedPropFirmDefinition | undefined {
+  return (
+    getDxFeedPropFirm(credentials.propFirmId) ??
+    getDxFeedPropFirmByAuthName(credentials.propfirmName) ??
+    getDxFeedPropFirmByHistoricalHost(credentials.historicalHost)
+  );
+}
+
+export function isDxFeedStoredCredentialsOutdated(
+  credentials: DxFeedStoredCredentials,
+): boolean {
+  return !resolveDxFeedPropFirmFromStoredCredentials(credentials);
+}
+
+export function withResolvedDxFeedPropFirmId(
+  credentials: DxFeedStoredCredentials,
+  firm: DxFeedPropFirmDefinition,
+): DxFeedStoredCredentials {
+  if (credentials.propFirmId === firm.id) return credentials;
+
+  return {
+    ...credentials,
+    propFirmId: firm.id,
+    propfirmName: credentials.propfirmName ?? firm.name,
+  };
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2143,6 +2143,9 @@ export default {
       title: "Connect DxFeed Account",
       description:
         "Choose your prop firm, then sign in with the same credentials you use on that firm's platform.",
+      reconnectTitle: "Reconnect DxFeed Account",
+      reconnectDescription:
+        "Choose the prop firm and enter the password for {accountId} to refresh this connection.",
       propFirmLabel: "Prop firm",
       propFirmPlaceholder: "Select your prop firm",
       propFirmHint:
@@ -2208,6 +2211,11 @@ export default {
       savedAccounts: "Saved Accounts",
       addNew: "Add New",
       syncAll: "Sync All",
+      syncAccount: "Sync {accountId}",
+      accountActions: "Actions for {accountId}",
+      reloadAccounts: "Reload saved accounts",
+      noActiveAccountsToSync:
+        "No active DxFeed connections to sync. Reconnect an account first.",
       noSavedAccounts: "No saved accounts found",
       accountsReloaded: "Accounts reloaded successfully",
       reloadError: "Failed to reload accounts",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2191,6 +2191,7 @@ export default {
       tokenStatus: "Token Status",
       actions: "Actions",
       expired: "Expired",
+      reconnectRequired: "Reconnect required",
       valid: "Valid",
       connected: "Connected",
       expandTradingAccounts: "View {count} trading account(s)",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2272,6 +2272,9 @@ export default {
       title: "Connecter un compte DxFeed",
       description:
         "Choisissez votre propfirm, puis connectez-vous avec les mêmes identifiants que sur sa plateforme.",
+      reconnectTitle: "Reconnecter un compte DxFeed",
+      reconnectDescription:
+        "Choisissez la propfirm et saisissez le mot de passe de {accountId} pour actualiser cette connexion.",
       propFirmLabel: "Propfirm",
       propFirmPlaceholder: "Sélectionnez votre propfirm",
       propFirmHint:
@@ -2338,6 +2341,11 @@ export default {
       savedAccounts: "Comptes Enregistrés",
       addNew: "Ajouter",
       syncAll: "Synchroniser Tout",
+      syncAccount: "Synchroniser {accountId}",
+      accountActions: "Actions pour {accountId}",
+      reloadAccounts: "Recharger les comptes enregistrés",
+      noActiveAccountsToSync:
+        "Aucune connexion DxFeed active à synchroniser. Reconnectez d'abord un compte.",
       noSavedAccounts: "Aucun compte enregistré trouvé",
       accountsReloaded: "Comptes rechargés avec succès",
       reloadError: "Échec du rechargement des comptes",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2321,6 +2321,7 @@ export default {
       tokenStatus: "Statut du Token",
       actions: "Actions",
       expired: "Expiré",
+      reconnectRequired: "Reconnexion requise",
       valid: "Valide",
       connected: "Connecté",
       expandTradingAccounts: "Voir {count} compte(s) de trading",


### PR DESCRIPTION
## Summary

- resolve legacy DxFeed credentials by stored prop-firm id, legacy auth name, or historical host
- expose a distinct reconnect-required state instead of showing an unusable connection as connected
- migrate resolvable legacy credentials without dropping provider expiry metadata or cached account numbers
- keep the provider/JWT expiry behavior introduced in #312

## Root cause

The saved-account status endpoint only checked token expiry, while the sync path also required a resolvable prop firm. Legacy rows without `propFirmId` could therefore appear connected but fail synchronization with `MISSING_PROP_FIRM_RECONNECT`.

## User impact

Resolvable legacy connections continue syncing and are migrated automatically. Connections that cannot be mapped to a supported prop firm show an amber **Reconnect required** badge and are excluded from manual, bulk, and automatic sync attempts.

## Validation

- `bun test lib/dxfeed-stored-credentials.test.ts lib/dxfeed-token.test.ts lib/dxfeed-auth.test.ts`
- `bun run typecheck`
- targeted ESLint on all changed files
- production build with local dummy service keys

Supersedes #262 with a focused implementation based on the current `beta` branch.
