### PR TITLE
Fix Rithmic delete popover

### DIFF
--- a/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-credentials-manager.tsx
@@ -80,6 +80,9 @@ export function RithmicCredentialsManager({
   const [isLoadingSynchronizations, setIsLoadingSynchronizations] =
     useState(true);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [actionsMenuCredentialId, setActionsMenuCredentialId] = useState<
+    string | null
+  >(null);
   const [selectedCredentialId, setSelectedCredentialId] = useState<
     string | null
   >(null);
@@ -464,7 +467,15 @@ export function RithmicCredentialsManager({
                               <RefreshCw className="h-4 w-4 text-muted-foreground" />
                             )}
                           </Button>
-                          <Popover modal>
+                          <Popover
+                            modal
+                            open={actionsMenuCredentialId === credentialId}
+                            onOpenChange={(open) =>
+                              setActionsMenuCredentialId(
+                                open ? credentialId : null
+                              )
+                            }
+                          >
                             <PopoverTrigger asChild>
                               <Button
                                 variant="ghost"
@@ -480,7 +491,10 @@ export function RithmicCredentialsManager({
                                   variant="ghost"
                                   size="sm"
                                   className="justify-start"
-                                  onClick={() => handleLoadMoreData(credential)}
+                                  onClick={() => {
+                                    setActionsMenuCredentialId(null);
+                                    handleLoadMoreData(credential);
+                                  }}
                                   disabled={isAutoSyncing}
                                 >
                                   {syncingId === credentialId ? (
@@ -494,7 +508,10 @@ export function RithmicCredentialsManager({
                                   variant="ghost"
                                   size="sm"
                                   className="justify-start"
-                                  onClick={() => onSelectCredential(credential)}
+                                  onClick={() => {
+                                    setActionsMenuCredentialId(null);
+                                    onSelectCredential(credential);
+                                  }}
                                 >
                                   <Edit2 className="h-4 w-4 mr-2" />
                                   {t("rithmic.actions.edit")}
@@ -504,6 +521,7 @@ export function RithmicCredentialsManager({
                                   size="sm"
                                   className="justify-start text-destructive hover:text-destructive"
                                   onClick={() => {
+                                    setActionsMenuCredentialId(null);
                                     setSelectedCredentialId(credentialId);
                                     setIsDeleteDialogOpen(true);
                                   }}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "private"]
 }


### PR DESCRIPTION
## What changed

- control the Rithmic credential action popover by credential ID
- close the action popover before opening the delete confirmation dialog
- consistently close the menu for edit and load-more actions
- exclude the private reference-material folder from the TypeScript project

## Why

The delete confirmation was opened while the uncontrolled Radix popover remained mounted, leaving the action menu visible behind the confirmation dialog. The broad TypeScript include pattern also unintentionally pulled a vendor/reference TypeScript file from `private/` into application typechecking.

## Impact

Deleting saved Rithmic credentials now presents a single clean confirmation layer, and `bun run typecheck` no longer checks non-application private reference files.

## Validation

- `bun install`
- `bun run typecheck`
- targeted ESLint check for the changed Rithmic component
- `git diff --check`