### PR TITLE
Encrypt Connection.token credentials at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ DISCORD_SECRET=your_discord_secret_here
 DISCORD_ID=your_discord_id_here
 REDIRECT_URL='http://localhost:3000/api/auth/callback'
 
-# Security
+# Security — AES-256-GCM key for Connection.token at rest (server-only, never NEXT_PUBLIC_)
+# Generate: openssl rand -hex 32
+# Any non-placeholder string also works (hashed with SHA-256). Required in production for broker sync.
 ENCRYPTION_KEY=your_encryption_key_here
 
 # Email Service

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 OPENAI_API_KEY=dummy
+ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 If the shell already exports `DATABASE_URL`, run `unset DATABASE_URL DIRECT_URL` before sourcing `.env.local`.

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -35,6 +35,10 @@ import type {
   DxFeedTradingAccount,
 } from './dxfeed-types'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import {
+  decryptConnectionToken,
+  encryptConnectionToken,
+} from '@/lib/connection-token-crypto'
 
 const DXFEED_AUTH_URL = resolveDxFeedV2AuthUrl(process.env.DXFEED_AUTH_URL)
 const DXFEED_PLATFORM_KEY = process.env.DXFEED_PLATFORM_KEY
@@ -508,7 +512,7 @@ function buildTradesFromDxFeedReport(
 
 export async function getDxFeedTrades(
   initialTokenJson: string,
-  options?: { userId?: string },
+  options?: { userId?: string; accountId?: string },
 ): Promise<DxFeedTradesResult> {
   try {
     const credentials = parseStoredCredentials(initialTokenJson)
@@ -526,7 +530,7 @@ export async function getDxFeedTrades(
     const historicalHost = coerceDxFeedHistoricalHostForSync(credentials.historicalHost, propFirm)
 
     let userId = options?.userId ?? null
-    let syncAccountId: string | null = null
+    let syncAccountId: string | null = options?.accountId ?? null
     if (!userId) {
       const supabase = await createClient()
       const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -540,14 +544,25 @@ export async function getDxFeedTrades(
     }
     const resolvedUserId = userId
 
-    let storedTokenJson = initialTokenJson
     const baseUrl = historicalHost.endsWith('/') ? historicalHost.slice(0, -1) : historicalHost
 
-    const syncRow = await prisma.connection.findFirst({
-      where: { userId: resolvedUserId, service: 'dxfeed', token: initialTokenJson },
-      select: { externalId: true, tokenExpiresAt: true },
-    })
-    syncAccountId = syncRow?.externalId ?? null
+    const syncRow = syncAccountId
+      ? await prisma.connection.findUnique({
+          where: {
+            userId_service_externalId: {
+              userId: resolvedUserId,
+              service: 'dxfeed',
+              externalId: syncAccountId,
+            },
+          },
+          select: { externalId: true, tokenExpiresAt: true },
+        })
+      : await prisma.connection.findFirst({
+          where: { userId: resolvedUserId, service: 'dxfeed' },
+          select: { externalId: true, tokenExpiresAt: true },
+          orderBy: { updatedAt: 'desc' },
+        })
+    syncAccountId = syncRow?.externalId ?? syncAccountId
 
     if (
       isDxFeedAccessTokenExpired(accessToken, syncRow?.tokenExpiresAt, {
@@ -582,8 +597,9 @@ export async function getDxFeedTrades(
         accountNumbers,
       }
       const updatedJson = JSON.stringify(updatedCreds)
-      await updateStoredCredentials(resolvedUserId, storedTokenJson, updatedJson)
-      storedTokenJson = updatedJson
+      if (syncAccountId) {
+        await updateStoredCredentials(resolvedUserId, syncAccountId, updatedJson)
+      }
     }
 
     const syncStats = {
@@ -603,7 +619,9 @@ export async function getDxFeedTrades(
           syncStats,
         }
       }
-      await updateLastSyncedAt(resolvedUserId, storedTokenJson)
+      if (syncAccountId) {
+        await updateLastSyncedAt(resolvedUserId, syncAccountId)
+      }
       return { processedTrades: [], savedCount: 0, tradesCount: 0, syncStats }
     }
 
@@ -670,7 +688,9 @@ export async function getDxFeedTrades(
 
     syncStats.closedTrades = allTrades.length
 
-    await updateLastSyncedAt(resolvedUserId, storedTokenJson)
+    if (syncAccountId) {
+      await updateLastSyncedAt(resolvedUserId, syncAccountId)
+    }
 
     if (syncStats.fetchFailures > 0 && syncStats.fetchFailures >= accounts.length) {
       return {
@@ -682,24 +702,17 @@ export async function getDxFeedTrades(
 
     if (allTrades.length === 0) {
       logger.info(`No closed trades to save: ${JSON.stringify(syncStats)}`)
-      if (accountNumbers.length > 0) {
-        const connectionForAccounts = syncAccountId
-          ? await prisma.connection.findFirst({
-              where: {
-                userId: resolvedUserId,
-                service: 'dxfeed',
-                externalId: syncAccountId,
-              },
-              select: { id: true },
-            })
-          : await prisma.connection.findFirst({
-              where: {
-                userId: resolvedUserId,
-                service: 'dxfeed',
-                token: storedTokenJson,
-              },
-              select: { id: true },
-            })
+      if (accountNumbers.length > 0 && syncAccountId) {
+        const connectionForAccounts = await prisma.connection.findUnique({
+          where: {
+            userId_service_externalId: {
+              userId: resolvedUserId,
+              service: 'dxfeed',
+              externalId: syncAccountId,
+            },
+          },
+          select: { id: true },
+        })
         if (connectionForAccounts) {
           await upsertAccountsForNumbers(
             resolvedUserId,
@@ -713,22 +726,17 @@ export async function getDxFeedTrades(
 
     logger.info(`Saving ${allTrades.length} trades...`)
     const connection = syncAccountId
-      ? await prisma.connection.findFirst({
+      ? await prisma.connection.findUnique({
           where: {
-            userId: resolvedUserId,
-            service: 'dxfeed',
-            externalId: syncAccountId,
+            userId_service_externalId: {
+              userId: resolvedUserId,
+              service: 'dxfeed',
+              externalId: syncAccountId,
+            },
           },
           select: { id: true },
         })
-      : await prisma.connection.findFirst({
-          where: {
-            userId: resolvedUserId,
-            service: 'dxfeed',
-            token: storedTokenJson,
-          },
-          select: { id: true },
-        })
+      : null
 
     const saveResult = await saveTradesAction(allTrades, {
       userId: resolvedUserId,
@@ -768,12 +776,12 @@ export async function getDxFeedTrades(
   }
 }
 
-async function updateLastSyncedAt(userId: string, storedTokenJson: string) {
+async function updateLastSyncedAt(userId: string, accountId: string) {
   await prisma.connection.updateMany({
     where: {
       userId,
       service: 'dxfeed',
-      token: storedTokenJson,
+      externalId: accountId,
     },
     data: {
       lastSyncedAt: new Date(),
@@ -781,15 +789,19 @@ async function updateLastSyncedAt(userId: string, storedTokenJson: string) {
   })
 }
 
-async function updateStoredCredentials(userId: string, oldTokenJson: string, newTokenJson: string) {
+async function updateStoredCredentials(
+  userId: string,
+  accountId: string,
+  newTokenJson: string,
+) {
   await prisma.connection.updateMany({
     where: {
       userId,
       service: 'dxfeed',
-      token: oldTokenJson,
+      externalId: accountId,
     },
     data: {
-      token: newTokenJson,
+      token: encryptConnectionToken(newTokenJson),
     },
   })
 }
@@ -826,7 +838,7 @@ export async function storeDxFeedToken(
         },
       },
       update: {
-        token: tokenJson,
+        token: encryptConnectionToken(tokenJson),
         tokenExpiresAt: options?.tokenExpiresAt ?? null,
         lastSyncedAt: new Date(),
         updatedAt: new Date(),
@@ -836,7 +848,7 @@ export async function storeDxFeedToken(
         userId: user.id,
         service: 'dxfeed',
         externalId: accountId,
-        token: tokenJson,
+        token: encryptConnectionToken(tokenJson),
         tokenExpiresAt: options?.tokenExpiresAt ?? null,
         lastSyncedAt: new Date(),
         includedFeeTypes: undefined, // DxFeed has no fee differentiator
@@ -882,7 +894,12 @@ export async function getDxFeedToken(accountId: string = 'default') {
       return { error: DxFeedErrorCode.NO_TOKEN_RECONNECT }
     }
 
-    const credentials = parseStoredCredentials(syncData.token)
+    const plaintextToken = decryptConnectionToken(syncData.token)
+    if (!plaintextToken) {
+      return { error: DxFeedErrorCode.NO_TOKEN_RECONNECT }
+    }
+
+    const credentials = parseStoredCredentials(plaintextToken)
     if (
       credentials &&
       isDxFeedAccessTokenExpired(credentials.accessToken, syncData.tokenExpiresAt, {
@@ -893,7 +910,7 @@ export async function getDxFeedToken(accountId: string = 'default') {
     }
 
     return {
-      storedTokenJson: syncData.token,
+      storedTokenJson: plaintextToken,
       accountId: syncData.externalId,
     }
   } catch (error) {
@@ -952,8 +969,8 @@ export async function getDxFeedSynchronizations() {
       },
     })
 
-    const { toConnectionViews } = await import('@/lib/connection-view')
-    return { synchronizations: toConnectionViews(synchronizations) }
+    const { toDecryptedConnectionViews } = await import('@/lib/connection-view')
+    return { synchronizations: toDecryptedConnectionViews(synchronizations) }
   } catch (error) {
     logger.error('Failed to get DxFeed synchronizations:', error)
     return { error: 'Failed to get synchronizations' }

--- a/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
@@ -2,7 +2,8 @@
 import { prisma } from "@/lib/prisma"
 import { getUserId } from "@/server/auth"
 import { Connection } from "@/prisma/generated/prisma/client"
-import { toConnectionViews } from "@/lib/connection-view"
+import { toDecryptedConnectionViews } from "@/lib/connection-view"
+import { encryptConnectionToken } from "@/lib/connection-token-crypto"
 import { capturePostHogEvent } from "@/lib/posthog-server"
 
 export async function getRithmicSynchronizations() {
@@ -11,7 +12,7 @@ export async function getRithmicSynchronizations() {
   const connections = await prisma.connection.findMany({
     where: { userId: userId, service: "rithmic" },
   })
-  return toConnectionViews(connections)
+  return toDecryptedConnectionViews(connections)
 }
 
 export async function setRithmicSynchronization(synchronization: Partial<Connection> & { accountId?: string }) {
@@ -19,6 +20,10 @@ export async function setRithmicSynchronization(synchronization: Partial<Connect
   const userId = await getUserId()
   const service = synchronization.service || 'rithmic'
   const externalId = synchronization.externalId || synchronization.accountId || ''
+  const encryptedToken =
+    synchronization.token !== undefined
+      ? encryptConnectionToken(synchronization.token)
+      : undefined
   const existingConnection = await prisma.connection.findUnique({
     where: {
       userId_service_externalId: { userId, service, externalId },
@@ -37,7 +42,7 @@ export async function setRithmicSynchronization(synchronization: Partial<Connect
       service,
       externalId,
       lastSyncedAt: synchronization.lastSyncedAt || new Date(),
-      token: synchronization.token,
+      ...(encryptedToken !== undefined ? { token: encryptedToken } : {}),
       tokenExpiresAt: synchronization.tokenExpiresAt,
       dailySyncTime: synchronization.dailySyncTime,
       environment: synchronization.environment,
@@ -48,7 +53,7 @@ export async function setRithmicSynchronization(synchronization: Partial<Connect
       service,
       externalId,
       lastSyncedAt: synchronization.lastSyncedAt || new Date(),
-      token: synchronization.token,
+      token: encryptedToken ?? null,
       tokenExpiresAt: synchronization.tokenExpiresAt,
       dailySyncTime: synchronization.dailySyncTime,
       environment: synchronization.environment || 'demo',

--- a/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
@@ -14,6 +14,10 @@ import { formatTimestamp, formatDateToTimestamp } from '@/lib/date-utils'
 import { createTradeWithDefaults } from '@/lib/trade-factory'
 import { getUserId } from '@/server/auth'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import {
+  decryptConnectionToken,
+  encryptConnectionToken,
+} from '@/lib/connection-token-crypto'
 
 // Helper function to format dates in the required format: 2025-06-05T08:38:40+00:00
 function formatDateForAPI(date: Date): string {
@@ -1258,14 +1262,7 @@ async function linkTradovateAccountsToConnection(params: {
         },
         select: { id: true },
       })
-    : await prisma.connection.findFirst({
-        where: {
-          userId,
-          service: 'tradovate',
-          token: accessToken,
-        },
-        select: { id: true },
-      })
+    : null
 
   if (!connection) {
     return
@@ -1505,7 +1502,7 @@ export async function storeTradovateToken(
         }
       },
       update: {
-        token: accessToken,
+        token: encryptConnectionToken(accessToken),
         tokenExpiresAt: new Date(expiresAt),
         environment,
         lastSyncedAt: new Date(),
@@ -1515,7 +1512,7 @@ export async function storeTradovateToken(
         userId: user.id,
         service: 'tradovate',
         externalId: accountId,
-        token: accessToken,
+        token: encryptConnectionToken(accessToken),
         tokenExpiresAt: new Date(expiresAt),
         environment,
         lastSyncedAt: new Date()
@@ -1562,8 +1559,13 @@ export async function getTradovateToken(accountId: string = 'default') {
       return { error: 'No Tradovate token found' }
     }
 
+    const plaintextToken = decryptConnectionToken(syncData.token)
+    if (!plaintextToken) {
+      return { error: 'No Tradovate token found' }
+    }
+
     try {
-      const parsed = JSON.parse(syncData.token) as { authError?: string }
+      const parsed = JSON.parse(plaintextToken) as { authError?: string }
       if (typeof parsed.authError === 'string' && parsed.authError.length > 0) {
         return { error: parsed.authError }
       }
@@ -1581,7 +1583,7 @@ export async function getTradovateToken(accountId: string = 'default') {
 
     const includedFeeTypes = syncData.includedFeeTypes as Record<string, boolean> | null | undefined
     return {
-      accessToken: syncData.token,
+      accessToken: plaintextToken,
       expiresAt: syncData.tokenExpiresAt?.toISOString() || '',
       environment: normalizeEnvironment(syncData.environment),
       accountId: syncData.externalId,
@@ -1674,8 +1676,8 @@ export async function getTradovateSynchronizations() {
       }
     })
 
-    const { toConnectionViews } = await import('@/lib/connection-view')
-    return { synchronizations: toConnectionViews(synchronizations) }
+    const { toDecryptedConnectionViews } = await import('@/lib/connection-view')
+    return { synchronizations: toDecryptedConnectionViews(synchronizations) }
   } catch (error) {
     console.error('TRADOVATE SYNC: Failed to get Tradovate synchronizations:', error)
     return { error: 'Failed to get synchronizations' }
@@ -1786,13 +1788,13 @@ export async function testCustomTradovateToken(
   }
 }
 
-async function updateLastSyncedAt(userId: string, accessToken: string) {
+async function updateLastSyncedAt(userId: string, connectionExternalId: string) {
     // Update last synced at
     const updateResult = await prisma.connection.updateMany({
       where: {
         userId: userId,
         service: 'tradovate',
-        token: accessToken,
+        externalId: connectionExternalId,
       },
       data: {
         lastSyncedAt: new Date()
@@ -1805,7 +1807,13 @@ async function updateLastSyncedAt(userId: string, accessToken: string) {
   
 export async function getTradovateTrades(
   accessToken: string,
-  options?: { userId?: string; includeAllFees?: boolean; includedFeeTypes?: TradovateIncludedFeeTypes; environment?: TradovateEnvironment }
+  options?: {
+    userId?: string
+    includeAllFees?: boolean
+    includedFeeTypes?: TradovateIncludedFeeTypes
+    environment?: TradovateEnvironment
+    connectionExternalId?: string
+  }
 ): Promise<TradovateTradesResult> {
   try {
     // If we are on the server
@@ -1829,6 +1837,7 @@ export async function getTradovateTrades(
       return { error: 'User not authenticated' }
     }
     const resolvedUserId = userId
+    const connectionExternalId = options?.connectionExternalId ?? null
 
     const apiBaseUrl = getApiBaseUrl(environment)
 
@@ -1840,11 +1849,14 @@ export async function getTradovateTrades(
     // Means there are no trades to import — still attach trading accounts to the Connection
     if (fillPairs.length === 0) {
       logger.info('No fill pairs returned from Tradovate')
-      await updateLastSyncedAt(resolvedUserId, accessToken)
+      if (connectionExternalId) {
+        await updateLastSyncedAt(resolvedUserId, connectionExternalId)
+      }
       await linkTradovateAccountsToConnection({
         userId: resolvedUserId,
         accessToken,
         environment,
+        connectionExternalId,
       })
       return { processedTrades: [], savedCount: 0, ordersCount: 0 }
     }
@@ -1859,14 +1871,18 @@ export async function getTradovateTrades(
     accounts.forEach(account => accountsById.set(account.id, account))
     logger.info(`Fetched ${accounts.length} accounts for resolution`)
 
-    const connectionForAccounts = await prisma.connection.findFirst({
-      where: {
-        userId: resolvedUserId,
-        service: 'tradovate',
-        token: accessToken,
-      },
-      select: { id: true },
-    })
+    const connectionForAccounts = connectionExternalId
+      ? await prisma.connection.findUnique({
+          where: {
+            userId_service_externalId: {
+              userId: resolvedUserId,
+              service: 'tradovate',
+              externalId: connectionExternalId,
+            },
+          },
+          select: { id: true },
+        })
+      : null
     if (connectionForAccounts && accounts.length > 0) {
       await upsertAccountsForNumbers(
         resolvedUserId,
@@ -1967,21 +1983,16 @@ export async function getTradovateTrades(
       tickDetails,
     )
     
-    await updateLastSyncedAt(resolvedUserId, accessToken)
+    if (connectionExternalId) {
+      await updateLastSyncedAt(resolvedUserId, connectionExternalId)
+    }
 
     if (processedTrades.length === 0) {
       logger.info('No trades could be created from fill pairs')
       return { processedTrades: [], savedCount: 0 }
     }
 
-    const connection = connectionForAccounts ?? await prisma.connection.findFirst({
-      where: {
-        userId: resolvedUserId,
-        service: 'tradovate',
-        token: accessToken,
-      },
-      select: { id: true },
-    })
+    const connection = connectionForAccounts
 
     // Save trades to database
     logger.info(`Attempting to save ${processedTrades.length} fill pair trades to database`)

--- a/app/[locale]/dashboard/connections/data.ts
+++ b/app/[locale]/dashboard/connections/data.ts
@@ -2,6 +2,7 @@ import { cacheLife, cacheTag, updateTag } from 'next/cache'
 import { getUserId } from '@/server/auth'
 import { prisma } from '@/lib/prisma'
 import { toConnectionView } from '@/lib/connection-view'
+import { decryptConnectionToken } from '@/lib/connection-token-crypto'
 import { getDxFeedPropFirm } from '@/lib/dxfeed-propfirms'
 import type { Connection } from '@/prisma/generated/prisma/client'
 import type {
@@ -14,10 +15,20 @@ function connectionsCacheTag(userId: string) {
   return `connections-${userId}`
 }
 
-function parseConnectionAuthError(token: string | null): string | null {
+function plaintextConnectionToken(token: string | null): string | null {
   if (!token) return null
   try {
-    const parsed = JSON.parse(token) as { authError?: string }
+    return decryptConnectionToken(token)
+  } catch {
+    return null
+  }
+}
+
+function parseConnectionAuthError(token: string | null): string | null {
+  const plaintext = plaintextConnectionToken(token)
+  if (!plaintext) return null
+  try {
+    const parsed = JSON.parse(plaintext) as { authError?: string }
     return typeof parsed.authError === 'string' && parsed.authError.length > 0
       ? parsed.authError
       : null
@@ -48,9 +59,10 @@ function deriveConnectionStatus(
 }
 
 function getDxFeedPropFirmName(token: string | null): string | null {
-  if (!token) return null
+  const plaintext = plaintextConnectionToken(token)
+  if (!plaintext) return null
   try {
-    const parsed = JSON.parse(token) as {
+    const parsed = JSON.parse(plaintext) as {
       propFirmId?: string
       propfirmName?: string
     }

--- a/app/api/cron/renew-tradovate-token/route.ts
+++ b/app/api/cron/renew-tradovate-token/route.ts
@@ -1,5 +1,9 @@
 // app/api/cron/renew-tradovate-token/route.ts
 import { prisma } from '@/lib/prisma';
+import {
+  decryptConnectionToken,
+  encryptConnectionToken,
+} from '@/lib/connection-token-crypto';
 import { NextRequest } from 'next/server';
 
 /**
@@ -109,11 +113,17 @@ async function renewUserToken(synchronization: any): Promise<boolean> {
       ? 'https://demo.tradovateapi.com' 
       : 'https://live.tradovateapi.com';
     
+        const plaintextToken = decryptConnectionToken(synchronization.token)
+    if (!plaintextToken) {
+      console.error(`[CRON] Missing token for account ${synchronization.externalId}`);
+      return false;
+    }
+    
     console.log(`[CRON] Attempting token renewal for account ${synchronization.externalId}`);
     
     const renewal = await fetch(`${apiBaseUrl}/auth/renewAccessToken`, {
       headers: {
-        'Authorization': `Bearer ${synchronization.token}`
+        'Authorization': `Bearer ${plaintextToken}`
       }
     });
     
@@ -133,7 +143,10 @@ async function renewUserToken(synchronization: any): Promise<boolean> {
     // Update database
     await prisma.connection.update({
       where: { id: synchronization.id },
-      data: { token: renewalData.accessToken, tokenExpiresAt: new Date(renewalData.expirationTime) }
+      data: {
+        token: encryptConnectionToken(renewalData.accessToken),
+        tokenExpiresAt: new Date(renewalData.expirationTime),
+      }
     });
 
     return true;
@@ -162,10 +175,16 @@ async function performDailySync(synchronization: any): Promise<boolean> {
     
     // Use account-level fee config from DB (includedFeeTypes on sync record)
     const includedFeeTypes = synchronization.includedFeeTypes as Record<string, boolean> | null | undefined
-    const result = await getTradovateTrades(synchronization.token, {
+    const plaintextToken = decryptConnectionToken(synchronization.token)
+    if (!plaintextToken) {
+      console.error(`[CRON] Missing token for daily sync of account ${synchronization.externalId}`);
+      return false;
+    }
+    const result = await getTradovateTrades(plaintextToken, {
       userId: synchronization.userId,
       includedFeeTypes: includedFeeTypes ?? undefined,
       environment: synchronization.environment === 'live' ? 'live' : 'demo',
+      connectionExternalId: synchronization.externalId,
     });
     
     if (result.error) {

--- a/app/api/dxfeed/sync/route.ts
+++ b/app/api/dxfeed/sync/route.ts
@@ -28,7 +28,9 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const syncResult = await getDxFeedTrades(tokenResult.storedTokenJson)
+    const syncResult = await getDxFeedTrades(tokenResult.storedTokenJson, {
+      accountId,
+    })
     if (syncResult.error) {
       return NextResponse.json(
         {

--- a/app/api/tradovate/sync/route.ts
+++ b/app/api/tradovate/sync/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: NextRequest) {
     const syncResult = await getTradovateTrades(tokenResult.accessToken, {
       includedFeeTypes: tokenResult.includedFeeTypes,
       environment: tokenResult.environment,
+      connectionExternalId: accountId,
     });
     if (syncResult.error) {
       return NextResponse.json(

--- a/lib/connection-token-crypto.test.ts
+++ b/lib/connection-token-crypto.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  CONNECTION_TOKEN_ENC_PREFIX,
+  decryptConnectionToken,
+  encryptConnectionToken,
+  hasConnectionTokenEncryptionKey,
+  isEncryptedConnectionToken,
+  withDecryptedConnectionToken,
+} from './connection-token-crypto'
+
+const ORIGINAL_KEY = process.env.ENCRYPTION_KEY
+
+afterEach(() => {
+  if (ORIGINAL_KEY === undefined) {
+    delete process.env.ENCRYPTION_KEY
+  } else {
+    process.env.ENCRYPTION_KEY = ORIGINAL_KEY
+  }
+})
+
+describe('connection-token-crypto', () => {
+  it('encrypts and decrypts with a hex ENCRYPTION_KEY', () => {
+    process.env.ENCRYPTION_KEY = 'a'.repeat(64)
+    const plaintext = JSON.stringify({ username: 'u', password: 'p' })
+
+    const encrypted = encryptConnectionToken(plaintext)
+    expect(encrypted).toBeTruthy()
+    expect(isEncryptedConnectionToken(encrypted)).toBe(true)
+    expect(encrypted!.startsWith(CONNECTION_TOKEN_ENC_PREFIX)).toBe(true)
+    expect(encrypted).not.toContain('password')
+    expect(decryptConnectionToken(encrypted)).toBe(plaintext)
+  })
+
+  it('uses a different ciphertext each encrypt (random IV)', () => {
+    process.env.ENCRYPTION_KEY = 'b'.repeat(64)
+    const a = encryptConnectionToken('same-secret')
+    const b = encryptConnectionToken('same-secret')
+    expect(a).not.toBe(b)
+    expect(decryptConnectionToken(a)).toBe('same-secret')
+    expect(decryptConnectionToken(b)).toBe('same-secret')
+  })
+
+  it('passes through legacy plaintext on decrypt', () => {
+    process.env.ENCRYPTION_KEY = 'c'.repeat(64)
+    expect(decryptConnectionToken('plain-oauth-token')).toBe('plain-oauth-token')
+  })
+
+  it('is idempotent for already-encrypted values', () => {
+    process.env.ENCRYPTION_KEY = 'd'.repeat(64)
+    const once = encryptConnectionToken('token')!
+    expect(encryptConnectionToken(once)).toBe(once)
+  })
+
+  it('accepts a non-hex passphrase via SHA-256', () => {
+    process.env.ENCRYPTION_KEY = 'local-dev-passphrase'
+    expect(hasConnectionTokenEncryptionKey()).toBe(true)
+    const encrypted = encryptConnectionToken('hello')
+    expect(decryptConnectionToken(encrypted)).toBe('hello')
+  })
+
+  it('throws when encrypting without ENCRYPTION_KEY', () => {
+    delete process.env.ENCRYPTION_KEY
+    expect(() => encryptConnectionToken('secret')).toThrow(/ENCRYPTION_KEY/)
+  })
+
+  it('decrypts token fields on connection-like rows', () => {
+    process.env.ENCRYPTION_KEY = 'e'.repeat(64)
+    const encrypted = encryptConnectionToken('abc')
+    const row = withDecryptedConnectionToken({ id: '1', token: encrypted })
+    expect(row).toEqual({ id: '1', token: 'abc' })
+  })
+})

--- a/lib/connection-token-crypto.ts
+++ b/lib/connection-token-crypto.ts
@@ -1,0 +1,106 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+/** Stored ciphertext format: enc:v1:<iv_b64url>:<ciphertext_and_tag_b64url> */
+export const CONNECTION_TOKEN_ENC_PREFIX = 'enc:v1:'
+
+const IV_LENGTH = 12
+const AUTH_TAG_LENGTH = 16
+const KEY_LENGTH = 32
+
+function resolveEncryptionKeyBytes(): Buffer | null {
+  const raw = process.env.ENCRYPTION_KEY?.trim()
+  if (!raw || raw === 'your_encryption_key_here') {
+    return null
+  }
+
+  // Prefer openssl rand -hex 32 (64 hex chars → 32 bytes)
+  if (/^[0-9a-fA-F]{64}$/.test(raw)) {
+    return Buffer.from(raw, 'hex')
+  }
+
+  // Fall back to SHA-256 of any passphrase so self-host setups stay simple
+  return createHash('sha256').update(raw, 'utf8').digest()
+}
+
+export function hasConnectionTokenEncryptionKey(): boolean {
+  return resolveEncryptionKeyBytes() !== null
+}
+
+export function isEncryptedConnectionToken(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.startsWith(CONNECTION_TOKEN_ENC_PREFIX)
+}
+
+function requireKey(operation: 'encrypt' | 'decrypt'): Buffer {
+  const key = resolveEncryptionKeyBytes()
+  if (!key || key.length !== KEY_LENGTH) {
+    throw new Error(
+      `ENCRYPTION_KEY is required to ${operation} connection tokens. Set a 64-char hex secret (openssl rand -hex 32).`,
+    )
+  }
+  return key
+}
+
+/**
+ * Encrypt a connection credential / OAuth token for DB storage.
+ * Idempotent for already-encrypted values.
+ */
+export function encryptConnectionToken(plaintext: string | null | undefined): string | null {
+  if (plaintext == null) return null
+  if (plaintext === '') return ''
+  if (isEncryptedConnectionToken(plaintext)) return plaintext
+
+  const key = requireKey('encrypt')
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+    cipher.getAuthTag(),
+  ])
+
+  return (
+    CONNECTION_TOKEN_ENC_PREFIX +
+    `${iv.toString('base64url')}:${ciphertext.toString('base64url')}`
+  )
+}
+
+/**
+ * Decrypt a stored connection token.
+ * Plaintext legacy values pass through unchanged (migration-friendly).
+ */
+export function decryptConnectionToken(stored: string | null | undefined): string | null {
+  if (stored == null) return null
+  if (stored === '') return ''
+  if (!isEncryptedConnectionToken(stored)) return stored
+
+  const payload = stored.slice(CONNECTION_TOKEN_ENC_PREFIX.length)
+  const separator = payload.indexOf(':')
+  if (separator <= 0) {
+    throw new Error('Invalid encrypted connection token format')
+  }
+
+  const iv = Buffer.from(payload.slice(0, separator), 'base64url')
+  const data = Buffer.from(payload.slice(separator + 1), 'base64url')
+  if (iv.length !== IV_LENGTH || data.length <= AUTH_TAG_LENGTH) {
+    throw new Error('Invalid encrypted connection token payload')
+  }
+
+  const key = requireKey('decrypt')
+  const ciphertext = data.subarray(0, data.length - AUTH_TAG_LENGTH)
+  const authTag = data.subarray(data.length - AUTH_TAG_LENGTH)
+  const decipher = createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(authTag)
+
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8')
+}
+
+/** Decrypt token on a connection-like row; leaves other fields untouched. */
+export function withDecryptedConnectionToken<T extends { token?: string | null }>(
+  row: T,
+): T {
+  if (row.token == null) return row
+  return {
+    ...row,
+    token: decryptConnectionToken(row.token),
+  }
+}

--- a/lib/connection-view.ts
+++ b/lib/connection-view.ts
@@ -1,4 +1,5 @@
 import type { Connection } from '@/prisma/generated/prisma/client'
+import { withDecryptedConnectionToken } from '@/lib/connection-token-crypto'
 
 /**
  * Client-facing connection shape.
@@ -25,6 +26,15 @@ export function toConnectionViews(
   connections: Connection[]
 ): ConnectionView[] {
   return connections.map(toConnectionView)
+}
+
+/** Map DB rows to views with Connection.token decrypted for server use. */
+export function toDecryptedConnectionViews(
+  connections: Connection[]
+): ConnectionView[] {
+  return connections.map((connection) =>
+    toConnectionView(withDecryptedConnectionToken(connection)),
+  )
 }
 
 /** Resolve externalId from request body that may send accountId or externalId */

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "capture:changelog-media": "node scripts/capture-changelog-media.mjs",
     "capture:calendar-responsive": "node scripts/capture-calendar-responsive.mjs",
     "capture:changelog-pr-249": "node scripts/capture-changelog-pr-249.mjs",
-    "seed:self-host": "bun scripts/seed-self-host.ts"
+    "seed:self-host": "bun scripts/seed-self-host.ts",
+    "migrate:encrypt-connection-tokens": "bun scripts/migrate-encrypt-connection-tokens.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.10",

--- a/scripts/migrate-encrypt-connection-tokens.ts
+++ b/scripts/migrate-encrypt-connection-tokens.ts
@@ -1,0 +1,96 @@
+/**
+ * Encrypt plaintext Connection.token values at rest (AES-256-GCM).
+ *
+ * Safe to re-run: already-encrypted tokens (enc:v1:…) are skipped.
+ * Decrypt remains compatible with legacy plaintext until every row is migrated.
+ *
+ * Prerequisites:
+ *   - ENCRYPTION_KEY set (openssl rand -hex 32)
+ *   - DATABASE_URL / DIRECT_URL pointing at the target DB
+ *
+ * Usage:
+ *   bun run migrate:encrypt-connection-tokens
+ *   bun run migrate:encrypt-connection-tokens -- --dry-run
+ */
+import '@/lib/load-env-local.node'
+import { PrismaClient } from '@/prisma/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import {
+  encryptConnectionToken,
+  hasConnectionTokenEncryptionKey,
+  isEncryptedConnectionToken,
+} from '@/lib/connection-token-crypto'
+
+const dryRun = process.argv.includes('--dry-run')
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+})
+const prisma = new PrismaClient({ adapter })
+
+async function main() {
+  if (!hasConnectionTokenEncryptionKey()) {
+    throw new Error(
+      'ENCRYPTION_KEY is missing or still the .env.example placeholder. Generate with: openssl rand -hex 32',
+    )
+  }
+
+  console.log(
+    `[migrate-encrypt-connection-tokens] Starting${dryRun ? ' (dry-run)' : ''}…`,
+  )
+
+  const rows = await prisma.connection.findMany({
+    where: { token: { not: null } },
+    select: { id: true, service: true, externalId: true, token: true },
+  })
+
+  let alreadyEncrypted = 0
+  let migrated = 0
+  let skippedEmpty = 0
+
+  for (const row of rows) {
+    if (!row.token) {
+      skippedEmpty += 1
+      continue
+    }
+    if (isEncryptedConnectionToken(row.token)) {
+      alreadyEncrypted += 1
+      continue
+    }
+
+    const encrypted = encryptConnectionToken(row.token)
+    if (!encrypted) {
+      skippedEmpty += 1
+      continue
+    }
+
+    if (!dryRun) {
+      await prisma.connection.update({
+        where: { id: row.id },
+        data: { token: encrypted },
+      })
+    }
+
+    migrated += 1
+    console.log(
+      `  ${dryRun ? 'would encrypt' : 'encrypted'} ${row.service}/${row.externalId} (${row.id})`,
+    )
+  }
+
+  console.log('[migrate-encrypt-connection-tokens] Done', {
+    totalWithToken: rows.length,
+    migrated,
+    alreadyEncrypted,
+    skippedEmpty,
+    dryRun,
+  })
+}
+
+main()
+  .catch((error) => {
+    console.error('[migrate-encrypt-connection-tokens] Failed:', error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/scripts/self-host-quickstart.sh
+++ b/scripts/self-host-quickstart.sh
@@ -42,6 +42,8 @@ LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 OPENAI_API_KEY=dummy
+# Local AES key for Connection.token encryption (dev only — rotate for real deployments)
+ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 EOF
 
 unset DATABASE_URL DIRECT_URL

--- a/server/connections.ts
+++ b/server/connections.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { encryptConnectionToken } from '@/lib/connection-token-crypto'
 import { prisma } from '@/lib/prisma'
 
 /**
@@ -68,6 +69,9 @@ export async function ensureConnection(params: {
     includedFeeTypes,
   } = params
 
+  const encryptedToken =
+    token !== undefined ? encryptConnectionToken(token) : undefined
+
   return prisma.connection.upsert({
     where: {
       userId_service_externalId: {
@@ -78,7 +82,7 @@ export async function ensureConnection(params: {
     },
     update: {
       lastSyncedAt,
-      ...(token !== undefined ? { token } : {}),
+      ...(encryptedToken !== undefined ? { token: encryptedToken } : {}),
       ...(tokenExpiresAt !== undefined ? { tokenExpiresAt } : {}),
       ...(dailySyncTime !== undefined ? { dailySyncTime } : {}),
       ...(includedFeeTypes !== undefined
@@ -91,7 +95,7 @@ export async function ensureConnection(params: {
       service,
       externalId,
       lastSyncedAt,
-      token: token ?? null,
+      token: encryptedToken ?? null,
       tokenExpiresAt: tokenExpiresAt ?? null,
       dailySyncTime: dailySyncTime ?? null,
       includedFeeTypes: includedFeeTypes as object | undefined,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Encrypts all `Connection.token` values at rest with a server-only `ENCRYPTION_KEY` (AES-256-GCM). Covers DxFeed credential JSON, Tradovate OAuth tokens, Rithmic sync tokens, and Thor tokens written through `ensureConnection`.

## How it works

- Format: `enc:v1:<iv>:<ciphertext+tag>` (base64url)
- Encrypt on every write; decrypt on every server read that needs the plaintext
- Legacy plaintext tokens still decrypt (pass-through) so deploys are non-breaking
- Lookups that previously matched on token equality now use `externalId` (random IVs make ciphertext non-deterministic)

## Migration

1. Set `ENCRYPTION_KEY` in Vercel / `.env.local` (`openssl rand -hex 32`)
2. Deploy this PR (new writes encrypt; old plaintext still works)
3. Run once against production (or staging first):

```bash
bun run migrate:encrypt-connection-tokens -- --dry-run
bun run migrate:encrypt-connection-tokens
```

Idempotent: already-encrypted rows are skipped.

## Follow-up

When [PR #327](https://github.com/hugodemenez/deltalytix/pull/327) (Rithmic Protocol) lands, its store/get paths should use the same `encryptConnectionToken` / `decryptConnectionToken` helpers (or `ensureConnection`).

## Test plan

- [x] `bunx vitest run lib/connection-token-crypto.test.ts`
- [x] `bun run typecheck` (only pre-existing `next.config` experimental warning)
- [ ] Set `ENCRYPTION_KEY`, connect/sync DxFeed + Tradovate, confirm DB `token` starts with `enc:v1:`
- [ ] Dry-run then run `migrate:encrypt-connection-tokens` on a DB with legacy plaintext rows
- [ ] Confirm cron Tradovate renew still works with encrypted tokens
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7c6d-3a89-71ad-90cb-79565b3df149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7c6d-3a89-71ad-90cb-79565b3df149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

