### PR TITLE
Fix mobile dashboard hydration flash and nested button warnings

### DIFF
--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -33,7 +33,7 @@ interface MobileWidgetMinimapContextValue {
   renderWidget: (widget: Widget) => React.ReactNode
   slideHeight: string
   onSelectIndex: (index: number) => void
-  triggerRef: React.RefObject<HTMLButtonElement | null>
+  triggerRef: React.RefObject<HTMLDivElement | null>
   closeButtonRef: React.RefObject<HTMLButtonElement | null>
   dialogRef: React.RefObject<HTMLDivElement | null>
 }
@@ -99,7 +99,7 @@ export function MobileWidgetMinimapProvider({
   children,
 }: MobileWidgetMinimapProviderProps) {
   const [isExpanded, setIsExpanded] = useState(false)
-  const triggerRef = useRef<HTMLButtonElement>(null)
+  const triggerRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
   const wasExpandedRef = useRef(false)
@@ -229,10 +229,16 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
     return null
   }
 
+  // Use a div with role="button" (not <button>) because ScaledWidgetPreview
+  // mounts live widgets that may contain their own buttons — nested <button>
+  // elements are invalid HTML and cause hydration errors.
+  const openMinimap = () => setIsExpanded(true)
+
   return (
-    <button
+    <div
       ref={triggerRef}
-      type="button"
+      role="button"
+      tabIndex={0}
       aria-expanded={isExpanded}
       aria-haspopup="dialog"
       aria-label={t("widgets.mobile.minimapOpen", {
@@ -240,12 +246,18 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
         total: widgets.length,
       })}
       className={cn(
-        "flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-transform active:scale-95",
+        "flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full transition-transform active:scale-95",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isExpanded && "pointer-events-none opacity-0",
         className
       )}
-      onClick={() => setIsExpanded(true)}
+      onClick={openMinimap}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault()
+          openMinimap()
+        }
+      }}
     >
       <span
         className="relative block"
@@ -320,7 +332,7 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
           })}
         </AnimatePresence>
       </span>
-    </button>
+    </div>
   )
 }
 
@@ -417,11 +429,12 @@ export function MobileWidgetMinimapOverlay() {
                 {upcomingWidgets.map(({ widget, index }) => {
                   const widgetName = getWidgetDisplayName(t, widget.type)
 
+                  // Div + role="option" avoids nesting live-widget <button>s inside <button>
                   return (
-                    <button
+                    <div
                       key={widget.i}
-                      type="button"
                       role="option"
+                      tabIndex={0}
                       aria-selected={false}
                       aria-label={t("widgets.mobile.carouselGoTo", {
                         index: index + 1,
@@ -429,11 +442,17 @@ export function MobileWidgetMinimapOverlay() {
                         widgetName,
                       })}
                       className={cn(
-                        "flex flex-col gap-1.5 rounded-xl border p-2 text-left transition-colors",
+                        "flex cursor-pointer flex-col gap-1.5 rounded-xl border p-2 text-left transition-colors",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                         "border-border/70 bg-card hover:border-primary/40 hover:bg-muted/40"
                       )}
                       onClick={() => onSelectIndex(index)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault()
+                          onSelectIndex(index)
+                        }
+                      }}
                     >
                       <ScaledWidgetPreview
                         widget={widget}
@@ -444,7 +463,7 @@ export function MobileWidgetMinimapOverlay() {
                       <span className="truncate px-0.5 text-xs font-medium text-foreground/90">
                         {widgetName}
                       </span>
-                    </button>
+                    </div>
                   )
                 })}
               </div>

--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -205,6 +205,7 @@ export function MobileWidgetMinimapProvider({
 
 export function MobileWidgetMinimapTrigger({ className }: { className?: string }) {
   const t = useI18n()
+  const shouldReduceMotion = useReducedMotion()
   const {
     widgets,
     currentIndex,
@@ -246,7 +247,7 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
         total: widgets.length,
       })}
       className={cn(
-        "flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full transition-transform active:scale-95",
+        "flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-full transition-transform active:scale-95",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isExpanded && "pointer-events-none opacity-0",
         className
@@ -314,12 +315,11 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
                         },
                 }}
                 exit="exit"
-                transition={{
-                  type: "spring",
-                  stiffness: 420,
-                  damping: 34,
-                  mass: 0.7,
-                }}
+                transition={
+                  shouldReduceMotion
+                    ? { duration: 0 }
+                    : { type: "spring", stiffness: 420, damping: 34, mass: 0.7 }
+                }
               >
                 <ScaledWidgetPreview
                   widget={widget}

--- a/app/[locale]/dashboard/components/share-button.tsx
+++ b/app/[locale]/dashboard/components/share-button.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect, useCallback, forwardRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Share, Check, ChevronsUpDown, Copy, Layout, ExternalLink, Download } from "lucide-react"
+import { useIsMobile } from "@/hooks/use-mobile"
 import {
   Dialog,
   DialogContent,
@@ -52,22 +53,6 @@ interface ShareButtonProps {
     mobile: any[]
   }
   compact?: boolean
-}
-
-function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(false)
-
-  useEffect(() => {
-    const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 768)
-    }
-
-    checkIsMobile()
-    window.addEventListener('resize', checkIsMobile)
-    return () => window.removeEventListener('resize', checkIsMobile)
-  }, [])
-
-  return isMobile
 }
 
 function triggerConfetti() {

--- a/app/[locale]/dashboard/components/share-button.tsx
+++ b/app/[locale]/dashboard/components/share-button.tsx
@@ -121,6 +121,7 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
     const [shareTitle, setShareTitle] = useState("")
     const [shareAllAccounts, setShareAllAccounts] = useState(true)
     const [isExporting, setIsExporting] = useState(false)
+    const [isSharing, setIsSharing] = useState(false)
     const useCompactButton = compact || isMobile
 
     // Get the earliest and latest trade dates
@@ -193,6 +194,9 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
     }, [t])
 
     const handleShare = async () => {
+      if (isSharing) {
+        return
+      }
       try {
         if (!user) {
           toast.error(t('share.error'), {
@@ -226,6 +230,8 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
           })
           return
         }
+
+        setIsSharing(true)
 
         const slug = await createShared({
           userId: user.id,
@@ -360,6 +366,8 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
         toast.error(t('share.error'), {
           description: error instanceof Error ? error.message : t('share.error.description'),
         })
+      } finally {
+        setIsSharing(false)
       }
     }
 
@@ -479,6 +487,7 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
             ref={ref}
             variant={variant}
             size={size}
+            aria-label={useCompactButton ? t("share.button") : undefined}
             className={cn(
               "h-10 rounded-full flex items-center justify-center transition-transform active:scale-95",
               useCompactButton ? "w-10 p-0" : "min-w-[120px] gap-3 px-4"
@@ -713,7 +722,9 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
                       <Layout className="h-4 w-4 mr-2" />
                       {t("share.manageLayouts")}
                     </Button>
-                    <Button onClick={handleShare}>{t("share.shareButton")}</Button>
+                    <Button onClick={handleShare} disabled={isSharing}>
+                      {isSharing ? t("share.shareInProgress") : t("share.shareButton")}
+                    </Button>
                   </div>
                 ) : (
                   <Button onClick={() => {

--- a/app/[locale]/dashboard/components/widget-canvas.tsx
+++ b/app/[locale]/dashboard/components/widget-canvas.tsx
@@ -37,6 +37,20 @@ import { defaultLayouts } from "@/lib/default-layouts"
 import { getCarouselWidgetSize, MOBILE_CAROUSEL_HEIGHT } from "@/lib/widget-carousel"
 import { useIsMobileLayout } from "@/hooks/use-mobile"
 import { Prisma, DashboardLayout } from "@/prisma/generated/prisma/browser"
+import { Skeleton } from "@/components/ui/skeleton"
+
+function CanvasSkeleton() {
+  return (
+    <div className="flex h-full min-h-[16rem] w-full flex-col gap-4 p-4" aria-hidden>
+      <Skeleton className="h-24 w-full rounded-lg" />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Skeleton className="h-40 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg max-md:hidden" />
+      </div>
+      <Skeleton className="h-32 w-full rounded-lg max-md:hidden" />
+    </div>
+  )
+}
 
 // Helper function to convert internal layout to Prisma type
 const toPrismaLayout = (layout: DashboardLayoutWithWidgets): DashboardLayout => {
@@ -487,10 +501,13 @@ export default function WidgetCanvas() {
       }
     } catch (error) {
       console.error('Error updating layout:', error);
+      toast.error(t('widgets.layoutSaveFailed'), {
+        description: t('widgets.layoutSaveFailedDescription'),
+      });
       // Revert to previous layout on error
       setLayouts(layouts);
     }
-  }, [user?.id, isCustomizing, setLayouts, layouts, activeLayout, isMobile, isUserAction, saveDashboardLayout, setIsUserAction]);
+  }, [user?.id, isCustomizing, setLayouts, layouts, activeLayout, isMobile, isUserAction, saveDashboardLayout, setIsUserAction, t]);
 
   // Define addWidget with all dependencies
   const addWidget = useCallback(async (type: WidgetType, size: WidgetSize = 'medium') => {
@@ -834,6 +851,7 @@ export default function WidgetCanvas() {
             ) : undefined
           }
         />
+        {!isLayoutReady && <CanvasSkeleton />}
         {isLayoutReady && layouts && (
           <div className="relative">
             <div id="tooltip-portal" className="fixed inset-0 pointer-events-none z-50" />

--- a/app/[locale]/dashboard/components/widget-canvas.tsx
+++ b/app/[locale]/dashboard/components/widget-canvas.tsx
@@ -35,6 +35,7 @@ import { useUserStore, DashboardLayoutWithWidgets } from '../../../../store/user
 import { toast } from "sonner"
 import { defaultLayouts } from "@/lib/default-layouts"
 import { getCarouselWidgetSize, MOBILE_CAROUSEL_HEIGHT } from "@/lib/widget-carousel"
+import { useIsMobileLayout } from "@/hooks/use-mobile"
 import { Prisma, DashboardLayout } from "@/prisma/generated/prisma/browser"
 
 // Helper function to convert internal layout to Prisma type
@@ -379,7 +380,10 @@ type WidgetDimensions = { w: number; h: number; width: string; height: string }
 export default function WidgetCanvas() {
   const { dashboardLayout: layouts, setDashboardLayout: setLayouts } = useUserStore(state => state)
   const user = useUserStore(state => state.user)
-  const { isMobile, saveDashboardLayout } = useData()
+  const { saveDashboardLayout } = useData()
+  // undefined until layout-effect measurement — prevents desktop→mobile flash
+  const isMobile = useIsMobileLayout()
+  const isLayoutReady = isMobile !== undefined
   const [isCustomizing, setIsCustomizing] = useState(false)
   const [isUserAction, setIsUserAction] = useState(false)
   const [mobileActiveWidget, setMobileActiveWidget] = useState<Widget | null>(null)
@@ -390,7 +394,10 @@ export default function WidgetCanvas() {
   const t = useI18n()
 
   // Add this state to track if the layout change is from user interaction
-  const activeLayout = useMemo(() => isMobile ? 'mobile' : 'desktop', [isMobile])
+  const activeLayout = useMemo(
+    () => (isMobile === true ? "mobile" : "desktop"),
+    [isMobile]
+  )
   
   // Move all memoized values up, out of conditional rendering paths
   const ResponsiveGridLayout = useMemo(() => WidthProvider(Responsive), [])
@@ -401,7 +408,7 @@ export default function WidgetCanvas() {
     
     const widgets = layouts[activeLayout]
     return widgets.reduce((acc: Record<string, WidgetDimensions>, widget) => {
-      acc[widget.i] = getWidgetDimensions(widget, isMobile)
+      acc[widget.i] = getWidgetDimensions(widget, isMobile === true)
       return acc
     }, {} as Record<string, WidgetDimensions>)
   }, [layouts, activeLayout, isMobile])
@@ -453,9 +460,9 @@ export default function WidgetCanvas() {
           // Create updated widget with proper type assertions
           const updatedWidget = {
             ...existingWidget,
-            x: isMobile ? 0 : item.x,
+            x: isMobile === true ? 0 : item.x,
             y: item.y,
-            w: isMobile ? 12 : item.w,
+            w: isMobile === true ? 12 : item.w,
             h: item.h,
           };
 
@@ -713,7 +720,7 @@ export default function WidgetCanvas() {
     setMobileActiveWidget(widget)
   }, [])
 
-  const useMobileCarousel = isMobile
+  const useMobileCarousel = isMobile === true
 
   const carouselWidgets = useMemo(
     () => sortWidgetsForCarousel(currentLayout),
@@ -745,7 +752,7 @@ export default function WidgetCanvas() {
       if (config.allowedSizes.length === 1) {
         return config.allowedSizes[0]
       }
-      if (isMobile && widget.size !== 'tiny') {
+      if (isMobile === true && widget.size !== 'tiny') {
         return 'small' as WidgetSize
       }
       return widget.size as WidgetSize
@@ -755,13 +762,13 @@ export default function WidgetCanvas() {
   }, [isMobile, removeWidget]);
 
   useEffect(() => {
-    if (isCustomizing && !isMobile) {
+    if (isCustomizing && isMobile === false) {
       document.addEventListener('click', handleOutsideClick)
       return () => document.removeEventListener('click', handleOutsideClick)
     }
   }, [isCustomizing, isMobile, handleOutsideClick]);
 
-  useAutoScroll(!isMobile && isCustomizing)
+  useAutoScroll(isMobile === false && isCustomizing)
 
   const renderWidgetCard = useCallback((widget: Widget, forCarousel = false) => {
     const widgetConfig = WIDGET_REGISTRY[widget.type as WidgetType]
@@ -800,9 +807,15 @@ export default function WidgetCanvas() {
       <div
         className={cn(
           "relative w-full",
-          useMobileCarousel ? "mt-0 overflow-hidden" : "mt-6 pb-16 min-h-screen",
+          // Before viewport is known: mobile-sized shell that expands on md+
+          // so we never paint the desktop grid on a phone for a frame.
+          !isLayoutReady &&
+            "overflow-hidden md:mt-6 md:min-h-screen md:overflow-visible md:pb-16 max-md:[height:calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem)-var(--mobile-toolbar-top,5.5rem))]",
+          isLayoutReady && useMobileCarousel && "mt-0 overflow-hidden",
+          isLayoutReady && !useMobileCarousel && "mt-6 pb-16 min-h-screen",
         )}
         style={useMobileCarousel ? { height: MOBILE_CAROUSEL_HEIGHT } : undefined}
+        aria-busy={!isLayoutReady}
       >
         <Toolbar
           onAddWidget={addWidget}
@@ -821,7 +834,7 @@ export default function WidgetCanvas() {
             ) : undefined
           }
         />
-        {layouts && (
+        {isLayoutReady && layouts && (
           <div className="relative">
             <div id="tooltip-portal" className="fixed inset-0 pointer-events-none z-50" />
             {useMobileCarousel ? (

--- a/app/[locale]/shared/[slug]/shared-widget-canvas.tsx
+++ b/app/[locale]/shared/[slug]/shared-widget-canvas.tsx
@@ -6,11 +6,25 @@ import { WIDGET_REGISTRY, getWidgetComponent } from '@/app/[locale]/dashboard/co
 import { MobileWidgetCarousel } from '@/app/[locale]/dashboard/components/mobile-widget-carousel'
 import { Widget, WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useI18n } from '@/locales/client'
 import { defaultLayouts } from '@/lib/default-layouts'
 import { getCarouselWidgetSize, MOBILE_CAROUSEL_VIEWPORT_HEIGHT } from '@/lib/widget-carousel'
 import { useIsMobileLayout } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
+
+function CanvasSkeleton() {
+  return (
+    <div className="flex h-full min-h-[16rem] w-full flex-col gap-4 p-4 md:mt-0" aria-hidden>
+      <Skeleton className="h-24 w-full rounded-lg" />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Skeleton className="h-40 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg max-md:hidden" />
+      </div>
+      <Skeleton className="h-32 w-full rounded-lg max-md:hidden" />
+    </div>
+  )
+}
 
 
 // Update sizeToGrid to handle responsive sizes (copy from widget-canvas.tsx)
@@ -173,6 +187,7 @@ export function SharedWidgetCanvas() {
       aria-busy={!isLayoutReady}
     >
       <div id="tooltip-portal" className="fixed inset-0 pointer-events-none z-9999" />
+      {!isLayoutReady && <CanvasSkeleton />}
       {isLayoutReady &&
         (useMobileCarousel ? (
           <MobileWidgetCarousel

--- a/app/[locale]/shared/[slug]/shared-widget-canvas.tsx
+++ b/app/[locale]/shared/[slug]/shared-widget-canvas.tsx
@@ -6,10 +6,11 @@ import { WIDGET_REGISTRY, getWidgetComponent } from '@/app/[locale]/dashboard/co
 import { MobileWidgetCarousel } from '@/app/[locale]/dashboard/components/mobile-widget-carousel'
 import { Widget, WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { useData } from '@/context/data-provider'
 import { useI18n } from '@/locales/client'
 import { defaultLayouts } from '@/lib/default-layouts'
 import { getCarouselWidgetSize, MOBILE_CAROUSEL_VIEWPORT_HEIGHT } from '@/lib/widget-carousel'
+import { useIsMobileLayout } from '@/hooks/use-mobile'
+import { cn } from '@/lib/utils'
 
 
 // Update sizeToGrid to handle responsive sizes (copy from widget-canvas.tsx)
@@ -102,11 +103,13 @@ function SharedUnsupportedWidget() {
 }
 
 export function SharedWidgetCanvas() {
-  const { isMobile } = useData()
+  const isMobile = useIsMobileLayout()
+  const isLayoutReady = isMobile !== undefined
+  const useMobileCarousel = isMobile === true
   const ResponsiveGridLayout = useMemo(() => WidthProvider(Responsive), [])
   
   // Use default layouts instead of the passed layout prop
-  const activeLayout = isMobile ? 'mobile' : 'desktop'
+  const activeLayout = useMobileCarousel ? 'mobile' : 'desktop'
 
   const renderWidget = (widget: Widget, forCarousel = false) => {
     // Ensure widget.type is a valid WidgetType
@@ -126,7 +129,7 @@ export function SharedWidgetCanvas() {
       if (config.allowedSizes.length === 1) {
         return config.allowedSizes[0]
       }
-      if (isMobile && widget.size !== 'tiny') {
+      if (useMobileCarousel && widget.size !== 'tiny') {
         return 'small' as WidgetSize
       }
       return widget.size
@@ -144,10 +147,10 @@ export function SharedWidgetCanvas() {
       // Preserve original x,y positions from default layouts
       x: item.x,
       y: item.y,
-      w: sizeToGrid(item.size, isMobile).w,
-      h: sizeToGrid(item.size, isMobile).h
+      w: sizeToGrid(item.size, useMobileCarousel).w,
+      h: sizeToGrid(item.size, useMobileCarousel).h
     }))
-  }, [activeLayout, isMobile])
+  }, [activeLayout, useMobileCarousel])
 
   const renderWidgetCard = (widget: Widget, forCarousel = false) => (
     <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-lg bg-background shadow-[0_2px_4px_rgba(0,0,0,0.05)]">
@@ -159,38 +162,46 @@ export function SharedWidgetCanvas() {
 
   return (
     <div
-      className={isMobile ? "relative mt-0 overflow-hidden" : "relative mt-6"}
-      style={isMobile ? { height: MOBILE_CAROUSEL_VIEWPORT_HEIGHT } : undefined}
+      className={cn(
+        "relative",
+        !isLayoutReady &&
+          "overflow-hidden md:mt-6 max-md:[height:calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem))]",
+        isLayoutReady && useMobileCarousel && "mt-0 overflow-hidden",
+        isLayoutReady && !useMobileCarousel && "mt-6",
+      )}
+      style={useMobileCarousel ? { height: MOBILE_CAROUSEL_VIEWPORT_HEIGHT } : undefined}
+      aria-busy={!isLayoutReady}
     >
       <div id="tooltip-portal" className="fixed inset-0 pointer-events-none z-9999" />
-      {isMobile ? (
-        <MobileWidgetCarousel
-          widgets={transformedLayout}
-          renderWidget={(widget) => renderWidgetCard(widget, true)}
-          slideHeight={MOBILE_CAROUSEL_VIEWPORT_HEIGHT}
-        />
-      ) : (
-        <ResponsiveGridLayout
-          className="layout"
-          layouts={generateResponsiveLayout(transformedLayout)}
-          breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
-          cols={{ lg: 12, md: 12, sm: 12, xs: 12, xxs: 12 }}
-          rowHeight={70}
-          isDraggable={false}
-          isResizable={false}
-          margin={[16, 16]}
-          containerPadding={[0, 0]}
-          compactType="vertical"
-          preventCollision={false}
-          useCSSTransforms={true}
-        >
-          {transformedLayout.map((widget: Widget) => (
-            <div key={widget.i} className="h-full">
-              {renderWidgetCard(widget)}
-            </div>
-          ))}
-        </ResponsiveGridLayout>
-      )}
+      {isLayoutReady &&
+        (useMobileCarousel ? (
+          <MobileWidgetCarousel
+            widgets={transformedLayout}
+            renderWidget={(widget) => renderWidgetCard(widget, true)}
+            slideHeight={MOBILE_CAROUSEL_VIEWPORT_HEIGHT}
+          />
+        ) : (
+          <ResponsiveGridLayout
+            className="layout"
+            layouts={generateResponsiveLayout(transformedLayout)}
+            breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
+            cols={{ lg: 12, md: 12, sm: 12, xs: 12, xxs: 12 }}
+            rowHeight={70}
+            isDraggable={false}
+            isResizable={false}
+            margin={[16, 16]}
+            containerPadding={[0, 0]}
+            compactType="vertical"
+            preventCollision={false}
+            useCSSTransforms={true}
+          >
+            {transformedLayout.map((widget: Widget) => (
+              <div key={widget.i} className="h-full">
+                {renderWidgetCard(widget)}
+              </div>
+            ))}
+          </ResponsiveGridLayout>
+        ))}
     </div>
   )
 }

--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -1,19 +1,36 @@
+"use client"
+
 import * as React from "react"
+import { useMediaQuery } from "@/hooks/use-media-query"
 
-const MOBILE_BREAKPOINT = 768
+export const MOBILE_BREAKPOINT = 768
 
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+/**
+ * Viewport mobile check. Safe for general UI branching.
+ * On the server / during hydration this is `false`, then syncs to the
+ * real viewport — prefer `useIsMobileLayout` for layout swaps that would
+ * otherwise flash the desktop dashboard on mobile.
+ */
 export function useIsMobile() {
+  return useMediaQuery(MOBILE_MEDIA_QUERY)
+}
+
+/**
+ * Mobile flag that stays `undefined` until measured in `useLayoutEffect`,
+ * so the first paint never shows the wrong dashboard layout.
+ */
+export function useIsMobileLayout(): boolean | undefined {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
+  React.useLayoutEffect(() => {
+    const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
+    const onChange = () => setIsMobile(mql.matches)
+    onChange()
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -660,6 +660,9 @@ export default {
   "widgets.widgetAdded": "Widget Added",
   "widgets.widgetAddedDescription":
     "The widget has been added to your dashboard",
+  "widgets.layoutSaveFailed": "Failed to save layout",
+  "widgets.layoutSaveFailedDescription":
+    "Your previous layout has been restored. Please try again.",
   "widgets.size.tiny": "Tiny (3x1)",
   "widgets.size.small": "Small (3x4)",
   "widgets.size.medium": "Medium (6x4)",
@@ -1238,6 +1241,7 @@ export default {
   "share.accounts": "accounts",
   "share.expiration": "Expiration",
   "share.shareButton": "Share",
+  "share.shareInProgress": "Sharing...",
   "share.cancel": "Cancel",
   "share.titleLabel": "Title",
   "share.titlePlaceholder": "Enter a title for your shared dashboard",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -666,6 +666,9 @@ export default {
   "widgets.widgetAdded": "Widget ajouté",
   "widgets.widgetAddedDescription":
     "Le widget a été ajouté à votre tableau de bord",
+  "widgets.layoutSaveFailed": "Échec de l'enregistrement de la disposition",
+  "widgets.layoutSaveFailedDescription":
+    "Votre disposition précédente a été restaurée. Veuillez réessayer.",
   "widgets.size.tiny": "Minuscule (3x1)",
   "widgets.size.small": "Petit (3x4)",
   "widgets.size.medium": "Moyen (6x4)",
@@ -1185,6 +1188,7 @@ export default {
   "share.accounts": "comptes",
   "share.expiration": "Expiration",
   "share.shareButton": "Partager",
+  "share.shareInProgress": "Partage...",
   "share.cancel": "Annuler",
   "share.titleLabel": "Titre",
   "share.titlePlaceholder":


### PR DESCRIPTION
## Summary
- Fix invalid nested `<button>` hydration errors from the mobile widget minimap wrapping live widget previews (e.g. news impact filter) inside a native button.
- Stop the short desktop-layout flash on mobile by deferring desktop/mobile canvas switching until the viewport is measured in `useLayoutEffect`.
- Align shared dashboard canvas and `useIsMobile` with the same hydration-safe behavior.

## Test plan
- [ ] Load `/dashboard` on a phone-width viewport and confirm no desktop grid flashes before the mobile carousel appears
- [ ] Confirm console no longer reports nested `<button>` / hydration errors on dashboard load
- [ ] Open the mobile widget minimap and select another widget
- [ ] Load a shared dashboard link on mobile and desktop and confirm the correct layout
- [ ] Desktop dashboard still renders the responsive grid as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, accessibility, and client-side layout timing changes with no auth or data-model impact; main risk is brief skeleton state or edge cases in keyboard/focus on minimap div controls.
> 
> **Overview**
> Fixes **mobile dashboard hydration** and layout polish across the main and shared canvases.
> 
> **Mobile widget minimap** no longer wraps live widget previews in native `<button>` elements. The trigger and list options use `div` with `role="button"` / `role="option"`, keyboard handlers, and reduced-motion for stack animations so nested widget buttons do not cause invalid HTML or hydration errors.
> 
> **Layout switching** uses new `useIsMobileLayout()` (viewport measured in `useLayoutEffect`, `undefined` until ready) instead of immediate mobile flags from data context. Dashboard and shared canvases show a **skeleton** and `aria-busy` until measurement completes, avoiding a one-frame **desktop grid flash** on phones. `useIsMobile()` is centralized in `hooks/use-mobile` (via `useMediaQuery`) for lighter UI branching like the share button.
> 
> **Share flow**: duplicate-submit guard with disabled “Sharing…” state, compact trigger `aria-label`, and i18n for layout save failure toasts on widget canvas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafe9c1be82c817f3c638eb83b0e3d2af69bd7a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->