### PR TITLE
Reuse trusted request origin for preview OAuth callbacks

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,5 +1,6 @@
 'use server'
 import { createClient, ensureUserInDatabase } from '@/server/auth'
+import { getRequestOrigin } from '@/lib/site-url'
 import { NextResponse } from 'next/server'
 // The client you created from the Server-Side Auth instructions
 
@@ -11,11 +12,13 @@ export async function GET(request: Request) {
   const next = searchParams.get('next')
   const action = searchParams.get('action')
   const locale = searchParams.get('locale') || undefined
+  const requestOrigin = getRequestOrigin(request.headers)
 
   // Add debugging for Edge
   console.log('Auth callback debug:', {
     userAgent: request.headers.get('user-agent'),
     origin,
+    requestOrigin,
     hasCode: !!code,
     next,
     action
@@ -34,23 +37,15 @@ export async function GET(request: Request) {
       if (!error) {
         // Handle password recovery redirect
         if (type === 'recovery') {
-          const forwardedHost = request.headers.get('x-forwarded-host')
-          const isLocalEnv = process.env.NODE_ENV === 'development'
-          const baseUrl = isLocalEnv
-            ? `${origin}/dashboard/settings`
-            : `https://${forwardedHost || origin}/dashboard/settings`
-          const redirectUrl = `${baseUrl}?passwordReset=true`
+          const redirectUrl = new URL('/dashboard/settings', requestOrigin)
+          redirectUrl.searchParams.set('passwordReset', 'true')
           return NextResponse.redirect(redirectUrl)
         }
 
         // Handle identity linking redirect
         if (action === 'link') {
-          const forwardedHost = request.headers.get('x-forwarded-host')
-          const isLocalEnv = process.env.NODE_ENV === 'development'
-          const baseUrl = isLocalEnv
-            ? `${origin}/dashboard/settings`
-            : `https://${forwardedHost || origin}/dashboard/settings`
-          const redirectUrl = `${baseUrl}?linked=true`
+          const redirectUrl = new URL('/dashboard/settings', requestOrigin)
+          redirectUrl.searchParams.set('linked', 'true')
           return NextResponse.redirect(redirectUrl)
         }
 
@@ -65,25 +60,10 @@ export async function GET(request: Request) {
           // Non-fatal: continue redirect
         }
 
-        const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
-        const isLocalEnv = process.env.NODE_ENV === 'development'
-        if (isLocalEnv) {
-          // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-          if (decodedNext) {
-            return NextResponse.redirect(new URL(decodedNext, origin))
-          }
-          return NextResponse.redirect(`${origin}${next ?? '/dashboard'}`)
-        } else if (forwardedHost) {
-          if (decodedNext) {
-            return NextResponse.redirect(new URL(decodedNext, `https://${forwardedHost}`))
-          }
-          return NextResponse.redirect(`https://${forwardedHost}${next ?? '/dashboard'}`)
-        } else {
-          if (decodedNext) {
-            return NextResponse.redirect(new URL(decodedNext, origin))
-          }
-          return NextResponse.redirect(`${origin}${next ?? '/dashboard'}`)
+        if (decodedNext) {
+          return NextResponse.redirect(new URL(decodedNext, requestOrigin))
         }
+        return NextResponse.redirect(new URL(next ?? '/dashboard', requestOrigin))
       } else {
         console.log('Auth callback error:', error)
       }
@@ -97,12 +77,14 @@ export async function GET(request: Request) {
       ) {
         console.error('[Auth Callback] Supabase API returned non-JSON response:', error)
         // Redirect to auth page with error message
-        return NextResponse.redirect(`${origin}/authentication?error=service_unavailable`)
+        const errorUrl = new URL('/authentication', requestOrigin)
+        errorUrl.searchParams.set('error', 'service_unavailable')
+        return NextResponse.redirect(errorUrl)
       }
       console.error('Auth callback unexpected error:', error)
     }
   }
 
   // return the user to the authentication page
-  return NextResponse.redirect(`${origin}/authentication`)
+  return NextResponse.redirect(new URL('/authentication', requestOrigin))
 }

--- a/lib/site-url.ts
+++ b/lib/site-url.ts
@@ -10,8 +10,10 @@ type HeaderLike = {
 
 function originCandidatesFromEnv() {
   return [
+    process.env.NEXT_PUBLIC_SITE_URL,
     process.env.NEXT_PUBLIC_BASE_URL,
     process.env.NEXT_PUBLIC_APP_URL,
+    process.env.NEXT_PUBLIC_VERCEL_URL,
     process.env.VERCEL_PROJECT_PRODUCTION_URL,
     process.env.VERCEL_URL,
   ];

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -16,15 +16,32 @@ import { ensureLocalDashboardUserInDatabase } from '@/server/local-dashboard-boo
 import { capturePostHogEvent } from '@/lib/posthog-server'
 
 export async function getWebsiteURL() {
+  const requestHeaders = await headers()
+  const host = (
+    requestHeaders.get('x-forwarded-host') ??
+    requestHeaders.get('host')
+  )?.split(',')[0]?.trim()
+
+  if (host) {
+    const forwardedProtocol = requestHeaders
+      .get('x-forwarded-proto')
+      ?.split(',')[0]
+      ?.trim()
+    const protocol =
+      forwardedProtocol ??
+      (host.startsWith('localhost') || host.startsWith('127.0.0.1')
+        ? 'http'
+        : 'https')
+
+    return `${protocol}://${host}/`
+  }
+
   let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ?? // Set this to your site URL in production env.
-    process?.env?.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
+    process?.env?.NEXT_PUBLIC_SITE_URL ??
+    process?.env?.NEXT_PUBLIC_VERCEL_URL ??
     'http://localhost:3000/'
-  // Make sure to include `https://` when not localhost.
   url = url.startsWith('http') ? url : `https://${url}`
-  // Make sure to include a trailing `/`.
-  url = url.endsWith('/') ? url : `${url}/`
-  return url
+  return url.endsWith('/') ? url : `${url}/`
 }
 
 /**

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -14,34 +14,14 @@ import {
 import { createLocalDashboardBypassAuthStub } from '@/lib/local-dashboard-bypass-client'
 import { ensureLocalDashboardUserInDatabase } from '@/server/local-dashboard-bootstrap'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import { getRequestOrigin } from '@/lib/site-url'
 
 export async function getWebsiteURL() {
-  const requestHeaders = await headers()
-  const host = (
-    requestHeaders.get('x-forwarded-host') ??
-    requestHeaders.get('host')
-  )?.split(',')[0]?.trim()
-
-  if (host) {
-    const forwardedProtocol = requestHeaders
-      .get('x-forwarded-proto')
-      ?.split(',')[0]
-      ?.trim()
-    const protocol =
-      forwardedProtocol ??
-      (host.startsWith('localhost') || host.startsWith('127.0.0.1')
-        ? 'http'
-        : 'https')
-
-    return `${protocol}://${host}/`
-  }
-
-  let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ??
-    process?.env?.NEXT_PUBLIC_VERCEL_URL ??
-    'http://localhost:3000/'
-  url = url.startsWith('http') ? url : `https://${url}`
-  return url.endsWith('/') ? url : `${url}/`
+  // Reuse the shared trusted-host allowlist (*.deltalytix.app, *.vercel.app,
+  // configured env origins, localhost in non-prod) so preview OAuth callbacks
+  // stay on the deployment the user opened without accepting arbitrary Host headers.
+  const origin = getRequestOrigin(await headers())
+  return origin.endsWith('/') ? origin : `${origin}/`
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Route `getWebsiteURL()` through `getRequestOrigin()` so OAuth / magic-link / Stripe redirects use the shared trusted-host allowlist
- Route auth callback post-login redirects through `getRequestOrigin()` instead of raw `x-forwarded-host`
- Preview hosts (`*.vercel.app`) and app hosts (`*.deltalytix.app`) stay on the deployment the user opened
- Arbitrary `Host` / `x-forwarded-host` values fall back to configured env origin instead of being trusted
- Include `NEXT_PUBLIC_SITE_URL` and `NEXT_PUBLIC_VERCEL_URL` in the shared env origin candidates (previous `getWebsiteURL` fallbacks)

## Why

Vercel preview OAuth was redirecting to `localhost` when env-based origin resolution missed the preview host. PR #345 fixed that by reading request headers, but trusted those headers unconditionally.

`lib/site-url.ts` already allowlists `*.vercel.app` specifically for preview self-reference — reuse that instead of duplicating unsafe header parsing. The auth callback had the same raw-header redirect gap after code exchange.

## Impact

Discord, Google, magic-link, signup, recovery, identity-linking, Stripe checkout return URLs, and `/api/auth/callback` redirects all stay on allowlisted origins.

## Related

Supersedes the approach in #345 (same goal, trusted-host reuse).

## Validation

- Confirmed `TRUSTED_HOST_SUFFIXES` includes `.vercel.app`
- `bun run typecheck` (workspace)
- No new linter issues on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7655-5d27-7c93-8bb5-43ddb341f7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7655-5d27-7c93-8bb5-43ddb341f7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

