### PR TITLE
Serve connections OG through auth redirect for social crawlers

### DIFF
--- a/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
+++ b/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Image from "next/image"
+import Link from "next/link"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+import { UserAuthForm } from "../components/user-auth-form"
+import { Logo } from "@/components/logo"
+import { useI18n } from '@/locales/client'
+
+export default function AuthenticationPageClient() {
+  const t = useI18n()
+
+  return (
+    <div>
+      <div className="flex relative h-screen flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+        <div className="relative hidden h-full flex-col bg-gray-900 p-10 text-white dark:border-r lg:flex">
+          <div className="absolute inset-0 overflow-hidden">
+          <Image src={"/auth-background.jpeg"} width={928} height={1232} className="opacity-35 w-full" alt="Auth abstract image background"></Image>
+          </div>
+          <div className="relative z-20 flex items-center text-lg font-medium">
+            <Link href="/" className="flex items-center gap-2">
+              <Logo className="w-10 h-10 fill-white"/>
+              Deltalytix
+            </Link>
+          </div>
+          <div className="relative z-20 mt-auto">
+            <blockquote className="space-y-2">
+              <p className="text-lg">
+                {t('authentication.testimonial')}
+              </p>
+              <footer className="text-sm">{t('authentication.testimonialAuthor')}</footer>
+            </blockquote>
+          </div>
+        </div>
+        <div className="p-4 lg:p-8">
+          <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
+            <div className="flex flex-col space-y-2 text-center">
+              <h1 className="text-2xl font-semibold tracking-tight">
+                {t('authentication.title')}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                {t('authentication.description')}
+              </p>
+            </div>
+            <UserAuthForm />
+            <p className="px-8 text-center text-sm text-muted-foreground">
+              {t('authentication.termsAndPrivacy.prefix')}{" "}
+              <Link
+                href="/terms"
+                className="underline underline-offset-4 hover:text-primary"
+              >
+                {t('authentication.termsAndPrivacy.terms')}
+              </Link>{" "}
+              {t('authentication.termsAndPrivacy.and')}{" "}
+              <Link
+                href="/privacy"
+                className="underline underline-offset-4 hover:text-primary"
+              >
+                {t('authentication.termsAndPrivacy.privacy')}
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/[locale]/(authentication)/authentication/page.tsx
+++ b/app/[locale]/(authentication)/authentication/page.tsx
@@ -1,70 +1,25 @@
-'use client'
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { getAuthRedirectMetadata } from "@/lib/og/auth-redirect-metadata";
+import { getRequestOrigin } from "@/lib/site-url";
+import AuthenticationPageClient from "./authentication-page-client";
 
-import Image from "next/image"
-import Link from "next/link"
+type PageProps = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ next?: string | string[] }>;
+};
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
-import { UserAuthForm } from "../components/user-auth-form"
-import { Logo } from "@/components/logo"
-import { useI18n } from '@/locales/client'
+export async function generateMetadata({
+  searchParams,
+}: PageProps): Promise<Metadata> {
+  const { next } = await searchParams;
+  const requestHeaders = await headers();
+  const origin = getRequestOrigin(requestHeaders);
+  const redirectMetadata = getAuthRedirectMetadata(next, origin);
+
+  return redirectMetadata ?? {};
+}
 
 export default function AuthenticationPage() {
-  const t = useI18n()
-
-  return (
-    <div>
-      <div className="flex relative h-screen flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
-        <div className="relative hidden h-full flex-col bg-gray-900 p-10 text-white dark:border-r lg:flex">
-          <div className="absolute inset-0 overflow-hidden">
-          <Image src={"/auth-background.jpeg"} width={928} height={1232} className="opacity-35 w-full" alt="Auth abstract image background"></Image>
-          </div>
-          <div className="relative z-20 flex items-center text-lg font-medium">
-            <Link href="/" className="flex items-center gap-2">
-              <Logo className="w-10 h-10 fill-white"/>
-              Deltalytix
-            </Link>
-          </div>
-          <div className="relative z-20 mt-auto">
-            <blockquote className="space-y-2">
-              <p className="text-lg">
-                {t('authentication.testimonial')}
-              </p>
-              <footer className="text-sm">{t('authentication.testimonialAuthor')}</footer>
-            </blockquote>
-          </div>
-        </div>
-        <div className="p-4 lg:p-8">
-          <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
-            <div className="flex flex-col space-y-2 text-center">
-              <h1 className="text-2xl font-semibold tracking-tight">
-                {t('authentication.title')}
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                {t('authentication.description')}
-              </p>
-            </div>
-            <UserAuthForm />
-            <p className="px-8 text-center text-sm text-muted-foreground">
-              {t('authentication.termsAndPrivacy.prefix')}{" "}
-              <Link
-                href="/terms"
-                className="underline underline-offset-4 hover:text-primary"
-              >
-                {t('authentication.termsAndPrivacy.terms')}
-              </Link>{" "}
-              {t('authentication.termsAndPrivacy.and')}{" "}
-              <Link
-                href="/privacy"
-                className="underline underline-offset-4 hover:text-primary"
-              >
-                {t('authentication.termsAndPrivacy.privacy')}
-              </Link>
-              .
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
+  return <AuthenticationPageClient />;
 }

--- a/app/[locale]/dashboard/connections/page.tsx
+++ b/app/[locale]/dashboard/connections/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { getConnectionsMetadataCopy } from '@/lib/og/site-metadata'
+import { getRequestOrigin, siteUrl } from '@/lib/site-url'
 import { ConnectionsPageClient } from './components/connections-page-client'
 import { getConnectionsPageDataCached } from './data'
 
@@ -11,6 +13,8 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const { locale } = await props.params
   const copy = getConnectionsMetadataCopy(locale)
+  const origin = getRequestOrigin(await headers())
+  const imageUrl = siteUrl(`/${locale}/dashboard/connections/opengraph-image`, origin)
 
   return {
     title: {
@@ -21,11 +25,20 @@ export async function generateMetadata(props: {
       title: copy.title,
       description: copy.description,
       locale: locale === 'fr' ? 'fr_FR' : 'en_US',
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: copy.ogAlt,
+        },
+      ],
     },
     twitter: {
       card: 'summary_large_image',
       title: copy.title,
       description: copy.description,
+      images: [imageUrl],
     },
   }
 }

--- a/lib/og/auth-redirect-metadata.test.ts
+++ b/lib/og/auth-redirect-metadata.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAuthRedirectMetadata,
+  resolveAuthNextOgTarget,
+} from "./auth-redirect-metadata";
+
+describe("resolveAuthNextOgTarget", () => {
+  it("resolves locale-prefixed connections next paths", () => {
+    expect(resolveAuthNextOgTarget("fr/dashboard/connections")).toEqual({
+      locale: "fr",
+      kind: "connections",
+    });
+    expect(resolveAuthNextOgTarget("en/dashboard/connections")).toEqual({
+      locale: "en",
+      kind: "connections",
+    });
+  });
+
+  it("defaults to English when next has no locale prefix", () => {
+    expect(resolveAuthNextOgTarget("dashboard/connections")).toEqual({
+      locale: "en",
+      kind: "connections",
+    });
+  });
+
+  it("ignores unrelated next targets", () => {
+    expect(resolveAuthNextOgTarget("fr/dashboard")).toBeNull();
+    expect(resolveAuthNextOgTarget("fr/pricing")).toBeNull();
+    expect(resolveAuthNextOgTarget(undefined)).toBeNull();
+  });
+});
+
+describe("getAuthRedirectMetadata", () => {
+  it("returns French connections OG copy and image URL", () => {
+    const metadata = getAuthRedirectMetadata(
+      "fr/dashboard/connections",
+      "https://beta.deltalytix.app",
+    );
+
+    expect(metadata?.description).toContain("connexions broker");
+    expect(metadata?.openGraph).toMatchObject({
+      locale: "fr_FR",
+      images: [
+        {
+          url: "https://beta.deltalytix.app/fr/dashboard/connections/opengraph-image",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    });
+  });
+
+  it("returns null for non-connections redirects", () => {
+    expect(getAuthRedirectMetadata("fr/dashboard")).toBeNull();
+  });
+});

--- a/lib/og/auth-redirect-metadata.ts
+++ b/lib/og/auth-redirect-metadata.ts
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { siteUrl } from "../site-url";
+import {
+  getConnectionsMetadataCopy,
+  type OgLocale,
+  resolveOgLocale,
+} from "./site-metadata";
+
+export type AuthNextOgTarget = {
+  locale: OgLocale;
+  kind: "connections";
+};
+
+function normalizeNextPath(next: string): string {
+  return next.replace(/^\//, "").split("?")[0] ?? "";
+}
+
+/**
+ * Map authentication `?next=` targets to page-specific social metadata.
+ * Social crawlers follow the dashboard → /authentication redirect, so the
+ * auth page must expose the destination's OG tags for previews to work.
+ */
+export function resolveAuthNextOgTarget(
+  next: string | string[] | undefined,
+): AuthNextOgTarget | null {
+  if (typeof next !== "string" || !next.trim()) {
+    return null;
+  }
+
+  const segments = normalizeNextPath(next)
+    .split("/")
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  let locale: OgLocale = "en";
+  let rest = segments;
+
+  if (segments[0] === "en" || segments[0] === "fr") {
+    locale = resolveOgLocale(segments[0]);
+    rest = segments.slice(1);
+  }
+
+  if (rest[0] === "dashboard" && rest[1] === "connections") {
+    return { locale, kind: "connections" };
+  }
+
+  return null;
+}
+
+export function getAuthRedirectMetadata(
+  next: string | string[] | undefined,
+  origin?: string,
+): Metadata | null {
+  const target = resolveAuthNextOgTarget(next);
+  if (!target) {
+    return null;
+  }
+
+  if (target.kind === "connections") {
+    const copy = getConnectionsMetadataCopy(target.locale);
+    const imageUrl = siteUrl(
+      `/${target.locale}/dashboard/connections/opengraph-image`,
+      origin,
+    );
+
+    return {
+      title: {
+        absolute: copy.title,
+      },
+      description: copy.description,
+      openGraph: {
+        title: copy.title,
+        description: copy.description,
+        locale: target.locale === "fr" ? "fr_FR" : "en_US",
+        type: "website",
+        images: [
+          {
+            url: imageUrl,
+            width: 1200,
+            height: 630,
+            alt: copy.ogAlt,
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: copy.title,
+        description: copy.description,
+        images: [imageUrl],
+      },
+    };
+  }
+
+  return null;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -437,7 +437,13 @@ export default async function proxy(req: NextRequest) {
   if (!user || error) {
     if (isProtectedDashboardPath(pathname)) {
       const encodedSearchParams = `${pathname.substring(1)}${req.nextUrl.search}`
-      const authUrl = new URL("/authentication", req.url)
+      const pathLocale = pathname.split("/").find((segment) =>
+        LOCALES.includes(segment),
+      )
+      const authPath = pathLocale
+        ? `/${pathLocale}/authentication`
+        : "/authentication"
+      const authUrl = new URL(authPath, req.url)
 
       if (encodedSearchParams) {
         authUrl.searchParams.append("next", encodedSearchParams)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Not an OG image cache issue. `/fr/dashboard/connections/opengraph-image` is already live with the correct French card, but unauthenticated requests (including Discord/Slack/Twitter crawlers) get a `307` to `/authentication`, which still served the root marketing OG tags.

This PR:
- Maps `?next=.../dashboard/connections` on the authentication page to the connections EN/FR OG title/description/image
- Preserves locale when redirecting protected dashboard paths to authentication (`/fr/...` → `/fr/authentication?...`)
- Sets an explicit `openGraph.images` / `twitter.images` URL on the connections page itself

## How to verify after deploy
1. Open [the live image](https://beta.deltalytix.app/fr/dashboard/connections/opengraph-image) — already correct today
2. `curl -sL "https://beta.deltalytix.app/fr/dashboard/connections" | rg 'og:title|og:image'`
   - Expect connections title + `/fr/dashboard/connections/opengraph-image`
3. Paste the URL into a social debugger / Slack after deploy

## Test plan
- [x] `bunx vitest run lib/og/auth-redirect-metadata.test.ts lib/og/site-metadata.test.ts`
- [ ] After deploy: unauthenticated HTML for `/fr/dashboard/connections` includes connections OG tags via the auth redirect destination
- [ ] Logged-in page head still includes connections OG image URL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f748d-2ee1-7597-be22-2f9cb8c2d534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f748d-2ee1-7597-be22-2f9cb8c2d534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

