### PR TITLE
Show connection survey without analytics consent

### DIFF
--- a/lib/connection-analytics.ts
+++ b/lib/connection-analytics.ts
@@ -107,11 +107,14 @@ export function captureConnectionCreated(
   service: string,
   extra?: Record<string, string | boolean | number | null | undefined>
 ) {
-  if (!canCapture()) return;
-  posthog.capture("connection_created", {
-    service,
-    source: "connections_page",
-    ...extra,
-  });
+  // Always attempt the feedback survey after a successful connect.
+  // Analytics capture is optional (beta is a separate origin/consent jar).
+  if (canCapture()) {
+    posthog.capture("connection_created", {
+      service,
+      source: "connections_page",
+      ...extra,
+    });
+  }
   showConnectionFeedbackSurvey();
 }


### PR DESCRIPTION
## Summary
- On `beta.deltalytix.app`, analytics consent is separate from production.
- `connection_created` capture was gated by consent, which also blocked the programmatic feedback survey.
- Survey display now runs after a successful connect even if capture is opted out (still gated by `beta-connection-flow-invite`).

## Test plan
- [ ] On beta with analytics rejected, successfully add a Tradovate/other connection as a flagged user
- [ ] Confirm survey still appears
- [ ] With analytics accepted, confirm `connection_created` is still captured

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in connection analytics only; survey display is unchanged aside from no longer being blocked by opt-out, and event capture remains consent-gated.
> 
> **Overview**
> **`captureConnectionCreated`** no longer exits early when PostHog capture is opted out. **`connection_created`** is still sent only when **`canCapture()`** is true; **`showConnectionFeedbackSurvey()`** now runs on every successful connect path that calls this helper.
> 
> This fixes beta (separate consent) users who reject analytics but should still see the programmatic connection-flow survey when **`beta-connection-flow-invite`** is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ab9fbf993407d7562406db52ea4bf3e2fe065c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->