### PR TITLE
Backport: encrypt Synchronization.token at rest (main)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ DISCORD_SECRET=your_discord_secret_here
 DISCORD_ID=your_discord_id_here
 REDIRECT_URL='http://localhost:3000/api/auth/callback'
 
-# Security
+# Security — AES-256-GCM key for Synchronization.token at rest (server-only, never NEXT_PUBLIC_)
+# Generate: openssl rand -hex 32
+# Any non-placeholder string also works (hashed with SHA-256). Required in production for broker sync.
 ENCRYPTION_KEY=your_encryption_key_here
 
 # Email Service

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 OPENAI_API_KEY=dummy
+ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 If the shell already exports `DATABASE_URL`, run `unset DATABASE_URL DIRECT_URL` before sourcing `.env.local`.

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -34,6 +34,11 @@ import type {
   DxFeedTradingAccount,
 } from './dxfeed-types'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import {
+  decryptConnectionToken,
+  encryptConnectionToken,
+  withDecryptedConnectionToken,
+} from '@/lib/connection-token-crypto'
 
 const DXFEED_AUTH_URL = resolveDxFeedV2AuthUrl(process.env.DXFEED_AUTH_URL)
 const DXFEED_PLATFORM_KEY = process.env.DXFEED_PLATFORM_KEY
@@ -481,7 +486,7 @@ function buildTradesFromDxFeedReport(
 
 export async function getDxFeedTrades(
   initialTokenJson: string,
-  options?: { userId?: string },
+  options?: { userId?: string; accountId?: string },
 ): Promise<DxFeedTradesResult> {
   try {
     const credentials = parseStoredCredentials(initialTokenJson)
@@ -499,7 +504,7 @@ export async function getDxFeedTrades(
     const historicalHost = coerceDxFeedHistoricalHostForSync(credentials.historicalHost, propFirm)
 
     let userId = options?.userId ?? null
-    let syncAccountId: string | null = null
+    let syncAccountId: string | null = options?.accountId ?? null
     if (!userId) {
       const supabase = await createClient()
       const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -513,14 +518,25 @@ export async function getDxFeedTrades(
     }
     const resolvedUserId = userId
 
-    let storedTokenJson = initialTokenJson
     const baseUrl = historicalHost.endsWith('/') ? historicalHost.slice(0, -1) : historicalHost
 
-    const syncRow = await prisma.synchronization.findFirst({
-      where: { userId: resolvedUserId, service: 'dxfeed', token: initialTokenJson },
-      select: { accountId: true, tokenExpiresAt: true },
-    })
-    syncAccountId = syncRow?.accountId ?? null
+    const syncRow = syncAccountId
+      ? await prisma.synchronization.findUnique({
+          where: {
+            userId_service_accountId: {
+              userId: resolvedUserId,
+              service: 'dxfeed',
+              accountId: syncAccountId,
+            },
+          },
+          select: { accountId: true, tokenExpiresAt: true },
+        })
+      : await prisma.synchronization.findFirst({
+          where: { userId: resolvedUserId, service: 'dxfeed' },
+          select: { accountId: true, tokenExpiresAt: true },
+          orderBy: { updatedAt: 'desc' },
+        })
+    syncAccountId = syncRow?.accountId ?? syncAccountId
 
     if (
       isDxFeedAccessTokenExpired(accessToken, syncRow?.tokenExpiresAt, {
@@ -555,8 +571,9 @@ export async function getDxFeedTrades(
         accountNumbers,
       }
       const updatedJson = JSON.stringify(updatedCreds)
-      await updateStoredCredentials(resolvedUserId, storedTokenJson, updatedJson)
-      storedTokenJson = updatedJson
+      if (syncAccountId) {
+        await updateStoredCredentials(resolvedUserId, syncAccountId, updatedJson)
+      }
     }
 
     const syncStats = {
@@ -576,7 +593,9 @@ export async function getDxFeedTrades(
           syncStats,
         }
       }
-      await updateLastSyncedAt(resolvedUserId, storedTokenJson)
+      if (syncAccountId) {
+        await updateLastSyncedAt(resolvedUserId, syncAccountId)
+      }
       return { processedTrades: [], savedCount: 0, tradesCount: 0, syncStats }
     }
 
@@ -643,7 +662,9 @@ export async function getDxFeedTrades(
 
     syncStats.closedTrades = allTrades.length
 
-    await updateLastSyncedAt(resolvedUserId, storedTokenJson)
+    if (syncAccountId) {
+      await updateLastSyncedAt(resolvedUserId, syncAccountId)
+    }
 
     if (syncStats.fetchFailures > 0 && syncStats.fetchFailures >= accounts.length) {
       return {
@@ -694,12 +715,12 @@ export async function getDxFeedTrades(
   }
 }
 
-async function updateLastSyncedAt(userId: string, storedTokenJson: string) {
+async function updateLastSyncedAt(userId: string, accountId: string) {
   await prisma.synchronization.updateMany({
     where: {
       userId,
       service: 'dxfeed',
-      token: storedTokenJson,
+      accountId,
     },
     data: {
       lastSyncedAt: new Date(),
@@ -707,15 +728,19 @@ async function updateLastSyncedAt(userId: string, storedTokenJson: string) {
   })
 }
 
-async function updateStoredCredentials(userId: string, oldTokenJson: string, newTokenJson: string) {
+async function updateStoredCredentials(
+  userId: string,
+  accountId: string,
+  newTokenJson: string,
+) {
   await prisma.synchronization.updateMany({
     where: {
       userId,
       service: 'dxfeed',
-      token: oldTokenJson,
+      accountId,
     },
     data: {
-      token: newTokenJson,
+      token: encryptConnectionToken(newTokenJson),
     },
   })
 }
@@ -752,7 +777,7 @@ export async function storeDxFeedToken(
         },
       },
       update: {
-        token: tokenJson,
+        token: encryptConnectionToken(tokenJson),
         tokenExpiresAt: options?.tokenExpiresAt ?? null,
         lastSyncedAt: new Date(),
         updatedAt: new Date(),
@@ -762,7 +787,7 @@ export async function storeDxFeedToken(
         userId: user.id,
         service: 'dxfeed',
         accountId,
-        token: tokenJson,
+        token: encryptConnectionToken(tokenJson),
         tokenExpiresAt: options?.tokenExpiresAt ?? null,
         lastSyncedAt: new Date(),
         includedFeeTypes: undefined, // DxFeed has no fee differentiator
@@ -808,7 +833,12 @@ export async function getDxFeedToken(accountId: string = 'default') {
       return { error: DxFeedErrorCode.NO_TOKEN_RECONNECT }
     }
 
-    const credentials = parseStoredCredentials(syncData.token)
+    const plaintextToken = decryptConnectionToken(syncData.token)
+    if (!plaintextToken) {
+      return { error: DxFeedErrorCode.NO_TOKEN_RECONNECT }
+    }
+
+    const credentials = parseStoredCredentials(plaintextToken)
     if (
       credentials &&
       isDxFeedAccessTokenExpired(credentials.accessToken, syncData.tokenExpiresAt, {
@@ -819,7 +849,7 @@ export async function getDxFeedToken(accountId: string = 'default') {
     }
 
     return {
-      storedTokenJson: syncData.token,
+      storedTokenJson: plaintextToken,
       accountId: syncData.accountId,
     }
   } catch (error) {
@@ -878,7 +908,9 @@ export async function getDxFeedSynchronizations() {
       },
     })
 
-    return { synchronizations }
+    return {
+      synchronizations: synchronizations.map(withDecryptedConnectionToken),
+    }
   } catch (error) {
     logger.error('Failed to get DxFeed synchronizations:', error)
     return { error: 'Failed to get synchronizations' }

--- a/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
@@ -3,6 +3,10 @@ import { prisma } from "@/lib/prisma"
 import { getUserId } from "@/server/auth"
 import { Synchronization } from "@/prisma/generated/prisma/client"
 import { capturePostHogEvent } from "@/lib/posthog-server"
+import {
+  encryptConnectionToken,
+  withDecryptedConnectionToken,
+} from "@/lib/connection-token-crypto"
 
 export async function getRithmicSynchronizations() {
   console.log('CHECKING RITHMIC SYNCHRONIZATIONS')
@@ -10,7 +14,7 @@ export async function getRithmicSynchronizations() {
   const synchronizations = await prisma.synchronization.findMany({
     where: { userId: userId, service: "rithmic" },
   })
-  return synchronizations
+  return synchronizations.map(withDecryptedConnectionToken)
 }
 
 export async function setRithmicSynchronization(synchronization: Partial<Synchronization>) {
@@ -24,6 +28,10 @@ export async function setRithmicSynchronization(synchronization: Partial<Synchro
     },
     select: { id: true },
   })
+  const encryptedToken =
+    synchronization.token !== undefined
+      ? encryptConnectionToken(synchronization.token)
+      : undefined
   await prisma.synchronization.upsert({
     where: { 
       userId_service_accountId: {
@@ -34,11 +42,13 @@ export async function setRithmicSynchronization(synchronization: Partial<Synchro
     },
     update: {
       ...synchronization,
+      ...(encryptedToken !== undefined ? { token: encryptedToken } : {}),
       userId: userId,
       includedFeeTypes: undefined, // Rithmic has no fee differentiator
     },
     create: {
       ...synchronization,
+      ...(encryptedToken !== undefined ? { token: encryptedToken } : {}),
       service,
       accountId,
       lastSyncedAt: synchronization.lastSyncedAt || new Date(),

--- a/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
@@ -12,6 +12,11 @@ import { formatTimestamp, formatDateToTimestamp } from '@/lib/date-utils'
 import { createTradeWithDefaults } from '@/lib/trade-factory'
 import { getUserId } from '@/server/auth'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import {
+  decryptConnectionToken,
+  encryptConnectionToken,
+  withDecryptedConnectionToken,
+} from '@/lib/connection-token-crypto'
 
 // Helper function to format dates in the required format: 2025-06-05T08:38:40+00:00
 function formatDateForAPI(date: Date): string {
@@ -1255,7 +1260,7 @@ export async function storeTradovateToken(
         }
       },
       update: {
-        token: accessToken,
+        token: encryptConnectionToken(accessToken),
         tokenExpiresAt: new Date(expiresAt),
         environment,
         lastSyncedAt: new Date(),
@@ -1265,7 +1270,7 @@ export async function storeTradovateToken(
         userId: user.id,
         service: 'tradovate',
         accountId: accountId,
-        token: accessToken,
+        token: encryptConnectionToken(accessToken),
         tokenExpiresAt: new Date(expiresAt),
         environment,
         lastSyncedAt: new Date()
@@ -1312,6 +1317,11 @@ export async function getTradovateToken(accountId: string = 'default') {
       return { error: 'No Tradovate token found' }
     }
 
+    const plaintextToken = decryptConnectionToken(syncData.token)
+    if (!plaintextToken) {
+      return { error: 'No Tradovate token found' }
+    }
+
     // Check if token is expired
     const now = new Date()
     const expiresAt = syncData.tokenExpiresAt
@@ -1322,7 +1332,7 @@ export async function getTradovateToken(accountId: string = 'default') {
 
     const includedFeeTypes = syncData.includedFeeTypes as Record<string, boolean> | null | undefined
     return {
-      accessToken: syncData.token,
+      accessToken: plaintextToken,
       expiresAt: syncData.tokenExpiresAt?.toISOString() || '',
       environment: normalizeEnvironment(syncData.environment),
       accountId: syncData.accountId,
@@ -1415,7 +1425,9 @@ export async function getTradovateSynchronizations() {
       }
     })
 
-    return { synchronizations }
+    return {
+      synchronizations: synchronizations.map(withDecryptedConnectionToken),
+    }
   } catch (error) {
     console.error('TRADOVATE SYNC: Failed to get Tradovate synchronizations:', error)
     return { error: 'Failed to get synchronizations' }
@@ -1526,13 +1538,13 @@ export async function testCustomTradovateToken(
   }
 }
 
-async function updateLastSyncedAt(userId: string, accessToken: string) {
+async function updateLastSyncedAt(userId: string, accountId: string) {
     // Update last synced at
     const updateResult = await prisma.synchronization.updateMany({
       where: {
         userId: userId,
         service: 'tradovate',
-        token: accessToken,
+        accountId,
       },
       data: {
         lastSyncedAt: new Date()
@@ -1545,7 +1557,13 @@ async function updateLastSyncedAt(userId: string, accessToken: string) {
   
 export async function getTradovateTrades(
   accessToken: string,
-  options?: { userId?: string; includeAllFees?: boolean; includedFeeTypes?: TradovateIncludedFeeTypes; environment?: TradovateEnvironment }
+  options?: {
+    userId?: string
+    includeAllFees?: boolean
+    includedFeeTypes?: TradovateIncludedFeeTypes
+    environment?: TradovateEnvironment
+    accountId?: string
+  }
 ): Promise<TradovateTradesResult> {
   try {
     // If we are on the server
@@ -1569,6 +1587,7 @@ export async function getTradovateTrades(
       return { error: 'User not authenticated' }
     }
     const resolvedUserId = userId
+    const accountId = options?.accountId ?? null
 
     const apiBaseUrl = getApiBaseUrl(environment)
 
@@ -1580,7 +1599,9 @@ export async function getTradovateTrades(
     // Means there are no trades to import
     if (fillPairs.length === 0) {
       logger.info('No fill pairs returned from Tradovate')
-      await updateLastSyncedAt(resolvedUserId, accessToken)
+      if (accountId) {
+        await updateLastSyncedAt(resolvedUserId, accountId)
+      }
       return { processedTrades: [], savedCount: 0, ordersCount: 0 }
     }
 
@@ -1689,7 +1710,9 @@ export async function getTradovateTrades(
       tickDetails,
     )
     
-    await updateLastSyncedAt(resolvedUserId, accessToken)
+    if (accountId) {
+      await updateLastSyncedAt(resolvedUserId, accountId)
+    }
 
     if (processedTrades.length === 0) {
       logger.info('No trades could be created from fill pairs')

--- a/app/api/cron/renew-tradovate-token/route.ts
+++ b/app/api/cron/renew-tradovate-token/route.ts
@@ -1,5 +1,9 @@
 // app/api/cron/renew-tradovate-token/route.ts
 import { prisma } from '@/lib/prisma';
+import {
+  decryptConnectionToken,
+  encryptConnectionToken,
+} from '@/lib/connection-token-crypto';
 import { NextRequest } from 'next/server';
 
 /**
@@ -109,11 +113,17 @@ async function renewUserToken(synchronization: any): Promise<boolean> {
       ? 'https://demo.tradovateapi.com' 
       : 'https://live.tradovateapi.com';
     
+    const plaintextToken = decryptConnectionToken(synchronization.token)
+    if (!plaintextToken) {
+      console.error(`[CRON] Missing token for account ${synchronization.accountId}`);
+      return false;
+    }
+    
     console.log(`[CRON] Attempting token renewal for account ${synchronization.accountId}`);
     
     const renewal = await fetch(`${apiBaseUrl}/auth/renewAccessToken`, {
       headers: {
-        'Authorization': `Bearer ${synchronization.token}`
+        'Authorization': `Bearer ${plaintextToken}`
       }
     });
     
@@ -144,7 +154,7 @@ async function renewUserToken(synchronization: any): Promise<boolean> {
         synchronizations: {
           update: {
             where: { id: synchronization.id },
-            data: { token: renewalData.accessToken, tokenExpiresAt: new Date(renewalData.expirationTime) }
+            data: { token: encryptConnectionToken(renewalData.accessToken), tokenExpiresAt: new Date(renewalData.expirationTime) }
           }
         }
       }
@@ -183,10 +193,16 @@ async function performDailySync(synchronization: any): Promise<boolean> {
     
     // Use account-level fee config from DB (includedFeeTypes on sync record)
     const includedFeeTypes = synchronization.includedFeeTypes as Record<string, boolean> | null | undefined
-    const result = await getTradovateTrades(synchronization.token, {
+    const plaintextToken = decryptConnectionToken(synchronization.token)
+    if (!plaintextToken) {
+      console.error(`[CRON] Missing token for daily sync of account ${synchronization.accountId}`);
+      return false;
+    }
+    const result = await getTradovateTrades(plaintextToken, {
       userId: synchronization.userId,
       includedFeeTypes: includedFeeTypes ?? undefined,
       environment: synchronization.environment === 'live' ? 'live' : 'demo',
+      accountId: synchronization.accountId,
     });
     
     if (result.error) {

--- a/app/api/dxfeed/sync/route.ts
+++ b/app/api/dxfeed/sync/route.ts
@@ -28,7 +28,9 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const syncResult = await getDxFeedTrades(tokenResult.storedTokenJson)
+    const syncResult = await getDxFeedTrades(tokenResult.storedTokenJson, {
+      accountId,
+    })
     if (syncResult.error) {
       return NextResponse.json(
         {

--- a/app/api/tradovate/sync/route.ts
+++ b/app/api/tradovate/sync/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: NextRequest) {
     const syncResult = await getTradovateTrades(tokenResult.accessToken, {
       includedFeeTypes: tokenResult.includedFeeTypes,
       environment: tokenResult.environment,
+      accountId,
     });
     if (syncResult.error) {
       return NextResponse.json(

--- a/lib/connection-token-crypto.test.ts
+++ b/lib/connection-token-crypto.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  CONNECTION_TOKEN_ENC_PREFIX,
+  decryptConnectionToken,
+  encryptConnectionToken,
+  hasConnectionTokenEncryptionKey,
+  isEncryptedConnectionToken,
+  withDecryptedConnectionToken,
+} from './connection-token-crypto'
+
+const ORIGINAL_KEY = process.env.ENCRYPTION_KEY
+
+afterEach(() => {
+  if (ORIGINAL_KEY === undefined) {
+    delete process.env.ENCRYPTION_KEY
+  } else {
+    process.env.ENCRYPTION_KEY = ORIGINAL_KEY
+  }
+})
+
+describe('connection-token-crypto', () => {
+  it('encrypts and decrypts with a hex ENCRYPTION_KEY', () => {
+    process.env.ENCRYPTION_KEY = 'a'.repeat(64)
+    const plaintext = JSON.stringify({ username: 'u', password: 'p' })
+
+    const encrypted = encryptConnectionToken(plaintext)
+    expect(encrypted).toBeTruthy()
+    expect(isEncryptedConnectionToken(encrypted)).toBe(true)
+    expect(encrypted!.startsWith(CONNECTION_TOKEN_ENC_PREFIX)).toBe(true)
+    expect(encrypted).not.toContain('password')
+    expect(decryptConnectionToken(encrypted)).toBe(plaintext)
+  })
+
+  it('uses a different ciphertext each encrypt (random IV)', () => {
+    process.env.ENCRYPTION_KEY = 'b'.repeat(64)
+    const a = encryptConnectionToken('same-secret')
+    const b = encryptConnectionToken('same-secret')
+    expect(a).not.toBe(b)
+    expect(decryptConnectionToken(a)).toBe('same-secret')
+    expect(decryptConnectionToken(b)).toBe('same-secret')
+  })
+
+  it('passes through legacy plaintext on decrypt', () => {
+    process.env.ENCRYPTION_KEY = 'c'.repeat(64)
+    expect(decryptConnectionToken('plain-oauth-token')).toBe('plain-oauth-token')
+  })
+
+  it('is idempotent for already-encrypted values', () => {
+    process.env.ENCRYPTION_KEY = 'd'.repeat(64)
+    const once = encryptConnectionToken('token')!
+    expect(encryptConnectionToken(once)).toBe(once)
+  })
+
+  it('accepts a non-hex passphrase via SHA-256', () => {
+    process.env.ENCRYPTION_KEY = 'local-dev-passphrase'
+    expect(hasConnectionTokenEncryptionKey()).toBe(true)
+    const encrypted = encryptConnectionToken('hello')
+    expect(decryptConnectionToken(encrypted)).toBe('hello')
+  })
+
+  it('throws when encrypting without ENCRYPTION_KEY', () => {
+    delete process.env.ENCRYPTION_KEY
+    expect(() => encryptConnectionToken('secret')).toThrow(/ENCRYPTION_KEY/)
+  })
+
+  it('decrypts token fields on connection-like rows', () => {
+    process.env.ENCRYPTION_KEY = 'e'.repeat(64)
+    const encrypted = encryptConnectionToken('abc')
+    const row = withDecryptedConnectionToken({ id: '1', token: encrypted })
+    expect(row).toEqual({ id: '1', token: 'abc' })
+  })
+})

--- a/lib/connection-token-crypto.ts
+++ b/lib/connection-token-crypto.ts
@@ -1,0 +1,106 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+/** Stored ciphertext format: enc:v1:<iv_b64url>:<ciphertext_and_tag_b64url> */
+export const CONNECTION_TOKEN_ENC_PREFIX = 'enc:v1:'
+
+const IV_LENGTH = 12
+const AUTH_TAG_LENGTH = 16
+const KEY_LENGTH = 32
+
+function resolveEncryptionKeyBytes(): Buffer | null {
+  const raw = process.env.ENCRYPTION_KEY?.trim()
+  if (!raw || raw === 'your_encryption_key_here') {
+    return null
+  }
+
+  // Prefer openssl rand -hex 32 (64 hex chars → 32 bytes)
+  if (/^[0-9a-fA-F]{64}$/.test(raw)) {
+    return Buffer.from(raw, 'hex')
+  }
+
+  // Fall back to SHA-256 of any passphrase so self-host setups stay simple
+  return createHash('sha256').update(raw, 'utf8').digest()
+}
+
+export function hasConnectionTokenEncryptionKey(): boolean {
+  return resolveEncryptionKeyBytes() !== null
+}
+
+export function isEncryptedConnectionToken(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.startsWith(CONNECTION_TOKEN_ENC_PREFIX)
+}
+
+function requireKey(operation: 'encrypt' | 'decrypt'): Buffer {
+  const key = resolveEncryptionKeyBytes()
+  if (!key || key.length !== KEY_LENGTH) {
+    throw new Error(
+      `ENCRYPTION_KEY is required to ${operation} connection tokens. Set a 64-char hex secret (openssl rand -hex 32).`,
+    )
+  }
+  return key
+}
+
+/**
+ * Encrypt a connection credential / OAuth token for DB storage.
+ * Idempotent for already-encrypted values.
+ */
+export function encryptConnectionToken(plaintext: string | null | undefined): string | null {
+  if (plaintext == null) return null
+  if (plaintext === '') return ''
+  if (isEncryptedConnectionToken(plaintext)) return plaintext
+
+  const key = requireKey('encrypt')
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+    cipher.getAuthTag(),
+  ])
+
+  return (
+    CONNECTION_TOKEN_ENC_PREFIX +
+    `${iv.toString('base64url')}:${ciphertext.toString('base64url')}`
+  )
+}
+
+/**
+ * Decrypt a stored connection token.
+ * Plaintext legacy values pass through unchanged (migration-friendly).
+ */
+export function decryptConnectionToken(stored: string | null | undefined): string | null {
+  if (stored == null) return null
+  if (stored === '') return ''
+  if (!isEncryptedConnectionToken(stored)) return stored
+
+  const payload = stored.slice(CONNECTION_TOKEN_ENC_PREFIX.length)
+  const separator = payload.indexOf(':')
+  if (separator <= 0) {
+    throw new Error('Invalid encrypted connection token format')
+  }
+
+  const iv = Buffer.from(payload.slice(0, separator), 'base64url')
+  const data = Buffer.from(payload.slice(separator + 1), 'base64url')
+  if (iv.length !== IV_LENGTH || data.length <= AUTH_TAG_LENGTH) {
+    throw new Error('Invalid encrypted connection token payload')
+  }
+
+  const key = requireKey('decrypt')
+  const ciphertext = data.subarray(0, data.length - AUTH_TAG_LENGTH)
+  const authTag = data.subarray(data.length - AUTH_TAG_LENGTH)
+  const decipher = createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(authTag)
+
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8')
+}
+
+/** Decrypt token on a connection-like row; leaves other fields untouched. */
+export function withDecryptedConnectionToken<T extends { token?: string | null }>(
+  row: T,
+): T {
+  if (row.token == null) return row
+  return {
+    ...row,
+    token: decryptConnectionToken(row.token),
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "capture:changelog-media": "node scripts/capture-changelog-media.mjs",
     "capture:calendar-responsive": "node scripts/capture-calendar-responsive.mjs",
     "capture:changelog-pr-249": "node scripts/capture-changelog-pr-249.mjs",
-    "seed:self-host": "bun scripts/seed-self-host.ts"
+    "seed:self-host": "bun scripts/seed-self-host.ts",
+    "migrate:encrypt-connection-tokens": "bun scripts/migrate-encrypt-connection-tokens.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.10",

--- a/scripts/migrate-encrypt-connection-tokens.ts
+++ b/scripts/migrate-encrypt-connection-tokens.ts
@@ -1,0 +1,96 @@
+/**
+ * Encrypt plaintext Synchronization.token values at rest (AES-256-GCM).
+ *
+ * Safe to re-run: already-encrypted tokens (enc:v1:…) are skipped.
+ * Decrypt remains compatible with legacy plaintext until every row is migrated.
+ *
+ * Prerequisites:
+ *   - ENCRYPTION_KEY set (openssl rand -hex 32)
+ *   - DATABASE_URL / DIRECT_URL pointing at the target DB
+ *
+ * Usage:
+ *   bun run migrate:encrypt-connection-tokens
+ *   bun run migrate:encrypt-connection-tokens -- --dry-run
+ */
+import '@/lib/load-env-local.node'
+import { PrismaClient } from '@/prisma/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import {
+  encryptConnectionToken,
+  hasConnectionTokenEncryptionKey,
+  isEncryptedConnectionToken,
+} from '@/lib/connection-token-crypto'
+
+const dryRun = process.argv.includes('--dry-run')
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+})
+const prisma = new PrismaClient({ adapter })
+
+async function main() {
+  if (!hasConnectionTokenEncryptionKey()) {
+    throw new Error(
+      'ENCRYPTION_KEY is missing or still the .env.example placeholder. Generate with: openssl rand -hex 32',
+    )
+  }
+
+  console.log(
+    `[migrate-encrypt-connection-tokens] Starting${dryRun ? ' (dry-run)' : ''}…`,
+  )
+
+  const rows = await prisma.synchronization.findMany({
+    where: { token: { not: null } },
+    select: { id: true, service: true, accountId: true, token: true },
+  })
+
+  let alreadyEncrypted = 0
+  let migrated = 0
+  let skippedEmpty = 0
+
+  for (const row of rows) {
+    if (!row.token) {
+      skippedEmpty += 1
+      continue
+    }
+    if (isEncryptedConnectionToken(row.token)) {
+      alreadyEncrypted += 1
+      continue
+    }
+
+    const encrypted = encryptConnectionToken(row.token)
+    if (!encrypted) {
+      skippedEmpty += 1
+      continue
+    }
+
+    if (!dryRun) {
+      await prisma.synchronization.update({
+        where: { id: row.id },
+        data: { token: encrypted },
+      })
+    }
+
+    migrated += 1
+    console.log(
+      `  ${dryRun ? 'would encrypt' : 'encrypted'} ${row.service}/${row.accountId} (${row.id})`,
+    )
+  }
+
+  console.log('[migrate-encrypt-connection-tokens] Done', {
+    totalWithToken: rows.length,
+    migrated,
+    alreadyEncrypted,
+    skippedEmpty,
+    dryRun,
+  })
+}
+
+main()
+  .catch((error) => {
+    console.error('[migrate-encrypt-connection-tokens] Failed:', error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/scripts/self-host-quickstart.sh
+++ b/scripts/self-host-quickstart.sh
@@ -42,6 +42,8 @@ LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_LOCAL_DASHBOARD_USER_EMAIL=local-dashboard@deltalytix.local
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 OPENAI_API_KEY=dummy
+# Local AES key for Synchronization.token encryption (dev only — rotate for real deployments)
+ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 EOF
 
 unset DATABASE_URL DIRECT_URL


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backport of [#358](https://github.com/hugodemenez/deltalytix/pull/358) onto **`main` only** — does not promote the rest of `beta`.

Encrypts `Synchronization.token` at rest with server-only `ENCRYPTION_KEY` (AES-256-GCM) for DxFeed, Tradovate, and Rithmic. Adapted for production’s `Synchronization` / `accountId` model (beta’s `Connection` / `externalId` rename is not included).

## Why a separate PR

A full `beta` → `main` promotion would ship unrelated beta work. This cherry-ports just credential encryption.

## After merge (prod)

1. Set `ENCRYPTION_KEY` in Vercel Production (`openssl rand -hex 32`) — keep this key stable
2. Deploy this PR
3. Migrate existing plaintext rows:

```bash
bun run migrate:encrypt-connection-tokens -- --dry-run
bun run migrate:encrypt-connection-tokens
```

(Use prod `DATABASE_URL` + the **same** prod `ENCRYPTION_KEY`.)

## Test plan

- [x] `bunx vitest run lib/connection-token-crypto.test.ts`
- [x] `bun run typecheck`
- [ ] Deploy to production with `ENCRYPTION_KEY` set
- [ ] Dry-run then run migrate against prod
- [ ] Spot-check DxFeed / Tradovate sync after encryption
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7c6d-3a89-71ad-90cb-79565b3df149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7c6d-3a89-71ad-90cb-79565b3df149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

