### PR TITLE
feat(dashboard): widget carousel minimap stack navigation

### DIFF
--- a/app/[locale]/dashboard/components/mobile-widget-carousel.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-carousel.tsx
@@ -95,12 +95,12 @@ export function MobileWidgetCarousel({
     return () => observer.disconnect()
   }, [sortedWidgets, widgetIds])
 
-  const scrollToIndex = useCallback((index: number) => {
+  const scrollToIndex = useCallback((index: number, behavior: ScrollBehavior = "smooth") => {
     const scroller = scrollerRef.current
     if (!scroller) return
     scroller.scrollTo({
       top: index * scroller.clientHeight,
-      behavior: "smooth",
+      behavior,
     })
   }, [])
 
@@ -117,6 +117,21 @@ export function MobileWidgetCarousel({
     >
       <div
         ref={scrollerRef}
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) return
+
+          if (event.key === "ArrowDown") {
+            event.preventDefault()
+            scrollToIndex(
+              Math.min(currentIndex + 1, sortedWidgets.length - 1),
+              "auto"
+            )
+          } else if (event.key === "ArrowUp") {
+            event.preventDefault()
+            scrollToIndex(Math.max(currentIndex - 1, 0), "auto")
+          }
+        }}
         className="h-full w-full snap-y snap-mandatory overflow-y-auto overscroll-y-contain touch-pan-y [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         role="region"
         aria-roledescription="carousel"
@@ -132,9 +147,11 @@ export function MobileWidgetCarousel({
             }}
             className="w-full shrink-0 snap-start snap-always"
             style={{ height: slideHeight, scrollSnapStop: "always" }}
-            role="tabpanel"
+            role="group"
+            aria-roledescription="slide"
             aria-label={getWidgetDisplayName(t, widget.type)}
             aria-hidden={index !== currentIndex}
+            inert={index !== currentIndex ? true : undefined}
           >
             <div className="h-full w-full min-h-0 px-2 pb-2">
               {renderWidget(widget)}

--- a/app/[locale]/dashboard/components/mobile-widget-carousel.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-carousel.tsx
@@ -6,6 +6,7 @@ import { useCarouselGestureLock } from "@/hooks/use-carousel-gesture-lock"
 import { MOBILE_CAROUSEL_HEIGHT } from "@/lib/widget-carousel"
 import { useI18n } from "@/locales/client"
 import { getWidgetDisplayName } from "../lib/widget-display-name"
+import { MobileWidgetMinimap } from "./mobile-widget-minimap"
 import { Widget } from "../types/dashboard"
 
 interface MobileWidgetCarouselProps {
@@ -114,81 +115,41 @@ export function MobileWidgetCarousel({
       className={cn("relative w-full overflow-hidden", className)}
       style={{ height: slideHeight }}
     >
-      <div className="flex h-full w-full">
-        <div
-          ref={scrollerRef}
-          className="h-full min-w-0 flex-1 snap-y snap-mandatory overflow-y-auto overscroll-y-contain touch-pan-y [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          role="region"
-          aria-roledescription="carousel"
-          aria-label={t("widgets.mobile.carouselNavigation")}
-        >
-          {sortedWidgets.map((widget, index) => (
-            <div
-              key={widget.i}
-              id={`mobile-widget-slide-${widget.i}`}
-              data-slide-index={index}
-              ref={(el) => {
-                slideRefs.current[index] = el
-              }}
-              className="w-full shrink-0 snap-start snap-always"
-              style={{ height: slideHeight, scrollSnapStop: "always" }}
-              role="tabpanel"
-              aria-label={getWidgetDisplayName(t, widget.type)}
-              aria-hidden={index !== currentIndex}
-            >
-              <div className="h-full w-full min-h-0 px-2 pb-2">
-                {renderWidget(widget)}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {sortedWidgets.length > 1 && (
+      <div
+        ref={scrollerRef}
+        className="h-full w-full snap-y snap-mandatory overflow-y-auto overscroll-y-contain touch-pan-y [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        role="region"
+        aria-roledescription="carousel"
+        aria-label={t("widgets.mobile.carouselNavigation")}
+      >
+        {sortedWidgets.map((widget, index) => (
           <div
-            className="flex h-full w-11 shrink-0 flex-col items-center gap-0 py-4 pr-1"
-            role="tablist"
-            aria-orientation="vertical"
-            aria-label={t("widgets.mobile.carouselNavigation")}
+            key={widget.i}
+            id={`mobile-widget-slide-${widget.i}`}
+            data-slide-index={index}
+            ref={(el) => {
+              slideRefs.current[index] = el
+            }}
+            className="w-full shrink-0 snap-start snap-always"
+            style={{ height: slideHeight, scrollSnapStop: "always" }}
+            role="tabpanel"
+            aria-label={getWidgetDisplayName(t, widget.type)}
+            aria-hidden={index !== currentIndex}
           >
-            {sortedWidgets.map((widget, index) => {
-              const widgetName = getWidgetDisplayName(t, widget.type)
-
-              return (
-                <button
-                  key={widget.i}
-                  type="button"
-                  role="tab"
-                  aria-selected={index === currentIndex}
-                  aria-controls={`mobile-widget-slide-${widget.i}`}
-                  aria-label={t("widgets.mobile.carouselGoTo", {
-                    index: index + 1,
-                    total: sortedWidgets.length,
-                    widgetName,
-                  })}
-                  className={cn(
-                    "flex min-h-11 min-w-11 flex-1 items-center justify-center rounded-full transition-colors",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                    index === currentIndex
-                      ? "bg-primary/10"
-                      : "bg-muted/40 hover:bg-muted/60"
-                  )}
-                  onClick={() => scrollToIndex(index)}
-                >
-                  <span
-                    aria-hidden
-                    className={cn(
-                      "block min-h-6 w-2 rounded-full transition-all",
-                      index === currentIndex
-                        ? "bg-primary"
-                        : "bg-muted-foreground/60"
-                    )}
-                  />
-                </button>
-              )
-            })}
+            <div className="h-full w-full min-h-0 px-2 pb-2">
+              {renderWidget(widget)}
+            </div>
           </div>
-        )}
+        ))}
       </div>
+
+      <MobileWidgetMinimap
+        widgets={sortedWidgets}
+        currentIndex={currentIndex}
+        renderWidget={renderWidget}
+        onSelectIndex={scrollToIndex}
+        slideHeight={slideHeight}
+      />
     </div>
   )
 }

--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import React, { useCallback, useEffect, useMemo, useState } from "react"
-import { AnimatePresence, motion } from "framer-motion"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
 import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useI18n } from "@/locales/client"
@@ -57,6 +57,11 @@ export function MobileWidgetMinimap({
 }: MobileWidgetMinimapProps) {
   const t = useI18n()
   const [isExpanded, setIsExpanded] = useState(false)
+  const shouldReduceMotion = useReducedMotion()
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const wasExpandedRef = useRef(false)
 
   const stackWidgets = useMemo(() => {
     if (widgets.length <= 1) return []
@@ -84,16 +89,58 @@ export function MobileWidgetMinimap({
   )
 
   useEffect(() => {
-    if (!isExpanded) return
+    if (!isExpanded) {
+      if (wasExpandedRef.current) {
+        wasExpandedRef.current = false
+        triggerRef.current?.focus()
+      }
+      return
+    }
+
+    wasExpandedRef.current = true
+    const focusFrame = requestAnimationFrame(() => closeButtonRef.current?.focus())
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault()
         setIsExpanded(false)
+        return
+      }
+
+      if (event.key !== "Tab") return
+
+      const focusableElements = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]):not([tabindex="-1"]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        ) ?? []
+      ).filter((element) => !element.hasAttribute("inert"))
+
+      if (focusableElements.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+
+      if (!dialogRef.current?.contains(document.activeElement)) {
+        event.preventDefault()
+        const targetElement = event.shiftKey ? lastElement : firstElement
+        targetElement.focus()
+      } else if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault()
+        lastElement.focus()
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault()
+        firstElement.focus()
       }
     }
 
     document.addEventListener("keydown", handleKeyDown)
-    return () => document.removeEventListener("keydown", handleKeyDown)
+    return () => {
+      cancelAnimationFrame(focusFrame)
+      document.removeEventListener("keydown", handleKeyDown)
+    }
   }, [isExpanded])
 
   if (widgets.length <= 1) {
@@ -103,6 +150,7 @@ export function MobileWidgetMinimap({
   return (
     <>
       <button
+        ref={triggerRef}
         type="button"
         aria-expanded={isExpanded}
         aria-haspopup="dialog"
@@ -111,13 +159,13 @@ export function MobileWidgetMinimap({
           total: widgets.length,
         })}
         className={cn(
-          "absolute bottom-4 right-3 z-20",
+          "absolute bottom-4 right-3 z-20 min-h-11 min-w-11",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           isExpanded && "pointer-events-none opacity-0"
         )}
         onClick={() => setIsExpanded(true)}
       >
-        <span className="relative block" style={{ width: STACK_CARD_WIDTH + 8, height: STACK_CARD_HEIGHT + 8 }}>
+        <span className="relative block" style={{ width: STACK_CARD_WIDTH + 8, height: 44 }}>
           {stackWidgets
             .slice()
             .reverse()
@@ -147,6 +195,7 @@ export function MobileWidgetMinimap({
       <AnimatePresence>
         {isExpanded && (
           <motion.div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-label={t("widgets.mobile.minimapNavigation")}
@@ -154,10 +203,11 @@ export function MobileWidgetMinimap({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
+            transition={{ duration: shouldReduceMotion ? 0.15 : 0.2 }}
           >
             <button
               type="button"
+              tabIndex={-1}
               aria-label={t("widgets.mobile.minimapClose")}
               className="absolute inset-0 bg-background/80 backdrop-blur-sm"
               onClick={() => setIsExpanded(false)}
@@ -165,19 +215,32 @@ export function MobileWidgetMinimap({
 
             <motion.div
               className="relative z-10 m-3 mb-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-background/95 shadow-2xl"
-              initial={{ y: 24, scale: 0.96 }}
-              animate={{ y: 0, scale: 1 }}
-              exit={{ y: 24, scale: 0.96 }}
-              transition={{ type: "spring", stiffness: 380, damping: 32 }}
+              initial={
+                shouldReduceMotion
+                  ? false
+                  : { transform: "translateY(24px) scale(0.96)" }
+              }
+              animate={{ transform: "translateY(0) scale(1)" }}
+              exit={
+                shouldReduceMotion
+                  ? { transform: "translateY(0) scale(1)" }
+                  : { transform: "translateY(24px) scale(0.96)" }
+              }
+              transition={
+                shouldReduceMotion
+                  ? { duration: 0 }
+                  : { type: "spring", stiffness: 380, damping: 32 }
+              }
             >
               <div className="flex items-center justify-between border-b px-4 py-3">
                 <p className="text-sm font-medium">
                   {t("widgets.mobile.minimapNavigation")}
                 </p>
                 <button
+                  ref={closeButtonRef}
                   type="button"
                   aria-label={t("widgets.mobile.minimapClose")}
-                  className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-muted"
+                  className="flex h-11 w-11 items-center justify-center rounded-full hover:bg-muted"
                   onClick={() => setIsExpanded(false)}
                 >
                   <X className="h-4 w-4" />

--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -1,0 +1,232 @@
+"use client"
+
+import React, { useCallback, useEffect, useMemo, useState } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+import { X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useI18n } from "@/locales/client"
+import { getWidgetDisplayName } from "../lib/widget-display-name"
+import { Widget } from "../types/dashboard"
+
+const MINIMAP_SCALE = 0.15
+const STACK_CARD_WIDTH = 44
+const STACK_CARD_HEIGHT = 32
+
+interface MobileWidgetMinimapProps {
+  widgets: Widget[]
+  currentIndex: number
+  renderWidget: (widget: Widget) => React.ReactNode
+  onSelectIndex: (index: number) => void
+  slideHeight: string
+}
+
+function ScaledWidgetPreview({
+  widget,
+  renderWidget,
+  slideHeight,
+  className,
+}: {
+  widget: Widget
+  renderWidget: (widget: Widget) => React.ReactNode
+  slideHeight: string
+  className?: string
+}) {
+  return (
+    <div className={cn("relative overflow-hidden bg-background", className)}>
+      <div
+        className="pointer-events-none origin-top-left"
+        style={{
+          transform: `scale(${MINIMAP_SCALE})`,
+          width: `${100 / MINIMAP_SCALE}%`,
+          height: slideHeight,
+        }}
+        aria-hidden
+      >
+        {renderWidget(widget)}
+      </div>
+    </div>
+  )
+}
+
+export function MobileWidgetMinimap({
+  widgets,
+  currentIndex,
+  renderWidget,
+  onSelectIndex,
+  slideHeight,
+}: MobileWidgetMinimapProps) {
+  const t = useI18n()
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const stackWidgets = useMemo(() => {
+    if (widgets.length <= 1) return []
+    const layers = Math.min(3, widgets.length)
+    return Array.from({ length: layers }, (_, offset) => {
+      const index = (currentIndex + offset) % widgets.length
+      return { widget: widgets[index], index, offset }
+    })
+  }, [widgets, currentIndex])
+
+  const handleSelect = useCallback(
+    (index: number) => {
+      onSelectIndex(index)
+      setIsExpanded(false)
+    },
+    [onSelectIndex]
+  )
+
+  useEffect(() => {
+    if (!isExpanded) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsExpanded(false)
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [isExpanded])
+
+  if (widgets.length <= 1) {
+    return null
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        aria-haspopup="dialog"
+        aria-label={t("widgets.mobile.minimapOpen", {
+          index: currentIndex + 1,
+          total: widgets.length,
+        })}
+        className={cn(
+          "absolute bottom-4 right-3 z-20",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          isExpanded && "pointer-events-none opacity-0"
+        )}
+        onClick={() => setIsExpanded(true)}
+      >
+        <span className="relative block" style={{ width: STACK_CARD_WIDTH + 8, height: STACK_CARD_HEIGHT + 8 }}>
+          {stackWidgets
+            .slice()
+            .reverse()
+            .map(({ widget, offset }) => (
+              <span
+                key={`${widget.i}-${offset}`}
+                className={cn(
+                  "absolute overflow-hidden rounded-md border border-border/80 bg-card shadow-md",
+                  offset === 0 && "ring-1 ring-primary/40"
+                )}
+                style={{
+                  width: STACK_CARD_WIDTH,
+                  height: STACK_CARD_HEIGHT,
+                  right: offset * 4,
+                  bottom: offset * 4,
+                  zIndex: 3 - offset,
+                }}
+              >
+                <ScaledWidgetPreview
+                  widget={widget}
+                  renderWidget={renderWidget}
+                  slideHeight={slideHeight}
+                  className="h-full w-full"
+                />
+              </span>
+            ))}
+        </span>
+      </button>
+
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-label={t("widgets.mobile.minimapNavigation")}
+            className="absolute inset-0 z-30 flex flex-col"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <button
+              type="button"
+              aria-label={t("widgets.mobile.minimapClose")}
+              className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+              onClick={() => setIsExpanded(false)}
+            />
+
+            <motion.div
+              className="relative z-10 m-3 mb-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-background/95 shadow-2xl"
+              initial={{ y: 24, scale: 0.96 }}
+              animate={{ y: 0, scale: 1 }}
+              exit={{ y: 24, scale: 0.96 }}
+              transition={{ type: "spring", stiffness: 380, damping: 32 }}
+            >
+              <div className="flex items-center justify-between border-b px-4 py-3">
+                <p className="text-sm font-medium">
+                  {t("widgets.mobile.minimapNavigation")}
+                </p>
+                <button
+                  type="button"
+                  aria-label={t("widgets.mobile.minimapClose")}
+                  className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-muted"
+                  onClick={() => setIsExpanded(false)}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <div className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain p-3 [-webkit-overflow-scrolling:touch]">
+                <div
+                  className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+                  role="listbox"
+                  aria-label={t("widgets.mobile.minimapNavigation")}
+                >
+                  {widgets.map((widget, index) => {
+                    const widgetName = getWidgetDisplayName(t, widget.type)
+                    const isActive = index === currentIndex
+
+                    return (
+                      <button
+                        key={widget.i}
+                        type="button"
+                        role="option"
+                        aria-selected={isActive}
+                        aria-label={t("widgets.mobile.carouselGoTo", {
+                          index: index + 1,
+                          total: widgets.length,
+                          widgetName,
+                        })}
+                        className={cn(
+                          "flex flex-col gap-1.5 rounded-xl border p-2 text-left transition-colors",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          isActive
+                            ? "border-primary bg-primary/5 ring-1 ring-primary/30"
+                            : "border-border/70 bg-card hover:border-primary/40 hover:bg-muted/40"
+                        )}
+                        onClick={() => handleSelect(index)}
+                      >
+                        <ScaledWidgetPreview
+                          widget={widget}
+                          renderWidget={renderWidget}
+                          slideHeight={slideHeight}
+                          className="aspect-[4/3] w-full rounded-lg border border-border/50"
+                        />
+                        <span className="truncate px-0.5 text-xs font-medium text-foreground/90">
+                          {widgetName}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  )
+}

--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -60,10 +60,18 @@ export function MobileWidgetMinimap({
 
   const stackWidgets = useMemo(() => {
     if (widgets.length <= 1) return []
-    const layers = Math.min(3, widgets.length)
-    return Array.from({ length: layers }, (_, offset) => {
-      const index = (currentIndex + offset) % widgets.length
-      return { widget: widgets[index], index, offset }
+    const layers = Math.min(3, widgets.length - 1)
+    return Array.from({ length: layers }, (_, stackOffset) => {
+      const index = (currentIndex + 1 + stackOffset) % widgets.length
+      return { widget: widgets[index], index, stackOffset }
+    })
+  }, [widgets, currentIndex])
+
+  const upcomingWidgets = useMemo(() => {
+    if (widgets.length <= 1) return []
+    return Array.from({ length: widgets.length - 1 }, (_, step) => {
+      const index = (currentIndex + 1 + step) % widgets.length
+      return { widget: widgets[index], index }
     })
   }, [widgets, currentIndex])
 
@@ -113,19 +121,16 @@ export function MobileWidgetMinimap({
           {stackWidgets
             .slice()
             .reverse()
-            .map(({ widget, offset }) => (
+            .map(({ widget, stackOffset }) => (
               <span
-                key={`${widget.i}-${offset}`}
-                className={cn(
-                  "absolute overflow-hidden rounded-md border border-border/80 bg-card shadow-md",
-                  offset === 0 && "ring-1 ring-primary/40"
-                )}
+                key={`${widget.i}-${stackOffset}`}
+                className="absolute overflow-hidden rounded-md border border-border/80 bg-card shadow-md"
                 style={{
                   width: STACK_CARD_WIDTH,
                   height: STACK_CARD_HEIGHT,
-                  right: offset * 4,
-                  bottom: offset * 4,
-                  zIndex: 3 - offset,
+                  right: stackOffset * 4,
+                  bottom: stackOffset * 4,
+                  zIndex: 3 - stackOffset,
                 }}
               >
                 <ScaledWidgetPreview
@@ -185,16 +190,15 @@ export function MobileWidgetMinimap({
                   role="listbox"
                   aria-label={t("widgets.mobile.minimapNavigation")}
                 >
-                  {widgets.map((widget, index) => {
+                  {upcomingWidgets.map(({ widget, index }) => {
                     const widgetName = getWidgetDisplayName(t, widget.type)
-                    const isActive = index === currentIndex
 
                     return (
                       <button
                         key={widget.i}
                         type="button"
                         role="option"
-                        aria-selected={isActive}
+                        aria-selected={false}
                         aria-label={t("widgets.mobile.carouselGoTo", {
                           index: index + 1,
                           total: widgets.length,
@@ -203,9 +207,7 @@ export function MobileWidgetMinimap({
                         className={cn(
                           "flex flex-col gap-1.5 rounded-xl border p-2 text-left transition-colors",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                          isActive
-                            ? "border-primary bg-primary/5 ring-1 ring-primary/30"
-                            : "border-border/70 bg-card hover:border-primary/40 hover:bg-muted/40"
+                          "border-border/70 bg-card hover:border-primary/40 hover:bg-muted/40"
                         )}
                         onClick={() => handleSelect(index)}
                       >

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -748,6 +748,9 @@ export default {
   "widgets.mobile.deleteWidgetNamed": "Delete {widgetName}",
   "widgets.mobile.carouselNavigation": "Widget navigation",
   "widgets.mobile.carouselGoTo": "Go to {widgetName} ({index} of {total})",
+  "widgets.mobile.minimapOpen": "Open widget minimap ({index} of {total})",
+  "widgets.mobile.minimapClose": "Close widget minimap",
+  "widgets.mobile.minimapNavigation": "Widget minimap",
   "widgets.shared.unavailableTitle": "Widget unavailable",
   "widgets.shared.unavailableDescription":
     "This widget type is not supported in shared dashboard views.",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -755,6 +755,9 @@ export default {
   "widgets.mobile.deleteWidgetNamed": "Supprimer {widgetName}",
   "widgets.mobile.carouselNavigation": "Navigation des widgets",
   "widgets.mobile.carouselGoTo": "Aller à {widgetName} ({index} sur {total})",
+  "widgets.mobile.minimapOpen": "Ouvrir la mini-carte des widgets ({index} sur {total})",
+  "widgets.mobile.minimapClose": "Fermer la mini-carte des widgets",
+  "widgets.mobile.minimapNavigation": "Mini-carte des widgets",
   "widgets.shared.unavailableTitle": "Widget indisponible",
   "widgets.shared.unavailableDescription":
     "Ce type de widget n'est pas pris en charge dans les tableaux de bord partagés.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the right-side vertical pill navigator on the mobile widget carousel with a minimap-style stack, matching the sketched interaction:

- **Collapsed:** A bottom-right stack of up to 3 scaled previews of the **upcoming** widgets (current widget excluded)
- **Expanded:** Tapping the stack opens a scrollable overlay with miniature widget representations (`scale(0.15)`) for upcoming widgets only
- **Navigation:** Selecting a minimap item scrolls the carousel to that widget and closes the overlay

The carousel scroller now uses the full width previously consumed by the `w-11` right rail.

## Changes

- New `MobileWidgetMinimap` component
- `MobileWidgetCarousel` integrates minimap and removes pill navigator
- EN/FR i18n strings for minimap open/close/navigation labels
- Minimap excludes the current widget; stack and overlay show upcoming widgets in carousel order

## Notes

- Minimap previews reuse the same `renderWidget` callback as full slides, scaled via CSS transform
- Escape key and backdrop tap close the expanded overlay

## Test plan

- [x] On mobile viewport, open Widgets tab with 2+ widgets
- [x] Confirm right pill rail is gone; stack appears bottom-right
- [x] Confirm stack does **not** preview the current widget — only upcoming ones
- [x] Tap stack → overlay opens with upcoming mini widgets only
- [x] Tap a mini widget → carousel navigates and overlay closes
- [x] Swipe carousel → stack preview updates to show next widgets from new position
- [ ] Verify shared dashboard mobile view still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f62bc-63cd-7e0f-a3c0-154bb157a629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f62bc-63cd-7e0f-a3c0-154bb157a629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

