### PR TITLE
perf(dashboard): remove authenticated critical-path request waterfall

### DIFF
--- a/context/data-provider.tsx
+++ b/context/data-provider.tsx
@@ -34,7 +34,6 @@ import {
   deleteAccountAction,
   setupAccountAction,
   savePayoutAction,
-  calculateAccountMetricsAction,
   deleteTradesByIdsAction,
 } from "@/server/accounts";
 import { computeMetricsForAccounts } from "@/lib/account-metrics";
@@ -68,6 +67,34 @@ import { computeEquityChartData } from "@/lib/equity-chart";
 import { defaultLayouts } from "@/lib/default-layouts";
 import { getTimeRangeKey } from "@/lib/time-range";
 import { useIsMobile } from "@/hooks/use-mobile";
+
+/** Dev-only / opt-in timing for dashboard critical-path work. No production overhead. */
+const DASHBOARD_PERF_LOG =
+  process.env.NODE_ENV === "development" ||
+  process.env.NEXT_PUBLIC_DASHBOARD_PERF_LOG === "1";
+
+function logDashboardPerf(
+  label: string,
+  startMs: number,
+  detail?: Record<string, number | string | boolean>
+) {
+  if (!DASHBOARD_PERF_LOG) return;
+  const elapsed = performance.now() - startMs;
+  if (detail) {
+    console.info(`[dashboard-perf] ${label}: ${elapsed.toFixed(1)}ms`, detail);
+  } else {
+    console.info(`[dashboard-perf] ${label}: ${elapsed.toFixed(1)}ms`);
+  }
+}
+
+async function timedPromise<T>(
+  name: string,
+  promise: Promise<T>
+): Promise<{ name: string; ms: number; value: T }> {
+  const start = performance.now();
+  const value = await promise;
+  return { name, ms: performance.now() - start, value };
+}
 
 // Types from trades-data.tsx
 type StatisticsProps = {
@@ -444,9 +471,30 @@ export const DataProvider: React.FC<{
     equityChartParams,
   ]);
 
-  // Load data from the server
+  const loadStripeSubscription = useCallback(async () => {
+    try {
+      setStripeSubscriptionLoading(true);
+      const stripeSubscriptionData = await getSubscriptionData();
+      setStripeSubscription(stripeSubscriptionData);
+      setStripeSubscriptionError(null);
+    } catch (error) {
+      console.error("Error loading Stripe subscription:", error);
+      setStripeSubscriptionError(
+        error instanceof Error ? error.message : "Failed to load subscription"
+      );
+      setStripeSubscription(null);
+    } finally {
+      setStripeSubscriptionLoading(false);
+    }
+  }, [
+    setStripeSubscription,
+    setStripeSubscriptionError,
+    setStripeSubscriptionLoading,
+  ]);
+
+  // Load authenticated dashboard data: auth first, then parallel critical fetches.
   const loadData = useCallback(async () => {
-    // Prevent multiple simultaneous loads
+    const loadStarted = performance.now();
     try {
       setIsLoading(true);
 
@@ -462,35 +510,36 @@ export const DataProvider: React.FC<{
             ),
           }));
 
-          // Batch state updates
-          const updates = async () => {
-            setTrades(processedSharedTrades);
-            setSharedParams(sharedData.params);
+          setTrades(processedSharedTrades);
+          setSharedParams(sharedData.params);
+          setDashboardLayout(defaultLayouts);
 
-            setDashboardLayout(defaultLayouts);
+          if (sharedData.params.tickDetails) {
+            setTickDetails(sharedData.params.tickDetails);
+          }
 
-            if (sharedData.params.tickDetails) {
-              setTickDetails(sharedData.params.tickDetails);
-            }
-
-            const accountsWithMetrics = await calculateAccountMetricsAction(
-              sharedData.groups?.flatMap((group) => group.accounts) || []
-            );
-            setGroups(sharedData.groups || []);
-            setAccounts(accountsWithMetrics);
-          };
-
-          await updates();
+          // Shared views: compute metrics from already-loaded trades (no extra DB round-trip).
+          const sharedAccounts =
+            sharedData.groups?.flatMap((group) => group.accounts) || [];
+          const accountsWithMetrics = computeMetricsForAccounts(
+            sharedAccounts,
+            processedSharedTrades
+          );
+          setGroups(sharedData.groups || []);
+          setAccounts(accountsWithMetrics);
         }
         setIsLoading(false);
+        logDashboardPerf("shared loadData", loadStarted);
         return;
       }
 
-      // Step 1: Get Supabase user
+      // Only authentication must complete before parallel critical-path work.
+      const authStarted = performance.now();
       const supabase = createClient();
       const {
         data: { user },
       } = await supabase.auth.getUser();
+      logDashboardPerf("auth.getUser", authStarted);
 
       if (!user || !user.id) {
         await signOut();
@@ -500,49 +549,74 @@ export const DataProvider: React.FC<{
 
       setSupabaseUser(user);
 
-      // CRITICAL: Get dashboard layout first
-      // But check if the layout is already in the state
-      // TODO: Cache layout client side (lightweight)
-      if (!dashboardLayout) {
-        const dashboardLayoutResponse = await getDashboardLayout(user.id);
+      const existingLayout = useUserStore.getState().dashboardLayout;
+
+      const layoutPromise = existingLayout
+        ? Promise.resolve(null)
+        : getDashboardLayout(user.id);
+
+      const tradesPromise = (async (): Promise<PrismaTrade[]> => {
+        // Dev: prefer local IndexedDB to avoid hitting remote DB on reloads.
+        // IndexedDB is a cache only — never the authoritative source.
+        if (process.env.NODE_ENV === "development" && user.id) {
+          const cachedTrades = await getTradesCache(user.id);
+          if (
+            cachedTrades &&
+            Array.isArray(cachedTrades) &&
+            cachedTrades.length > 0
+          ) {
+            return cachedTrades;
+          }
+          const remoteTrades = await getTradesAction(user.id, false);
+          const safeTrades = Array.isArray(remoteTrades) ? remoteTrades : [];
+          setTradesCache(user.id, safeTrades).catch((err) =>
+            console.error(
+              "[DataProvider] Failed to cache trades in IndexedDB (loadData)",
+              err
+            )
+          );
+          return safeTrades;
+        }
+        const remoteTrades = await getTradesAction();
+        return Array.isArray(remoteTrades) ? remoteTrades : [];
+      })();
+
+      const userDataPromise = getUserData();
+
+      const parallelStarted = performance.now();
+      const [layoutResult, tradesResult, userDataResult] = await Promise.all([
+        timedPromise("layout", layoutPromise),
+        timedPromise("trades", tradesPromise),
+        timedPromise("userData", userDataPromise),
+      ]);
+
+      const parallelWallMs = performance.now() - parallelStarted;
+      const sequentialEstimateMs =
+        layoutResult.ms + tradesResult.ms + userDataResult.ms;
+      logDashboardPerf("critical path Promise.all", parallelStarted, {
+        layoutMs: Number(layoutResult.ms.toFixed(1)),
+        tradesMs: Number(tradesResult.ms.toFixed(1)),
+        userDataMs: Number(userDataResult.ms.toFixed(1)),
+        wallMs: Number(parallelWallMs.toFixed(1)),
+        sequentialEstimateMs: Number(sequentialEstimateMs.toFixed(1)),
+        savedMs: Number((sequentialEstimateMs - parallelWallMs).toFixed(1)),
+      });
+
+      const dashboardLayoutResponse = layoutResult.value;
+      const loadedTrades = tradesResult.value;
+      const data = userDataResult.value;
+
+      if (!existingLayout) {
         if (dashboardLayoutResponse) {
           setDashboardLayout(
-            // Convert from JSONB to DashboardLayoutWithWidgets type
             dashboardLayoutResponse as unknown as DashboardLayoutWithWidgets
           );
         } else {
-          // If no layout exists in database, use default layout
           setDashboardLayout(defaultLayouts);
         }
       }
 
-      // Step 2: Fetch trades (with caching server side)
-      // I think we could make basic computations server side to offload inital stats computations
-      // Dev: prefer local IndexedDB to avoid hitting remote DB on reloads
-      if (
-        process.env.NODE_ENV === "development" &&
-        user.id &&
-        !params?.isSharedView // avoid caching shared/public views
-      ) {
-        const cachedTrades = await getTradesCache(user.id);
-        if (cachedTrades && Array.isArray(cachedTrades) && cachedTrades.length > 0) {
-          setTrades(cachedTrades);
-        } else {
-          const trades = await getTradesAction(user.id, false);
-          const safeTrades = Array.isArray(trades) ? trades : [];
-          setTrades(safeTrades);
-          setTradesCache(user.id, safeTrades).catch((err) =>
-            console.error("[DataProvider] Failed to cache trades in IndexedDB (loadData)", err),
-          );
-        }
-      } else {
-        const trades = await getTradesAction();
-        setTrades(Array.isArray(trades) ? trades : []);
-      }
-
-      // Step 3: Fetch user data
-      // TODO: Check what we could cache client side
-      const data = await getUserData();
+      setTrades(loadedTrades);
 
       if (!data) {
         await signOut();
@@ -550,12 +624,18 @@ export const DataProvider: React.FC<{
         return;
       }
 
-      // Calculate metrics for each account
-      const accountsWithMetrics = await calculateAccountMetricsAction(
-        data.accounts || []
+      // Metrics from trades already in hand — avoids a second trades DB fetch via server action.
+      const metricsStarted = performance.now();
+      const accountsWithMetrics = computeMetricsForAccounts(
+        data.accounts || [],
+        loadedTrades
       );
-      setAccounts(accountsWithMetrics);
+      logDashboardPerf("computeMetricsForAccounts", metricsStarted, {
+        accountCount: data.accounts?.length ?? 0,
+        tradeCount: loadedTrades.length,
+      });
 
+      setAccounts(accountsWithMetrics);
       setUser(data.userData);
       setSubscription(data.subscription as PrismaSubscription | null);
       setTags(data.tags);
@@ -565,9 +645,9 @@ export const DataProvider: React.FC<{
       setTickDetails(data.tickDetails);
       setIsFirstConnection(data.userData?.isFirstConnection || false);
 
+      logDashboardPerf("authenticated loadData (critical path done)", loadStarted);
     } catch (error) {
       console.error("Error loading data:", error);
-      // Optionally handle specific error cases here
       if (error instanceof Error) {
         console.error("Error details:", error.message);
       }
@@ -578,33 +658,31 @@ export const DataProvider: React.FC<{
     isSharedView,
     params?.slug,
     timezone,
-    supabaseUser,
-    isLoading,
     setIsLoading,
+    setTrades,
+    setSharedParams,
+    setDashboardLayout,
+    setTickDetails,
+    setGroups,
+    setAccounts,
+    setSupabaseUser,
+    setUser,
+    setSubscription,
+    setTags,
+    setMoods,
+    setEvents,
+    setIsFirstConnection,
   ]);
 
-  // Load data on mount and when isSharedView changes
+  // Load data on mount and when isSharedView changes.
+  // Stripe starts concurrently and must not block the dashboard loading state.
   useEffect(() => {
     let mounted = true;
 
     const loadDataIfMounted = async () => {
       if (!mounted) return;
+      void loadStripeSubscription();
       await loadData();
-      // Load Stripe subscription data
-      try {
-        setStripeSubscriptionLoading(true);
-        const stripeSubscriptionData = await getSubscriptionData();
-        setStripeSubscription(stripeSubscriptionData);
-        setStripeSubscriptionError(null);
-      } catch (error) {
-        console.error("Error loading Stripe subscription:", error);
-        setStripeSubscriptionError(
-          error instanceof Error ? error.message : "Failed to load subscription"
-        );
-        setStripeSubscription(null);
-      } finally {
-        setStripeSubscriptionLoading(false);
-      }
     };
 
     loadDataIfMounted();
@@ -648,23 +726,6 @@ export const DataProvider: React.FC<{
     };
     updateLanguage();
   }, [locale, supabaseUser?.id]);
-
-  const loadStripeSubscription = useCallback(async () => {
-    try {
-      setStripeSubscriptionLoading(true);
-      const stripeSubscriptionData = await getSubscriptionData();
-      setStripeSubscription(stripeSubscriptionData);
-      setStripeSubscriptionError(null);
-    } catch (error) {
-      console.error("Error loading Stripe subscription:", error);
-      setStripeSubscriptionError(
-        error instanceof Error ? error.message : "Failed to load subscription"
-      );
-      setStripeSubscription(null);
-    } finally {
-      setStripeSubscriptionLoading(false);
-    }
-  }, []);
 
   const refreshTradesOnly = useCallback(
     async (options?: { force?: boolean; withLoading?: boolean }) => {
@@ -727,8 +788,11 @@ export const DataProvider: React.FC<{
           return;
         }
 
-        const accountsWithMetrics = await calculateAccountMetricsAction(
-          data.accounts || []
+        // Reuse trades already in the store — same metrics, no extra server round-trip.
+        const currentTrades = useTradesStore.getState().trades;
+        const accountsWithMetrics = computeMetricsForAccounts(
+          data.accounts || [],
+          currentTrades
         );
         setAccounts(accountsWithMetrics);
 
@@ -742,7 +806,8 @@ export const DataProvider: React.FC<{
         setIsFirstConnection(data.userData?.isFirstConnection || false);
 
         if (includeStripe) {
-          await loadStripeSubscription();
+          // Noncritical: do not extend the loading gate for Stripe.
+          void loadStripeSubscription();
         }
       } catch (error) {
         console.error("Error refreshing user data:", error);
@@ -772,12 +837,22 @@ export const DataProvider: React.FC<{
 
       setIsLoading(true);
       try {
-        await refreshTradesOnly({ force, withLoading: false });
-        await refreshUserDataOnly({
-          force,
-          includeStripe: true,
-          withLoading: false,
-        });
+        const refreshStarted = performance.now();
+        // Trades + user bundle are independent once the user is known.
+        await Promise.all([
+          refreshTradesOnly({ force, withLoading: false }),
+          refreshUserDataOnly({
+            force,
+            includeStripe: false,
+            withLoading: false,
+          }),
+        ]);
+        // refreshUserDataOnly may finish before trades land; recompute from final stores.
+        const latestAccounts = useUserStore.getState().accounts;
+        const latestTrades = useTradesStore.getState().trades;
+        setAccounts(computeMetricsForAccounts(latestAccounts, latestTrades));
+        void loadStripeSubscription();
+        logDashboardPerf("refreshAllData", refreshStarted);
         console.log("[refreshAllData] Successfully refreshed trades and user data");
       } catch (error) {
         console.error("Error refreshing all data:", error);
@@ -785,7 +860,13 @@ export const DataProvider: React.FC<{
         setIsLoading(false);
       }
     },
-    [refreshTradesOnly, refreshUserDataOnly, supabaseUser?.id]
+    [
+      refreshTradesOnly,
+      refreshUserDataOnly,
+      loadStripeSubscription,
+      setAccounts,
+      supabaseUser?.id,
+    ]
   );
 
   // Dev-only: persist trades store into IndexedDB so reloads avoid DB hits


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 of the dashboard performance project: after auth resolves, load layout, trades, and user data **in parallel**, keep Stripe **non-blocking**, and compute account metrics **client-side** from trades already in hand.

This does **not** introduce a new data library, change IndexedDB into a source of truth, or alter dashboard UX/behavior.

## Phase 0 baseline (code inspection on `beta`)

Confirmed authenticated `loadData()` waterfall in `context/data-provider.tsx` before this change:

1. `supabase.auth.getUser()` (required first)
2. `await getDashboardLayout(user.id)`
3. `await getTradesAction(...)` (or IndexedDB cache in development)
4. `await getUserData()`
5. `await calculateAccountMetricsAction(accounts)` — **re-fetched trades from Postgres**
6. `setIsLoading(false)`
7. **Then** `await getSubscriptionData()` (Stripe blocked perceived ready state)

`refreshAllData()` was also sequential: trades → user data (+ Stripe).

### Structural cost (pre-change)

| Stage | Blocking? | Notes |
| --- | --- | --- |
| Auth | Yes | Must stay first |
| Layout | Yes, alone | Independent of trades/user bundle |
| Trades | Yes, alone | Independent of layout/user bundle |
| User data | Yes, alone | Independent of layout/trades |
| Account metrics server action | Yes, alone | Duplicate trades query |
| Stripe | Yes, after critical path | Subscription UI only |

Wall-clock for the parallelizable trio was approximately **sum(layout + trades + userData)** instead of **max(...)**.

Full Chrome/React Profiler numbers against a large production account were not captured in this cloud environment (no representative multi-widget browser session). Dev-only timing logs were added so local profiling can quantify `savedMs = sequentialEstimate − wall`.

## What changed

In `context/data-provider.tsx`:

1. **Parallel critical path** — after auth:
   ```ts
   await Promise.all([layoutPromise, tradesPromise, userDataPromise])
   ```
2. **Stripe noncritical** — `void loadStripeSubscription()` starts alongside `loadData()`; it no longer runs after `isLoading` clears as a second awaited stage.
3. **Client metrics** — `computeMetricsForAccounts(accounts, loadedTrades)` replaces `calculateAccountMetricsAction` on the authenticated load/refresh paths (same shared util the server action already used), removing an extra trades DB round-trip.
4. **`refreshAllData`** — trades + user data via `Promise.all`, then a final metrics recompute from the latest stores (avoids a race), Stripe fired without awaiting.
5. **Dev / opt-in instrumentation** — `[dashboard-perf]` logs behind `NODE_ENV === "development"` or `NEXT_PUBLIC_DASHBOARD_PERF_LOG=1`. Reports per-fetch ms, parallel wall time, and estimated sequential savings. No production overhead when unset.

Shared/admin views remain isolated from authenticated caching; shared views also compute metrics from already-loaded trades (no behavior change intended).

## How to measure locally

1. Open the authenticated dashboard with DevTools console.
2. Cold load (clear site data / disable IndexedDB cache path if needed).
3. Look for:
   ```
   [dashboard-perf] critical path Promise.all: …ms {
     layoutMs, tradesMs, userDataMs, wallMs, sequentialEstimateMs, savedMs
   }
   ```
4. Network panel: layout / trades / user-data server actions should overlap after auth; Stripe should not gate the main loading spinner.
5. Optional: `NEXT_PUBLIC_DASHBOARD_PERF_LOG=1` in non-dev builds for staging checks.

## Out of scope (later PRs)

- Phase 2: Zustand selector / rerender narrowing (`perf/dashboard-store-selectors`)
- Phase 3: stale-while-revalidate trades (`perf/trades-stale-while-revalidate`)
- Phase 4: layout drag/resize persistence debouncing (`perf/dashboard-layout-persistence`)

## Test plan

- [x] `bun run typecheck`
- [x] `OPENAI_API_KEY=dummy LOCAL_DASHBOARD_AUTH_BYPASS_ALLOW_PRODUCTION=1 bun run build`
- [ ] Cold dashboard load: leaves loading state without waiting on Stripe
- [ ] Warm reload: layout/trades/user data still correct
- [ ] Account metrics (prop firm progress / daily metrics) match pre-change expectations
- [ ] Import → refresh all still updates trades + accounts
- [ ] Shared dashboard view still loads trades/groups
- [ ] Console `[dashboard-perf]` shows `savedMs > 0` when fetches are non-trivial

## Claimed improvement

**Structural only (measured locally via timing helpers, not claimed as a fixed % here):**

- Critical path wall time becomes ~`max(layout, trades, userData)` instead of their sum.
- One fewer server round-trip for account metrics (no duplicate trades fetch).
- Stripe no longer extends the main dashboard loading gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f79da-d011-72db-896f-85b9db859074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f79da-d011-72db-896f-85b9db859074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

