### PR TITLE
Stabilize Instant Navigations for locale dashboard layouts

### DIFF
--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -171,7 +171,8 @@ function ConnectionRow({
   const [scheduleOpen, setScheduleOpen] = useState(false)
   const [dailySyncTime, setDailySyncTime] = useState('')
   const [savingSchedule, setSavingSchedule] = useState(false)
-  const [nowMs, setNowMs] = useState(() => Date.now())
+  // Countdown must not SSR with Date.now() — minute boundaries cause hydration mismatches.
+  const [nowMs, setNowMs] = useState<number | null>(null)
   const { performSyncForAccount: syncTradovate } = useTradovateSyncContext()
   const { performSyncForAccount: syncDxFeed } = useDxFeedSyncContext()
 
@@ -183,6 +184,7 @@ function ConnectionRow({
 
   useEffect(() => {
     if (!canSchedule || !nextSyncAt) return
+    setNowMs(Date.now())
     const id = window.setInterval(() => setNowMs(Date.now()), 60_000)
     return () => window.clearInterval(id)
   }, [canSchedule, nextSyncAt])
@@ -355,7 +357,7 @@ function ConnectionRow({
                         openScheduleDialog()
                       }}
                     >
-                      {nextSyncAt
+                      {nextSyncAt && nowMs != null
                         ? t('connections.nextSyncIn', {
                             time: formatCountdown(nextSyncAt, nowMs),
                           })

--- a/app/[locale]/dashboard/connections/page.tsx
+++ b/app/[locale]/dashboard/connections/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { cacheLife } from 'next/cache'
 import { Suspense } from 'react'
+import { connection } from 'next/server'
 import { getConnectionsMetadataCopy } from '@/lib/og/site-metadata'
 import { resolveLocale } from '@/lib/locale-params'
 import { getSiteOrigin, siteUrl } from '@/lib/site-url'
@@ -68,8 +69,12 @@ export async function generateMetadata(props: {
  * Resolve auth outside `'use cache'`, then render the tagged cached list UI.
  * Cold cache → list skeleton under the instant chrome.
  * Warm cache → list included instantly (no skeleton).
+ *
+ * `connection()` marks the route intentionally dynamic so locale-aware
+ * `generateMetadata()` does not block Instant Navigations prefetch.
  */
 async function ConnectionsPageContent() {
+  await connection()
   const userId = await getUserId()
   return <CachedConnectionsPage userId={userId} />
 }

--- a/app/[locale]/dashboard/layout.tsx
+++ b/app/[locale]/dashboard/layout.tsx
@@ -10,17 +10,26 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { RithmicSyncContextProvider } from "@/context/rithmic-sync-context";
 import { TradovateSyncContextProvider } from "@/context/tradovate-sync-context";
 import { DxFeedSyncContextProvider } from "@/context/dxfeed-sync-context";
-import { I18nProviderClient } from "@/locales/client";
 import { ConsentBanner } from "@/components/consent-banner";
 import { BetaConnectionFlowInvite } from "@/components/beta-connection-flow-invite";
 import { PostHogIdentity } from "@/components/posthog-identity";
 import { createClient } from "@/server/auth";
 import { resolveLocale } from "@/lib/locale-params";
 
-async function DashboardPostHogIdentity({ locale }: { locale: string }) {
+/**
+ * Locale + auth for PostHog only — keep URL data inside Suspense so the
+ * dashboard App Shell stays reusable for Instant Navigations.
+ * Parent `[locale]/layout` already provides `I18nProviderClient`.
+ */
+async function DashboardPostHogIdentity({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
   // Request-time only — avoid running auth/bypass checks during prerender.
   await connection();
 
+  const locale = await resolveLocale(params);
   const supabase = await createClient();
   const {
     data: { user },
@@ -33,20 +42,21 @@ async function DashboardPostHogIdentity({ locale }: { locale: string }) {
   );
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
   params,
 }: {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  const locale = await resolveLocale(params);
-
+  // Do not await `params` here — Instant Navigations needs a shared App Shell.
+  // Locale i18n comes from `app/[locale]/layout.tsx`; only PostHog needs locale
+  // and that read stays behind Suspense.
   return (
-    <I18nProviderClient locale={locale}>
+    <>
       <ConsentBanner />
       <Suspense fallback={null}>
-        <DashboardPostHogIdentity locale={locale} />
+        <DashboardPostHogIdentity params={params} />
       </Suspense>
       <TooltipProvider>
         <ThemeProvider>
@@ -66,6 +76,6 @@ export default async function RootLayout({
           </DataProvider>
         </ThemeProvider>
       </TooltipProvider>
-    </I18nProviderClient>
+    </>
   );
 }

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -6,6 +6,13 @@ export function generateStaticParams() {
   return getStaticParams();
 }
 
+/**
+ * Locale must be read from `params` to seed `I18nProviderClient`, so this
+ * segment cannot share a URL-agnostic App Shell. Nested routes (e.g. dashboard
+ * pages with `export const instant = true`) remain independently validated.
+ */
+export const instant = false;
+
 export default async function LocaleLayout({
   children,
   params,


### PR DESCRIPTION
## Summary
- Mark `[locale]/layout` as `instant = false` because it must await `params` for `I18nProviderClient` (documented Instant Nav pattern for blocking ancestors with instant child pages).
- Stop awaiting `params` in the dashboard layout shell; resolve locale for PostHog only inside Suspense and rely on the parent locale provider for i18n.
- Mark Connections content with `connection()` so locale metadata does not block Instant Navigations prefetch.
- Defer Connections sync-countdown `Date.now()` until mount to avoid hydration mismatches.

## Test plan
- [ ] Open `/en/dashboard` and `/en/dashboard/connections`; confirm Instant Nav overlay no longer flags locale layout params as blocking the dashboard shell incorrectly.
- [ ] Navigate between dashboard home and Connections; chrome should stay stable and list still streams.
- [ ] Toggle FR/EN; i18n still works via parent `[locale]` provider.
- [ ] On Connections with a scheduled sync, countdown appears after mount without hydration warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation, layout, and hydration-only changes; no auth, data, or business-logic modifications.
> 
> **Overview**
> Aligns the locale and dashboard layout tree with **Next.js Instant Navigations** so prefetch and shared App Shell validation behave as intended.
> 
> **`[locale]/layout`** is explicitly **`instant = false`** because it must await `params` for `I18nProviderClient`; child routes like Connections can still opt into `instant = true`.
> 
> The **dashboard layout** no longer awaits `params` or wraps **`I18nProviderClient`** (i18n stays on the parent locale layout). Locale and auth for **PostHog** move into **`DashboardPostHogIdentity`** behind **Suspense**, keeping the dashboard shell URL-agnostic for instant nav.
> 
> On **Connections**, **`connection()`** in page content marks the route intentionally dynamic so locale-aware **`generateMetadata()`** does not block instant prefetch.
> 
> The scheduled-sync **countdown** defers **`Date.now()`** until after mount (`nowMs` starts as `null`) to avoid SSR/hydration mismatches at minute boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e098ec875717c74aa01fdf98bb86a051eeafd0ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->