### PR TITLE
Localize Supabase auth emails

### DIFF
--- a/lib/auth-email-locale.test.ts
+++ b/lib/auth-email-locale.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAuthEmailLocale } from "./auth-email-locale";
+
+describe("resolveAuthEmailLocale", () => {
+  it("keeps French requests in French", () => {
+    expect(resolveAuthEmailLocale("fr")).toBe("fr");
+  });
+
+  it.each(["en", undefined, null, "de", "FR"])(
+    "falls back to English for %s",
+    (locale) => {
+      expect(resolveAuthEmailLocale(locale)).toBe("en");
+    },
+  );
+});

--- a/lib/auth-email-locale.ts
+++ b/lib/auth-email-locale.ts
@@ -1,0 +1,5 @@
+export type AuthEmailLocale = "en" | "fr";
+
+export function resolveAuthEmailLocale(locale?: string | null): AuthEmailLocale {
+  return locale === "fr" ? "fr" : "en";
+}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -15,6 +15,7 @@ import { createLocalDashboardBypassAuthStub } from '@/lib/local-dashboard-bypass
 import { ensureLocalDashboardUserInDatabase } from '@/server/local-dashboard-bootstrap'
 import { capturePostHogEvent } from '@/lib/posthog-server'
 import { getRequestOrigin } from '@/lib/site-url'
+import { resolveAuthEmailLocale } from '@/lib/auth-email-locale'
 
 export async function getWebsiteURL() {
   // Reuse the shared trusted-host allowlist (*.deltalytix.app, *.vercel.app,
@@ -166,12 +167,14 @@ export async function signInWithEmail(email: string, next: string | null = null,
   try {
     const supabase = await createClient()
     const websiteURL = await getWebsiteURL()
+    const language = resolveAuthEmailLocale(locale)
     const callbackParams = new URLSearchParams()
     if (next) callbackParams.set('next', next)
     if (locale) callbackParams.set('locale', locale)
     const { error } = await supabase.auth.signInWithOtp({
       email: email,
       options: {
+        data: { language },
         emailRedirectTo: `${websiteURL}api/auth/callback/${callbackParams.toString() ? `?${callbackParams.toString()}` : ''}`,
       },
     })
@@ -204,6 +207,7 @@ export async function signInWithPasswordAction(
         
         // Try to sign up - if user exists, this will fail and we'll know it's a wrong password
         const websiteURL = await getWebsiteURL()
+        const language = resolveAuthEmailLocale(locale)
         const callbackParams = new URLSearchParams()
         if (next) callbackParams.set('next', next)
         if (locale) callbackParams.set('locale', locale)
@@ -212,6 +216,7 @@ export async function signInWithPasswordAction(
           email,
           password,
           options: {
+            data: { language },
             emailRedirectTo: `${websiteURL}api/auth/callback/${callbackParams.toString() ? `?${callbackParams.toString()}` : ''}`,
           },
         })
@@ -333,6 +338,7 @@ export async function signUpWithPasswordAction(
   try {
     const supabase = await createClient()
     const websiteURL = await getWebsiteURL()
+    const language = resolveAuthEmailLocale(locale)
     const callbackParams = new URLSearchParams()
     if (next) callbackParams.set('next', next)
     if (locale) callbackParams.set('locale', locale)
@@ -340,6 +346,7 @@ export async function signUpWithPasswordAction(
       email,
       password,
       options: {
+        data: { language },
         emailRedirectTo: `${websiteURL}api/auth/callback/${callbackParams.toString() ? `?${callbackParams.toString()}` : ''}`,
       },
     })
@@ -634,8 +641,7 @@ export async function getUserEmail(): Promise<string> {
 // Lightweight updater for user language without full ensure logic
 export async function updateUserLanguage(locale: string): Promise<{ updated: boolean }> {
   console.log("[Auth] updateUserLanguage", locale)
-  const allowedLocales = new Set(['en', 'fr'])
-  if (!allowedLocales.has(locale)) {
+  if (locale !== 'en' && locale !== 'fr') {
     return { updated: false }
   }
 
@@ -650,14 +656,29 @@ export async function updateUserLanguage(locale: string): Promise<{ updated: boo
     return { updated: false }
   }
 
-  if (existing.language === locale) {
+  const shouldUpdateDatabase = existing.language !== locale
+  const shouldUpdateAuthMetadata = user.user_metadata?.language !== locale
+
+  if (!shouldUpdateDatabase && !shouldUpdateAuthMetadata) {
     return { updated: false }
   }
 
-  await prisma.user.update({
-    where: { auth_user_id: user.id },
-    data: { language: locale },
-  })
+  if (shouldUpdateDatabase) {
+    await prisma.user.update({
+      where: { auth_user_id: user.id },
+      data: { language: locale },
+    })
+  }
+
+  if (shouldUpdateAuthMetadata) {
+    const { error } = await supabase.auth.updateUser({
+      data: { language: locale },
+    })
+    if (error) {
+      throw error
+    }
+  }
+
   return { updated: true }
 }
 

--- a/supabase/templates/README.md
+++ b/supabase/templates/README.md
@@ -1,0 +1,16 @@
+# Supabase Auth email templates
+
+The hosted Supabase project does not load these files automatically. They are the
+version-controlled source for the values pasted into **Authentication → Emails →
+Templates → Magic Link** in the Supabase dashboard.
+
+- Subject: `magic-link-subject.txt`
+- Body: `magic-link.html`
+
+The template defaults to English and renders French when
+`user_metadata.language` is `fr`. The application passes this metadata when it
+requests a Magic Link and keeps it synchronized after authentication.
+
+After publishing the template, send controlled requests from both
+`/en/authentication` and `/fr/authentication`. Confirm the subject, copy, Magic
+Link, and OTP, then check Auth logs for template parsing errors.

--- a/supabase/templates/magic-link-subject.txt
+++ b/supabase/templates/magic-link-subject.txt
@@ -1,0 +1,1 @@
+{{ if eq .Data.language "fr" }}Connectez-vous à Deltalytix{{ else }}Sign in to Deltalytix{{ end }}

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,0 +1,74 @@
+{{ $fr := eq .Data.language "fr" }}
+<!DOCTYPE html>
+<html lang="{{ if $fr }}fr{{ else }}en{{ end }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="color-scheme" content="light">
+  <meta name="supported-color-schemes" content="light">
+  <title>{{ if $fr }}Connexion à Deltalytix{{ else }}Sign in to Deltalytix{{ end }}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f7f7f4;font-family:Arial,Helvetica,sans-serif;color:#1f211e;">
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;mso-hide:all;">{{ if $fr }}Votre lien de connexion sécurisé et votre code de vérification Deltalytix.{{ else }}Your secure Deltalytix sign-in link and verification code.{{ end }}</div>
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" role="presentation" bgcolor="#f7f7f4" style="width:100%;background-color:#f7f7f4;">
+    <tr>
+      <td align="center" style="padding-top:24px;padding-right:12px;padding-bottom:24px;padding-left:12px;">
+        <table width="600" cellpadding="0" cellspacing="0" border="0" role="presentation" bgcolor="#ffffff" style="width:100%;max-width:600px;background-color:#ffffff;border:1px solid #e5e6e1;">
+          <tr>
+            <td style="padding-top:40px;padding-right:32px;padding-bottom:40px;padding-left:32px;">
+              <p style="margin-top:0;margin-right:0;margin-bottom:32px;margin-left:0;color:#1f211e;font-family:Arial,Helvetica,sans-serif;font-size:17px;line-height:24px;font-weight:600;letter-spacing:-0.02em;">Deltalytix</p>
+              <p style="margin-top:0;margin-right:0;margin-bottom:10px;margin-left:0;color:#5d625c;font-family:Arial,Helvetica,sans-serif;font-size:15px;line-height:24px;word-break:break-word;">{{ if $fr }}Connexion en tant que{{ else }}Signing in as{{ end }} {{ .Email }}</p>
+              <h1 style="margin:0;color:#1f211e;font-family:Arial,Helvetica,sans-serif;font-size:40px;line-height:43px;letter-spacing:-0.045em;font-weight:400;">{{ if $fr }}Heureux de vous revoir.{{ else }}Welcome back.{{ end }}</h1>
+              <p style="margin-top:16px;margin-right:0;margin-bottom:0;margin-left:0;color:#5d625c;font-family:Arial,Helvetica,sans-serif;font-size:17px;line-height:28px;">{{ if $fr }}Utilisez le lien sécurisé ci-dessous pour vous connecter à votre compte Deltalytix.{{ else }}Use the secure link below to sign in to your Deltalytix account.{{ end }}</p>
+
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" role="presentation"><tr><td style="padding-top:30px;padding-bottom:30px;"><div style="height:1px;background-color:#e8e9e5;font-size:1px;line-height:1px;">&nbsp;</div></td></tr></table>
+
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" role="presentation" bgcolor="#eef4ef" style="width:100%;background-color:#eef4ef;border-radius:12px;">
+                <tr>
+                  <td bgcolor="#eef4ef" style="padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;background-color:#eef4ef;border-radius:12px;">
+                    <p style="margin-top:0;margin-right:0;margin-bottom:8px;margin-left:0;color:#697069;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:18px;font-weight:700;letter-spacing:0.08em;">{{ if $fr }}CONNEXION SÉCURISÉE{{ else }}SECURE SIGN-IN{{ end }}</p>
+                    <h2 style="margin-top:0;margin-right:0;margin-bottom:10px;margin-left:0;color:#1f211e;font-family:Arial,Helvetica,sans-serif;font-size:29px;line-height:34px;letter-spacing:-0.035em;font-weight:500;">{{ if $fr }}Continuer vers Deltalytix{{ else }}Continue to Deltalytix{{ end }}</h2>
+                    <p style="margin:0;color:#626760;font-family:Arial,Helvetica,sans-serif;font-size:15px;line-height:24px;">{{ if $fr }}Ce lien vous est réservé et ne peut être utilisé qu’une seule fois.{{ else }}This link is unique to you and can only be used once.{{ end }}</p>
+                    <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="margin-top:20px;">
+                      <tr>
+                        <td bgcolor="#242722" style="background-color:#242722;border-radius:4px;">
+                          <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding-top:13px;padding-right:18px;padding-bottom:13px;padding-left:18px;white-space:nowrap;color:#ffffff;font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:20px;font-weight:600;text-decoration:none;">{{ if $fr }}Se connecter en toute sécurité →{{ else }}Sign in securely →{{ end }}</a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" role="presentation"><tr><td style="padding-top:30px;padding-bottom:30px;"><div style="height:1px;background-color:#e8e9e5;font-size:1px;line-height:1px;">&nbsp;</div></td></tr></table>
+
+              <h2 style="margin-top:0;margin-right:0;margin-bottom:8px;margin-left:0;color:#1f211e;font-family:Arial,Helvetica,sans-serif;font-size:24px;line-height:30px;letter-spacing:-0.025em;font-weight:500;">{{ if $fr }}Ou utilisez votre code de vérification{{ else }}Or use your verification code{{ end }}</h2>
+              <p style="margin:0;color:#626760;font-family:Arial,Helvetica,sans-serif;font-size:15px;line-height:24px;">{{ if $fr }}Saisissez ce code à usage unique dans l’application Deltalytix.{{ else }}Enter this one-time code in the Deltalytix app.{{ end }}</p>
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" role="presentation" bgcolor="#f3f4f1" style="width:100%;margin-top:18px;background-color:#f3f4f1;border-radius:12px;">
+                <tr>
+                  <td bgcolor="#f3f4f1" style="padding-top:22px;padding-right:22px;padding-bottom:22px;padding-left:22px;background-color:#f3f4f1;border-radius:12px;">
+                    <p style="margin-top:0;margin-right:0;margin-bottom:6px;margin-left:0;color:#777c74;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:18px;font-weight:700;letter-spacing:0.08em;">{{ if $fr }}CODE DE VÉRIFICATION{{ else }}VERIFICATION CODE{{ end }}</p>
+                    <p style="margin:0;color:#30342f;font-family:'Courier New',Courier,monospace;font-size:30px;line-height:38px;font-weight:700;letter-spacing:0.16em;">{{ .Token }}</p>
+                  </td>
+                </tr>
+              </table>
+
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" role="presentation"><tr><td style="padding-top:30px;padding-bottom:30px;"><div style="height:1px;background-color:#e8e9e5;font-size:1px;line-height:1px;">&nbsp;</div></td></tr></table>
+
+              <h2 style="margin-top:0;margin-right:0;margin-bottom:8px;margin-left:0;color:#1f211e;font-family:Arial,Helvetica,sans-serif;font-size:24px;line-height:30px;letter-spacing:-0.025em;font-weight:500;">{{ if $fr }}Vous n’êtes pas à l’origine de cette demande ?{{ else }}Didn’t request this?{{ end }}</h2>
+              <p style="margin:0;color:#626760;font-family:Arial,Helvetica,sans-serif;font-size:15px;line-height:24px;">{{ if $fr }}Vous pouvez ignorer cet e-mail. Le lien et le code expirent rapidement et ne peuvent être utilisés qu’une seule fois.{{ else }}You can safely ignore this email. The link and code expire shortly and can only be used once.{{ end }}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-top:24px;padding-right:32px;padding-bottom:28px;padding-left:32px;border-top:1px solid #e8e9e5;">
+              <p style="margin-top:0;margin-right:0;margin-bottom:8px;margin-left:0;color:#858981;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:20px;">{{ if $fr }}Deltalytix · Analyses de trading pour les traders modernes{{ else }}Deltalytix · Trading analytics for modern traders{{ end }}</p>
+              <p style="margin:0;color:#858981;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:20px;">{{ if $fr }}Besoin d’aide ?{{ else }}Need help?{{ end }} <a href="https://discord.gg/a5YVF5Ec2n" style="color:#73776f;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:20px;text-decoration:underline;">{{ if $fr }}Rejoignez la communauté Discord{{ else }}Join the Discord community{{ end }}</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add a Deltalytix-styled Supabase Magic Link template with English fallback and French localization
- pass the current locale into Supabase Auth user metadata for magic-link and password signup flows
- keep authenticated users' Supabase language metadata synchronized with their Deltalytix profile language
- document the subject/body values to publish in the hosted Supabase dashboard

## Validation

- `bunx vitest run lib/auth-email-locale.test.ts` (6 tests passed)
- `bun run typecheck`
- `bunx eslint lib/auth-email-locale.ts lib/auth-email-locale.test.ts`
- `git diff --check`

The repository-wide `bun run lint` remains red on pre-existing beta issues (414 errors across unrelated files). Full build validation was skipped at the request of the maintainer.

## Supabase publishing

After merging/deploying, paste the version-controlled subject and body from `supabase/templates/` into **Authentication → Emails → Templates → Magic Link** in the hosted Supabase dashboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication signup/OTP metadata and language sync; mis-sync or template errors could affect email language but not core credential validation.
> 
> **Overview**
> **Magic-link and signup emails can render in French or English** based on `user_metadata.language`, with English as the default for any locale other than exact `fr`.
> 
> The app now sets that metadata via `resolveAuthEmailLocale` on **magic link OTP**, **password sign-up**, and the **auto sign-up path inside password sign-in**. **`updateUserLanguage`** was extended to update Supabase `user_metadata.language` when it diverges from the Prisma profile, not only the database row.
> 
> Version-controlled **Supabase Magic Link** subject/body templates live under `supabase/templates/` (with a README for manual dashboard paste). Templates branch on `.Data.language === "fr"`. Unit tests cover the locale resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5968b8dbb64285c20f969f7aac36909eae62c966. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->