### PR TITLE
Add localized Open Graph image for connections page

### DIFF
--- a/app/[locale]/dashboard/connections/opengraph-image.tsx
+++ b/app/[locale]/dashboard/connections/opengraph-image.tsx
@@ -1,0 +1,23 @@
+import { createMarketingOgImageResponse } from "@/lib/og/shared";
+import { getConnectionsMetadataCopy } from "@/lib/og/site-metadata";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const copy = getConnectionsMetadataCopy(locale);
+
+  return createMarketingOgImageResponse({
+    headline: copy.ogHeadline,
+    subheadline: copy.ogSubheadline,
+    cta: copy.ogCta,
+  });
+}

--- a/app/[locale]/dashboard/connections/page.tsx
+++ b/app/[locale]/dashboard/connections/page.tsx
@@ -1,6 +1,34 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
+import { getConnectionsMetadataCopy } from '@/lib/og/site-metadata'
 import { ConnectionsPageClient } from './components/connections-page-client'
 import { getConnectionsPageDataCached } from './data'
+
+type Locale = 'en' | 'fr'
+
+export async function generateMetadata(props: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await props.params
+  const copy = getConnectionsMetadataCopy(locale)
+
+  return {
+    title: {
+      absolute: copy.title,
+    },
+    description: copy.description,
+    openGraph: {
+      title: copy.title,
+      description: copy.description,
+      locale: locale === 'fr' ? 'fr_FR' : 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: copy.title,
+      description: copy.description,
+    },
+  }
+}
 
 export default async function ConnectionsPage() {
   const initialData = await getConnectionsPageDataCached()

--- a/lib/og/site-metadata.test.ts
+++ b/lib/og/site-metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getConnectionsMetadataCopy,
   getSiteMetadataCopy,
   SOCIAL_DESCRIPTION_MAX_LENGTH,
   truncateForSocialDescription,
@@ -18,6 +19,24 @@ describe("site metadata copy", () => {
   it("returns French copy with SEO-friendly description length", () => {
     const copy = getSiteMetadataCopy("fr");
 
+    expect(copy.description.length).toBeLessThanOrEqual(SOCIAL_DESCRIPTION_MAX_LENGTH);
+    expect(copy.ogCta).toContain("→");
+  });
+});
+
+describe("connections metadata copy", () => {
+  it("returns English connections OG copy with social-safe lengths", () => {
+    const copy = getConnectionsMetadataCopy("en");
+
+    expect(copy.ogHeadline).toBe("Connect your brokers.");
+    expect(copy.description.length).toBeLessThanOrEqual(SOCIAL_DESCRIPTION_MAX_LENGTH);
+    expect(copy.ogCta).toContain("→");
+  });
+
+  it("returns French connections OG copy with social-safe lengths", () => {
+    const copy = getConnectionsMetadataCopy("fr");
+
+    expect(copy.ogHeadline).toBe("Connectez vos brokers.");
     expect(copy.description.length).toBeLessThanOrEqual(SOCIAL_DESCRIPTION_MAX_LENGTH);
     expect(copy.ogCta).toContain("→");
   });

--- a/lib/og/site-metadata.ts
+++ b/lib/og/site-metadata.ts
@@ -59,6 +59,31 @@ const SHARED_OG_COPY: Record<OgLocale, { cta: string; alt: string }> = {
   },
 };
 
+const CONNECTIONS_METADATA: Record<OgLocale, SiteMetadataCopy> = {
+  en: {
+    title: "Connections — Sync Brokers on Deltalytix",
+    description:
+      "Manage broker connections and sync trading accounts across Rithmic, Tradovate, and more.",
+    ogHeadline: "Connect your brokers.",
+    ogSubheadline:
+      "Manage connections and sync trading accounts in one place.",
+    ogCta: "Open Connections →",
+    ogAlt:
+      "Deltalytix — Connect your brokers. Manage connections and sync trading accounts. Open Connections.",
+  },
+  fr: {
+    title: "Connexions — Synchronisez vos brokers sur Deltalytix",
+    description:
+      "Gérez vos connexions broker et synchronisez vos comptes Rithmic, Tradovate et plus encore.",
+    ogHeadline: "Connectez vos brokers.",
+    ogSubheadline:
+      "Gérez vos connexions et synchronisez vos comptes au même endroit.",
+    ogCta: "Ouvrir les connexions →",
+    ogAlt:
+      "Deltalytix — Connectez vos brokers. Gérez vos connexions et synchronisez vos comptes. Ouvrir les connexions.",
+  },
+};
+
 export function resolveOgLocale(locale: string | undefined): OgLocale {
   return locale === "fr" ? "fr" : "en";
 }
@@ -73,6 +98,12 @@ export function getUpdatesOgCopy(locale: string | undefined) {
 
 export function getSharedOgCopy(locale: string | undefined) {
   return SHARED_OG_COPY[resolveOgLocale(locale)];
+}
+
+export function getConnectionsMetadataCopy(
+  locale: string | undefined,
+): SiteMetadataCopy {
+  return CONNECTIONS_METADATA[resolveOgLocale(locale)];
 }
 
 export function truncateForSocialDescription(

--- a/scripts/preview-og-images.mjs
+++ b/scripts/preview-og-images.mjs
@@ -14,6 +14,7 @@ import {
 } from "../lib/og/shared.tsx";
 import { ReferralOgImage } from "../lib/og/referral-opengraph.tsx";
 import {
+  getConnectionsMetadataCopy,
   getSiteMetadataCopy,
   getUpdatesOgCopy,
 } from "../lib/og/site-metadata.ts";
@@ -40,6 +41,8 @@ async function renderPng(element, filename) {
 
 const en = getSiteMetadataCopy("en");
 const fr = getSiteMetadataCopy("fr");
+const connectionsEn = getConnectionsMetadataCopy("en");
+const connectionsFr = getConnectionsMetadataCopy("fr");
 const updatesEn = getUpdatesOgCopy("en");
 
 await renderPng(
@@ -58,6 +61,24 @@ await renderPng(
     cta: fr.ogCta,
   }),
   "marketing-fr.png",
+);
+
+await renderPng(
+  createElement(MarketingOgImage, {
+    headline: connectionsEn.ogHeadline,
+    subheadline: connectionsEn.ogSubheadline,
+    cta: connectionsEn.ogCta,
+  }),
+  "connections-en.png",
+);
+
+await renderPng(
+  createElement(MarketingOgImage, {
+    headline: connectionsFr.ogHeadline,
+    subheadline: connectionsFr.ogSubheadline,
+    cta: connectionsFr.ogCta,
+  }),
+  "connections-fr.png",
 );
 
 await renderPng(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a colocated `opengraph-image.tsx` for `/[locale]/dashboard/connections` using the existing marketing OG template (`createMarketingOgImageResponse`).
- Introduces EN/FR connections-specific OG copy and page metadata (`title`, `description`, Open Graph, Twitter).
- Extends OG unit tests and the local preview script so both locale variants can be reviewed as PNGs.

## Copy
| | English | French |
|---|---|---|
| Headline | Connect your brokers. | Connectez vos brokers. |
| Subheadline | Manage connections and sync trading accounts in one place. | Gérez vos connexions et synchronisez vos comptes au même endroit. |
| CTA | Open Connections → | Ouvrir les connexions → |

## Previews
![Connections OG English](https://cursor.com/artifacts/c/art-96d7078e-0df7-4536-ae2e-b97bf649a9c6)
![Connections OG French](https://cursor.com/artifacts/c/art-e7247e6b-010f-4904-91bd-ebc8c31a3707)

## Test plan
- [x] `bunx vitest run lib/og/site-metadata.test.ts`
- [x] `bun scripts/preview-og-images.mjs` renders `connections-en.png` / `connections-fr.png`
- [ ] After deploy preview: open `/en/dashboard/connections/opengraph-image` and `/fr/dashboard/connections/opengraph-image`
- [ ] Confirm social meta (title/description) on the connections page HTML head
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f748d-2ee1-7597-be22-2f9cb8c2d534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f748d-2ee1-7597-be22-2f9cb8c2d534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

