### PR TITLE
Fix Rithmic accounts landing in Standalone instead of under Rithmic

### DIFF
--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
@@ -204,7 +204,7 @@ export async function authenticateRithmicProtocol(
     )
 
     await upsertAccountsForNumbers(userId, accountIds, connection.id)
-
+    await invalidateConnectionsPageCache(userId)
 
     return {
       success: true,
@@ -446,6 +446,8 @@ export async function getRithmicProtocolTrades(
         resolvedAccountIds,
         connection.id,
       )
+      // Persist the account links even when the remote fill fetch below fails.
+      await invalidateConnectionsPageCache(userId)
     }
 
     logger.info(
@@ -514,6 +516,10 @@ export async function getRithmicProtocolTrades(
       )
     }
 
+    // Account links and lastSyncedAt are already committed at this point.
+    // Invalidate before saving trades because duplicate/error results return early.
+    await invalidateConnectionsPageCache(userId)
+
     let savedCount = 0
     if (trades.length > 0) {
       const saveResult = await saveTradesAction(trades, {
@@ -532,8 +538,6 @@ export async function getRithmicProtocolTrades(
       }
       savedCount = saveResult.numberOfTradesAdded
     }
-
-    await invalidateConnectionsPageCache(userId)
 
     return {
       processedTrades: trades,

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
@@ -294,7 +294,7 @@ export async function getRithmicProtocolToken(accountId: string) {
     return { error: 'NO_TOKEN_RECONNECT' as const }
   }
 
-  return { storedTokenJson, lastSyncedAt: row.lastSyncedAt }
+  return { storedTokenJson, lastSyncedAt: row.lastSyncedAt, connectionId: row.id }
 }
 
 export async function removeRithmicProtocolToken(accountId: string) {
@@ -365,7 +365,7 @@ export async function updateRithmicProtocolDailySyncTimeAction(
 
 export async function getRithmicProtocolTrades(
   initialTokenJson: string,
-  options?: { userId?: string },
+  options?: { userId?: string; connectionId?: string },
 ): Promise<RithmicProtocolTradesResult> {
   const syncStats = {
     tradingAccounts: 0,
@@ -429,25 +429,31 @@ export async function getRithmicProtocolTrades(
 
     // Attach trading accounts to the Connection on every sync so accounts that
     // only appear during fill processing (or that were created before linking)
-    // leave the standalone bucket.
-    const connection = await prisma.connection.findUnique({
-      where: {
-        userId_service_externalId: {
-          userId,
-          service: SERVICE,
-          externalId: credentials.username,
+    // leave the standalone bucket. Callers that already hold the row (the
+    // daily-sync cron) pass its id so a username/externalId mismatch can't
+    // silently skip the linking.
+    let connectionId = options?.connectionId
+    if (!connectionId) {
+      const connection = await prisma.connection.findUnique({
+        where: {
+          userId_service_externalId: {
+            userId,
+            service: SERVICE,
+            externalId: credentials.username,
+          },
         },
-      },
-      select: { id: true },
-    })
-    if (connection && resolvedAccountIds.length > 0) {
-      await upsertAccountsForNumbers(
-        userId,
-        resolvedAccountIds,
-        connection.id,
-      )
-      // Persist the account links even when the remote fill fetch below fails.
+        select: { id: true },
+      })
+      connectionId = connection?.id
+    }
+    if (connectionId) {
+      await upsertAccountsForNumbers(userId, resolvedAccountIds, connectionId)
+      // Invalidate now so the links show up even if the fill fetch below fails.
       await invalidateConnectionsPageCache(userId)
+    } else {
+      logger.warn(
+        `No ${SERVICE} connection found for externalId=${credentials.username}; trading accounts will stay standalone`,
+      )
     }
 
     logger.info(
@@ -500,32 +506,19 @@ export async function getRithmicProtocolTrades(
       data: { lastSyncedAt: new Date() },
     })
 
-    // Also link any account numbers that appear only on fills/trades.
-    const tradeAccountNumbers = [
-      ...new Set(
-        trades
-          .map((trade) => trade.accountNumber)
-          .filter((n): n is string => Boolean(n)),
-      ),
-    ]
-    if (connection && tradeAccountNumbers.length > 0) {
-      await upsertAccountsForNumbers(
-        userId,
-        tradeAccountNumbers,
-        connection.id,
-      )
-    }
+    // saveTradesAction links every account number it sees on the trades to this
+    // Connection, so accounts that only appear on fills are covered too.
+    const saveResult =
+      trades.length > 0
+        ? await saveTradesAction(trades, { userId, connectionId })
+        : null
 
-    // Account links and lastSyncedAt are already committed at this point.
-    // Invalidate before saving trades because duplicate/error results return early.
+    // Invalidate after the save so the trade-derived account links are picked
+    // up, including on the duplicate/error results that return early below.
     await invalidateConnectionsPageCache(userId)
 
     let savedCount = 0
-    if (trades.length > 0) {
-      const saveResult = await saveTradesAction(trades, {
-        userId,
-        connectionId: connection?.id,
-      })
+    if (saveResult) {
       if (saveResult.error === 'DUPLICATE_TRADES') {
         return { error: 'DUPLICATE_TRADES', syncStats, tradesCount: trades.length }
       }

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
@@ -427,6 +427,27 @@ export async function getRithmicProtocolTrades(
       return { processedTrades: [], savedCount: 0, tradesCount: 0, syncStats }
     }
 
+    // Attach trading accounts to the Connection on every sync so accounts that
+    // only appear during fill processing (or that were created before linking)
+    // leave the standalone bucket.
+    const connection = await prisma.connection.findUnique({
+      where: {
+        userId_service_externalId: {
+          userId,
+          service: SERVICE,
+          externalId: credentials.username,
+        },
+      },
+      select: { id: true },
+    })
+    if (connection && resolvedAccountIds.length > 0) {
+      await upsertAccountsForNumbers(
+        userId,
+        resolvedAccountIds,
+        connection.id,
+      )
+    }
+
     logger.info(
       `Fetching fills for ${resolvedAccountIds.length} accounts (from ${credentials.historyStartDate ?? `${DEFAULT_LOOKBACK_DAYS}d lookback`}, ≤30d windows)`,
     )
@@ -477,9 +498,28 @@ export async function getRithmicProtocolTrades(
       data: { lastSyncedAt: new Date() },
     })
 
+    // Also link any account numbers that appear only on fills/trades.
+    const tradeAccountNumbers = [
+      ...new Set(
+        trades
+          .map((trade) => trade.accountNumber)
+          .filter((n): n is string => Boolean(n)),
+      ),
+    ]
+    if (connection && tradeAccountNumbers.length > 0) {
+      await upsertAccountsForNumbers(
+        userId,
+        tradeAccountNumbers,
+        connection.id,
+      )
+    }
+
     let savedCount = 0
     if (trades.length > 0) {
-      const saveResult = await saveTradesAction(trades, { userId })
+      const saveResult = await saveTradesAction(trades, {
+        userId,
+        connectionId: connection?.id,
+      })
       if (saveResult.error === 'DUPLICATE_TRADES') {
         return { error: 'DUPLICATE_TRADES', syncStats, tradesCount: trades.length }
       }
@@ -492,6 +532,8 @@ export async function getRithmicProtocolTrades(
       }
       savedCount = saveResult.numberOfTradesAdded
     }
+
+    await invalidateConnectionsPageCache(userId)
 
     return {
       processedTrades: trades,

--- a/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
@@ -5,6 +5,8 @@ import { Connection } from "@/prisma/generated/prisma/client"
 import { toDecryptedConnectionViews } from "@/lib/connection-view"
 import { encryptConnectionToken } from "@/lib/connection-token-crypto"
 import { capturePostHogEvent } from "@/lib/posthog-server"
+import { upsertAccountsForNumbers } from "@/server/connections"
+import { invalidateConnectionsPageCache } from "@/app/[locale]/dashboard/connections/data"
 
 export async function getRithmicSynchronizations() {
   console.log('CHECKING RITHMIC SYNCHRONIZATIONS')
@@ -15,7 +17,17 @@ export async function getRithmicSynchronizations() {
   return toDecryptedConnectionViews(connections)
 }
 
-export async function setRithmicSynchronization(synchronization: Partial<Connection> & { accountId?: string }) {
+/**
+ * Upsert the Rithmic Connection and optionally attach trading accounts so they
+ * leave the Connections page "standalone / imported without broker sync" bucket.
+ */
+export async function setRithmicSynchronization(
+  synchronization: Partial<Connection> & {
+    accountId?: string
+    /** Trading account numbers to attach to this Connection */
+    accountNumbers?: string[]
+  }
+) {
   console.log('SETTING RITHMIC SYNCHRONIZATION')
   const userId = await getUserId()
   const service = synchronization.service || 'rithmic'
@@ -30,7 +42,7 @@ export async function setRithmicSynchronization(synchronization: Partial<Connect
     },
     select: { id: true },
   })
-  await prisma.connection.upsert({
+  const connection = await prisma.connection.upsert({
     where: { 
       userId_service_externalId: {
         userId: userId,
@@ -62,6 +74,13 @@ export async function setRithmicSynchronization(synchronization: Partial<Connect
     },
   })
 
+  const accountNumbers = synchronization.accountNumbers ?? []
+  if (accountNumbers.length > 0) {
+    await upsertAccountsForNumbers(userId, accountNumbers, connection.id)
+  }
+
+  await invalidateConnectionsPageCache(userId)
+
   await capturePostHogEvent({
     distinctId: userId,
     event: 'integration_connected',
@@ -70,6 +89,8 @@ export async function setRithmicSynchronization(synchronization: Partial<Connect
       is_first_connection: !existingConnection,
     },
   })
+
+  return connection
 }
 
 export async function removeRithmicSynchronization(accountId: string) {
@@ -83,4 +104,6 @@ export async function removeRithmicSynchronization(accountId: string) {
       externalId: accountId,
     },
   })
+
+  await invalidateConnectionsPageCache(userId)
 }

--- a/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
@@ -8,6 +8,22 @@ import { capturePostHogEvent } from "@/lib/posthog-server"
 import { upsertAccountsForNumbers } from "@/server/connections"
 import { invalidateConnectionsPageCache } from "@/app/[locale]/dashboard/connections/data"
 
+/** Upper bound on accounts linked in one call, so a malformed body can't fan out. */
+const MAX_LINKED_ACCOUNTS = 500
+
+/**
+ * `accountNumbers` reaches this action straight from a request body
+ * (`/api/rithmic/synchronizations`), so it is untrusted: keep only non-empty
+ * strings and cap the count before it hits the database.
+ */
+function sanitizeAccountNumbers(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const numbers = value
+    .filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+    .map((n) => n.trim())
+  return [...new Set(numbers)].slice(0, MAX_LINKED_ACCOUNTS)
+}
+
 export async function getRithmicSynchronizations() {
   console.log('CHECKING RITHMIC SYNCHRONIZATIONS')
   const userId = await getUserId()
@@ -72,9 +88,12 @@ export async function setRithmicSynchronization(
       userId: userId,
       includedFeeTypes: undefined, // Rithmic has no fee differentiator
     },
+    // This action is called from the client; never send the row back wholesale
+    // or the encrypted token crosses the boundary with it.
+    select: { id: true },
   })
 
-  const accountNumbers = synchronization.accountNumbers ?? []
+  const accountNumbers = sanitizeAccountNumbers(synchronization.accountNumbers)
   if (accountNumbers.length > 0) {
     await upsertAccountsForNumbers(userId, accountNumbers, connection.id)
   }

--- a/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-sync-connection.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-sync-connection.tsx
@@ -440,13 +440,19 @@ export function RithmicSyncConnection({
 
     // Save credentials and accounts locally
     saveCredentialsAndAccounts()
-    // Store synchronization data in db
+
+    // Use all available accounts if allAccounts is true
+    const accountsToSync = allAccounts ? availableAccounts.map(acc => acc.account_id) : selectedAccounts
+
+    // Store synchronization data in db and attach trading accounts to the
+    // Connection so they appear under Rithmic instead of Standalone.
     try {
       await setRithmicSynchronization({
         service: 'rithmic',
         accountId: credentials.username || '',
         token: token,
-        tokenExpiresAt: null
+        tokenExpiresAt: null,
+        accountNumbers: accountsToSync,
       })
       captureConnectionCreated('rithmic')
     } catch (error) {
@@ -456,8 +462,6 @@ export function RithmicSyncConnection({
       })
     }
 
-    // Use all available accounts if allAccounts is true
-    const accountsToSync = allAccounts ? availableAccounts.map(acc => acc.account_id) : selectedAccounts
     const startDate = calculateStartDate(accountsToSync)
     console.log('Connecting to WebSocket:', wsUrl)
     connect(wsUrl, token, accountsToSync, startDate)

--- a/app/[locale]/dashboard/connections/data.ts
+++ b/app/[locale]/dashboard/connections/data.ts
@@ -1,4 +1,4 @@
-import { cacheLife, cacheTag, updateTag } from 'next/cache'
+import { cacheLife, cacheTag, revalidateTag, updateTag } from 'next/cache'
 import { getUserId } from '@/server/auth'
 import { prisma } from '@/lib/prisma'
 import { toConnectionView } from '@/lib/connection-view'
@@ -208,9 +208,14 @@ export async function getConnectionsPageDataFresh(): Promise<ConnectionsPageData
 
 export async function invalidateConnectionsPageCache(userId?: string) {
   const id = userId ?? (await getUserId())
+  // Prefer updateTag: in a Server Action context it expires AND immediately
+  // refreshes the cache, so the caller reads its own writes without a separate
+  // refetch. updateTag throws when called from a Route Handler (e.g.
+  // /api/rithmic/synchronizations, /api/rithmic-protocol/sync), so fall back to
+  // revalidateTag there — that's expected, not an error.
   try {
     updateTag(connectionsCacheTag(id))
   } catch {
-    // updateTag is only valid in some server contexts; ignore elsewhere
+    revalidateTag(connectionsCacheTag(id), { expire: 0 })
   }
 }

--- a/app/api/cron/daily-sync/route.ts
+++ b/app/api/cron/daily-sync/route.ts
@@ -23,6 +23,7 @@ const WALL_CLOCK_BUDGET_MS = 240_000
 const DUPLICATE_TRADES = 'DUPLICATE_TRADES'
 
 async function syncConnection(connection: {
+  id: string
   service: string
   userId: string
   externalId: string
@@ -44,6 +45,7 @@ async function syncConnection(connection: {
       : (
           await getRithmicProtocolTrades(storedTokenJson, {
             userId: connection.userId,
+            connectionId: connection.id,
           })
         ).error
 

--- a/app/api/rithmic-protocol/sync/route.ts
+++ b/app/api/rithmic-protocol/sync/route.ts
@@ -29,7 +29,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const syncResult = await getRithmicProtocolTrades(tokenResult.storedTokenJson)
+    const syncResult = await getRithmicProtocolTrades(
+      tokenResult.storedTokenJson,
+      { connectionId: tokenResult.connectionId },
+    )
     if (syncResult.error) {
       return NextResponse.json(
         {

--- a/app/api/rithmic/synchronizations/route.ts
+++ b/app/api/rithmic/synchronizations/route.ts
@@ -28,7 +28,10 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const synchronization: Partial<Connection> & { accountId?: string } = body;
+    const synchronization: Partial<Connection> & {
+      accountId?: string
+      accountNumbers?: string[]
+    } = body;
 
     await setRithmicSynchronization(synchronization);
     return NextResponse.json({

--- a/context/rithmic-sync-context.tsx
+++ b/context/rithmic-sync-context.tsx
@@ -652,7 +652,7 @@ export function RithmicSyncContextProvider({
           message: `Starting automatic background sync for ${savedData.name || savedData.credentials.username}`,
         });
 
-        // Update last sync time in the database
+        // Update last sync time in the database and (re)link trading accounts
         // Call API route instead of server action
         const syncResponse = await fetch("/api/rithmic/synchronizations", {
           method: "POST",
@@ -660,6 +660,7 @@ export function RithmicSyncContextProvider({
           body: JSON.stringify({
             accountId: savedData.id,
             lastSyncedAt: new Date(),
+            accountNumbers: accountsToSync,
           }),
         });
 

--- a/context/rithmic-sync-context.tsx
+++ b/context/rithmic-sync-context.tsx
@@ -642,6 +642,30 @@ export function RithmicSyncContextProvider({
             .replace(/-/g, "");
         }
 
+        // Update last sync time in the database and (re)link trading accounts
+        // before opening the socket: trades saved by the sync server in between
+        // would otherwise create accounts that are briefly standalone.
+        // Call API route instead of server action
+        const syncResponse = await fetch("/api/rithmic/synchronizations", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            // Match the externalId the connect flow writes. Legacy credential
+            // sets can carry a generated `cred_…` id, which would target a
+            // different Connection row and drag the accounts onto it.
+            accountId: savedData.credentials.username || savedData.id,
+            lastSyncedAt: new Date(),
+            accountNumbers: accountsToSync,
+          }),
+        });
+
+        // Reported below rather than here: a failed link must not stop the
+        // trade sync itself, which is what this call is really for.
+        const syncLinkError = syncResponse.ok
+          ? null
+          : ((await syncResponse.json().catch(() => null))?.message ??
+            "Failed to update synchronization");
+
         // Connect and start syncing
         connect(wsUrl, data.token, accountsToSync, startDate);
         updateLastSyncTime(credentialId);
@@ -652,23 +676,8 @@ export function RithmicSyncContextProvider({
           message: `Starting automatic background sync for ${savedData.name || savedData.credentials.username}`,
         });
 
-        // Update last sync time in the database and (re)link trading accounts
-        // Call API route instead of server action
-        const syncResponse = await fetch("/api/rithmic/synchronizations", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            accountId: savedData.id,
-            lastSyncedAt: new Date(),
-            accountNumbers: accountsToSync,
-          }),
-        });
-
-        if (!syncResponse.ok) {
-          const errorData = await syncResponse.json();
-          throw new Error(
-            errorData.message || "Failed to update synchronization"
-          );
+        if (syncLinkError) {
+          throw new Error(syncLinkError);
         }
 
         return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Synced Rithmic trading accounts could fetch trades successfully but still appeared under **Standalone accounts** (“Imported without a broker sync”) instead of under the Rithmic connection section.

The Connections page groups accounts only by `Account.connectionId`. It does not infer Rithmic from trade source.

## Root cause

- **Classic Rithmic (`service: 'rithmic'`)**: creating a Connection and syncing trades never called `upsertAccountsForNumbers(..., connectionId)`, so accounts stayed `connectionId: null`.
- **Rithmic Protocol**: authenticate linked accounts, but sync did not re-link and `saveTradesAction` was called without `connectionId`, so accounts created only during trade save (or before linking existed) stayed standalone.

## Fix

- Classic Rithmic: `setRithmicSynchronization` accepts `accountNumbers`, attaches them to the Connection, and invalidates the connections cache. Connect + auto-sync pass the accounts being synced.
- Protocol: on every sync, attach listed (and trade-derived) account numbers to the Connection and pass `connectionId` into `saveTradesAction`.

## How to verify

1. Connect a Rithmic (or Protocol) account and sync trades.
2. Open Connections: the trading account should appear under the Rithmic / Rithmic Protocol section, not Standalone.
3. For an already-synced standalone Rithmic account, run sync again — it should move under the connection.

Existing standalone accounts are fixed on the next connect/sync (no manual DB migration).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3fb45f5-f901-4488-a525-02d6b7cf2a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3fb45f5-f901-4488-a525-02d6b7cf2a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

