### PR TITLE
Fix auth header trust, open redirects, and shared visibility

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,5 +1,6 @@
 'use server'
 import { createClient, ensureUserInDatabase } from '@/server/auth'
+import { safeRedirectPath } from '@/lib/safe-redirect-path'
 import { NextResponse } from 'next/server'
 // The client you created from the Server-Side Auth instructions
 
@@ -21,11 +22,6 @@ export async function GET(request: Request) {
     action
   })
 
-  // Redirect to the decoded 'next' URL if it exists, otherwise to the homepage
-  let decodedNext: string | null = null;
-  if (next) {
-    decodedNext = decodeURIComponent(next)
-  }
   if (code) {
     try {
       const supabase = await createClient()
@@ -67,22 +63,14 @@ export async function GET(request: Request) {
 
         const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
         const isLocalEnv = process.env.NODE_ENV === 'development'
+        const redirectPath = safeRedirectPath(next)
         if (isLocalEnv) {
           // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-          if (decodedNext) {
-            return NextResponse.redirect(new URL(decodedNext, origin))
-          }
-          return NextResponse.redirect(`${origin}${next ?? '/dashboard'}`)
+          return NextResponse.redirect(new URL(redirectPath, origin))
         } else if (forwardedHost) {
-          if (decodedNext) {
-            return NextResponse.redirect(new URL(decodedNext, `https://${forwardedHost}`))
-          }
-          return NextResponse.redirect(`https://${forwardedHost}${next ?? '/dashboard'}`)
+          return NextResponse.redirect(new URL(redirectPath, `https://${forwardedHost}`))
         } else {
-          if (decodedNext) {
-            return NextResponse.redirect(new URL(decodedNext, origin))
-          }
-          return NextResponse.redirect(`${origin}${next ?? '/dashboard'}`)
+          return NextResponse.redirect(new URL(redirectPath, origin))
         }
       } else {
         console.log('Auth callback error:', error)

--- a/lib/safe-redirect-path.test.ts
+++ b/lib/safe-redirect-path.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { safeRedirectPath } from "./safe-redirect-path"
+
+describe("safeRedirectPath", () => {
+  it("returns fallback for nullish values", () => {
+    expect(safeRedirectPath(null)).toBe("/dashboard")
+    expect(safeRedirectPath(undefined)).toBe("/dashboard")
+    expect(safeRedirectPath("")).toBe("/dashboard")
+  })
+
+  it("allows in-app relative paths", () => {
+    expect(safeRedirectPath("/dashboard/settings")).toBe("/dashboard/settings")
+    expect(safeRedirectPath("dashboard/settings")).toBe("/dashboard/settings")
+    expect(safeRedirectPath("%2Fdashboard%2Ftrades")).toBe("/dashboard/trades")
+  })
+
+  it("rejects absolute and protocol-relative URLs", () => {
+    expect(safeRedirectPath("https://evil.example")).toBe("/dashboard")
+    expect(safeRedirectPath("//evil.example")).toBe("/dashboard")
+    expect(safeRedirectPath("\\\\evil.example")).toBe("/dashboard")
+    expect(safeRedirectPath("/\\evil.example")).toBe("/dashboard")
+    expect(safeRedirectPath("http://evil.example/path")).toBe("/dashboard")
+  })
+
+  it("rejects invalid percent-encoding", () => {
+    expect(safeRedirectPath("%E0%A4%A")).toBe("/dashboard")
+  })
+
+  it("supports a custom fallback", () => {
+    expect(safeRedirectPath("//evil.example", "/home")).toBe("/home")
+  })
+})

--- a/lib/safe-redirect-path.ts
+++ b/lib/safe-redirect-path.ts
@@ -1,0 +1,38 @@
+/**
+ * Sanitize user-controlled redirect targets (e.g. `?next=`) so only same-app
+ * relative paths are allowed. Rejects protocol-relative URLs, absolute URLs,
+ * and backslash tricks that can escape the origin.
+ */
+export function safeRedirectPath(
+  nextParam: string | null | undefined,
+  fallback = "/dashboard",
+): string {
+  if (!nextParam) {
+    return fallback
+  }
+
+  let nextPath = nextParam
+
+  try {
+    nextPath = decodeURIComponent(nextPath)
+  } catch {
+    return fallback
+  }
+
+  if (
+    nextPath.startsWith("//") ||
+    nextPath.startsWith("\\") ||
+    nextPath.includes("://") ||
+    nextPath.includes("\\")
+  ) {
+    return fallback
+  }
+
+  const normalizedPath = nextPath.startsWith("/") ? nextPath : `/${nextPath}`
+
+  if (normalizedPath.startsWith("//")) {
+    return fallback
+  }
+
+  return normalizedPath
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -12,6 +12,7 @@ import {
   getLocalDashboardUserId,
   isLocalDashboardAuthBypassEnabled,
 } from "@/lib/local-dashboard-auth"
+import { safeRedirectPath } from "@/lib/safe-redirect-path"
 
 // Maintenance mode flag - Set to true to enable maintenance mode
 const MAINTENANCE_MODE = false
@@ -454,8 +455,7 @@ export default async function proxy(req: NextRequest) {
     // Authenticated - redirect from auth to dashboard
     if (pathname.includes("/authentication")) {
       const nextParam = req.nextUrl.searchParams.get("next")
-      const redirectUrl = nextParam ? `/${nextParam}` : "/dashboard"
-      return NextResponse.redirect(new URL(redirectUrl, req.url))
+      return NextResponse.redirect(new URL(safeRedirectPath(nextParam), req.url))
     }
   }
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -3,7 +3,6 @@ import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
-import { headers } from "next/headers"
 import { User } from '@supabase/supabase-js'
 import {
   buildLocalDashboardBypassUser,
@@ -588,25 +587,15 @@ export async function verifyOtp(email: string, token: string, type: 'email' | 's
   }
 }
 
-// Optimized function that uses middleware data when available
 export async function getUserId(): Promise<string> {
   if (isLocalDashboardAuthBypassEnabled()) {
     await ensureLocalDashboardUserInDatabase()
     return getLocalDashboardUserId()
   }
 
-  // First try to get user ID from middleware headers
-  const headersList = await headers()
-  const userIdFromMiddleware = headersList.get("x-user-id")
-
-  if (userIdFromMiddleware) {
-    console.log("[Auth] Using user ID from middleware")
-    return userIdFromMiddleware
-  }
-
-  // Fallback to Supabase call (for API routes or edge cases)
+  // Always validate identity via Supabase session — never trust request headers
+  // such as x-user-id, which clients can spoof.
   try {
-    console.log("[Auth] Fallback to Supabase call")
     const supabase = await createClient()
     const {
       data: { user },
@@ -628,10 +617,17 @@ export async function getUserEmail(): Promise<string> {
     return getLocalDashboardUserEmail()
   }
 
-  const headersList = await headers()
-  const userEmail = headersList.get("x-user-email")
-  console.log("[Auth] getUserEmail FROM HEADERS", userEmail)
-  return userEmail || ""
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return ""
+  }
+
+  return user.email || ""
 }
 
 // Lightweight updater for user language without full ensure logic

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -103,6 +103,10 @@ export async function getShared(slug: string): Promise<{params: SharedParams, tr
       return null
     }
 
+    if (!shared.isPublic || (shared.expiresAt && shared.expiresAt < new Date())) {
+      return null
+    }
+
     // Parse the date range
     const dateRange = shared.dateRange as unknown as DateRange
     if (!dateRange?.from) {

--- a/server/subscription.ts
+++ b/server/subscription.ts
@@ -1,8 +1,7 @@
 'use server'
 
 import { prisma } from '@/lib/prisma'
-import { headers } from 'next/headers';
-import { createClient } from './auth';
+import { getUserEmail } from './auth';
 
 interface SubscriptionInfo {
     isActive: boolean;
@@ -20,18 +19,7 @@ function isValidEmail(email: string): boolean {
 }
 
 export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null> {
-    // Get user email using headers from our middleware
-    const headersList = await headers()
-    let email = headersList.get("x-user-email")
-    if (!email) {
-        // USE supabase to get user email
-        const supabase = await createClient()
-        const { data: { user } } = await supabase.auth.getUser()
-        if (!user) {
-            return null
-        }
-        email = user.email || null
-    }
+    const email = await getUserEmail()
     // Input validation
     if (!email || !isValidEmail(email)) {
         console.error('[getSubscriptionDetails] Invalid email format:', email)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Re-applies the still-valid security fixes from closed draft [#161](https://github.com/hugodemenez/deltalytix/pull/161) on current `beta` (that PR was 187 commits behind and conflicted).

- Stop trusting spoofable `x-user-id` / `x-user-email` request headers in `getUserId` / `getUserEmail`; identity now comes from the Supabase session (local dashboard auth bypass unchanged).
- Route subscription email lookup through `getUserEmail` so it cannot be spoofed via headers either.
- Sanitize `next` redirect targets in the auth callback and authenticated `/authentication` redirect via shared `safeRedirectPath` (blocks absolute / protocol-relative / backslash open redirects).
- Enforce `isPublic` and `expiresAt` in `getShared` before returning shared trade data.

Skipped from #161: shared opengraph `await params` — already fixed on `beta`.

## Test plan
- [x] `bunx vitest run lib/safe-redirect-path.test.ts`
- [x] `bun run typecheck`
- [ ] Confirm spoofed `x-user-id` / `x-user-email` headers no longer change authenticated identity
- [ ] Confirm `?next=https://evil.example` and `?next=//evil.example` fall back to `/dashboard`
- [ ] Confirm non-public or expired shared slugs return null / 404
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f71fa-54c5-78f8-916e-064245a22946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f71fa-54c5-78f8-916e-064245a22946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

