### PR TITLE
Fix Safari top chrome strip on theme change everywhere

### DIFF
--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -378,12 +378,6 @@ export default function Component() {
       />
 
       <span
-        key={`safari-theme-top-${effectiveTheme}`}
-        className="landing-safari-theme-sampler"
-        aria-hidden="true"
-      />
-
-      <span
         className={`fixed top-0 left-0 right-0 z-50 bg-background pt-safe min-h-nav-safe transition-transform duration-300 ${isVisible ? "translate-y-0" : "-translate-y-full"}`}
       ></span>
       <header

--- a/app/[locale]/(landing)/layout.tsx
+++ b/app/[locale]/(landing)/layout.tsx
@@ -5,15 +5,11 @@ import { ThemeProvider } from "@/context/theme-provider";
 import { I18nProviderClient } from "@/locales/landing-client";
 import { ConsentBanner } from "@/components/consent-banner";
 
-import { Metadata, Viewport } from "next";
+import { Metadata } from "next";
 import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 
 type Locale = "en" | "fr";
 const TITLE_TEMPLATE = "%s | Deltalytix";
-
-export const viewport: Viewport = {
-  viewportFit: "cover",
-};
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: Locale }>;
@@ -51,16 +47,20 @@ export default async function RootLayout(
   const { locale } = await params;
 
   return (
-    <ThemeProvider>
-      <I18nProviderClient locale={locale}>
-        <ConsentBanner />
-        <div className="min-h-dvh bg-[oklch(0.97_0_0)] text-[oklch(0.17_0_0)] [--background:0_0%_96.1%] [--card:0_0%_100%] [--foreground:0_0%_9%] dark:bg-[oklch(0.17_0_0)] dark:text-[oklch(0.93_0_0)] dark:[--background:0_0%_6.7%] dark:[--card:0_0%_0%] dark:[--foreground:0_0%_93%]">
+    <I18nProviderClient locale={locale}>
+      <ConsentBanner />
+      {/*
+        Theme tokens wrap ThemeProvider so the shared Safari chrome sampler
+        inherits the landing --background values (not the app shell defaults).
+      */}
+      <div className="min-h-dvh bg-[oklch(0.97_0_0)] text-[oklch(0.17_0_0)] [--background:0_0%_96.1%] [--card:0_0%_100%] [--foreground:0_0%_9%] dark:bg-[oklch(0.17_0_0)] dark:text-[oklch(0.93_0_0)] dark:[--background:0_0%_6.7%] dark:[--card:0_0%_0%] dark:[--foreground:0_0%_93%]">
+        <ThemeProvider>
           <Toaster />
           <Navbar />
           <div className="pt-nav-content">{children}</div>
           <Footer />
-        </div>
-      </I18nProviderClient>
-    </ThemeProvider>
+        </ThemeProvider>
+      </div>
+    </I18nProviderClient>
   );
 }

--- a/app/[locale]/dashboard/components/navbar.tsx
+++ b/app/[locale]/dashboard/components/navbar.tsx
@@ -33,8 +33,8 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky py-2 top-0 left-0 right-0 z-40 flex w-full flex-col border-b bg-background/80 text-primary shadow-xs backdrop-blur-md">
-        <div className="flex items-center justify-between px-3 sm:px-6 lg:px-10 h-16 gap-3 sm:gap-4">
+      <nav className="sticky top-0 left-0 right-0 z-40 flex w-full flex-col border-b bg-background pt-safe text-primary shadow-xs">
+        <div className="flex items-center justify-between px-3 sm:px-6 lg:px-10 h-16 gap-3 sm:gap-4 py-2">
           <div className="flex items-center gap-x-4">
             <div className="flex flex-col items-center">
               <Popover open={isLogoPopoverOpen} onOpenChange={setIsLogoPopoverOpen} modal={false}>

--- a/app/[locale]/shared/[slug]/shared-page-client.tsx
+++ b/app/[locale]/shared/[slug]/shared-page-client.tsx
@@ -116,7 +116,7 @@ function TopBanner({ t }: { t: any }) {
   ]
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b shadow-xs">
+    <div className="fixed top-0 left-0 right-0 z-50 border-b bg-background pt-safe shadow-xs">
       <div className="w-full mx-auto py-3 px-4 md:px-10">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
           <div className="flex items-center gap-x-4">

--- a/app/[locale]/teams/components/team-navbar.tsx
+++ b/app/[locale]/teams/components/team-navbar.tsx
@@ -180,8 +180,9 @@ export default function TeamNavbar() {
     return (
         <>
             <div className={`fixed inset-0 bg-background/80  backdrop-blur-xs z-40 transition-opacity duration-300 ${hoveredItem ? 'opacity-100' : 'opacity-0 pointer-events-none'}`} />
-            <span className={`h-14 fixed top-0 left-0 right-0 bg-background z-50 ${isVisible ? 'translate-y-0' : '-translate-y-full'}`}></span>
-            <header className={`max-w-7xl mx-auto fixed top-0 left-0 right-0 px-4 lg:px-6 h-14 flex items-center justify-between z-50  text-foreground transition-transform duration-300 ${isVisible ? 'translate-y-0' : '-translate-y-full'}`}>
+            <span className={`fixed top-0 left-0 right-0 z-50 bg-background pt-safe min-h-nav-safe transition-transform duration-300 ${isVisible ? 'translate-y-0' : '-translate-y-full'}`}></span>
+            <header className={`fixed top-0 left-0 right-0 z-50 pt-safe text-foreground transition-transform duration-300 ${isVisible ? 'translate-y-0' : '-translate-y-full'}`}>
+                <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 lg:px-6">
                 <Link href="/teams" className="flex items-center space-x-2">
                     <Logo className='w-6 h-6 fill-black dark:fill-white' />
                     <span className="font-bold text-xl">Deltalytix</span>
@@ -299,6 +300,7 @@ export default function TeamNavbar() {
                             </div>
                         </SheetContent>
                     </Sheet>
+                </div>
                 </div>
             </header>
         </>

--- a/app/globals.css
+++ b/app/globals.css
@@ -453,21 +453,18 @@
 
 @layer utilities {
   /*
-   * Safari 26 samples fixed elements at initial render to tint its top chrome.
-   * Use the system media query here so the correct color is available before
-   * the client theme script adds the light/dark class.
+   * Safari samples a fixed top-edge element to tint its browser chrome.
+   * Prefer the active --background token so dashboard, landing, and other
+   * shells stay in sync. Fall back via prefers-color-scheme before the
+   * client theme script adds the light/dark class.
    */
-  .landing-safari-theme-sampler {
-    background-color: hsl(0 0% 96.1%);
-  }
-
-  .dark .landing-safari-theme-sampler {
-    background-color: hsl(0 0% 6.7%);
+  .safari-theme-sampler {
+    background-color: hsl(var(--background));
   }
 
   @media (prefers-color-scheme: dark) {
-    :root:not(.light) .landing-safari-theme-sampler {
-      background-color: hsl(0 0% 6.7%);
+    :root:not(.light) .safari-theme-sampler {
+      background-color: hsl(0 0% calc(100% - var(--theme-intensity, 100%)));
     }
   }
 
@@ -476,7 +473,7 @@
    * browser-chrome sampler. Animated overlays are not reliably re-sampled
    * when the theme changes.
    */
-  .landing-safari-theme-sampler {
+  .safari-theme-sampler {
     position: fixed;
     top: 0;
     left: 0;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
@@ -86,6 +86,12 @@ export const metadata: Metadata = {
   creator: "Hugo DEMENEZ",
   publisher: "Hugo DEMENEZ",
   formatDetection: { email: false, address: false, telephone: false },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/context/theme-provider.tsx
+++ b/context/theme-provider.tsx
@@ -111,6 +111,16 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <ThemeContext.Provider value={value}>
+      {/*
+        Safari samples a fixed top-edge element for browser-chrome tinting.
+        Remount on theme change so the status-bar region stays in sync and
+        does not leave a light strip after toggling light/dark.
+      */}
+      <span
+        key={`safari-theme-top-${effectiveTheme}`}
+        className="safari-theme-sampler"
+        aria-hidden="true"
+      />
       {children}
     </ThemeContext.Provider>
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On iOS Safari, changing light/dark theme on the dashboard (and other non-landing pages) left a mismatched strip at the top of the browser chrome. The landing page already had a fix for this (#305); other shells did not.

## Root cause

Safari samples a fixed element at the viewport’s top edge to tint its status-bar / chrome region. The landing navbar remounted an 8px sampler on `effectiveTheme` changes; dashboard/teams/shared only had sticky or translucent navbars, so Safari kept a stale light tint after theme toggles. `viewport-fit: cover` was also scoped to landing only, so safe-area painting did not apply app-wide.

## Fix

- Move the Safari theme sampler into `ThemeProvider` so every themed surface remounts it on theme change
- Drive sampler color from `hsl(var(--background))` (with a system dark fallback) instead of landing-hardcoded values
- Nest landing’s token wrapper around `ThemeProvider` so the sampler still inherits landing’s custom `--background`
- Enable `viewportFit: "cover"` on the root layout
- Extend dashboard, teams, and shared top chrome into the iOS safe area with solid backgrounds

## Testing

- `bun run typecheck`
- Manual: on iOS Safari, toggle theme on dashboard / teams / shared / landing — top chrome should match the page background with no light strip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f757d-1e71-78bb-afd3-7c9b69a6fcd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f757d-1e71-78bb-afd3-7c9b69a6fcd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

