### PR TITLE
fix(dashboard): place minimap on toolbar and remove clipped shadows

### DIFF
--- a/app/[locale]/dashboard/components/mobile-widget-carousel.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-carousel.tsx
@@ -1,12 +1,11 @@
 "use client"
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import { useCarouselGestureLock } from "@/hooks/use-carousel-gesture-lock"
 import { MOBILE_CAROUSEL_HEIGHT } from "@/lib/widget-carousel"
 import { useI18n } from "@/locales/client"
 import { getWidgetDisplayName } from "../lib/widget-display-name"
-import { MobileWidgetMinimap } from "./mobile-widget-minimap"
 import { Widget } from "../types/dashboard"
 
 interface MobileWidgetCarouselProps {
@@ -14,23 +13,35 @@ interface MobileWidgetCarouselProps {
   renderWidget: (widget: Widget) => React.ReactNode
   className?: string
   onActiveWidgetChange?: (widget: Widget | null) => void
+  onCurrentIndexChange?: (index: number) => void
   slideHeight?: string
 }
 
-function sortWidgetsForCarousel(widgets: Widget[]): Widget[] {
+export function sortWidgetsForCarousel(widgets: Widget[]): Widget[] {
   return [...widgets].sort((a, b) => {
     if (a.y !== b.y) return a.y - b.y
     return a.x - b.x
   })
 }
 
-export function MobileWidgetCarousel({
-  widgets,
-  renderWidget,
-  className,
-  onActiveWidgetChange,
-  slideHeight = MOBILE_CAROUSEL_HEIGHT,
-}: MobileWidgetCarouselProps) {
+export interface MobileWidgetCarouselHandle {
+  scrollToIndex: (index: number, behavior?: ScrollBehavior) => void
+}
+
+export const MobileWidgetCarousel = React.forwardRef<
+  MobileWidgetCarouselHandle,
+  MobileWidgetCarouselProps
+>(function MobileWidgetCarousel(
+  {
+    widgets,
+    renderWidget,
+    className,
+    onActiveWidgetChange,
+    onCurrentIndexChange,
+    slideHeight = MOBILE_CAROUSEL_HEIGHT,
+  },
+  ref
+) {
   const t = useI18n()
   const scrollerRef = useRef<HTMLDivElement>(null)
   const slideRefs = useRef<(HTMLDivElement | null)[]>([])
@@ -104,6 +115,12 @@ export function MobileWidgetCarousel({
     })
   }, [])
 
+  useImperativeHandle(ref, () => ({ scrollToIndex }), [scrollToIndex])
+
+  useEffect(() => {
+    onCurrentIndexChange?.(currentIndex)
+  }, [currentIndex, onCurrentIndexChange])
+
   useCarouselGestureLock(scrollerRef)
 
   if (sortedWidgets.length === 0) {
@@ -159,14 +176,6 @@ export function MobileWidgetCarousel({
           </div>
         ))}
       </div>
-
-      <MobileWidgetMinimap
-        widgets={sortedWidgets}
-        currentIndex={currentIndex}
-        renderWidget={renderWidget}
-        onSelectIndex={scrollToIndex}
-        slideHeight={slideHeight}
-      />
     </div>
   )
-}
+})

--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -1,6 +1,14 @@
 "use client"
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
 import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -9,15 +17,43 @@ import { getWidgetDisplayName } from "../lib/widget-display-name"
 import { Widget } from "../types/dashboard"
 
 const MINIMAP_SCALE = 0.15
-const STACK_CARD_WIDTH = 44
-const STACK_CARD_HEIGHT = 32
+const STACK_CARD_WIDTH = 36
+const STACK_CARD_HEIGHT = 26
+const STACK_CARD_OFFSET = 3
 
-interface MobileWidgetMinimapProps {
+interface MobileWidgetMinimapContextValue {
+  widgets: Widget[]
+  currentIndex: number
+  isExpanded: boolean
+  setIsExpanded: (expanded: boolean) => void
+  renderWidget: (widget: Widget) => React.ReactNode
+  slideHeight: string
+  onSelectIndex: (index: number) => void
+  triggerRef: React.RefObject<HTMLButtonElement | null>
+  closeButtonRef: React.RefObject<HTMLButtonElement | null>
+  dialogRef: React.RefObject<HTMLDivElement | null>
+}
+
+const MobileWidgetMinimapContext =
+  createContext<MobileWidgetMinimapContextValue | null>(null)
+
+function useMobileWidgetMinimapContext() {
+  const context = useContext(MobileWidgetMinimapContext)
+  if (!context) {
+    throw new Error(
+      "MobileWidgetMinimap components must be used within MobileWidgetMinimapProvider"
+    )
+  }
+  return context
+}
+
+interface MobileWidgetMinimapProviderProps {
   widgets: Widget[]
   currentIndex: number
   renderWidget: (widget: Widget) => React.ReactNode
   onSelectIndex: (index: number) => void
   slideHeight: string
+  children: React.ReactNode
 }
 
 function ScaledWidgetPreview({
@@ -48,37 +84,19 @@ function ScaledWidgetPreview({
   )
 }
 
-export function MobileWidgetMinimap({
+export function MobileWidgetMinimapProvider({
   widgets,
   currentIndex,
   renderWidget,
   onSelectIndex,
   slideHeight,
-}: MobileWidgetMinimapProps) {
-  const t = useI18n()
+  children,
+}: MobileWidgetMinimapProviderProps) {
   const [isExpanded, setIsExpanded] = useState(false)
-  const shouldReduceMotion = useReducedMotion()
   const triggerRef = useRef<HTMLButtonElement>(null)
-  const dialogRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
   const wasExpandedRef = useRef(false)
-
-  const stackWidgets = useMemo(() => {
-    if (widgets.length <= 1) return []
-    const layers = Math.min(3, widgets.length - 1)
-    return Array.from({ length: layers }, (_, stackOffset) => {
-      const index = (currentIndex + 1 + stackOffset) % widgets.length
-      return { widget: widgets[index], index, stackOffset }
-    })
-  }, [widgets, currentIndex])
-
-  const upcomingWidgets = useMemo(() => {
-    if (widgets.length <= 1) return []
-    return Array.from({ length: widgets.length - 1 }, (_, step) => {
-      const index = (currentIndex + 1 + step) % widgets.length
-      return { widget: widgets[index], index }
-    })
-  }, [widgets, currentIndex])
 
   const handleSelect = useCallback(
     (index: number) => {
@@ -143,155 +161,243 @@ export function MobileWidgetMinimap({
     }
   }, [isExpanded])
 
+  const contextValue = useMemo<MobileWidgetMinimapContextValue>(
+    () => ({
+      widgets,
+      currentIndex,
+      isExpanded,
+      setIsExpanded,
+      renderWidget,
+      slideHeight,
+      onSelectIndex: handleSelect,
+      triggerRef,
+      closeButtonRef,
+      dialogRef,
+    }),
+    [
+      widgets,
+      currentIndex,
+      isExpanded,
+      renderWidget,
+      slideHeight,
+      handleSelect,
+    ]
+  )
+
+  if (widgets.length <= 1) {
+    return <>{children}</>
+  }
+
+  return (
+    <MobileWidgetMinimapContext.Provider value={contextValue}>
+      {children}
+    </MobileWidgetMinimapContext.Provider>
+  )
+}
+
+export function MobileWidgetMinimapTrigger({ className }: { className?: string }) {
+  const t = useI18n()
+  const {
+    widgets,
+    currentIndex,
+    isExpanded,
+    setIsExpanded,
+    renderWidget,
+    slideHeight,
+    triggerRef,
+  } = useMobileWidgetMinimapContext()
+
+  const stackWidgets = useMemo(() => {
+    if (widgets.length <= 1) return []
+    const layers = Math.min(3, widgets.length - 1)
+    return Array.from({ length: layers }, (_, stackOffset) => {
+      const index = (currentIndex + 1 + stackOffset) % widgets.length
+      return { widget: widgets[index], stackOffset }
+    })
+  }, [widgets, currentIndex])
+
   if (widgets.length <= 1) {
     return null
   }
 
   return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-expanded={isExpanded}
-        aria-haspopup="dialog"
-        aria-label={t("widgets.mobile.minimapOpen", {
-          index: currentIndex + 1,
-          total: widgets.length,
-        })}
-        className={cn(
-          "absolute bottom-4 right-3 z-20 min-h-11 min-w-11",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-          isExpanded && "pointer-events-none opacity-0"
-        )}
-        onClick={() => setIsExpanded(true)}
+    <button
+      ref={triggerRef}
+      type="button"
+      aria-expanded={isExpanded}
+      aria-haspopup="dialog"
+      aria-label={t("widgets.mobile.minimapOpen", {
+        index: currentIndex + 1,
+        total: widgets.length,
+      })}
+      className={cn(
+        "flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-transform active:scale-95",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        isExpanded && "pointer-events-none opacity-0",
+        className
+      )}
+      onClick={() => setIsExpanded(true)}
+    >
+      <span
+        className="relative block"
+        style={{ width: STACK_CARD_WIDTH + 6, height: STACK_CARD_HEIGHT + 6 }}
       >
-        <span className="relative block" style={{ width: STACK_CARD_WIDTH + 8, height: 44 }}>
-          {stackWidgets
-            .slice()
-            .reverse()
-            .map(({ widget, stackOffset }) => (
-              <span
-                key={`${widget.i}-${stackOffset}`}
-                className="absolute overflow-hidden rounded-md border border-border/80 bg-card shadow-md"
-                style={{
-                  width: STACK_CARD_WIDTH,
-                  height: STACK_CARD_HEIGHT,
-                  right: stackOffset * 4,
-                  bottom: stackOffset * 4,
-                  zIndex: 3 - stackOffset,
-                }}
-              >
-                <ScaledWidgetPreview
-                  widget={widget}
-                  renderWidget={renderWidget}
-                  slideHeight={slideHeight}
-                  className="h-full w-full"
-                />
-              </span>
-            ))}
-        </span>
-      </button>
-
-      <AnimatePresence>
-        {isExpanded && (
-          <motion.div
-            ref={dialogRef}
-            role="dialog"
-            aria-modal="true"
-            aria-label={t("widgets.mobile.minimapNavigation")}
-            className="absolute inset-0 z-30 flex flex-col"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: shouldReduceMotion ? 0.15 : 0.2 }}
-          >
-            <button
-              type="button"
-              tabIndex={-1}
-              aria-label={t("widgets.mobile.minimapClose")}
-              className="absolute inset-0 bg-background/80 backdrop-blur-sm"
-              onClick={() => setIsExpanded(false)}
-            />
-
-            <motion.div
-              className="relative z-10 m-3 mb-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-background/95 shadow-2xl"
-              initial={
-                shouldReduceMotion
-                  ? false
-                  : { transform: "translateY(24px) scale(0.96)" }
-              }
-              animate={{ transform: "translateY(0) scale(1)" }}
-              exit={
-                shouldReduceMotion
-                  ? { transform: "translateY(0) scale(1)" }
-                  : { transform: "translateY(24px) scale(0.96)" }
-              }
-              transition={
-                shouldReduceMotion
-                  ? { duration: 0 }
-                  : { type: "spring", stiffness: 380, damping: 32 }
-              }
+        {stackWidgets
+          .slice()
+          .reverse()
+          .map(({ widget, stackOffset }) => (
+            <span
+              key={`${widget.i}-${stackOffset}`}
+              className="absolute overflow-hidden rounded border border-border/80 bg-card"
+              style={{
+                width: STACK_CARD_WIDTH,
+                height: STACK_CARD_HEIGHT,
+                right: stackOffset * STACK_CARD_OFFSET,
+                bottom: stackOffset * STACK_CARD_OFFSET,
+                zIndex: 3 - stackOffset,
+              }}
             >
-              <div className="flex items-center justify-between border-b px-4 py-3">
-                <p className="text-sm font-medium">
-                  {t("widgets.mobile.minimapNavigation")}
-                </p>
-                <button
-                  ref={closeButtonRef}
-                  type="button"
-                  aria-label={t("widgets.mobile.minimapClose")}
-                  className="flex h-11 w-11 items-center justify-center rounded-full hover:bg-muted"
-                  onClick={() => setIsExpanded(false)}
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
+              <ScaledWidgetPreview
+                widget={widget}
+                renderWidget={renderWidget}
+                slideHeight={slideHeight}
+                className="h-full w-full"
+              />
+            </span>
+          ))}
+      </span>
+    </button>
+  )
+}
 
-              <div className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain p-3 [-webkit-overflow-scrolling:touch]">
-                <div
-                  className="grid grid-cols-2 gap-3 sm:grid-cols-3"
-                  role="listbox"
-                  aria-label={t("widgets.mobile.minimapNavigation")}
-                >
-                  {upcomingWidgets.map(({ widget, index }) => {
-                    const widgetName = getWidgetDisplayName(t, widget.type)
+export function MobileWidgetMinimapOverlay() {
+  const t = useI18n()
+  const shouldReduceMotion = useReducedMotion()
+  const {
+    widgets,
+    currentIndex,
+    isExpanded,
+    setIsExpanded,
+    renderWidget,
+    slideHeight,
+    onSelectIndex,
+    closeButtonRef,
+    dialogRef,
+  } = useMobileWidgetMinimapContext()
 
-                    return (
-                      <button
-                        key={widget.i}
-                        type="button"
-                        role="option"
-                        aria-selected={false}
-                        aria-label={t("widgets.mobile.carouselGoTo", {
-                          index: index + 1,
-                          total: widgets.length,
-                          widgetName,
-                        })}
-                        className={cn(
-                          "flex flex-col gap-1.5 rounded-xl border p-2 text-left transition-colors",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                          "border-border/70 bg-card hover:border-primary/40 hover:bg-muted/40"
-                        )}
-                        onClick={() => handleSelect(index)}
-                      >
-                        <ScaledWidgetPreview
-                          widget={widget}
-                          renderWidget={renderWidget}
-                          slideHeight={slideHeight}
-                          className="aspect-[4/3] w-full rounded-lg border border-border/50"
-                        />
-                        <span className="truncate px-0.5 text-xs font-medium text-foreground/90">
-                          {widgetName}
-                        </span>
-                      </button>
-                    )
-                  })}
-                </div>
+  const upcomingWidgets = useMemo(() => {
+    if (widgets.length <= 1) return []
+    return Array.from({ length: widgets.length - 1 }, (_, step) => {
+      const index = (currentIndex + 1 + step) % widgets.length
+      return { widget: widgets[index], index }
+    })
+  }, [widgets, currentIndex])
+
+  if (widgets.length <= 1) {
+    return null
+  }
+
+  return (
+    <AnimatePresence>
+      {isExpanded && (
+        <motion.div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("widgets.mobile.minimapNavigation")}
+          className="fixed inset-x-0 top-0 z-40 flex flex-col"
+          style={{ bottom: "var(--mobile-toolbar-top, 5.5rem)" }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: shouldReduceMotion ? 0.15 : 0.2 }}
+        >
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label={t("widgets.mobile.minimapClose")}
+            className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+            onClick={() => setIsExpanded(false)}
+          />
+
+          <motion.div
+            className="relative z-10 m-3 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-background/95"
+            initial={
+              shouldReduceMotion
+                ? false
+                : { transform: "translateY(24px) scale(0.96)" }
+            }
+            animate={{ transform: "translateY(0) scale(1)" }}
+            exit={
+              shouldReduceMotion
+                ? { transform: "translateY(0) scale(1)" }
+                : { transform: "translateY(24px) scale(0.96)" }
+            }
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : { type: "spring", stiffness: 380, damping: 32 }
+            }
+          >
+            <div className="flex items-center justify-between border-b px-4 py-3">
+              <p className="text-sm font-medium">
+                {t("widgets.mobile.minimapNavigation")}
+              </p>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                aria-label={t("widgets.mobile.minimapClose")}
+                className="flex h-11 w-11 items-center justify-center rounded-full hover:bg-muted"
+                onClick={() => setIsExpanded(false)}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain p-3 [-webkit-overflow-scrolling:touch]">
+              <div
+                className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+                role="listbox"
+                aria-label={t("widgets.mobile.minimapNavigation")}
+              >
+                {upcomingWidgets.map(({ widget, index }) => {
+                  const widgetName = getWidgetDisplayName(t, widget.type)
+
+                  return (
+                    <button
+                      key={widget.i}
+                      type="button"
+                      role="option"
+                      aria-selected={false}
+                      aria-label={t("widgets.mobile.carouselGoTo", {
+                        index: index + 1,
+                        total: widgets.length,
+                        widgetName,
+                      })}
+                      className={cn(
+                        "flex flex-col gap-1.5 rounded-xl border p-2 text-left transition-colors",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                        "border-border/70 bg-card hover:border-primary/40 hover:bg-muted/40"
+                      )}
+                      onClick={() => onSelectIndex(index)}
+                    >
+                      <ScaledWidgetPreview
+                        widget={widget}
+                        renderWidget={renderWidget}
+                        slideHeight={slideHeight}
+                        className="aspect-[4/3] w-full rounded-lg border border-border/50"
+                      />
+                      <span className="truncate px-0.5 text-xs font-medium text-foreground/90">
+                        {widgetName}
+                      </span>
+                    </button>
+                  )
+                })}
               </div>
-            </motion.div>
+            </div>
           </motion.div>
-        )}
-      </AnimatePresence>
-    </>
+        </motion.div>
+      )}
+    </AnimatePresence>
   )
 }

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -27,7 +27,7 @@ import {
   ContextMenuContent,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, type ReactNode } from "react"
 import { useToolbarSettingsStore } from "@/store/toolbar-settings-store"
 import { motion } from "framer-motion"
 import { toast } from "sonner"
@@ -42,6 +42,7 @@ interface ToolbarProps {
   onRestoreDefaults: () => void
   mobileActiveWidget?: Widget | null
   onRemoveWidget?: (widgetId: string) => void
+  minimapTrigger?: ReactNode
 }
 
 export function Toolbar({
@@ -53,6 +54,7 @@ export function Toolbar({
   onRestoreDefaults,
   mobileActiveWidget = null,
   onRemoveWidget,
+  minimapTrigger,
 }: ToolbarProps) {
   const t = useI18n()
   const { isMobile } = useData()
@@ -260,6 +262,8 @@ export function Toolbar({
               compactBreakpoint={DASHBOARD_COMPACT_BREAKPOINT}
               compact={useCompactLayout}
             />
+
+            {minimapTrigger}
 
             {isCustomizing && (
               <div className="flex items-center gap-2">

--- a/app/[locale]/dashboard/components/widget-canvas.tsx
+++ b/app/[locale]/dashboard/components/widget-canvas.tsx
@@ -20,7 +20,16 @@ import { useAutoScroll } from '../../../../hooks/use-auto-scroll'
 import { cn } from '@/lib/utils'
 import { Widget, WidgetType, WidgetSize, LayoutItem } from '../types/dashboard'
 import { Toolbar } from './toolbar'
-import { MobileWidgetCarousel } from './mobile-widget-carousel'
+import {
+  MobileWidgetCarousel,
+  sortWidgetsForCarousel,
+  type MobileWidgetCarouselHandle,
+} from './mobile-widget-carousel'
+import {
+  MobileWidgetMinimapOverlay,
+  MobileWidgetMinimapProvider,
+  MobileWidgetMinimapTrigger,
+} from './mobile-widget-minimap'
 import { useUserStore, DashboardLayoutWithWidgets } from '../../../../store/user-store'
 import { toast } from "sonner"
 import { defaultLayouts } from "@/lib/default-layouts"
@@ -373,6 +382,8 @@ export default function WidgetCanvas() {
   const [isCustomizing, setIsCustomizing] = useState(false)
   const [isUserAction, setIsUserAction] = useState(false)
   const [mobileActiveWidget, setMobileActiveWidget] = useState<Widget | null>(null)
+  const [carouselCurrentIndex, setCarouselCurrentIndex] = useState(0)
+  const carouselRef = useRef<MobileWidgetCarouselHandle>(null)
   const t = useI18n()
 
   // Add this state to track if the layout change is from user interaction
@@ -701,6 +712,15 @@ export default function WidgetCanvas() {
 
   const useMobileCarousel = isMobile
 
+  const carouselWidgets = useMemo(
+    () => sortWidgetsForCarousel(currentLayout),
+    [currentLayout]
+  )
+
+  const handleCarouselIndexSelect = useCallback((index: number) => {
+    carouselRef.current?.scrollToIndex(index)
+  }, [])
+
   // Define renderWidget with all dependencies
   const renderWidget = useCallback((widget: Widget, forCarousel = false) => {
     // Ensure widget.type is a valid WidgetType
@@ -766,73 +786,89 @@ export default function WidgetCanvas() {
   }, [changeWidgetSize, isCustomizing, removeWidget, renderWidget])
 
   return (
-    <div
-      className={cn(
-        "relative w-full",
-        useMobileCarousel ? "mt-0 overflow-hidden" : "mt-6 pb-16 min-h-screen",
-      )}
-      style={useMobileCarousel ? { height: MOBILE_CAROUSEL_HEIGHT } : undefined}
+    <MobileWidgetMinimapProvider
+      widgets={carouselWidgets}
+      currentIndex={carouselCurrentIndex}
+      renderWidget={(widget) => renderWidgetCard(widget, true)}
+      onSelectIndex={handleCarouselIndexSelect}
+      slideHeight={MOBILE_CAROUSEL_HEIGHT}
     >
-      <Toolbar 
-        onAddWidget={addWidget}
-        isCustomizing={isCustomizing}
-        onEditToggle={() => {
-          setIsCustomizing(!isCustomizing)
-        }}
-        currentLayout={layouts || { desktop: [], mobile: [] }}
-        onRemoveAll={removeAllWidgets}
-        onRestoreDefaults={restoreDefaultLayout}
-        mobileActiveWidget={mobileActiveWidget}
-        onRemoveWidget={removeWidget}
-      />
-      {layouts && (
-        <div className="relative">
-          <div id="tooltip-portal" className="fixed inset-0 pointer-events-none z-50" />
-          {useMobileCarousel ? (
-            <MobileWidgetCarousel
-              widgets={currentLayout}
-              renderWidget={(widget) => renderWidgetCard(widget, true)}
-              onActiveWidgetChange={handleMobileActiveWidgetChange}
-            />
-          ) : (
-            <ResponsiveGridLayout
-              layouts={responsiveLayout}
-              breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
-              cols={{ lg: 12, md: 12, sm: 12, xs: 12, xxs: 12 }}
-              rowHeight={isMobile ? 65 : 70}
-              isDraggable={isCustomizing}
-              isResizable={false}
-              draggableHandle=".drag-handle"
-              onDragStart={() => setIsUserAction(true)}
-              onLayoutChange={handleLayoutChange}
-              margin={[16, 16]}
-              containerPadding={[0, 0]}
-              useCSSTransforms={true}
-            >
-              {currentLayout.map((widget) => {
-                const dimensions = widgetDimensions[widget.i]
+      <div
+        className={cn(
+          "relative w-full",
+          useMobileCarousel ? "mt-0 overflow-hidden" : "mt-6 pb-16 min-h-screen",
+        )}
+        style={useMobileCarousel ? { height: MOBILE_CAROUSEL_HEIGHT } : undefined}
+      >
+        <Toolbar
+          onAddWidget={addWidget}
+          isCustomizing={isCustomizing}
+          onEditToggle={() => {
+            setIsCustomizing(!isCustomizing)
+          }}
+          currentLayout={layouts || { desktop: [], mobile: [] }}
+          onRemoveAll={removeAllWidgets}
+          onRestoreDefaults={restoreDefaultLayout}
+          mobileActiveWidget={mobileActiveWidget}
+          onRemoveWidget={removeWidget}
+          minimapTrigger={
+            useMobileCarousel && carouselWidgets.length > 1 ? (
+              <MobileWidgetMinimapTrigger />
+            ) : undefined
+          }
+        />
+        {layouts && (
+          <div className="relative">
+            <div id="tooltip-portal" className="fixed inset-0 pointer-events-none z-50" />
+            {useMobileCarousel ? (
+              <MobileWidgetCarousel
+                ref={carouselRef}
+                widgets={currentLayout}
+                renderWidget={(widget) => renderWidgetCard(widget, true)}
+                onActiveWidgetChange={handleMobileActiveWidgetChange}
+                onCurrentIndexChange={setCarouselCurrentIndex}
+              />
+            ) : (
+              <ResponsiveGridLayout
+                layouts={responsiveLayout}
+                breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
+                cols={{ lg: 12, md: 12, sm: 12, xs: 12, xxs: 12 }}
+                rowHeight={isMobile ? 65 : 70}
+                isDraggable={isCustomizing}
+                isResizable={false}
+                draggableHandle=".drag-handle"
+                onDragStart={() => setIsUserAction(true)}
+                onLayoutChange={handleLayoutChange}
+                margin={[16, 16]}
+                containerPadding={[0, 0]}
+                useCSSTransforms={true}
+              >
+                {currentLayout.map((widget) => {
+                  const dimensions = widgetDimensions[widget.i]
 
-                return (
-                  <div
-                    key={widget.i}
-                    className="h-full"
-                    data-customizing={isCustomizing}
-                    data-widget-id={widget.i}
-                    data-widget-type={widget.type}
-                    data-widget-category={WIDGET_REGISTRY[widget.type as WidgetType]?.category ?? "other"}
-                    style={{
-                      width: dimensions.width,
-                      height: dimensions.height
-                    }}
-                  >
-                    {renderWidgetCard(widget)}
-                  </div>
-                )
-              })}
-            </ResponsiveGridLayout>
-          )}
-        </div>
-      )}
-    </div>
+                  return (
+                    <div
+                      key={widget.i}
+                      className="h-full"
+                      data-customizing={isCustomizing}
+                      data-widget-id={widget.i}
+                      data-widget-type={widget.type}
+                      data-widget-category={WIDGET_REGISTRY[widget.type as WidgetType]?.category ?? "other"}
+                      style={{
+                        width: dimensions.width,
+                        height: dimensions.height
+                      }}
+                    >
+                      {renderWidgetCard(widget)}
+                    </div>
+                  )
+                })}
+              </ResponsiveGridLayout>
+            )}
+          </div>
+        )}
+      </div>
+      {useMobileCarousel && carouselWidgets.length > 1 && <MobileWidgetMinimapOverlay />}
+    </MobileWidgetMinimapProvider>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two minimap UX issues reported on PR #322:

- **Shadow cutoff:** The minimap lived inside the carousel container (`overflow-hidden`), so `shadow-md` / `shadow-2xl` were clipped and looked like they stopped abruptly. Shadows are removed from the stack cards and expanded panel.
- **Toolbar placement:** The minimap trigger is now a button in the mobile toolbar (after the filter), instead of floating at the bottom-right of the carousel.

## Changes

- Refactor `MobileWidgetMinimap` into provider/trigger/overlay compound components.
- Render `MobileWidgetMinimapTrigger` inside `Toolbar`.
- Render `MobileWidgetMinimapOverlay` as a `fixed` panel above the toolbar (`bottom: var(--mobile-toolbar-top)`), outside the carousel overflow container.
- Lift carousel index + scroll control to `widget-canvas` via `forwardRef`.

## Verification

- `bun run typecheck`

## Manual test plan

- On mobile, confirm the minimap stack appears as a toolbar button (not floating over widgets).
- Open the minimap and verify no clipped/abrupt shadow under the stack or panel.
- Select a widget from the minimap and confirm carousel navigation still works.
- Close with backdrop tap, X button, and Escape.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f64e8-88cc-78af-8402-3a53a5d21fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f64e8-88cc-78af-8402-3a53a5d21fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

