### PR TITLE
Reconnect privacy-first PostHog acquisition tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 
+# PostHog analytics (EU Cloud)
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=your_posthog_project_token_here
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
 # Local dashboard auth bypass (development/self-host only — never enable in production)
 # LOCAL_DASHBOARD_AUTH_BYPASS=true
 # NEXT_PUBLIC_LOCAL_DASHBOARD_AUTH_BYPASS=true

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -33,6 +33,7 @@ import type {
   DxFeedTradesResult,
   DxFeedTradingAccount,
 } from './dxfeed-types'
+import { capturePostHogEvent } from '@/lib/posthog-server'
 
 const DXFEED_AUTH_URL = resolveDxFeedV2AuthUrl(process.env.DXFEED_AUTH_URL)
 const DXFEED_PLATFORM_KEY = process.env.DXFEED_PLATFORM_KEY
@@ -731,6 +732,17 @@ export async function storeDxFeedToken(
       return { error: 'User not authenticated' }
     }
 
+    const existingSynchronization = await prisma.synchronization.findUnique({
+      where: {
+        userId_service_accountId: {
+          userId: user.id,
+          service: 'dxfeed',
+          accountId,
+        },
+      },
+      select: { id: true },
+    })
+
     await prisma.synchronization.upsert({
       where: {
         userId_service_accountId: {
@@ -754,6 +766,16 @@ export async function storeDxFeedToken(
         tokenExpiresAt: options?.tokenExpiresAt ?? null,
         lastSyncedAt: new Date(),
         includedFeeTypes: undefined, // DxFeed has no fee differentiator
+      },
+    })
+
+    await capturePostHogEvent({
+      distinctId: user.id,
+      event: 'integration_connected',
+      properties: {
+        integration: 'dxfeed',
+        environment: DXFEED_ENVIRONMENT === 0 ? 'production' : 'demo',
+        is_first_connection: !existingSynchronization,
       },
     })
 

--- a/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
@@ -2,6 +2,7 @@
 import { prisma } from "@/lib/prisma"
 import { getUserId } from "@/server/auth"
 import { Synchronization } from "@/prisma/generated/prisma/client"
+import { capturePostHogEvent } from "@/lib/posthog-server"
 
 export async function getRithmicSynchronizations() {
   console.log('CHECKING RITHMIC SYNCHRONIZATIONS')
@@ -15,12 +16,20 @@ export async function getRithmicSynchronizations() {
 export async function setRithmicSynchronization(synchronization: Partial<Synchronization>) {
   console.log('SETTING RITHMIC SYNCHRONIZATION')
   const userId = await getUserId()
+  const service = synchronization.service || 'rithmic'
+  const accountId = synchronization.accountId || ''
+  const existingSynchronization = await prisma.synchronization.findUnique({
+    where: {
+      userId_service_accountId: { userId, service, accountId },
+    },
+    select: { id: true },
+  })
   await prisma.synchronization.upsert({
     where: { 
       userId_service_accountId: {
         userId: userId,
-        service: synchronization.service || 'rithmic',
-        accountId: synchronization.accountId || ''
+        service,
+        accountId
       }
     },
     update: {
@@ -30,11 +39,20 @@ export async function setRithmicSynchronization(synchronization: Partial<Synchro
     },
     create: {
       ...synchronization,
-      service: synchronization.service || 'rithmic',
-      accountId: synchronization.accountId || '',
+      service,
+      accountId,
       lastSyncedAt: synchronization.lastSyncedAt || new Date(),
       userId: userId,
       includedFeeTypes: undefined, // Rithmic has no fee differentiator
+    },
+  })
+
+  await capturePostHogEvent({
+    distinctId: userId,
+    event: 'integration_connected',
+    properties: {
+      integration: service,
+      is_first_connection: !existingSynchronization,
     },
   })
 }

--- a/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
@@ -11,6 +11,7 @@ import { prisma } from '@/lib/prisma'
 import { formatTimestamp, formatDateToTimestamp } from '@/lib/date-utils'
 import { createTradeWithDefaults } from '@/lib/trade-factory'
 import { getUserId } from '@/server/auth'
+import { capturePostHogEvent } from '@/lib/posthog-server'
 
 // Helper function to format dates in the required format: 2025-06-05T08:38:40+00:00
 function formatDateForAPI(date: Date): string {
@@ -1233,6 +1234,17 @@ export async function storeTradovateToken(
       return { error: 'User not authenticated' }
     }
 
+    const existingSynchronization = await prisma.synchronization.findUnique({
+      where: {
+        userId_service_accountId: {
+          userId: user.id,
+          service: 'tradovate',
+          accountId: accountId
+        }
+      },
+      select: { id: true }
+    })
+
     // Store token in Synchronization table
     await prisma.synchronization.upsert({
       where: {
@@ -1258,6 +1270,16 @@ export async function storeTradovateToken(
         environment,
         lastSyncedAt: new Date()
       }
+    })
+
+    await capturePostHogEvent({
+      distinctId: user.id,
+      event: 'integration_connected',
+      properties: {
+        integration: 'tradovate',
+        environment,
+        is_first_connection: !existingSynchronization,
+      },
     })
 
     return { success: true }
@@ -1747,4 +1769,3 @@ export async function updateDailySyncTimeAction(
 }
 
 
- 

--- a/app/[locale]/dashboard/layout.tsx
+++ b/app/[locale]/dashboard/layout.tsx
@@ -10,6 +10,8 @@ import { TradovateSyncContextProvider } from "@/context/tradovate-sync-context";
 import { DxFeedSyncContextProvider } from "@/context/dxfeed-sync-context";
 import { I18nProviderClient } from "@/locales/client";
 import { ConsentBanner } from "@/components/consent-banner";
+import { PostHogIdentity } from "@/components/posthog-identity";
+import { createClient } from "@/server/auth";
 
 export default async function RootLayout({
   children,
@@ -19,10 +21,15 @@ export default async function RootLayout({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
 
   return (
     <I18nProviderClient locale={locale}>
       <ConsentBanner />
+      {user?.id && user.email && (
+        <PostHogIdentity userId={user.id} email={user.email} language={locale} />
+      )}
       <TooltipProvider>
       <ThemeProvider>
         <DataProvider>

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -5,6 +5,7 @@ import { createClient, getWebsiteURL } from "@/server/auth";
 import { stripe } from "@/server/stripe";
 import { getSubscriptionDetails } from "@/server/subscription";
 import { getReferralBySlug } from "@/server/referral";
+import { capturePostHogEvent, hasAnalyticsConsent } from "@/lib/posthog-server";
 
 async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: string, referral?: string | null, promo_code?: string | null) {
     const subscriptionDetails = await getSubscriptionDetails();
@@ -94,12 +95,17 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
     }
 
     // Create session with appropriate mode based on price type
+    const analyticsConsent = await hasAnalyticsConsent();
     const sessionConfig: any = {
         customer: customerId,
         metadata: {
             plan: lookup_key,
             ...(referral && { referral_code: referral }),
             ...(promo_code && { promo_code: promo_code }),
+            ...(analyticsConsent && {
+                analytics_consent: 'granted',
+                posthog_distinct_id: user.id,
+            }),
         },
         line_items: [
             {
@@ -129,6 +135,18 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
     }
 
     const session = await stripe.checkout.sessions.create(sessionConfig);
+
+    await capturePostHogEvent({
+        distinctId: user.id,
+        event: 'checkout_started',
+        properties: {
+            lookup_key,
+            is_lifetime: isLifetimePlan,
+            has_referral: Boolean(referral),
+            has_promo_code: Boolean(promo_code),
+            stripe_checkout_session_id: session.id,
+        },
+    });
 
     return NextResponse.redirect(session.url as string, 303);
 }

--- a/app/api/stripe/webhooks/route.ts
+++ b/app/api/stripe/webhooks/route.ts
@@ -6,6 +6,7 @@ import { stripe } from "@/server/stripe";
 import { PrismaClient } from "@/prisma/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { sendSubscriptionErrorEmail } from "@/app/[locale]/(landing)/actions/send-support-email";
+import { capturePostHogEvent } from "@/lib/posthog-server";
 
 // Helper function to get current period end from subscription items
 function getCurrentPeriodEnd(subscription: Stripe.Subscription): number {
@@ -135,6 +136,22 @@ export async function POST(req: Request) {
             });
 
             console.log('subscription created/updated', subscription)
+
+            if (data.metadata?.analytics_consent === 'granted' && user?.id) {
+              await capturePostHogEvent({
+                consentGranted: true,
+                distinctId: data.metadata.posthog_distinct_id || user.id,
+                event: 'subscription_purchased',
+                properties: {
+                  $insert_id: event.id,
+                  plan: subscriptionPlan,
+                  billing_interval: interval,
+                  currency: data.currency,
+                  revenue: data.amount_total ? data.amount_total / 100 : 0,
+                  stripe_checkout_session_id: data.id,
+                },
+              })
+            }
             
             // Apply referral code if present in metadata
             if (data.metadata?.referral_code && user?.id) {
@@ -209,6 +226,22 @@ export async function POST(req: Request) {
                 });
 
                 console.log('lifetime subscription created/updated')
+
+                if (data.metadata?.analytics_consent === 'granted' && user?.id) {
+                  await capturePostHogEvent({
+                    consentGranted: true,
+                    distinctId: data.metadata.posthog_distinct_id || user.id,
+                    event: 'subscription_purchased',
+                    properties: {
+                      $insert_id: event.id,
+                      plan: subscriptionPlan,
+                      billing_interval: 'lifetime',
+                      currency: data.currency,
+                      revenue: data.amount_total ? data.amount_total / 100 : 0,
+                      stripe_checkout_session_id: data.id,
+                    },
+                  })
+                }
                 
                 // Apply referral code if present in metadata (for lifetime plans too)
                 if (data.metadata?.referral_code && user?.id) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -265,19 +265,6 @@ export default function RootLayout({
           `}
         </Script>
 
-        {/* PostHog Analytics */}
-        {/*{process.env.NODE_ENV === "production" && (
-          <Script id="posthog-analytics" strategy="afterInteractive">
-            {`
-            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-            posthog.init('phc_NS2VmvRg0gY0tMBpq3tMX3gOBQdG79VOciAh8NDWSeX', {
-                api_host: 'https://eu.i.posthog.com',
-                person_profiles: 'identified_only',
-            })
-            `}
-          </Script>
-        )}*/}
-
         <link
           rel="apple-touch-icon"
           sizes="180x180"

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
         "pdf2json": "^3.2.2",
         "pg": "^8.17.2",
         "playwright-core": "^1.56.1",
+        "posthog-js": "^1.403.0",
         "prisma": "^7.3.0",
         "radix-ui": "^1.6.0",
         "react": "19.2.1",
@@ -559,6 +560,10 @@
     "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
 
     "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
+
+    "@posthog/core": ["@posthog/core@1.43.1", "", { "dependencies": { "@posthog/types": "^1.396.0" } }, "sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA=="],
+
+    "@posthog/types": ["@posthog/types@1.396.0", "", {}, "sha512-S0izvq+Hqvz2GPoYJO4x7fAtlCSHNN+JiugpBmQRdG7RrYW7kZ+GipmbTItjPSKuXoJx4KbEnxBvr6NHhoZV4w=="],
 
     "@prisma/adapter-pg": ["@prisma/adapter-pg@7.8.0", "", { "dependencies": { "@prisma/driver-adapter-utils": "7.8.0", "@types/pg": "^8.16.0", "pg": "^8.16.3", "postgres-array": "3.0.4" } }, "sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg=="],
 
@@ -1446,6 +1451,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
@@ -1810,7 +1817,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
@@ -2626,7 +2633,11 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "posthog-js": ["posthog-js@1.403.0", "", { "dependencies": { "@posthog/core": "^1.43.0", "@posthog/types": "^1.396.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-K4kInJ4JuTE4B7f1AEb1X6NbJFezA6bUB/bd2LXn2spX+ALm4e2bH4LfItbvguevgBOFjSu7EA0JNvRinKLYeg=="],
+
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "preact": ["preact@10.29.7", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
@@ -2695,6 +2706,8 @@
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
@@ -3194,6 +3207,8 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -3520,6 +3535,8 @@
 
     "pkg-up/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
+    "png-js/fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
@@ -3607,6 +3624,8 @@
     "react-grid-layout/fast-equals": ["fast-equals@4.0.3", "", {}, "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="],
 
     "react-promise-suspense/fast-deep-equal": ["fast-deep-equal@2.0.1", "", {}, "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="],
+
+    "read-excel-file/fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "read-pkg-up/find-up": ["find-up@1.1.2", "", { "dependencies": { "path-exists": "^2.0.0", "pinkie-promise": "^2.0.0" } }, "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA=="],
 

--- a/components/consent-banner.tsx
+++ b/components/consent-banner.tsx
@@ -22,6 +22,33 @@ import { Label } from "@/components/ui/label"
 import { motion, AnimatePresence } from "framer-motion"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useI18n } from "@/locales/client"
+import posthog from "posthog-js"
+
+const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent"
+const CONSENT_EVENT = "deltalytix:analytics-consent"
+
+function syncPostHogConsent(analyticsEnabled: boolean) {
+  const secure = window.location.protocol === "https:" ? "; Secure" : ""
+  document.cookie = `${ANALYTICS_CONSENT_COOKIE}=${analyticsEnabled ? "granted" : "denied"}; Max-Age=31536000; Path=/; SameSite=Lax${secure}`
+
+  if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return
+
+  if (analyticsEnabled) {
+    const wasOptedOut = posthog.has_opted_out_capturing()
+    if (!posthog.has_opted_in_capturing()) {
+      posthog.opt_in_capturing()
+    }
+    window.dispatchEvent(new Event(CONSENT_EVENT))
+
+    if (wasOptedOut) {
+      posthog.capture("$pageview", { $current_url: window.location.href })
+    }
+  } else {
+    if (!posthog.has_opted_out_capturing()) {
+      posthog.opt_out_capturing()
+    }
+  }
+}
 
 interface ConsentSettings {
   analytics_storage: boolean;
@@ -55,6 +82,15 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
     const hasConsent = localStorage.getItem("cookieConsent")
     if (!hasConsent) {
       setIsVisible(true)
+    } else {
+      try {
+        const savedSettings = JSON.parse(hasConsent) as ConsentSettings
+        setSettings(savedSettings)
+        syncPostHogConsent(savedSettings.analytics_storage)
+      } catch {
+        localStorage.removeItem("cookieConsent")
+        setIsVisible(true)
+      }
     }
 
     // Add keyboard shortcut for dev mode (Cmd/Ctrl + Shift + K)
@@ -104,6 +140,7 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
 
   const saveConsent = (consentSettings: ConsentSettings) => {
     localStorage.setItem("cookieConsent", JSON.stringify(consentSettings))
+    syncPostHogConsent(consentSettings.analytics_storage)
     window.gtag?.("consent", "update", {
       analytics_storage: consentSettings.analytics_storage ? "granted" : "denied",
       ad_storage: consentSettings.ad_storage ? "granted" : "denied",

--- a/components/posthog-identity.tsx
+++ b/components/posthog-identity.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import posthog from "posthog-js";
+
+const CONSENT_EVENT = "deltalytix:analytics-consent";
+
+export function PostHogIdentity({
+  email,
+  language,
+  userId,
+}: {
+  email: string;
+  language: string;
+  userId: string;
+}) {
+  const identify = useCallback(() => {
+    if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return;
+    if (posthog.has_opted_out_capturing()) return;
+
+    posthog.identify(userId, {
+      email,
+      language,
+    });
+  }, [email, language, userId]);
+
+  useEffect(() => {
+    identify();
+    window.addEventListener(CONSENT_EVENT, identify);
+    return () => window.removeEventListener(CONSENT_EVENT, identify);
+  }, [identify]);
+
+  return null;
+}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -20,7 +20,7 @@ if (projectToken) {
     defaults: "2026-05-30",
     person_profiles: "identified_only",
     opt_out_capturing_by_default: !hasAnalyticsConsent(),
-    opt_out_capturing_persistence_type: "local_storage",
+    opt_out_capturing_persistence_type: "localStorage",
     autocapture: false,
     capture_pageview: true,
     capture_pageleave: true,

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,31 @@
+import posthog from "posthog-js";
+
+const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+const apiHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
+
+function hasAnalyticsConsent() {
+  try {
+    const storedConsent = localStorage.getItem("cookieConsent");
+    if (!storedConsent) return false;
+
+    return JSON.parse(storedConsent).analytics_storage === true;
+  } catch {
+    return false;
+  }
+}
+
+if (projectToken) {
+  posthog.init(projectToken, {
+    api_host: apiHost,
+    defaults: "2026-05-30",
+    person_profiles: "identified_only",
+    opt_out_capturing_by_default: !hasAnalyticsConsent(),
+    opt_out_capturing_persistence_type: "local_storage",
+    autocapture: false,
+    capture_pageview: true,
+    capture_pageleave: true,
+    disable_session_recording: true,
+  });
+}
+
+export { posthog };

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent";
+
+type PostHogProperties = Record<string, boolean | number | string | null | undefined>;
+
+export async function hasAnalyticsConsent(): Promise<boolean> {
+  try {
+    return (await cookies()).get(ANALYTICS_CONSENT_COOKIE)?.value === "granted";
+  } catch {
+    return false;
+  }
+}
+
+export async function capturePostHogEvent({
+  consentGranted = false,
+  distinctId,
+  event,
+  properties = {},
+}: {
+  consentGranted?: boolean;
+  distinctId: string;
+  event: string;
+  properties?: PostHogProperties;
+}) {
+  const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+  if (!projectToken || (!consentGranted && !(await hasAnalyticsConsent()))) return;
+
+  const apiHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
+
+  try {
+    const response = await fetch(`${apiHost.replace(/\/$/, "")}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: projectToken,
+        event,
+        properties: {
+          distinct_id: distinctId,
+          $lib: "deltalytix-server",
+          ...properties,
+        },
+      }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(2_000),
+    });
+
+    if (!response.ok) {
+      console.warn(`[PostHog] Failed to capture ${event}: ${response.status}`);
+    }
+  } catch (error) {
+    console.warn(`[PostHog] Failed to capture ${event}`, error);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "pdf2json": "^3.2.2",
     "pg": "^8.17.2",
     "playwright-core": "^1.56.1",
+    "posthog-js": "^1.403.0",
     "prisma": "^7.3.0",
     "radix-ui": "^1.6.0",
     "react": "19.2.1",

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/local-dashboard-auth'
 import { createLocalDashboardBypassAuthStub } from '@/lib/local-dashboard-bypass-client'
 import { ensureLocalDashboardUserInDatabase } from '@/server/local-dashboard-bootstrap'
+import { capturePostHogEvent } from '@/lib/posthog-server'
 
 export async function getWebsiteURL() {
   let url =
@@ -492,6 +493,15 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
         },
       });
       console.log('[ensureUserInDatabase] SUCCESS: New user created successfully');
+
+      await capturePostHogEvent({
+        distinctId: user.id,
+        event: 'user_signed_up',
+        properties: {
+          auth_provider: user.app_metadata?.provider || 'unknown',
+          language: locale || 'en',
+        },
+      });
       
       // Create default dashboard layout for new user
       try {

--- a/server/database.ts
+++ b/server/database.ts
@@ -10,6 +10,7 @@ import { unstable_cache } from 'next/cache'
 import { defaultLayouts } from '@/lib/default-layouts'
 import { formatTimestamp } from '@/lib/date-utils'
 import { v5 as uuidv5 } from 'uuid'
+import { capturePostHogEvent } from '@/lib/posthog-server'
 
 type TradeError =
   | 'DUPLICATE_TRADES'
@@ -84,6 +85,11 @@ export async function saveTradesAction(
   }
 
   try {
+    const hadExistingTrades = Boolean(await prisma.trade.findFirst({
+      where: { userId },
+      select: { id: true },
+    }))
+
     // Clean the data to remove undefined values and ensure all required fields are present
     const userAssignedTrades = data.map(trade => {
 
@@ -131,6 +137,34 @@ export async function saveTradesAction(
       updateTag(`trades-${userId}`)
     } catch {
       revalidateTag(`trades-${userId}`, { expire: 0 })
+    }
+
+    if (result.count > 0) {
+      const sources = Array.from(new Set(
+        userAssignedTrades.flatMap((trade) => trade.tags ?? [])
+      ))
+
+      await capturePostHogEvent({
+        distinctId: userId,
+        event: 'trades_imported',
+        properties: {
+          imported_trade_count: result.count,
+          attempted_trade_count: data.length,
+          import_sources: sources.join(','),
+          is_first_import: !hadExistingTrades,
+        },
+      })
+
+      if (!hadExistingTrades) {
+        await capturePostHogEvent({
+          distinctId: userId,
+          event: 'first_trade_imported',
+          properties: {
+            imported_trade_count: result.count,
+            import_sources: sources.join(','),
+          },
+        })
+      }
     }
 
     return {


### PR DESCRIPTION
## What changed

- Reconnects the existing PostHog EU project using the current Next.js client instrumentation entrypoint.
- Keeps analytics opted out until the existing consent banner grants analytics storage.
- Disables broad autocapture and session replay to avoid collecting trading data unintentionally.
- Identifies authenticated users by Supabase UUID after consent.
- Captures the growth funnel:
  - `user_signed_up`
  - `integration_connected` for Rithmic, Tradovate, and DxFeed
  - `first_trade_imported` and `trades_imported`
  - `checkout_started`
  - Stripe-confirmed `subscription_purchased`
- Passes consent and the PostHog distinct ID through Stripe Checkout metadata so confirmed revenue is attributed to the correct consented user.
- Adds a two-second timeout and non-fatal error handling around server-side analytics.
- Removes the old commented inline PostHog snippet.

## Why

Supabase and Stripe show account and payment state but do not preserve landing-page, referrer, or UTM attribution. This reconnects product analytics so future subscriptions can be traced from acquisition through activation and purchase.

## Deployment configuration

Add these public environment variables to Preview and Production:

```env
NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<existing Deltalytix project token>
NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
```

## Validation

- `bun run typecheck` passes.
- New PostHog modules pass targeted ESLint.
- Next.js production compilation succeeds. Local page-data collection then requires a real database connection and cannot complete with the placeholder verification URL.
- `git diff --check` passes.

A pinned PostHog dashboard named **Deltalytix acquisition & conversion** has also been created. Funnel insights can be added after the first new events are ingested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe checkout metadata and webhook analytics plus user identification (email), but events are gated on consent and failures are non-blocking; core payment/subscription logic is unchanged aside from optional metadata.
> 
> **Overview**
> Reconnects **PostHog (EU)** with a privacy-first setup: client init via `instrumentation-client.ts` and `posthog-js`, default opt-out until the consent banner grants analytics, **no autocapture/session replay**, and removal of the old commented inline snippet.
> 
> The consent banner now drives PostHog opt-in/out, sets a `deltalytix_analytics_consent` cookie, and re-applies consent on return visits. Authenticated dashboard users are identified through **`PostHogIdentity`** (Supabase UUID, email, locale) only when capturing is allowed.
> 
> Adds **`lib/posthog-server`** for consent-aware server captures (2s timeout, non-fatal failures) and wires growth events across signup, broker connections (Rithmic/Tradovate/DxFeed `integration_connected` with `is_first_connection`), trade imports (`trades_imported` / `first_trade_imported`), **`checkout_started`**, and Stripe-confirmed **`subscription_purchased`** (with `$insert_id` dedup). Checkout session metadata carries analytics consent and `posthog_distinct_id` so webhook revenue events attribute to the right user.
> 
> **`.env.example`** documents `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` and `NEXT_PUBLIC_POSTHOG_HOST`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0041aad81c69a3e9e445f4de20aee1bc013e6fb1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->