### PR TITLE
Invite production users to try beta connection flow

### DIFF
--- a/app/[locale]/dashboard/layout.tsx
+++ b/app/[locale]/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import { TradovateSyncContextProvider } from "@/context/tradovate-sync-context";
 import { DxFeedSyncContextProvider } from "@/context/dxfeed-sync-context";
 import { I18nProviderClient } from "@/locales/client";
 import { ConsentBanner } from "@/components/consent-banner";
+import { BetaConnectionFlowInvite } from "@/components/beta-connection-flow-invite";
 import { PostHogIdentity } from "@/components/posthog-identity";
 import { createClient } from "@/server/auth";
 
@@ -41,6 +42,7 @@ export default async function RootLayout({
                 <Navbar />
                 {children}
                 <Modals />
+                <BetaConnectionFlowInvite />
               </DxFeedSyncContextProvider>
             </TradovateSyncContextProvider>
           </RithmicSyncContextProvider>

--- a/components/beta-connection-flow-invite.tsx
+++ b/components/beta-connection-flow-invite.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ExternalLink, X } from "lucide-react";
+import posthog from "posthog-js";
+import { Button } from "@/components/ui/button";
+import { useI18n } from "@/locales/client";
+
+export const BETA_CONNECTION_FLOW_INVITE_FLAG = "beta-connection-flow-invite";
+const DISMISS_STORAGE_KEY = "deltalytix:beta-connection-flow-invite:dismissed";
+const BETA_CONNECTION_URL = "https://beta.deltalytix.app/dashboard/connections";
+
+function isInviteHost() {
+  if (typeof window === "undefined") return false;
+  const host = window.location.hostname;
+  return (
+    host === "deltalytix.app" ||
+    host === "www.deltalytix.app" ||
+    host === "localhost" ||
+    host === "127.0.0.1"
+  );
+}
+
+function wasDismissed() {
+  try {
+    return localStorage.getItem(DISMISS_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markDismissed() {
+  try {
+    localStorage.setItem(DISMISS_STORAGE_KEY, "1");
+  } catch {
+    // Ignore storage failures; invite can still be closed for this session.
+  }
+}
+
+export function BetaConnectionFlowInvite() {
+  const t = useI18n();
+  const [isVisible, setIsVisible] = useState(false);
+  const hasTrackedShown = useRef(false);
+
+  const hide = useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  const dismiss = useCallback(() => {
+    markDismissed();
+    hide();
+    if (!posthog.has_opted_out_capturing()) {
+      posthog.capture("beta_connection_flow_invite_dismissed", {
+        flag: BETA_CONNECTION_FLOW_INVITE_FLAG,
+      });
+    }
+  }, [hide]);
+
+  const accept = useCallback(() => {
+    markDismissed();
+    hide();
+    if (!posthog.has_opted_out_capturing()) {
+      posthog.capture("beta_connection_flow_invite_clicked", {
+        flag: BETA_CONNECTION_FLOW_INVITE_FLAG,
+        destination: BETA_CONNECTION_URL,
+      });
+    }
+    window.open(BETA_CONNECTION_URL, "_blank", "noopener,noreferrer");
+  }, [hide]);
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return;
+    if (!isInviteHost() || wasDismissed()) return;
+
+    const syncVisibility = () => {
+      if (wasDismissed()) {
+        setIsVisible(false);
+        return;
+      }
+
+      const enabled = posthog.isFeatureEnabled(BETA_CONNECTION_FLOW_INVITE_FLAG) === true;
+      setIsVisible(enabled);
+
+      if (enabled && !hasTrackedShown.current && !posthog.has_opted_out_capturing()) {
+        hasTrackedShown.current = true;
+        posthog.capture("beta_connection_flow_invite_shown", {
+          flag: BETA_CONNECTION_FLOW_INVITE_FLAG,
+        });
+      }
+    };
+
+    syncVisibility();
+    return posthog.onFeatureFlags(syncVisibility);
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {isVisible ? (
+        <motion.aside
+          aria-label={t("betaInvite.connectionFlow.ariaLabel")}
+          className="fixed bottom-4 right-4 z-50 w-[min(100vw-2rem,22rem)] rounded-lg border border-border bg-background/95 p-4 shadow-lg backdrop-blur supports-backdrop-filter:bg-background/90"
+          initial={{ opacity: 0, y: 12, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 8, scale: 0.98 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium leading-snug">
+                {t("betaInvite.connectionFlow.title")}
+              </p>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {t("betaInvite.connectionFlow.description")}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="shrink-0 text-muted-foreground"
+              onClick={dismiss}
+              aria-label={t("betaInvite.connectionFlow.dismiss")}
+            >
+              <X />
+            </Button>
+          </div>
+          <div className="mt-3 flex items-center gap-2">
+            <Button type="button" size="sm" onClick={accept}>
+              {t("betaInvite.connectionFlow.tryBeta")}
+              <ExternalLink />
+            </Button>
+            <Button type="button" size="sm" variant="ghost" onClick={dismiss}>
+              {t("betaInvite.connectionFlow.notNow")}
+            </Button>
+          </div>
+        </motion.aside>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/components/posthog-identity.tsx
+++ b/components/posthog-identity.tsx
@@ -14,8 +14,12 @@ export function PostHogIdentity({
   language: string;
   userId: string;
 }) {
-  const identify = useCallback(() => {
+  const syncIdentity = useCallback(() => {
     if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return;
+
+    // Keep email available for feature-flag targeting even when analytics is opted out.
+    posthog.setPersonPropertiesForFlags({ email, language });
+
     if (posthog.has_opted_out_capturing()) return;
 
     posthog.identify(userId, {
@@ -25,10 +29,10 @@ export function PostHogIdentity({
   }, [email, language, userId]);
 
   useEffect(() => {
-    identify();
-    window.addEventListener(CONSENT_EVENT, identify);
-    return () => window.removeEventListener(CONSENT_EVENT, identify);
-  }, [identify]);
+    syncIdentity();
+    window.addEventListener(CONSENT_EVENT, syncIdentity);
+    return () => window.removeEventListener(CONSENT_EVENT, syncIdentity);
+  }, [syncIdentity]);
 
   return null;
 }

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -122,6 +122,13 @@ export default {
   "dashboard.profile": "Profile",
   "dashboard.billing": "Subscription",
   "dashboard.data": "Data",
+  "betaInvite.connectionFlow.ariaLabel": "Try the new connection flow on beta",
+  "betaInvite.connectionFlow.title": "Try the new connection flow",
+  "betaInvite.connectionFlow.description":
+    "A clearer way to manage broker connections is available on beta. Want to give it a try?",
+  "betaInvite.connectionFlow.tryBeta": "Try on beta",
+  "betaInvite.connectionFlow.notNow": "Not now",
+  "betaInvite.connectionFlow.dismiss": "Dismiss",
   "dashboard.refreshData": "Refresh Data",
   "dashboard.inviteUsers": "Invite users",
   "dashboard.email": "Email",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -123,6 +123,13 @@ export default {
   "dashboard.profile": "Profil",
   "dashboard.billing": "Abonnement",
   "dashboard.data": "Données",
+  "betaInvite.connectionFlow.ariaLabel": "Essayer le nouveau flux de connexions sur beta",
+  "betaInvite.connectionFlow.title": "Essayer le nouveau flux de connexions",
+  "betaInvite.connectionFlow.description":
+    "Une façon plus claire de gérer les connexions broker est disponible sur beta. Vous voulez l’essayer ?",
+  "betaInvite.connectionFlow.tryBeta": "Essayer sur beta",
+  "betaInvite.connectionFlow.notNow": "Pas maintenant",
+  "betaInvite.connectionFlow.dismiss": "Fermer",
   "dashboard.refreshData": "Actualiser les données",
   "dashboard.inviteUsers": "Inviter des utilisateurs",
   "dashboard.email": "Email",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a PostHog-gated, dismissible dashboard popup on **production** (`deltalytix.app`) that invites flagged users to try the new connection flow on [beta.deltalytix.app](https://beta.deltalytix.app/dashboard/connections).

## Scope
This PR is intentionally **popup-only** for `main`.
Survey instrumentation and connection-page event hooks live in the beta PR: https://github.com/hugodemenez/deltalytix/pull/335

## PostHog
- Flag: [`beta-connection-flow-invite`](https://eu.posthog.com/project/50101/feature_flags/230949)
- Currently targeted to `hdemenez@hotmail.fr` (+ local auth email for testing)

## Behavior
- Shows on `deltalytix.app` / `www.deltalytix.app` (and localhost for testing)
- Does **not** show on `beta.deltalytix.app`
- CTA opens beta Connections
- Dismiss remembered in `localStorage`
- Person email is set for flag targeting even when analytics is opted out
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7203-74d3-7ccc-a18e-cf5de6e64158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7203-74d3-7ccc-a18e-cf5de6e64158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

