### PR TITLE
Align OG images with dark landing design language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ WARP.md
 *.pem
 wip
 /private/
+/tmp/
 
 # debug
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ datafeeds/
 
 # Lock files
 !bun.lock
+og-preview-artifacts/

--- a/app/[locale]/(landing)/ref/[ref]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/ref/[ref]/opengraph-image.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/lib/og/referral-opengraph";
 import { isValidReferralSlug } from "@/lib/referral-url";
 
-export const alt = "Deltalytix Referral";
+export const alt = "Deltalytix referral — Sign up with an invite code";
 export const size = referralOgSize;
 export const contentType = "image/png";
 

--- a/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
@@ -3,9 +3,20 @@ import { getPostMetadata } from "@/lib/mdx"
 import type { ReactElement } from "react"
 import { enUS, fr } from "date-fns/locale"
 import { formatDateOnly } from "@/lib/format-date-only"
-import { OgCtaButton, ogImageCacheHeaders } from "@/lib/og/shared"
+import {
+  BrandLockup,
+  LandingAtmosphere,
+  OgCtaButton,
+  loadLandingProductPosterSrc,
+  ogImageCacheHeaders,
+} from "@/lib/og/shared"
 import { getUpdatesOgCopy } from "@/lib/og/site-metadata"
-import { OG_COLORS, OG_PADDING, OG_TRACKING } from "@/lib/og/tokens"
+import {
+  OG_COLORS,
+  OG_FONT_FAMILY,
+  OG_PADDING,
+  OG_TRACKING,
+} from "@/lib/og/tokens"
 
 export const alt = "Deltalytix Update"
 export const size = {
@@ -40,6 +51,7 @@ export default async function Image({
         })
 
         const updatesCopy = getUpdatesOgCopy(locale)
+        const productSrc = await loadLandingProductPosterSrc()
 
         const element = (
             <div
@@ -48,80 +60,60 @@ export default async function Image({
                     width: "100%",
                     height: "100%",
                     background: OG_COLORS.background,
-                    fontFamily: "system-ui, -apple-system, sans-serif",
+                    fontFamily: OG_FONT_FAMILY,
                     padding: `${OG_PADDING}px`,
                     flexDirection: "column",
                     justifyContent: "space-between",
                     alignItems: "flex-start",
+                    position: "relative",
                 }}
             >
-                {/* Top section with logo */}
-                <div
-                    style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "12px",
-                    }}
-                >
-                    <svg viewBox="0 0 255 255" xmlns="http://www.w3.org/2000/svg" style={{ width: "32px", height: "32px" }}>
-                        <path fillRule="evenodd" clipRule="evenodd" d="M159 63L127.5 0V255H255L236.5 218H159V63Z" fill={OG_COLORS.foreground} />
-                        <path fillRule="evenodd" clipRule="evenodd" d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z" fill={OG_COLORS.foreground} />
-                    </svg>
-                    <span
-                        style={{
-                            fontSize: "24px",
-                            fontWeight: "600",
-                            color: OG_COLORS.foreground,
-                            letterSpacing: OG_TRACKING.snug,
-                        }}
-                    >
-                        Deltalytix
-                    </span>
-                </div>
+                <LandingAtmosphere width={340} height={230} productSrc={productSrc} />
 
-                {/* Middle section with title */}
+                <BrandLockup logoSize={36} fontSize={26} />
+
                 <div
                     style={{
                         display: "flex",
                         flexDirection: "column",
-                        gap: "16px",
-                        maxWidth: "900px",
+                        gap: "20px",
+                        maxWidth: "760px",
+                        position: "relative",
                     }}
                 >
                     <h1
                         style={{
-                            fontSize: "56px",
-                            fontWeight: "700",
+                            fontSize: "52px",
+                            fontWeight: 400,
                             color: OG_COLORS.foreground,
                             margin: "0",
-                            lineHeight: "1.15",
-                            letterSpacing: OG_TRACKING.tight,
+                            lineHeight: "1.12",
+                            letterSpacing: OG_TRACKING.display,
                         }}
                     >
                         {meta.title}
                     </h1>
                 </div>
 
-                {/* Bottom section with date and CTA */}
                 <div
                     style={{
                         display: "flex",
-                        width: "100%",
-                        alignItems: "center",
-                        justifyContent: "space-between",
+                        flexDirection: "column",
+                        gap: 20,
+                        position: "relative",
                     }}
                 >
+                    <OgCtaButton label={updatesCopy.cta} />
                     <span
                         style={{
-                            fontSize: "18px",
-                            fontWeight: "400",
-                            color: OG_COLORS.muted,
+                            fontSize: "20px",
+                            fontWeight: 400,
+                            color: OG_COLORS.subtle,
                             letterSpacing: OG_TRACKING.wide,
                         }}
                     >
                         {formattedDate}
                     </span>
-                    <OgCtaButton label={updatesCopy.cta} accentColor={OG_COLORS.accent} />
                 </div>
             </div>
         ) as ReactElement

--- a/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
@@ -7,7 +7,6 @@ import {
   BrandLockup,
   LandingAtmosphere,
   OgCtaButton,
-  loadLandingProductPosterSrc,
   ogImageCacheHeaders,
 } from "@/lib/og/shared"
 import { getUpdatesOgCopy } from "@/lib/og/site-metadata"
@@ -51,7 +50,6 @@ export default async function Image({
         })
 
         const updatesCopy = getUpdatesOgCopy(locale)
-        const productSrc = await loadLandingProductPosterSrc()
 
         const element = (
             <div
@@ -68,7 +66,7 @@ export default async function Image({
                     position: "relative",
                 }}
             >
-                <LandingAtmosphere width={340} height={230} productSrc={productSrc} />
+                <LandingAtmosphere width={340} height={230} />
 
                 <BrandLockup logoSize={36} fontSize={26} />
 

--- a/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
@@ -66,7 +66,7 @@ export default async function Image({
                     position: "relative",
                 }}
             >
-                <LandingAtmosphere width={340} height={230} />
+                <LandingAtmosphere />
 
                 <BrandLockup logoSize={36} fontSize={26} />
 

--- a/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
@@ -87,6 +87,10 @@ export default async function Image({
                             margin: "0",
                             lineHeight: "1.12",
                             letterSpacing: OG_TRACKING.display,
+                            display: "-webkit-box",
+                            WebkitBoxOrient: "vertical",
+                            WebkitLineClamp: 2,
+                            overflow: "hidden",
                         }}
                     >
                         {meta.title}

--- a/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
+++ b/app/[locale]/(landing)/updates/[slug]/opengraph-image.tsx
@@ -17,7 +17,7 @@ import {
   OG_TRACKING,
 } from "@/lib/og/tokens"
 
-export const alt = "Deltalytix Update"
+export const alt = "Deltalytix product update — Read the Changelog"
 export const size = {
     width: 1200,
     height: 630,

--- a/app/opengraph-image.alt.txt
+++ b/app/opengraph-image.alt.txt
@@ -1,1 +1,1 @@
-Deltalytix trading analytics dashboard — Get Started Free
+Deltalytix trading analytics dashboard — Get Started

--- a/app/opengraph-image.alt.txt
+++ b/app/opengraph-image.alt.txt
@@ -1,1 +1,1 @@
-Deltalytix trading analytics dashboard — Get Started
+Deltalytix — Master your trading journey. Trading analytics for futures traders. Get Started.

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,14 +1,14 @@
 import { createMarketingOgImageResponse } from "@/lib/og/shared";
 import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 
-export const alt = "Deltalytix trading analytics dashboard — Get Started Free";
+export const alt = "Deltalytix trading analytics dashboard — Get Started";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
 export const runtime = "nodejs";
 export const revalidate = 3600;
 
-export default function Image() {
+export default async function Image() {
   const copy = getSiteMetadataCopy("en");
 
   return createMarketingOgImageResponse({

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { createMarketingOgImageResponse } from "@/lib/og/shared";
 import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 
-export const alt = "Deltalytix trading analytics dashboard — Get Started";
+export const alt = "Deltalytix — Master your trading journey. Trading analytics for futures traders. Get Started.";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/app/twitter-image.alt.txt
+++ b/app/twitter-image.alt.txt
@@ -1,1 +1,1 @@
-Deltalytix trading analytics dashboard — Get Started Free
+Deltalytix trading analytics dashboard — Get Started

--- a/app/twitter-image.alt.txt
+++ b/app/twitter-image.alt.txt
@@ -1,1 +1,1 @@
-Deltalytix trading analytics dashboard — Get Started
+Deltalytix — Master your trading journey. Trading analytics for futures traders. Get Started.

--- a/lib/og/referral-opengraph.tsx
+++ b/lib/og/referral-opengraph.tsx
@@ -8,6 +8,8 @@ import {
   ogImageSize,
 } from "@/lib/og/shared";
 import {
+  OG_CARD_PADDING_X,
+  OG_CARD_PADDING_Y,
   OG_COLORS,
   OG_FONT_FAMILY,
   OG_PADDING,
@@ -74,7 +76,7 @@ export function ReferralOgImage({
             display: "flex",
             alignItems: "center",
             alignSelf: "flex-start",
-            padding: "20px 32px",
+            padding: `${OG_CARD_PADDING_Y}px ${OG_CARD_PADDING_X}px`,
             borderRadius: OG_RADIUS.sm,
             border: `1px solid ${OG_COLORS.hairline}`,
             background: OG_COLORS.surface,

--- a/lib/og/referral-opengraph.tsx
+++ b/lib/og/referral-opengraph.tsx
@@ -4,7 +4,6 @@ import {
   BrandLockup,
   LandingAtmosphere,
   OgCtaButton,
-  loadLandingProductPosterSrc,
   ogImageCacheHeaders,
   ogImageSize,
 } from "@/lib/og/shared";
@@ -23,7 +22,6 @@ type ReferralOgImageProps = {
   joinLabel: string;
   tagline: string;
   cta: string;
-  productSrc?: string;
 };
 
 export function ReferralOgImage({
@@ -31,7 +29,6 @@ export function ReferralOgImage({
   joinLabel,
   tagline,
   cta,
-  productSrc,
 }: ReferralOgImageProps) {
   return (
     <div
@@ -47,7 +44,7 @@ export function ReferralOgImage({
         justifyContent: "space-between",
       }}
     >
-      <LandingAtmosphere width={380} height={250} productSrc={productSrc} />
+      <LandingAtmosphere width={380} height={250} />
 
       <BrandLockup />
 
@@ -128,7 +125,7 @@ export function ReferralOgImage({
   ) as ReactElement;
 }
 
-export async function createReferralOgImageResponse({
+export function createReferralOgImageResponse({
   ref,
   joinLabel,
   tagline,
@@ -139,15 +136,12 @@ export async function createReferralOgImageResponse({
   tagline: string;
   cta: string;
 }) {
-  const productSrc = await loadLandingProductPosterSrc();
-
   return new ImageResponse(
     <ReferralOgImage
       ref={ref}
       joinLabel={joinLabel}
       tagline={tagline}
       cta={cta}
-      productSrc={productSrc}
     />,
     {
       ...referralOgSize,

--- a/lib/og/referral-opengraph.tsx
+++ b/lib/og/referral-opengraph.tsx
@@ -44,7 +44,7 @@ export function ReferralOgImage({
         justifyContent: "space-between",
       }}
     >
-      <LandingAtmosphere width={380} height={250} />
+      <LandingAtmosphere />
 
       <BrandLockup />
 

--- a/lib/og/referral-opengraph.tsx
+++ b/lib/og/referral-opengraph.tsx
@@ -2,77 +2,36 @@ import { ImageResponse } from "next/og";
 import type { ReactElement } from "react";
 import {
   BrandLockup,
+  LandingAtmosphere,
   OgCtaButton,
+  loadLandingProductPosterSrc,
   ogImageCacheHeaders,
   ogImageSize,
 } from "@/lib/og/shared";
+import {
+  OG_COLORS,
+  OG_FONT_FAMILY,
+  OG_PADDING,
+  OG_RADIUS,
+  OG_TRACKING,
+} from "@/lib/og/tokens";
 
 export const referralOgSize = ogImageSize;
 
-function hslToHex(h: number, s: number, l: number): string {
-  s /= 100;
-  l /= 100;
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const m = l - c / 2;
-  let r = 0;
-  let g = 0;
-  let b = 0;
-
-  if (h < 60) {
-    r = c;
-    g = x;
-  } else if (h < 120) {
-    r = x;
-    g = c;
-  } else if (h < 180) {
-    g = c;
-    b = x;
-  } else if (h < 240) {
-    g = x;
-    b = c;
-  } else if (h < 300) {
-    r = x;
-    b = c;
-  } else {
-    r = c;
-    b = x;
-  }
-
-  r = Math.round((r + m) * 255);
-  g = Math.round((g + m) * 255);
-  b = Math.round((b + m) * 255);
-
-  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
-}
-
-export function generateReferralAccentColor(ref: string): string {
-  let hash = 0;
-  for (let i = 0; i < ref.length; i++) {
-    hash = ref.charCodeAt(i) + ((hash << 5) - hash);
-  }
-
-  const hue = Math.abs(hash % 360);
-  const saturation = 60 + (Math.abs(hash >> 8) % 30);
-  const lightness = 50 + (Math.abs(hash >> 16) % 20);
-
-  return hslToHex(hue, saturation, lightness);
-}
-
 type ReferralOgImageProps = {
   ref: string;
-  accentColor: string;
   joinLabel: string;
   tagline: string;
   cta: string;
+  productSrc?: string;
 };
 
 export function ReferralOgImage({
   ref,
-  accentColor,
   joinLabel,
   tagline,
   cta,
+  productSrc,
 }: ReferralOgImageProps) {
   return (
     <div
@@ -80,36 +39,15 @@ export function ReferralOgImage({
         display: "flex",
         width: "100%",
         height: "100%",
-        background: "#0a0a0a",
-        fontFamily: "system-ui, -apple-system, sans-serif",
+        background: OG_COLORS.background,
+        fontFamily: OG_FONT_FAMILY,
         position: "relative",
-        padding: "56px 72px",
+        padding: `${OG_PADDING}px`,
         flexDirection: "column",
         justifyContent: "space-between",
       }}
     >
-      <div
-        style={{
-          position: "absolute",
-          top: -100,
-          right: -100,
-          width: 480,
-          height: 480,
-          background: `radial-gradient(circle, ${accentColor}55 0%, rgba(10, 10, 10, 0) 72%)`,
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: -60,
-          left: -60,
-          width: 320,
-          height: 320,
-          background: "radial-gradient(circle, rgba(59, 130, 246, 0.25) 0%, rgba(10, 10, 10, 0) 70%)",
-          display: "flex",
-        }}
-      />
+      <LandingAtmosphere width={380} height={250} productSrc={productSrc} />
 
       <BrandLockup />
 
@@ -117,17 +55,18 @@ export function ReferralOgImage({
         style={{
           display: "flex",
           flexDirection: "column",
-          gap: 28,
-          maxWidth: 900,
+          gap: 24,
+          maxWidth: 820,
+          position: "relative",
         }}
       >
         <p
           style={{
             margin: 0,
-            fontSize: 28,
-            fontWeight: 500,
-            color: "#a1a1aa",
-            letterSpacing: "-0.01em",
+            fontSize: 24,
+            fontWeight: 400,
+            color: OG_COLORS.muted,
+            letterSpacing: OG_TRACKING.snug,
           }}
         >
           {joinLabel}
@@ -138,19 +77,18 @@ export function ReferralOgImage({
             display: "flex",
             alignItems: "center",
             alignSelf: "flex-start",
-            padding: "28px 40px",
-            borderRadius: 20,
-            border: `3px solid ${accentColor}`,
-            background: "rgba(255, 255, 255, 0.04)",
-            boxShadow: `0 0 60px ${accentColor}33`,
+            padding: "20px 32px",
+            borderRadius: OG_RADIUS.sm,
+            border: `1px solid ${OG_COLORS.hairline}`,
+            background: OG_COLORS.surface,
           }}
         >
           <span
             style={{
-              fontSize: 80,
-              fontWeight: 800,
-              color: "#FFFFFF",
-              letterSpacing: "0.12em",
+              fontSize: 64,
+              fontWeight: 500,
+              color: OG_COLORS.foreground,
+              letterSpacing: "0.08em",
               textTransform: "uppercase",
             }}
           >
@@ -161,25 +99,27 @@ export function ReferralOgImage({
         <p
           style={{
             margin: 0,
-            fontSize: 34,
-            fontWeight: 600,
-            color: "#f4f4f5",
+            fontSize: 32,
+            fontWeight: 400,
+            color: OG_COLORS.foreground,
             lineHeight: 1.3,
-            letterSpacing: "-0.02em",
+            letterSpacing: OG_TRACKING.tight,
+            maxWidth: 700,
           }}
         >
           {tagline}
         </p>
 
-        <OgCtaButton label={cta} accentColor={accentColor} />
+        <OgCtaButton label={cta} />
       </div>
 
       <p
         style={{
           margin: 0,
-          fontSize: 22,
-          fontWeight: 500,
-          color: "#71717a",
+          fontSize: 20,
+          fontWeight: 400,
+          color: OG_COLORS.subtle,
+          position: "relative",
         }}
       >
         deltalytix.app
@@ -188,7 +128,7 @@ export function ReferralOgImage({
   ) as ReactElement;
 }
 
-export function createReferralOgImageResponse({
+export async function createReferralOgImageResponse({
   ref,
   joinLabel,
   tagline,
@@ -199,15 +139,15 @@ export function createReferralOgImageResponse({
   tagline: string;
   cta: string;
 }) {
-  const accentColor = generateReferralAccentColor(ref);
+  const productSrc = await loadLandingProductPosterSrc();
 
   return new ImageResponse(
     <ReferralOgImage
       ref={ref}
-      accentColor={accentColor}
       joinLabel={joinLabel}
       tagline={tagline}
       cta={cta}
+      productSrc={productSrc}
     />,
     {
       ...referralOgSize,

--- a/lib/og/shared.tsx
+++ b/lib/og/shared.tsx
@@ -1,5 +1,3 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
 import { ImageResponse } from "next/og";
 import type { ReactElement } from "react";
 import {
@@ -9,14 +7,6 @@ import {
   OG_RADIUS,
   OG_TRACKING,
 } from "@/lib/og/tokens";
-
-/** Light-theme dashboard poster used in the landing hero frame. */
-export async function loadLandingProductPosterSrc(): Promise<string> {
-  const buffer = await readFile(
-    join(process.cwd(), "public/videos/demo_white_poster.png"),
-  );
-  return `data:image/png;base64,${buffer.toString("base64")}`;
-}
 
 export const ogImageSize = { width: 1200, height: 630 };
 
@@ -121,24 +111,111 @@ export function OgCtaButton({
   );
 }
 
+/** Stylized daily P&L bars — no labels, no axes, no numbers. */
+const OG_BAR_HEIGHTS = [
+  0.42, 0.68, -0.28, 0.55, 0.22, -0.48, 0.78, 0.35, -0.18, 0.62, 0.48, -0.32,
+  0.85, 0.3, -0.55, 0.58, 0.72, 0.18, -0.25, 0.92,
+] as const;
+
+function barColor(value: number): string {
+  if (value > 0.05) return OG_COLORS.chartWin;
+  if (value < -0.05) return OG_COLORS.chartLoss;
+  return OG_COLORS.chartNeutral;
+}
+
+export function OgBarChart({
+  width = 420,
+  height = 280,
+}: {
+  width?: number;
+  height?: number;
+} = {}) {
+  const gap = 8;
+  const barWidth = Math.floor(
+    (width - gap * (OG_BAR_HEIGHTS.length - 1)) / OG_BAR_HEIGHTS.length,
+  );
+  const midY = height / 2;
+  const maxBar = midY - 8;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        width,
+        height,
+        alignItems: "center",
+        justifyContent: "center",
+        position: "relative",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          top: midY,
+          height: 1,
+          background: OG_COLORS.hairline,
+          display: "flex",
+        }}
+      />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          height: "100%",
+          gap,
+        }}
+      >
+        {OG_BAR_HEIGHTS.map((value, index) => {
+          const barH = Math.max(6, Math.abs(value) * maxBar);
+          const isPositive = value >= 0;
+          return (
+            <div
+              key={index}
+              style={{
+                display: "flex",
+                width: barWidth,
+                height: "100%",
+                alignItems: isPositive ? "flex-end" : "flex-start",
+                paddingTop: isPositive ? 0 : midY,
+                paddingBottom: isPositive ? midY : 0,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  width: "100%",
+                  height: barH,
+                  borderRadius: OG_RADIUS.sm,
+                  background: barColor(value),
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 /**
- * Soft mint product-frame echo of the landing hero demo.
- * Keep it behind left-aligned copy; size props tune per OG variant.
+ * Right-side visual: mint-washed frame wrapping a text-free bar chart.
  */
 export function LandingAtmosphere({
   width = 420,
   height = 280,
   right = 48,
   bottom = 40,
-  productSrc,
 }: {
   width?: number;
   height?: number;
   right?: number;
   bottom?: number;
-  /** Optional data URL / absolute URL of the hero product poster. */
-  productSrc?: string;
 } = {}) {
+  const chartWidth = width - 48;
+  const chartHeight = height - 48;
+
   return (
     <div
       style={{
@@ -150,7 +227,7 @@ export function LandingAtmosphere({
         borderRadius: OG_RADIUS.md,
         background: OG_COLORS.wash,
         display: "flex",
-        padding: 14,
+        padding: 12,
       }}
     >
       <div
@@ -161,23 +238,11 @@ export function LandingAtmosphere({
           borderRadius: OG_RADIUS.sm,
           background: OG_COLORS.surface,
           border: `1px solid ${OG_COLORS.hairline}`,
-          overflow: "hidden",
+          alignItems: "center",
+          justifyContent: "center",
         }}
       >
-        {productSrc ? (
-          <img
-            src={productSrc}
-            alt=""
-            width={width}
-            height={height}
-            style={{
-              width: "100%",
-              height: "100%",
-              objectFit: "cover",
-              objectPosition: "left top",
-            }}
-          />
-        ) : null}
+        <OgBarChart width={chartWidth} height={chartHeight} />
       </div>
     </div>
   );
@@ -187,7 +252,6 @@ type MarketingOgImageProps = {
   headline: string;
   subheadline: string;
   cta: string;
-  productSrc?: string;
   /** @deprecated Kept for call-site compat; landing CTA color is used instead. */
   accentColor?: string;
 };
@@ -196,7 +260,6 @@ export function MarketingOgImage({
   headline,
   subheadline,
   cta,
-  productSrc,
 }: MarketingOgImageProps) {
   return (
     <div
@@ -212,13 +275,7 @@ export function MarketingOgImage({
         justifyContent: "space-between",
       }}
     >
-      <LandingAtmosphere
-        width={520}
-        height={340}
-        right={40}
-        bottom={36}
-        productSrc={productSrc}
-      />
+      <LandingAtmosphere width={520} height={340} right={40} bottom={36} />
 
       <BrandLockup />
 
@@ -274,21 +331,18 @@ export function MarketingOgImage({
   ) as ReactElement;
 }
 
-export async function createMarketingOgImageResponse({
+export function createMarketingOgImageResponse({
   headline,
   subheadline,
   cta,
   accentColor,
 }: MarketingOgImageProps) {
-  const productSrc = await loadLandingProductPosterSrc();
-
   return new ImageResponse(
     <MarketingOgImage
       headline={headline}
       subheadline={subheadline}
       cta={cta}
       accentColor={accentColor}
-      productSrc={productSrc}
     />,
     {
       ...ogImageSize,

--- a/lib/og/shared.tsx
+++ b/lib/og/shared.tsx
@@ -2,6 +2,8 @@ import { ImageResponse } from "next/og";
 import type { ReactElement } from "react";
 import {
   OG_COLORS,
+  OG_CTA_PADDING_X,
+  OG_CTA_PADDING_Y,
   OG_FONT_FAMILY,
   OG_PADDING,
   OG_RADIUS,
@@ -92,7 +94,7 @@ export function OgCtaButton({
         display: "flex",
         alignItems: "center",
         alignSelf: "flex-start",
-        padding: "16px 28px",
+        padding: `${OG_CTA_PADDING_Y}px ${OG_CTA_PADDING_X}px`,
         borderRadius: OG_RADIUS.sm,
         background: accentColor,
       }}
@@ -249,8 +251,6 @@ type MarketingOgImageProps = {
   headline: string;
   subheadline: string;
   cta: string;
-  /** @deprecated Kept for call-site compat; landing CTA color is used instead. */
-  accentColor?: string;
 };
 
 export function MarketingOgImage({
@@ -332,14 +332,12 @@ export function createMarketingOgImageResponse({
   headline,
   subheadline,
   cta,
-  accentColor,
 }: MarketingOgImageProps) {
   return new ImageResponse(
     <MarketingOgImage
       headline={headline}
       subheadline={subheadline}
       cta={cta}
-      accentColor={accentColor}
     />,
     {
       ...ogImageSize,

--- a/lib/og/shared.tsx
+++ b/lib/og/shared.tsx
@@ -1,5 +1,22 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { ImageResponse } from "next/og";
 import type { ReactElement } from "react";
+import {
+  OG_COLORS,
+  OG_FONT_FAMILY,
+  OG_PADDING,
+  OG_RADIUS,
+  OG_TRACKING,
+} from "@/lib/og/tokens";
+
+/** Light-theme dashboard poster used in the landing hero frame. */
+export async function loadLandingProductPosterSrc(): Promise<string> {
+  const buffer = await readFile(
+    join(process.cwd(), "public/videos/demo_white_poster.png"),
+  );
+  return `data:image/png;base64,${buffer.toString("base64")}`;
+}
 
 export const ogImageSize = { width: 1200, height: 630 };
 
@@ -9,7 +26,13 @@ export const ogImageCacheHeaders = {
   "Vercel-CDN-Cache-Control": "public, max-age=3600",
 } as const;
 
-export function LogoMark({ sizePx = 40 }: { sizePx?: number }) {
+export function LogoMark({
+  sizePx = 40,
+  color = OG_COLORS.foreground,
+}: {
+  sizePx?: number;
+  color?: string;
+}) {
   return (
     <svg
       viewBox="0 0 255 255"
@@ -20,24 +43,26 @@ export function LogoMark({ sizePx = 40 }: { sizePx?: number }) {
         fillRule="evenodd"
         clipRule="evenodd"
         d="M159 63L127.5 0V255H255L236.5 218H159V63Z"
-        fill="#FFFFFF"
+        fill={color}
       />
       <path
         fillRule="evenodd"
         clipRule="evenodd"
         d="M-3.05176e-05 255L127.5 -5.96519e-06L127.5 255L-3.05176e-05 255ZM64 217L121 104L121 217L64 217Z"
-        fill="#FFFFFF"
+        fill={color}
       />
     </svg>
   );
 }
 
 export function BrandLockup({
-  logoSize = 40,
-  fontSize = 28,
+  logoSize = 44,
+  fontSize = 32,
+  color = OG_COLORS.foreground,
 }: {
   logoSize?: number;
   fontSize?: number;
+  color?: string;
 }) {
   return (
     <div
@@ -47,13 +72,13 @@ export function BrandLockup({
         gap: 14,
       }}
     >
-      <LogoMark sizePx={logoSize} />
+      <LogoMark sizePx={logoSize} color={color} />
       <span
         style={{
           fontSize,
-          fontWeight: 700,
-          color: "#FFFFFF",
-          letterSpacing: "-0.03em",
+          fontWeight: 500,
+          color,
+          letterSpacing: OG_TRACKING.tight,
         }}
       >
         Deltalytix
@@ -64,10 +89,12 @@ export function BrandLockup({
 
 export function OgCtaButton({
   label,
-  accentColor = "#14B8A6",
+  accentColor = OG_COLORS.cta,
+  textColor = OG_COLORS.ctaText,
 }: {
   label: string;
   accentColor?: string;
+  textColor?: string;
 }) {
   return (
     <div
@@ -75,18 +102,17 @@ export function OgCtaButton({
         display: "flex",
         alignItems: "center",
         alignSelf: "flex-start",
-        padding: "18px 32px",
-        borderRadius: 999,
+        padding: "16px 28px",
+        borderRadius: OG_RADIUS.sm,
         background: accentColor,
-        boxShadow: `0 12px 40px ${accentColor}66`,
       }}
     >
       <span
         style={{
-          fontSize: 28,
-          fontWeight: 700,
-          color: "#FFFFFF",
-          letterSpacing: "-0.01em",
+          fontSize: 24,
+          fontWeight: 500,
+          color: textColor,
+          letterSpacing: OG_TRACKING.snug,
         }}
       >
         {label}
@@ -95,10 +121,74 @@ export function OgCtaButton({
   );
 }
 
+/**
+ * Soft mint product-frame echo of the landing hero demo.
+ * Keep it behind left-aligned copy; size props tune per OG variant.
+ */
+export function LandingAtmosphere({
+  width = 420,
+  height = 280,
+  right = 48,
+  bottom = 40,
+  productSrc,
+}: {
+  width?: number;
+  height?: number;
+  right?: number;
+  bottom?: number;
+  /** Optional data URL / absolute URL of the hero product poster. */
+  productSrc?: string;
+} = {}) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        right,
+        bottom,
+        width,
+        height,
+        borderRadius: OG_RADIUS.md,
+        background: OG_COLORS.wash,
+        display: "flex",
+        padding: 14,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          width: "100%",
+          height: "100%",
+          borderRadius: OG_RADIUS.sm,
+          background: OG_COLORS.surface,
+          border: `1px solid ${OG_COLORS.hairline}`,
+          overflow: "hidden",
+        }}
+      >
+        {productSrc ? (
+          <img
+            src={productSrc}
+            alt=""
+            width={width}
+            height={height}
+            style={{
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+              objectPosition: "left top",
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 type MarketingOgImageProps = {
   headline: string;
   subheadline: string;
   cta: string;
+  productSrc?: string;
+  /** @deprecated Kept for call-site compat; landing CTA color is used instead. */
   accentColor?: string;
 };
 
@@ -106,7 +196,7 @@ export function MarketingOgImage({
   headline,
   subheadline,
   cta,
-  accentColor = "#14B8A6",
+  productSrc,
 }: MarketingOgImageProps) {
   return (
     <div
@@ -114,35 +204,20 @@ export function MarketingOgImage({
         display: "flex",
         width: "100%",
         height: "100%",
-        background: "#0a0a0a",
-        fontFamily: "system-ui, -apple-system, sans-serif",
+        background: OG_COLORS.background,
+        fontFamily: OG_FONT_FAMILY,
         position: "relative",
-        padding: "56px 72px",
+        padding: `${OG_PADDING}px`,
         flexDirection: "column",
         justifyContent: "space-between",
       }}
     >
-      <div
-        style={{
-          position: "absolute",
-          top: -100,
-          right: -100,
-          width: 480,
-          height: 480,
-          background: `radial-gradient(circle, ${accentColor}55 0%, rgba(10, 10, 10, 0) 72%)`,
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: -60,
-          left: -60,
-          width: 320,
-          height: 320,
-          background: "radial-gradient(circle, rgba(59, 130, 246, 0.25) 0%, rgba(10, 10, 10, 0) 70%)",
-          display: "flex",
-        }}
+      <LandingAtmosphere
+        width={520}
+        height={340}
+        right={40}
+        bottom={36}
+        productSrc={productSrc}
       />
 
       <BrandLockup />
@@ -151,18 +226,19 @@ export function MarketingOgImage({
         style={{
           display: "flex",
           flexDirection: "column",
-          gap: 24,
-          maxWidth: 920,
+          gap: 28,
+          maxWidth: 620,
+          position: "relative",
         }}
       >
         <p
           style={{
             margin: 0,
             fontSize: 58,
-            fontWeight: 800,
-            color: "#FFFFFF",
-            lineHeight: 1.1,
-            letterSpacing: "-0.03em",
+            fontWeight: 400,
+            color: OG_COLORS.foreground,
+            lineHeight: 1.05,
+            letterSpacing: OG_TRACKING.display,
           }}
         >
           {headline}
@@ -170,24 +246,26 @@ export function MarketingOgImage({
         <p
           style={{
             margin: 0,
-            fontSize: 30,
-            fontWeight: 500,
-            color: "#a1a1aa",
-            lineHeight: 1.35,
-            letterSpacing: "-0.01em",
+            fontSize: 26,
+            fontWeight: 400,
+            color: OG_COLORS.muted,
+            lineHeight: 1.4,
+            letterSpacing: OG_TRACKING.snug,
+            maxWidth: 560,
           }}
         >
           {subheadline}
         </p>
-        <OgCtaButton label={cta} accentColor={accentColor} />
+        <OgCtaButton label={cta} />
       </div>
 
       <p
         style={{
           margin: 0,
-          fontSize: 22,
-          fontWeight: 500,
-          color: "#71717a",
+          fontSize: 20,
+          fontWeight: 400,
+          color: OG_COLORS.subtle,
+          position: "relative",
         }}
       >
         deltalytix.app
@@ -196,18 +274,21 @@ export function MarketingOgImage({
   ) as ReactElement;
 }
 
-export function createMarketingOgImageResponse({
+export async function createMarketingOgImageResponse({
   headline,
   subheadline,
   cta,
   accentColor,
 }: MarketingOgImageProps) {
+  const productSrc = await loadLandingProductPosterSrc();
+
   return new ImageResponse(
     <MarketingOgImage
       headline={headline}
       subheadline={subheadline}
       cta={cta}
       accentColor={accentColor}
+      productSrc={productSrc}
     />,
     {
       ...ogImageSize,

--- a/lib/og/shared.tsx
+++ b/lib/og/shared.tsx
@@ -114,23 +114,34 @@ export function OgCtaButton({
 /** Stylized daily P&L bars — no labels, no axes, no numbers. */
 const OG_BAR_HEIGHTS = [
   0.42, 0.68, -0.28, 0.55, 0.22, -0.48, 0.78, 0.35, -0.18, 0.62, 0.48, -0.32,
-  0.85, 0.3, -0.55, 0.58, 0.72, 0.18, -0.25, 0.92,
+  0.85, 0.3, -0.55, 0.58, 0.72, 0.18, -0.25, 0.92, 0.4, -0.38, 0.66, 0.52,
 ] as const;
 
-function barColor(value: number): string {
-  if (value > 0.05) return OG_COLORS.chartWin;
-  if (value < -0.05) return OG_COLORS.chartLoss;
-  return OG_COLORS.chartNeutral;
+function withAlpha(hex: string, alpha: number): string {
+  const normalized = hex.replace("#", "");
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function barColor(value: number, alpha: number): string {
+  if (value > 0.05) return withAlpha(OG_COLORS.chartWin, alpha);
+  if (value < -0.05) return withAlpha(OG_COLORS.chartLoss, alpha);
+  return `rgba(232, 232, 232, ${0.12 * alpha})`;
 }
 
 export function OgBarChart({
   width = 420,
   height = 280,
+  alpha = 0.45,
 }: {
   width?: number;
   height?: number;
+  /** Satori ignores parent opacity — bake alpha into bar fills instead. */
+  alpha?: number;
 } = {}) {
-  const gap = 8;
+  const gap = 10;
   const barWidth = Math.floor(
     (width - gap * (OG_BAR_HEIGHTS.length - 1)) / OG_BAR_HEIGHTS.length,
   );
@@ -155,7 +166,7 @@ export function OgBarChart({
           right: 0,
           top: midY,
           height: 1,
-          background: OG_COLORS.hairline,
+          background: `rgba(255, 255, 255, ${0.08 * alpha})`,
           display: "flex",
         }}
       />
@@ -188,7 +199,7 @@ export function OgBarChart({
                   width: "100%",
                   height: barH,
                   borderRadius: OG_RADIUS.sm,
-                  background: barColor(value),
+                  background: barColor(value, alpha),
                 }}
               />
             </div>
@@ -200,22 +211,22 @@ export function OgBarChart({
 }
 
 /**
- * Right-side visual: mint-washed frame wrapping a text-free bar chart.
+ * Soft bar-chart backdrop — sits behind copy, not inside a framed panel.
+ * Opacity is applied via bar fill alpha (Satori does not honor parent opacity).
  */
 export function LandingAtmosphere({
-  width = 420,
-  height = 280,
-  right = 48,
-  bottom = 40,
+  width = 620,
+  height = 460,
+  right = -48,
+  bottom = -36,
+  alpha = 0.32,
 }: {
   width?: number;
   height?: number;
   right?: number;
   bottom?: number;
+  alpha?: number;
 } = {}) {
-  const chartWidth = width - 48;
-  const chartHeight = height - 48;
-
   return (
     <div
       style={{
@@ -224,26 +235,12 @@ export function LandingAtmosphere({
         bottom,
         width,
         height,
-        borderRadius: OG_RADIUS.md,
-        background: OG_COLORS.wash,
         display: "flex",
-        padding: 12,
+        alignItems: "center",
+        justifyContent: "center",
       }}
     >
-      <div
-        style={{
-          display: "flex",
-          width: "100%",
-          height: "100%",
-          borderRadius: OG_RADIUS.sm,
-          background: OG_COLORS.surface,
-          border: `1px solid ${OG_COLORS.hairline}`,
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <OgBarChart width={chartWidth} height={chartHeight} />
-      </div>
+      <OgBarChart width={width} height={height} alpha={alpha} />
     </div>
   );
 }
@@ -275,7 +272,7 @@ export function MarketingOgImage({
         justifyContent: "space-between",
       }}
     >
-      <LandingAtmosphere width={520} height={340} right={40} bottom={36} />
+      <LandingAtmosphere />
 
       <BrandLockup />
 
@@ -284,7 +281,7 @@ export function MarketingOgImage({
           display: "flex",
           flexDirection: "column",
           gap: 28,
-          maxWidth: 620,
+          maxWidth: 540,
           position: "relative",
         }}
       >
@@ -308,7 +305,7 @@ export function MarketingOgImage({
             color: OG_COLORS.muted,
             lineHeight: 1.4,
             letterSpacing: OG_TRACKING.snug,
-            maxWidth: 560,
+            maxWidth: 500,
           }}
         >
           {subheadline}

--- a/lib/og/shared.tsx
+++ b/lib/og/shared.tsx
@@ -211,7 +211,7 @@ export function OgBarChart({
 }
 
 /**
- * Soft bar-chart backdrop — sits behind copy, not inside a framed panel.
+ * Soft bar-chart backdrop — decorative only (position encodes win/loss).
  * Opacity is applied via bar fill alpha (Satori does not honor parent opacity).
  */
 export function LandingAtmosphere({

--- a/lib/og/site-metadata.ts
+++ b/lib/og/site-metadata.ts
@@ -21,7 +21,8 @@ const SITE_METADATA: Record<OgLocale, SiteMetadataCopy> = {
     ogSubheadline:
       "Store, explore, and understand your track-record across brokers.",
     ogCta: "Get Started →",
-    ogAlt: "Deltalytix trading analytics dashboard — Get Started",
+    ogAlt:
+      "Deltalytix — Master your trading journey. Trading analytics for futures traders. Get Started.",
   },
   fr: {
     title: "Deltalytix — Tableau de bord de trading pour traders futures",
@@ -31,7 +32,8 @@ const SITE_METADATA: Record<OgLocale, SiteMetadataCopy> = {
     ogSubheadline:
       "Stockez, explorez et comprenez votre historique de trading futures.",
     ogCta: "Commencer maintenant →",
-    ogAlt: "Tableau de bord Deltalytix — Commencer maintenant",
+    ogAlt:
+      "Deltalytix — Votre journal de trading. Analyses pour traders futures. Commencer maintenant.",
   },
 };
 

--- a/lib/og/site-metadata.ts
+++ b/lib/og/site-metadata.ts
@@ -16,20 +16,22 @@ const SITE_METADATA: Record<OgLocale, SiteMetadataCopy> = {
     title: "Deltalytix — Trading Analytics Dashboard for Futures Traders",
     description:
       "Deltalytix is a trading dashboard for futures traders. Store, explore, and understand your track-record across brokers.",
-    ogHeadline: "Master your trading journey",
-    ogSubheadline: "Real-time analytics, journaling, and performance insights for futures traders.",
-    ogCta: "Get Started Free →",
-    ogAlt: "Deltalytix trading analytics dashboard — Get Started Free",
+    // Match landing hero cadence: brand-first display line + quiet supporting sentence.
+    ogHeadline: "Master your trading journey.",
+    ogSubheadline:
+      "Store, explore, and understand your track-record across brokers.",
+    ogCta: "Get Started →",
+    ogAlt: "Deltalytix trading analytics dashboard — Get Started",
   },
   fr: {
     title: "Deltalytix — Tableau de bord de trading pour traders futures",
     description:
       "Deltalytix est un journal de trading pour traders futures. Centralisez, analysez et comprenez vos performances.",
-    ogHeadline: "Maîtrisez votre parcours de trading",
+    ogHeadline: "Votre journal de trading.",
     ogSubheadline:
-      "Analyses en temps réel, journal et insights de performance pour traders futures.",
-    ogCta: "Commencer gratuitement →",
-    ogAlt: "Tableau de bord Deltalytix — Commencer gratuitement",
+      "Stockez, explorez et comprenez votre historique de trading futures.",
+    ogCta: "Commencer maintenant →",
+    ogAlt: "Tableau de bord Deltalytix — Commencer maintenant",
   },
 };
 

--- a/lib/og/tokens.ts
+++ b/lib/og/tokens.ts
@@ -1,27 +1,33 @@
 // Design tokens for generated OG images. Satori inline styles cannot use CSS
 // variables or Tailwind, so we centralize literals here for consistency.
 //
-// Hex values are sRGB approximations of the landing-page oklch tokens from
-// `.cursor/skills/deltalytix-styling-guidelines/SKILL.md` and the hero.
+// Hex values are sRGB approximations of the landing-page *dark* oklch tokens
+// from `.cursor/skills/deltalytix-styling-guidelines/SKILL.md`.
+// OG images cannot be theme-responsive — crawlers fetch one cached URL.
 
 export const OG_COLORS = {
-  /** Landing shell: oklch(0.97 0 0) */
-  background: "#f5f5f5",
-  /** Landing text: oklch(0.17 0 0) */
-  foreground: "#0f0f0f",
-  /** Secondary body ≈ text-black/55 on the light shell */
-  muted: "rgba(15, 15, 15, 0.55)",
-  /** Meta / footer ≈ text-black/45 */
-  subtle: "rgba(15, 15, 15, 0.45)",
-  /** Primary CTA fill: oklch(0.22 0.01 95) */
-  cta: "#1c1b15",
-  ctaText: "#ffffff",
-  /** Hero demo-frame wash: oklch(0.88 0.04 165) */
+  /** Dark landing shell: oklch(0.17 0 0) */
+  background: "#0f0f0f",
+  /** Dark landing text: oklch(0.93 0 0) */
+  foreground: "#e8e8e8",
+  /** Secondary body ≈ text-white/55 */
+  muted: "rgba(232, 232, 232, 0.55)",
+  /** Meta / footer ≈ text-white/45 */
+  subtle: "rgba(232, 232, 232, 0.45)",
+  /** Dark primary CTA: oklch(0.94 0.01 95) */
+  cta: "#edebe4",
+  ctaText: "#0f0f0f",
+  /** Soft mint wash (same hue as hero demo frame) */
   wash: "#c0e0d1",
-  /** Hairline borders: border-black/10 */
-  hairline: "rgba(0, 0, 0, 0.1)",
-  /** Soft panel surface for product-frame accents */
-  surface: "#ffffff",
+  /** Hairline borders: border-white/10 */
+  hairline: "rgba(255, 255, 255, 0.1)",
+  /** Panel surface on dark shell */
+  surface: "#161616",
+  /** Chart win / loss — hsl(173 60% 55%) / hsl(12 75% 65%) from globals dark */
+  chartWin: "#3dccb0",
+  chartLoss: "#f08a6c",
+  /** Neutral bar for quiet days */
+  chartNeutral: "rgba(232, 232, 232, 0.18)",
 } as const;
 
 export const OG_TRACKING = {

--- a/lib/og/tokens.ts
+++ b/lib/og/tokens.ts
@@ -33,7 +33,7 @@ export const OG_COLORS = {
 } as const;
 
 export const OG_TRACKING = {
-  display: "-0.04em",
+  display: "-0.03em",
   tight: "-0.03em",
   snug: "-0.01em",
   wide: "0.01em",
@@ -41,6 +41,14 @@ export const OG_TRACKING = {
 
 /** Canvas edge padding in px */
 export const OG_PADDING = 72;
+
+/** CTA button padding (vertical / horizontal) */
+export const OG_CTA_PADDING_Y = 16;
+export const OG_CTA_PADDING_X = 28;
+
+/** Inner card / ref-code box padding (vertical / horizontal) */
+export const OG_CARD_PADDING_Y = 20;
+export const OG_CARD_PADDING_X = 32;
 
 /** Matches landing `rounded-sm` (~4px) */
 export const OG_RADIUS = {

--- a/lib/og/tokens.ts
+++ b/lib/og/tokens.ts
@@ -1,18 +1,44 @@
 // Design tokens for generated OG images. Satori inline styles cannot use CSS
 // variables or Tailwind, so we centralize literals here for consistency.
+//
+// Hex values are sRGB approximations of the landing-page oklch tokens from
+// `.cursor/skills/deltalytix-styling-guidelines/SKILL.md` and the hero.
 
 export const OG_COLORS = {
-    background: "#000000",
-    foreground: "#FFFFFF",
-    muted: "#6B7280",
-    accent: "#14B8A6",
-} as const
+  /** Landing shell: oklch(0.97 0 0) */
+  background: "#f5f5f5",
+  /** Landing text: oklch(0.17 0 0) */
+  foreground: "#0f0f0f",
+  /** Secondary body ≈ text-black/55 on the light shell */
+  muted: "rgba(15, 15, 15, 0.55)",
+  /** Meta / footer ≈ text-black/45 */
+  subtle: "rgba(15, 15, 15, 0.45)",
+  /** Primary CTA fill: oklch(0.22 0.01 95) */
+  cta: "#1c1b15",
+  ctaText: "#ffffff",
+  /** Hero demo-frame wash: oklch(0.88 0.04 165) */
+  wash: "#c0e0d1",
+  /** Hairline borders: border-black/10 */
+  hairline: "rgba(0, 0, 0, 0.1)",
+  /** Soft panel surface for product-frame accents */
+  surface: "#ffffff",
+} as const;
 
 export const OG_TRACKING = {
-    tight: "-0.025em",
-    snug: "-0.01em",
-    wide: "0.01em",
-} as const
+  display: "-0.04em",
+  tight: "-0.03em",
+  snug: "-0.01em",
+  wide: "0.01em",
+} as const;
 
 /** Canvas edge padding in px */
-export const OG_PADDING = 80
+export const OG_PADDING = 72;
+
+/** Matches landing `rounded-sm` (~4px) */
+export const OG_RADIUS = {
+  sm: 4,
+  md: 8,
+} as const;
+
+export const OG_FONT_FAMILY =
+  'Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif';

--- a/lib/og/tokens.ts
+++ b/lib/og/tokens.ts
@@ -10,22 +10,24 @@ export const OG_COLORS = {
   background: "#0f0f0f",
   /** Dark landing text: oklch(0.93 0 0) */
   foreground: "#e8e8e8",
-  /** Secondary body ≈ text-white/55 */
+  /** Secondary body ≈ text-white/55 — ~5.3:1 on shell */
   muted: "rgba(232, 232, 232, 0.55)",
-  /** Meta / footer ≈ text-white/45 */
-  subtle: "rgba(232, 232, 232, 0.45)",
+  /** Meta / footer — same as muted so footer meets WCAG AA for text-in-image */
+  subtle: "rgba(232, 232, 232, 0.55)",
   /** Dark primary CTA: oklch(0.94 0.01 95) */
   cta: "#edebe4",
   ctaText: "#0f0f0f",
-  /** Soft mint wash (same hue as hero demo frame) */
-  wash: "#c0e0d1",
   /** Hairline borders: border-white/10 */
   hairline: "rgba(255, 255, 255, 0.1)",
   /** Panel surface on dark shell */
   surface: "#161616",
-  /** Chart win / loss — hsl(173 60% 55%) / hsl(12 75% 65%) from globals dark */
+  /**
+   * Decorative P&L backdrop only — not for reading values.
+   * Win/loss use position (above/below baseline) + hue/lightness.
+   * hsl(173 60% 55%) / hsl(12 70% 48%) from globals dark chart tokens.
+   */
   chartWin: "#3dccb0",
-  chartLoss: "#f08a6c",
+  chartLoss: "#c45c3a",
   /** Neutral bar for quiet days */
   chartNeutral: "rgba(232, 232, 232, 0.18)",
 } as const;

--- a/scripts/preview-og-images.mjs
+++ b/scripts/preview-og-images.mjs
@@ -11,7 +11,6 @@ import {
   LandingAtmosphere,
   MarketingOgImage,
   OgCtaButton,
-  loadLandingProductPosterSrc,
 } from "../lib/og/shared.tsx";
 import { ReferralOgImage } from "../lib/og/referral-opengraph.tsx";
 import {
@@ -39,7 +38,6 @@ async function renderPng(element, filename) {
   console.log(`wrote ${path} (${buffer.length} bytes)`);
 }
 
-const productSrc = await loadLandingProductPosterSrc();
 const en = getSiteMetadataCopy("en");
 const fr = getSiteMetadataCopy("fr");
 const updatesEn = getUpdatesOgCopy("en");
@@ -49,7 +47,6 @@ await renderPng(
     headline: en.ogHeadline,
     subheadline: en.ogSubheadline,
     cta: en.ogCta,
-    productSrc,
   }),
   "marketing-en.png",
 );
@@ -59,7 +56,6 @@ await renderPng(
     headline: fr.ogHeadline,
     subheadline: fr.ogSubheadline,
     cta: fr.ogCta,
-    productSrc,
   }),
   "marketing-fr.png",
 );
@@ -70,7 +66,6 @@ await renderPng(
     joinLabel: "Join with referral code",
     tagline: "Get started on Deltalytix with a friend.",
     cta: "Claim invite →",
-    productSrc,
   }),
   "referral-en.png",
 );
@@ -91,11 +86,7 @@ const updatesElement = createElement(
       position: "relative",
     },
   },
-  createElement(LandingAtmosphere, {
-    width: 340,
-    height: 230,
-    productSrc,
-  }),
+  createElement(LandingAtmosphere, { width: 340, height: 230 }),
   createElement(BrandLockup, { logoSize: 36, fontSize: 26 }),
   createElement(
     "div",

--- a/scripts/preview-og-images.mjs
+++ b/scripts/preview-og-images.mjs
@@ -1,0 +1,154 @@
+/**
+ * Renders marketing / referral / updates OG preview PNGs for design review.
+ * Usage: bun scripts/preview-og-images.mjs [outDir]
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ImageResponse } from "next/og";
+import { createElement } from "react";
+import {
+  BrandLockup,
+  LandingAtmosphere,
+  MarketingOgImage,
+  OgCtaButton,
+  loadLandingProductPosterSrc,
+} from "../lib/og/shared.tsx";
+import { ReferralOgImage } from "../lib/og/referral-opengraph.tsx";
+import {
+  getSiteMetadataCopy,
+  getUpdatesOgCopy,
+} from "../lib/og/site-metadata.ts";
+import {
+  OG_COLORS,
+  OG_FONT_FAMILY,
+  OG_PADDING,
+  OG_TRACKING,
+} from "../lib/og/tokens.ts";
+
+const outDir = process.argv[2] ?? "tmp/og-previews";
+await mkdir(outDir, { recursive: true });
+
+async function renderPng(element, filename) {
+  const response = new ImageResponse(element, {
+    width: 1200,
+    height: 630,
+  });
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const path = join(outDir, filename);
+  await writeFile(path, buffer);
+  console.log(`wrote ${path} (${buffer.length} bytes)`);
+}
+
+const productSrc = await loadLandingProductPosterSrc();
+const en = getSiteMetadataCopy("en");
+const fr = getSiteMetadataCopy("fr");
+const updatesEn = getUpdatesOgCopy("en");
+
+await renderPng(
+  createElement(MarketingOgImage, {
+    headline: en.ogHeadline,
+    subheadline: en.ogSubheadline,
+    cta: en.ogCta,
+    productSrc,
+  }),
+  "marketing-en.png",
+);
+
+await renderPng(
+  createElement(MarketingOgImage, {
+    headline: fr.ogHeadline,
+    subheadline: fr.ogSubheadline,
+    cta: fr.ogCta,
+    productSrc,
+  }),
+  "marketing-fr.png",
+);
+
+await renderPng(
+  createElement(ReferralOgImage, {
+    ref: "HUGO",
+    joinLabel: "Join with referral code",
+    tagline: "Get started on Deltalytix with a friend.",
+    cta: "Claim invite →",
+    productSrc,
+  }),
+  "referral-en.png",
+);
+
+const updatesElement = createElement(
+  "div",
+  {
+    style: {
+      display: "flex",
+      width: "100%",
+      height: "100%",
+      background: OG_COLORS.background,
+      fontFamily: OG_FONT_FAMILY,
+      padding: `${OG_PADDING}px`,
+      flexDirection: "column",
+      justifyContent: "space-between",
+      alignItems: "flex-start",
+      position: "relative",
+    },
+  },
+  createElement(LandingAtmosphere, {
+    width: 340,
+    height: 230,
+    productSrc,
+  }),
+  createElement(BrandLockup, { logoSize: 36, fontSize: 26 }),
+  createElement(
+    "div",
+    {
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        gap: "20px",
+        maxWidth: "760px",
+        position: "relative",
+      },
+    },
+    createElement(
+      "h1",
+      {
+        style: {
+          fontSize: "52px",
+          fontWeight: 400,
+          color: OG_COLORS.foreground,
+          margin: "0",
+          lineHeight: "1.12",
+          letterSpacing: OG_TRACKING.display,
+        },
+      },
+      "Smarter imports and clearer journals",
+    ),
+  ),
+  createElement(
+    "div",
+    {
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        gap: 20,
+        position: "relative",
+      },
+    },
+    createElement(OgCtaButton, { label: updatesEn.cta }),
+    createElement(
+      "span",
+      {
+        style: {
+          fontSize: "20px",
+          fontWeight: 400,
+          color: OG_COLORS.subtle,
+          letterSpacing: OG_TRACKING.wide,
+        },
+      },
+      "July 16, 2026",
+    ),
+  ),
+);
+
+await renderPng(updatesElement, "updates-en.png");
+
+console.log("done");

--- a/scripts/preview-og-images.mjs
+++ b/scripts/preview-og-images.mjs
@@ -86,7 +86,7 @@ const updatesElement = createElement(
       position: "relative",
     },
   },
-  createElement(LandingAtmosphere, { width: 340, height: 230 }),
+  createElement(LandingAtmosphere),
   createElement(BrandLockup, { logoSize: 36, fontSize: 26 }),
   createElement(
     "div",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refines marketing, referral, and updates Open Graph images so they match the dark landing visual language instead of the old teal-pill / glow look.

- Dark shell (`#0f0f0f`) with landing CTA inverse (`#edebe4`)
- Soft text-free P&L bar chart as a right-side backdrop (no screenshot, no mint frame)
- Copy aligned with the hero (EN/FR)
- Accessibility polish: AA footer contrast, win/loss lightness differentiation, descriptive alt text

## Design review follow-ups

Addressed Rams review items except static per-post alt (skipped — title/copy already live in the OG image; duplicating into alt would be redundant with page/OG description):

- Tokenized CTA + referral card padding (`OG_CTA_PADDING_*`, `OG_CARD_PADDING_*`)
- Capped `OG_TRACKING.display` at `-0.03em`
- Clamped long update titles to 2 lines
- Removed unused deprecated `accentColor` pass-through on marketing OG helpers

## Design / a11y review

Ran `deltalytix-styling-guidelines`, `emil-design-eng` (static polish), and `accessibility-and-inclusive-visualization`.

| Before | After | Why |
| --- | --- | --- |
| Dark teal-pill CTA + blue/teal glows | Warm near-black/cream `rounded-sm` CTA, no glows | Match landing CTA + hairline language |
| Product screenshot in mint panel | Decorative P&L bars as soft backdrop | User preference; chart is decorative, not data |
| Footer text at ~3.9:1 | Footer uses 0.55 white (~5.3:1) | WCAG AA for text-in-image |
| Loss bars similar lightness to wins | Darker loss hue + above/below baseline | Redundant encoding beyond color alone |
| Short generic alts | Alts include headline + CTA intent | Accessible path for complex OG images |

OG images cannot be theme-responsive (crawlers cache one URL).

## Test plan

- [ ] `bun scripts/preview-og-images.mjs` and spot-check EN/FR marketing, referral, updates
- [ ] Hit `/opengraph-image` and `/en/opengraph-image` locally and confirm dark + bar backdrop
- [ ] Confirm OG alt text in page metadata / `.alt.txt`
- [x] `bunx vitest run lib/og/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6cf0-905d-7eba-8161-8a6f604d02a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6cf0-905d-7eba-8161-8a6f604d02a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

