### PR TITLE
Fix empty renewal notification emails

### DIFF
--- a/components/emails/renewal-notice.test.tsx
+++ b/components/emails/renewal-notice.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@react-email/render";
+import { describe, expect, it } from "vitest";
+import RenewalNoticeEmail from "./renewal-notice";
+
+describe("RenewalNoticeEmail", () => {
+  it("renders the renewal content instead of an empty React shell", async () => {
+    const html = await render(
+      RenewalNoticeEmail({
+        userFirstName: "Hugo",
+        userEmail: "hugo@example.com",
+        accountName: "TFDRA_5044AU8",
+        propFirmName: "Test Prop Firm",
+        nextPaymentDate: "July 20, 2026",
+        daysUntilRenewal: 1,
+        paymentFrequency: "monthly",
+        language: "en",
+        unsubscribeUrl: "https://deltalytix.app/settings/notifications",
+      }),
+    );
+
+    expect(html).toContain("Account Renewal Notice");
+    expect(html).toContain("TFDRA_5044AU8");
+    expect(html).not.toContain("<template></template>");
+  });
+});

--- a/components/emails/renewal-notice.tsx
+++ b/components/emails/renewal-notice.tsx
@@ -101,9 +101,9 @@ export default function RenewalNoticeEmail({
 
   return (
     <Html>
-      <Head />
-      <Preview>{t.preview}</Preview>
       <Tailwind>
+        <Head />
+        <Preview>{t.preview}</Preview>
         <Body className="bg-gray-50 font-sans">
           <Section className="bg-white max-w-[600px] mx-auto rounded-lg shadow-xs">
             <Section className="px-6 py-8">


### PR DESCRIPTION
## What changed

- move the React Email `Head` and preview inside the `Tailwind` provider
- add a regression test that renders the real renewal template
- assert that the account details are present and that React Email does not return an empty `<template></template>` shell

## Root cause

The renewal template uses non-inlineable Tailwind utilities such as `space-y-3` and `hover:*`. React Email needs a `Head` inside the `Tailwind` tree to emit the required styles. Because the existing `Head` was outside that tree, rendering collapsed to an empty shell while Resend still accepted the message.

## Impact

Renewal emails now contain their expected content instead of being delivered empty.

## Validation

- `npx vitest run components/emails/renewal-notice.test.tsx`
- 1 test passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to one email template and a test; no auth, payments, or shared send pipeline changes.
> 
> **Overview**
> Fixes **empty renewal notification emails** by moving React Email **`Head`** and **`Preview`** inside the **`Tailwind`** wrapper in `renewal-notice.tsx`. Tailwind utilities such as `space-y-3` and `hover:*` need styles emitted from a `Head` within that tree; with `Head` outside, rendering collapsed to an empty `<template></template>` shell while sends still succeeded.
> 
> Adds a **Vitest regression test** that renders the real template and asserts account copy appears and the empty shell is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd322c2c62835c1be6ced11fab8d5d2a3b35f0a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->