### PR TITLE
Fix OAuth callbacks on preview deployments

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -16,15 +16,32 @@ import { ensureLocalDashboardUserInDatabase } from '@/server/local-dashboard-boo
 import { capturePostHogEvent } from '@/lib/posthog-server'
 
 export async function getWebsiteURL() {
+  const requestHeaders = await headers()
+  const host = (
+    requestHeaders.get('x-forwarded-host') ??
+    requestHeaders.get('host')
+  )?.split(',')[0]?.trim()
+
+  if (host) {
+    const forwardedProtocol = requestHeaders
+      .get('x-forwarded-proto')
+      ?.split(',')[0]
+      ?.trim()
+    const protocol =
+      forwardedProtocol ??
+      (host.startsWith('localhost') || host.startsWith('127.0.0.1')
+        ? 'http'
+        : 'https')
+
+    return `${protocol}://${host}/`
+  }
+
   let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ?? // Set this to your site URL in production env.
-    process?.env?.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
+    process?.env?.NEXT_PUBLIC_SITE_URL ??
+    process?.env?.NEXT_PUBLIC_VERCEL_URL ??
     'http://localhost:3000/'
-  // Make sure to include `https://` when not localhost.
   url = url.startsWith('http') ? url : `https://${url}`
-  // Make sure to include a trailing `/`.
-  url = url.endsWith('/') ? url : `${url}/`
-  return url
+  return url.endsWith('/') ? url : `${url}/`
 }
 
 /**


### PR DESCRIPTION
## What changed

- derive the application origin from the current request's forwarded host and protocol
- preserve the existing environment-variable and localhost fallbacks when request headers are unavailable
- normalize comma-separated forwarded header values

## Why

Preview OAuth requests were falling back to `http://localhost:3000` when `NEXT_PUBLIC_VERCEL_URL` was unavailable. Discord therefore returned users to localhost instead of the Vercel preview deployment.

Using the request host preserves the exact domain the user opened, including Vercel preview URLs, beta, production, and custom aliases.

## Impact

Discord, Google, magic-link, signup, recovery, and identity-linking callbacks all use `getWebsiteURL()`, so they now remain on the active deployment origin.

## Validation

- compared the branch against `beta`
- confirmed the branch is one commit ahead
- confirmed only `server/auth.ts` changed
- manually inspected production, preview, forwarded-proxy, and localhost resolution paths