### PR TITLE
Remove redundant feature section subtitle on landing page

### DIFF
--- a/app/[locale]/(landing)/components/features.tsx
+++ b/app/[locale]/(landing)/components/features.tsx
@@ -16,7 +16,6 @@ type FeatureCard = {
   title: string;
   icon: ReactNode;
   description: string;
-  stat: string;
   image: ReactNode | { light: string; dark: string };
   wrapperClass?: string;
 };
@@ -40,7 +39,6 @@ export default function Features() {
       title: t("landing.features.ai-journaling.title"),
       icon: <Brain className="h-5 w-5 text-muted-foreground" />,
       description: t("landing.features.ai-journaling.description"),
-      stat: t("landing.features.ai-journaling.stat"),
       image: <TradingChatAssistant />,
       wrapperClass: "h-[420px] sm:h-[440px]",
     },
@@ -49,7 +47,6 @@ export default function Features() {
       title: t("landing.features.performance-visualization.title"),
       icon: <BarChart3 className="h-5 w-5 text-muted-foreground" />,
       description: t("landing.features.performance-visualization.description"),
-      stat: t("landing.features.performance-visualization.stat"),
       image: <PerformanceVisualizationChart group="patterns" />,
       wrapperClass: "h-[420px] sm:h-[460px]",
     },
@@ -58,7 +55,6 @@ export default function Features() {
       title: t("landing.features.daily-performance.title"),
       icon: <Calendar className="h-5 w-5 text-muted-foreground" />,
       description: t("landing.features.daily-performance.description"),
-      stat: t("landing.features.daily-performance.stat"),
       image: <CalendarFeaturePreview />,
       wrapperClass: "h-[420px] lg:h-[480px]",
     },
@@ -67,7 +63,6 @@ export default function Features() {
       title: t("landing.features.performance-tracking.title"),
       icon: <BarChart3 className="h-5 w-5 text-muted-foreground" />,
       description: t("landing.features.performance-tracking.description"),
-      stat: t("landing.features.performance-tracking.stat"),
       image: <PerformanceVisualizationChart group="tracking" />,
       wrapperClass: "h-[420px] sm:h-[460px]",
     },
@@ -76,7 +71,6 @@ export default function Features() {
       title: t("landing.features.data-import.title"),
       icon: <Database className="h-5 w-5 text-muted-foreground" />,
       description: t("landing.features.data-import.description"),
-      stat: t("landing.features.data-import.stat"),
       image: <ImportFeature />,
     },
   ];
@@ -108,8 +102,7 @@ export default function Features() {
               <CardTitle className="text-2xl font-normal tracking-tight md:text-3xl">
                 {feature.title}
               </CardTitle>
-              <div className="mt-5 text-sm font-medium">{feature.stat}</div>
-              <p className="mt-3 max-w-sm text-sm leading-relaxed text-black/55 dark:text-white/55">
+              <p className="mt-5 max-w-sm text-sm leading-relaxed text-black/55 dark:text-white/55">
                 {feature.description}
               </p>
             </CardHeader>

--- a/locales/en/landing.ts
+++ b/locales/en/landing.ts
@@ -18,31 +18,26 @@ export default {
         title: "Data Import",
         description:
           "Import data from various providers. Our platform supports automatic imports with Rithmic via a sync or .CSV imports, allowing you to centralize all your trading information in one place.",
-        stat: "Sync & CSV imports",
       },
       "performance-visualization": {
         title: "Performance Visualization",
         description:
           "Visualize your trading performance with interactive charts and graphs. Analyze patterns, identify strengths, and pinpoint areas for improvement.",
-        stat: "Comprehensive Analytics",
       },
       "daily-performance": {
         title: "Daily Performance",
         description:
           "Track your daily trading results with an intuitive calendar view. Quickly identify trends and patterns in your trading performance.",
-        stat: "Calendar View",
       },
       "performance-tracking": {
         title: "Track Your Performance",
         description:
           "Follow your equity, daily results, trade distribution, and progress toward your targets with focused performance charts.",
-        stat: "Performance Tracking",
       },
       "ai-journaling": {
         title: "AI-Powered Journaling",
         description:
           "Improve your trading emotions with AI-assisted journaling. Our advanced algorithms analyze your entries to identify emotional patterns and biases.",
-        stat: "Emotional Intelligence",
       },
       "chat-feature": {
         title: "AI Trading Coach",

--- a/locales/fr/landing.ts
+++ b/locales/fr/landing.ts
@@ -19,31 +19,26 @@ export default {
         title: "Importation de données",
         description:
           "Notre plateforme offre une synchronisation automatique avec Rithmic et Tradovate, ainsi que des intégrations avec des copiers comme ETP et Thor. Grâce à notre système unique de mapping intelligent, vous pouvez importer n'importe quel fichier CSV, quelle que soit sa structure.",
-        stat: "Intégrations multiples et synchronisation",
       },
       "performance-visualization": {
         title: "Visualisation des performances",
         description:
           "Visualisez vos performances de trading avec des graphiques et des diagrammes interactifs. Analysez les tendances, identifiez vos points forts et repérez les domaines à améliorer.",
-        stat: "Analyses complètes",
       },
       "daily-performance": {
         title: "Performance quotidienne",
         description:
           "Suivez vos résultats de trading quotidiens avec une vue calendrier intuitive. Identifiez rapidement les tendances et les modèles dans vos performances de trading.",
-        stat: "Vue calendrier",
       },
       "performance-tracking": {
         title: "Suivez vos performances",
         description:
           "Suivez votre capital, vos résultats quotidiens, la répartition de vos trades et votre progression vers vos objectifs grâce à des graphiques dédiés.",
-        stat: "Suivi des performances",
       },
       "ai-journaling": {
         title: "Journal assisté par IA",
         description:
           "Améliorez vos émotions de trading grâce à un journal assisté par IA. Nos algorithmes avancés analysent vos entrées pour identifier les modèles émotionnels et les biais.",
-        stat: "Intelligence émotionnelle",
       },
       "chat-feature": {
         title: "Coach de Trading IA",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Each feature block on the landing page showed three text layers: a title, a short subtitle (`stat`), and a description. The subtitle repeated the title in different words (e.g. "Suivez vos performances" / "Suivi des performances") without adding information.

This PR removes that middle layer from all five feature sections.

## Changes

- Remove `stat` rendering from `features.tsx`
- Remove unused `stat` copy from EN/FR landing locale files for all feature sections

## Result

Each feature section now shows only:
1. **Title** (e.g. "Suivez vos performances")
2. **Description** (the longer explanatory paragraph)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f62a4-7899-7b4d-9fdf-aa014de47e85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f62a4-7899-7b4d-9fdf-aa014de47e85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

