### PR TITLE
Make beta connection survey reliable after 3 minutes

### DIFF
--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -41,6 +41,7 @@ import { platforms, type PlatformConfig } from '@/app/[locale]/dashboard/compone
 import {
   captureConnectionAddClicked,
   captureConnectionCreated,
+  startConnectionsPageDwellTracking,
 } from '@/lib/connection-analytics'
 import { PlatformTutorial } from '@/app/[locale]/dashboard/components/import/components/platform-tutorial'
 import {
@@ -872,6 +873,9 @@ export function ConnectionsPageClient({
     () => platforms.filter((p) => p.category !== 'Direct Account Sync'),
     []
   )
+
+  // Cumulative visible dwell survives OAuth leave/return via sessionStorage.
+  useEffect(() => startConnectionsPageDwellTracking(), [])
 
   // Full-page skeleton only when we have nothing useful to show yet.
   const showPageSkeleton = loading && !data && !oauthPending

--- a/components/consent-banner.tsx
+++ b/components/consent-banner.tsx
@@ -27,9 +27,35 @@ import posthog from "posthog-js"
 const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent"
 const CONSENT_EVENT = "deltalytix:analytics-consent"
 
+function isDeltalytixHost() {
+  const host = window.location.hostname
+  return host === "deltalytix.app" || host.endsWith(".deltalytix.app")
+}
+
+function getSharedAnalyticsConsent() {
+  const cookie = document.cookie
+    .split("; ")
+    .find((entry) => entry.startsWith(`${ANALYTICS_CONSENT_COOKIE}=`))
+
+  if (!cookie) return null
+
+  const value = cookie.split("=")[1]
+  if (value === "granted") return true
+  if (value === "denied") return false
+  return null
+}
+
 function syncPostHogConsent(analyticsEnabled: boolean) {
   const secure = window.location.protocol === "https:" ? "; Secure" : ""
-  document.cookie = `${ANALYTICS_CONSENT_COOKIE}=${analyticsEnabled ? "granted" : "denied"}; Max-Age=31536000; Path=/; SameSite=Lax${secure}`
+  const value = analyticsEnabled ? "granted" : "denied"
+  const attributes = `Max-Age=31536000; Path=/; SameSite=Lax${secure}`
+
+  // Keep the current-origin cookie in sync, then share the same choice with
+  // production and beta. This avoids asking twice or silently opting beta out.
+  document.cookie = `${ANALYTICS_CONSENT_COOKIE}=${value}; ${attributes}`
+  if (isDeltalytixHost()) {
+    document.cookie = `${ANALYTICS_CONSENT_COOKIE}=${value}; ${attributes}; Domain=.deltalytix.app`
+  }
 
   if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return
 
@@ -81,7 +107,23 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
   useEffect(() => {
     const hasConsent = localStorage.getItem("cookieConsent")
     if (!hasConsent) {
-      setIsVisible(true)
+      const sharedAnalyticsConsent = getSharedAnalyticsConsent()
+      if (sharedAnalyticsConsent === null) {
+        setIsVisible(true)
+      } else {
+        const sharedSettings: ConsentSettings = {
+          analytics_storage: sharedAnalyticsConsent,
+          ad_storage: false,
+          ad_user_data: false,
+          ad_personalization: false,
+          functionality_storage: true,
+          personalization_storage: false,
+          security_storage: true,
+        }
+        localStorage.setItem("cookieConsent", JSON.stringify(sharedSettings))
+        setSettings(sharedSettings)
+        syncPostHogConsent(sharedAnalyticsConsent)
+      }
     } else {
       try {
         const savedSettings = JSON.parse(hasConsent) as ConsentSettings

--- a/components/consent-banner.tsx
+++ b/components/consent-banner.tsx
@@ -105,40 +105,59 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
   const isDesktop = useMediaQuery("(min-width: 768px)")
 
   useEffect(() => {
+    const sharedAnalyticsConsent = getSharedAnalyticsConsent()
     const hasConsent = localStorage.getItem("cookieConsent")
-    if (!hasConsent) {
-      const sharedAnalyticsConsent = getSharedAnalyticsConsent()
-      if (sharedAnalyticsConsent === null) {
-        setIsVisible(true)
-      } else {
-        const sharedSettings: ConsentSettings = {
-          analytics_storage: sharedAnalyticsConsent,
-          ad_storage: false,
-          ad_user_data: false,
-          ad_personalization: false,
-          functionality_storage: true,
-          personalization_storage: false,
-          security_storage: true,
-        }
-        localStorage.setItem("cookieConsent", JSON.stringify(sharedSettings))
-        setSettings(sharedSettings)
-        syncPostHogConsent(sharedAnalyticsConsent)
+
+    // Parent-domain cookie is the cross-origin source of truth. Prefer it over
+    // a stale origin-local choice so beta/prod cannot overwrite each other.
+    if (sharedAnalyticsConsent !== null) {
+      let settingsToApply: ConsentSettings = {
+        analytics_storage: sharedAnalyticsConsent,
+        ad_storage: false,
+        ad_user_data: false,
+        ad_personalization: false,
+        functionality_storage: true,
+        personalization_storage: false,
+        security_storage: true,
       }
-    } else {
+
+      if (hasConsent) {
+        try {
+          settingsToApply = {
+            ...(JSON.parse(hasConsent) as ConsentSettings),
+            analytics_storage: sharedAnalyticsConsent,
+          }
+        } catch {
+          localStorage.removeItem("cookieConsent")
+        }
+      }
+
+      localStorage.setItem("cookieConsent", JSON.stringify(settingsToApply))
+      setSettings(settingsToApply)
+      syncPostHogConsent(sharedAnalyticsConsent)
+    } else if (hasConsent) {
       try {
         const savedSettings = JSON.parse(hasConsent) as ConsentSettings
         setSettings(savedSettings)
+        // Migrates existing origin-local consent onto the shared Domain cookie.
         syncPostHogConsent(savedSettings.analytics_storage)
       } catch {
         localStorage.removeItem("cookieConsent")
         setIsVisible(true)
       }
+    } else {
+      setIsVisible(true)
     }
 
     // Add keyboard shortcut for dev mode (Cmd/Ctrl + Shift + K)
     const handleKeyPress = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'K') {
         localStorage.removeItem("cookieConsent")
+        const secure = window.location.protocol === "https:" ? "; Secure" : ""
+        document.cookie = `${ANALYTICS_CONSENT_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax${secure}`
+        if (isDeltalytixHost()) {
+          document.cookie = `${ANALYTICS_CONSENT_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax${secure}; Domain=.deltalytix.app`
+        }
         setIsVisible(true)
       }
     }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,8 +2,29 @@ import posthog from "posthog-js";
 
 const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
 const apiHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
+const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent";
+
+function getSharedAnalyticsConsent() {
+  try {
+    const cookie = document.cookie
+      .split("; ")
+      .find((entry) => entry.startsWith(`${ANALYTICS_CONSENT_COOKIE}=`));
+
+    if (!cookie) return null;
+
+    const value = cookie.split("=")[1];
+    if (value === "granted") return true;
+    if (value === "denied") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 function hasAnalyticsConsent() {
+  const sharedConsent = getSharedAnalyticsConsent();
+  if (sharedConsent !== null) return sharedConsent;
+
   try {
     const storedConsent = localStorage.getItem("cookieConsent");
     if (!storedConsent) return false;

--- a/lib/connection-analytics.ts
+++ b/lib/connection-analytics.ts
@@ -70,40 +70,78 @@ function captureDwellThreshold(totalMs: number) {
 export function startConnectionsPageDwellTracking(): () => void {
   if (typeof window === "undefined") return () => {};
 
+  // Already done this tab session — nothing to track.
+  if (wasDwellEventFired()) return () => {};
+
   let segmentStart: number | null =
     document.visibilityState === "visible" ? Date.now() : null;
   let stopped = false;
   let pendingFireTimer: number | null = null;
+  let intervalId: number | null = null;
+
+  const stopTracking = () => {
+    if (stopped) return;
+    stopped = true;
+    segmentStart = null;
+    if (pendingFireTimer != null) {
+      window.clearTimeout(pendingFireTimer);
+      pendingFireTimer = null;
+    }
+    if (intervalId != null) {
+      window.clearInterval(intervalId);
+      intervalId = null;
+    }
+    document.removeEventListener("visibilitychange", onVisibility);
+    window.removeEventListener("pagehide", onPageHide);
+    window.removeEventListener(CONSENT_EVENT, onConsent);
+  };
 
   const accumulate = (endSegment = false) => {
     if (segmentStart == null) return readDwellMs();
     const now = Date.now();
     const elapsed = now - segmentStart;
     segmentStart = endSegment || stopped ? null : now;
-    const total = readDwellMs() + Math.max(0, elapsed);
+    // Cap at the threshold — no need to keep growing sessionStorage after that.
+    const total = Math.min(
+      DWELL_THRESHOLD_MS,
+      readDwellMs() + Math.max(0, elapsed)
+    );
     writeDwellMs(total);
     return total;
   };
 
   const maybeFire = (opts?: { defer?: boolean }) => {
+    if (stopped || wasDwellEventFired()) {
+      stopTracking();
+      return;
+    }
+
     const total = accumulate();
     if (total < DWELL_THRESHOLD_MS) return;
-    if (wasDwellEventFired()) return;
+
+    const finish = () => {
+      captureDwellThreshold(readDwellMs());
+      // Stop once fired, or keep waiting for consent if capture was blocked.
+      if (wasDwellEventFired()) {
+        stopTracking();
+      }
+    };
 
     if (opts?.defer) {
       // After OAuth remount, give PostHog surveys time to attach event listeners.
       if (pendingFireTimer != null) return;
       pendingFireTimer = window.setTimeout(() => {
         pendingFireTimer = null;
-        captureDwellThreshold(readDwellMs());
+        finish();
       }, 1500);
       return;
     }
 
-    captureDwellThreshold(total);
+    finish();
   };
 
   const onVisibility = () => {
+    if (stopped) return;
     if (document.visibilityState === "visible") {
       segmentStart = Date.now();
       maybeFire({ defer: readDwellMs() >= DWELL_THRESHOLD_MS });
@@ -120,7 +158,7 @@ export function startConnectionsPageDwellTracking(): () => void {
     accumulate(true);
   };
 
-  const intervalId = window.setInterval(() => {
+  intervalId = window.setInterval(() => {
     if (document.visibilityState !== "visible" || stopped) return;
     maybeFire();
   }, 1000);
@@ -132,18 +170,7 @@ export function startConnectionsPageDwellTracking(): () => void {
   // Resume from prior segments in this tab (e.g. after OAuth return).
   maybeFire({ defer: readDwellMs() >= DWELL_THRESHOLD_MS });
 
-  return () => {
-    stopped = true;
-    accumulate(true);
-    if (pendingFireTimer != null) {
-      window.clearTimeout(pendingFireTimer);
-      pendingFireTimer = null;
-    }
-    window.clearInterval(intervalId);
-    document.removeEventListener("visibilitychange", onVisibility);
-    window.removeEventListener("pagehide", onPageHide);
-    window.removeEventListener(CONSENT_EVENT, onConsent);
-  };
+  return stopTracking;
 }
 
 export function captureConnectionAddClicked(service: string) {

--- a/lib/connection-analytics.ts
+++ b/lib/connection-analytics.ts
@@ -1,98 +1,9 @@
-import posthog, { DisplaySurveyType } from "posthog-js";
-
-/** PostHog survey: Beta connection flow feedback */
-export const CONNECTION_FEEDBACK_SURVEY_ID =
-  "019f7215-397f-0000-90b4-c32b914ff31e";
-
-const BETA_CONNECTION_FLOW_INVITE_FLAG = "beta-connection-flow-invite";
-const SURVEY_SHOWN_STORAGE_KEY = `deltalytix:survey:${CONNECTION_FEEDBACK_SURVEY_ID}:programmatic-shown`;
-
-let surveyDisplayInFlight = false;
+import posthog from "posthog-js";
 
 function canCapture() {
   if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return false;
   if (typeof window === "undefined") return false;
   return !posthog.has_opted_out_capturing();
-}
-
-function wasProgrammaticSurveyShown() {
-  try {
-    return localStorage.getItem(SURVEY_SHOWN_STORAGE_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function markProgrammaticSurveyShown() {
-  try {
-    localStorage.setItem(SURVEY_SHOWN_STORAGE_KEY, "1");
-  } catch {
-    // Ignore storage failures; PostHog "once" schedule is still a backstop.
-  }
-}
-
-function displayConnectionFeedbackSurvey() {
-  if (surveyDisplayInFlight || wasProgrammaticSurveyShown()) return;
-  if (posthog.isFeatureEnabled(BETA_CONNECTION_FLOW_INVITE_FLAG) !== true) return;
-
-  surveyDisplayInFlight = true;
-  try {
-    posthog.displaySurvey(CONNECTION_FEEDBACK_SURVEY_ID, {
-      displayType: DisplaySurveyType.Popover,
-      // Event-trigger conditions are unreliable on OAuth remounts; we already
-      // gated on the invite flag and a successful connection_created capture.
-      ignoreConditions: true,
-      ignoreDelay: true,
-    });
-    markProgrammaticSurveyShown();
-  } catch (error) {
-    surveyDisplayInFlight = false;
-    console.warn("[connection-analytics] displaySurvey failed", error);
-  }
-}
-
-/**
- * Event-triggered PostHog surveys often miss OAuth return flows: the page
- * remounts, `connection_created` fires within a few seconds, and the surveys
- * extension may not have registered its event listeners yet.
- *
- * Display the feedback survey programmatically after a successful connect,
- * gated by the same invite flag.
- */
-export function showConnectionFeedbackSurvey() {
-  if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return;
-  if (typeof window === "undefined") return;
-  if (wasProgrammaticSurveyShown()) return;
-
-  const tryShow = () => {
-    if (surveyDisplayInFlight || wasProgrammaticSurveyShown()) return;
-    if (posthog.isFeatureEnabled(BETA_CONNECTION_FLOW_INVITE_FLAG) !== true) return;
-
-    posthog.getSurveys((surveys) => {
-      if (surveyDisplayInFlight || wasProgrammaticSurveyShown()) return;
-      if (!surveys?.some((survey) => survey.id === CONNECTION_FEEDBACK_SURVEY_ID)) {
-        // Force reload once if the survey list is still empty/stale.
-        posthog.getSurveys((reloaded) => {
-          if (reloaded?.some((survey) => survey.id === CONNECTION_FEEDBACK_SURVEY_ID)) {
-            displayConnectionFeedbackSurvey();
-          }
-        }, true);
-        return;
-      }
-      displayConnectionFeedbackSurvey();
-    }, true);
-  };
-
-  // Flags + surveys both load async after OAuth remount.
-  const unsubscribe = posthog.onFeatureFlags(() => {
-    tryShow();
-  });
-  tryShow();
-  window.setTimeout(tryShow, 1500);
-  window.setTimeout(() => {
-    tryShow();
-    unsubscribe?.();
-  }, 4000);
 }
 
 export function captureConnectionAddClicked(service: string) {
@@ -107,14 +18,10 @@ export function captureConnectionCreated(
   service: string,
   extra?: Record<string, string | boolean | number | null | undefined>
 ) {
-  // Always attempt the feedback survey after a successful connect.
-  // Analytics capture is optional (beta is a separate origin/consent jar).
-  if (canCapture()) {
-    posthog.capture("connection_created", {
-      service,
-      source: "connections_page",
-      ...extra,
-    });
-  }
-  showConnectionFeedbackSurvey();
+  if (!canCapture()) return;
+  posthog.capture("connection_created", {
+    service,
+    source: "connections_page",
+    ...extra,
+  });
 }

--- a/lib/connection-analytics.ts
+++ b/lib/connection-analytics.ts
@@ -1,9 +1,149 @@
 import posthog from "posthog-js";
 
+/** Fired once per tab session after cumulative visible time on Connections reaches the threshold. */
+export const CONNECTIONS_PAGE_DWELL_THRESHOLD_EVENT =
+  "connections_page_dwell_threshold";
+
+const DWELL_STORAGE_KEY = "deltalytix:connections-page-dwell-ms";
+const DWELL_EVENT_FIRED_KEY = "deltalytix:connections-page-dwell-event-fired";
+const DWELL_THRESHOLD_MS = 180_000;
+const CONSENT_EVENT = "deltalytix:analytics-consent";
+
 function canCapture() {
   if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return false;
   if (typeof window === "undefined") return false;
   return !posthog.has_opted_out_capturing();
+}
+
+function readDwellMs(): number {
+  try {
+    const raw = sessionStorage.getItem(DWELL_STORAGE_KEY);
+    const value = raw ? Number(raw) : 0;
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeDwellMs(ms: number) {
+  try {
+    sessionStorage.setItem(DWELL_STORAGE_KEY, String(Math.floor(ms)));
+  } catch {
+    // sessionStorage may be unavailable
+  }
+}
+
+function wasDwellEventFired(): boolean {
+  try {
+    return sessionStorage.getItem(DWELL_EVENT_FIRED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markDwellEventFired() {
+  try {
+    sessionStorage.setItem(DWELL_EVENT_FIRED_KEY, "1");
+  } catch {
+    // sessionStorage may be unavailable
+  }
+}
+
+function captureDwellThreshold(totalMs: number) {
+  if (wasDwellEventFired()) return;
+  if (!canCapture()) return;
+
+  markDwellEventFired();
+  posthog.capture(CONNECTIONS_PAGE_DWELL_THRESHOLD_EVENT, {
+    source: "connections_page",
+    dwell_ms: Math.floor(totalMs),
+    threshold_ms: DWELL_THRESHOLD_MS,
+  });
+}
+
+/**
+ * Accumulates visible time on the Connections page in sessionStorage so OAuth
+ * leave/return does not reset progress. Fires
+ * {@link CONNECTIONS_PAGE_DWELL_THRESHOLD_EVENT} once the tab has spent
+ * {@link DWELL_THRESHOLD_MS} visible milliseconds on the page.
+ */
+export function startConnectionsPageDwellTracking(): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  let segmentStart: number | null =
+    document.visibilityState === "visible" ? Date.now() : null;
+  let stopped = false;
+  let pendingFireTimer: number | null = null;
+
+  const accumulate = (endSegment = false) => {
+    if (segmentStart == null) return readDwellMs();
+    const now = Date.now();
+    const elapsed = now - segmentStart;
+    segmentStart = endSegment || stopped ? null : now;
+    const total = readDwellMs() + Math.max(0, elapsed);
+    writeDwellMs(total);
+    return total;
+  };
+
+  const maybeFire = (opts?: { defer?: boolean }) => {
+    const total = accumulate();
+    if (total < DWELL_THRESHOLD_MS) return;
+    if (wasDwellEventFired()) return;
+
+    if (opts?.defer) {
+      // After OAuth remount, give PostHog surveys time to attach event listeners.
+      if (pendingFireTimer != null) return;
+      pendingFireTimer = window.setTimeout(() => {
+        pendingFireTimer = null;
+        captureDwellThreshold(readDwellMs());
+      }, 1500);
+      return;
+    }
+
+    captureDwellThreshold(total);
+  };
+
+  const onVisibility = () => {
+    if (document.visibilityState === "visible") {
+      segmentStart = Date.now();
+      maybeFire({ defer: readDwellMs() >= DWELL_THRESHOLD_MS });
+    } else {
+      accumulate(true);
+    }
+  };
+
+  const onConsent = () => {
+    maybeFire({ defer: true });
+  };
+
+  const onPageHide = () => {
+    accumulate(true);
+  };
+
+  const intervalId = window.setInterval(() => {
+    if (document.visibilityState !== "visible" || stopped) return;
+    maybeFire();
+  }, 1000);
+
+  document.addEventListener("visibilitychange", onVisibility);
+  window.addEventListener("pagehide", onPageHide);
+  window.addEventListener(CONSENT_EVENT, onConsent);
+
+  // Resume from prior segments in this tab (e.g. after OAuth return).
+  maybeFire({ defer: readDwellMs() >= DWELL_THRESHOLD_MS });
+
+  return () => {
+    stopped = true;
+    accumulate(true);
+    if (pendingFireTimer != null) {
+      window.clearTimeout(pendingFireTimer);
+      pendingFireTimer = null;
+    }
+    window.clearInterval(intervalId);
+    document.removeEventListener("visibilitychange", onVisibility);
+    window.removeEventListener("pagehide", onPageHide);
+    window.removeEventListener(CONSENT_EVENT, onConsent);
+  };
 }
 
 export function captureConnectionAddClicked(service: string) {


### PR DESCRIPTION
## Summary

- add a parent-domain analytics-consent cookie and make beta honor it
- initialize beta PostHog from shared consent when available instead of silently opting out on a new origin
- remove the OAuth/connection-callback survey display code and its premature localStorage lock
- let PostHog display the feedback survey after 180 seconds on the Connections page

## Root cause

Beta is a separate browser origin, so localStorage consent from production cannot carry over. PostHog therefore initialized opted out on beta unless consent was granted again there. The survey also depended on connection callbacks and only retried flag/survey loading for four seconds after OAuth remounts, while marking itself shown before confirming visible rendering.

This branch makes beta read and write a consent cookie scoped to `.deltalytix.app`. Existing production consent becomes automatically reusable after the same consent change later reaches `main`; until then, granting consent once on beta enables beta analytics and creates the shared choice.

## PostHog

The live survey now:

- targets every beta user who visits `/dashboard/connections`
- is no longer dependent on an email list or feature flag
- remains once per user
- has no connection event requirement
- uses a 180-second popup delay

Connection events remain available for analytics when consent is granted.

## Validation

- compared branch against `beta`: three intended files only
- confirmed the live PostHog survey retained its questions, translations, page targeting, and once-only schedule
- confirmed both linked and custom email targeting flags were removed
- Vercel preview build passed on commit `1981779`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consent cookies and PostHog opt-in/out across prod and beta; mis-sync could affect analytics capture or survey timing, but connection flows and auth are unchanged.
> 
> **Overview**
> **Cross-origin analytics consent** now uses a `deltalytix_analytics_consent` cookie on `.deltalytix.app` (when on deltalytix hosts), with the consent banner preferring that cookie over stale per-origin `localStorage` and migrating existing local choices onto the shared cookie. **PostHog client init** reads the same cookie first so beta does not default to opted-out when production consent already exists.
> 
> **Connections feedback survey** no longer runs programmatic `displaySurvey` after `connection_created` or feature-flag gating. Instead, the Connections page starts **visible dwell tracking** (180s cumulative in `sessionStorage`, surviving OAuth remounts) and fires `connections_page_dwell_threshold` once per tab so PostHog can show the survey on a timer; capture is deferred briefly after OAuth/consent so survey listeners can attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d59b317d0206572e34a3410eacbf038a9b59b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->