### PR TITLE
fix trade table empty rows on initial load

### DIFF
--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef } from "react";
+import React, { useState, useMemo } from "react";
 import { useData } from "@/context/data-provider";
 import {
   ColumnDef,
@@ -105,6 +105,10 @@ import { EditableInstrumentCell } from "./editable-instrument-cell";
 import { BulkEditPanel } from "./bulk-edit-panel";
 import { TradeTableVirtualBody } from "./trade-table-virtual-body";
 import { useIsMobile } from "@/hooks/use-mobile";
+import {
+  DEFAULT_TRADE_TABLE_PAGE_SIZE,
+  sanitizeTablePageSize,
+} from "@/store/widgets/table-config-store";
 
 // Custom Tags Header Component
 function TagsColumnHeader() {
@@ -328,7 +332,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
     tableConfig?.columnVisibility || {},
   );
   const [expanded, setExpanded] = useState<ExpandedState>({});
-  const [pageSize, setPageSize] = useState(tableConfig?.pageSize || 50);
+  const [pageSize, setPageSize] = useState(() =>
+    sanitizeTablePageSize(tableConfig?.pageSize),
+  );
   const [groupingGranularity, setGroupingGranularity] = useState<number>(
     tableConfig?.groupingGranularity || 0,
   );
@@ -353,7 +359,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
       } else {
         setColumnVisibility(tableConfig.columnVisibility);
       }
-      setPageSize(tableConfig.pageSize);
+      setPageSize(sanitizeTablePageSize(tableConfig.pageSize));
       setGroupingGranularity(tableConfig.groupingGranularity);
       setGroupingMode(tableConfig.groupingMode || "time");
     }
@@ -401,9 +407,10 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
   };
 
   const handlePageSizeChange = (newPageSize: number) => {
-    setPageSize(newPageSize);
+    const safePageSize = sanitizeTablePageSize(newPageSize);
+    setPageSize(safePageSize);
     setPageIndex(0); // Reset to first page when page size changes
-    updatePageSize("trade-table", newPageSize);
+    updatePageSize("trade-table", safePageSize);
   };
 
   const handleGroupingGranularityChange = (newGranularity: number) => {
@@ -584,6 +591,15 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
 
     return Array.from(groups.values());
   }, [trades, groupingGranularity, groupingMode, config?.groupTrades]);
+
+  // Keep pageIndex in range when filters/data shrink (autoResetPageIndex is off)
+  React.useEffect(() => {
+    const safePageSize = Math.max(pageSize, 1);
+    const pageCount = Math.max(1, Math.ceil(groupedTrades.length / safePageSize));
+    if (pageIndex > pageCount - 1) {
+      setPageIndex(Math.max(0, pageCount - 1));
+    }
+  }, [groupedTrades.length, pageSize, pageIndex]);
 
   // Initialize expanded state when expandByDefault is enabled
   React.useEffect(() => {
@@ -1261,7 +1277,8 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
   // Note: This only controls the Card header, not the table column headers
   const showHeader = config?.showHeader !== false;
   const isMobile = useIsMobile();
-  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const [tableScrollElement, setTableScrollElement] =
+    useState<HTMLDivElement | null>(null);
 
   const columnConfigTrigger = isMobile ? (
     <Button variant="outline" size="icon" className="h-8 w-8 shrink-0">
@@ -1436,7 +1453,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
         </div>
       </CardHeader>
       )}
-      <CardContent ref={tableContainerRef} className="flex-1 min-h-0 overflow-auto p-0">
+      <CardContent ref={setTableScrollElement} className="flex-1 min-h-0 overflow-auto p-0">
         <div className="relative w-full min-w-max">
           <table
             className="w-full border-separate border-spacing-0 caption-bottom text-sm"
@@ -1468,7 +1485,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
 
             <TradeTableVirtualBody
               table={table}
-              scrollElementRef={tableContainerRef}
+              scrollElement={tableScrollElement}
               columnCount={visibleColumns.length}
               compact={isMobile}
             />
@@ -1636,7 +1653,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {
-                    handlePageSizeChange(50);
+                    handlePageSizeChange(DEFAULT_TRADE_TABLE_PAGE_SIZE);
                     table.resetPageSize();
                     table.setPageIndex(0);
                   }}
@@ -1645,7 +1662,11 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {
-                    const maxPageSize = groupedTrades.length;
+                    // Never persist 0 — Show All while empty would blank the table on reload
+                    const maxPageSize = Math.max(
+                      groupedTrades.length,
+                      DEFAULT_TRADE_TABLE_PAGE_SIZE,
+                    );
                     handlePageSizeChange(maxPageSize);
                     table.setPageSize(maxPageSize);
                     table.setPageIndex(0);
@@ -1674,7 +1695,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 size="sm"
                 className="hidden min-w-0 sm:inline-flex"
                 onClick={() => {
-                  handlePageSizeChange(50);
+                  handlePageSizeChange(DEFAULT_TRADE_TABLE_PAGE_SIZE);
                   table.resetPageSize();
                   table.setPageIndex(0);
                 }}
@@ -1686,7 +1707,11 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 size="sm"
                 className="hidden min-w-0 sm:inline-flex"
                 onClick={() => {
-                  const maxPageSize = groupedTrades.length;
+                  // Never persist 0 — Show All while empty would blank the table on reload
+                  const maxPageSize = Math.max(
+                    groupedTrades.length,
+                    DEFAULT_TRADE_TABLE_PAGE_SIZE,
+                  );
                   handlePageSizeChange(maxPageSize);
                   table.setPageSize(maxPageSize);
                   table.setPageIndex(0);

--- a/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
@@ -8,10 +8,12 @@ import { cn } from "@/lib/utils";
 const ROW_HEIGHT_ESTIMATE = 44;
 const ROW_HEIGHT_ESTIMATE_COMPACT = 36;
 const VIRTUAL_OVERSCAN = 10;
+/** Cap non-virtual fallback so a zero-height container can't mount thousands of DOM rows. */
+const NON_VIRTUAL_FALLBACK_LIMIT = 100;
 
 interface TradeTableVirtualBodyProps<TData> {
   table: Table<TData>;
-  scrollElementRef: React.RefObject<HTMLDivElement | null>;
+  scrollElement: HTMLDivElement | null;
   columnCount: number;
   compact?: boolean;
 }
@@ -61,7 +63,7 @@ function TradeTableBodyRow<TData>({
 
 export function TradeTableVirtualBody<TData>({
   table,
-  scrollElementRef,
+  scrollElement,
   columnCount,
   compact = false,
 }: TradeTableVirtualBodyProps<TData>) {
@@ -69,10 +71,12 @@ export function TradeTableVirtualBody<TData>({
 
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
-    getScrollElement: () => scrollElementRef.current,
+    getScrollElement: () => scrollElement,
     estimateSize: () =>
       compact ? ROW_HEIGHT_ESTIMATE_COMPACT : ROW_HEIGHT_ESTIMATE,
     overscan: VIRTUAL_OVERSCAN,
+    // Prefer a usable first paint before the flex layout settles a real height.
+    initialRect: { width: 0, height: 400 },
   });
 
   const virtualRows = rowVirtualizer.getVirtualItems();
@@ -81,6 +85,15 @@ export function TradeTableVirtualBody<TData>({
     virtualRows.length > 0
       ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
       : 0;
+
+  // Remeasure when the scroll parent mounts or rows appear but the range is empty
+  // (common when the flex container reports height 0 on the first layout pass).
+  React.useLayoutEffect(() => {
+    if (!scrollElement || rows.length === 0) return;
+    if (virtualRows.length === 0) {
+      rowVirtualizer.measure();
+    }
+  }, [scrollElement, rows.length, virtualRows.length, rowVirtualizer]);
 
   if (rows.length === 0) {
     return (
@@ -93,6 +106,24 @@ export function TradeTableVirtualBody<TData>({
             No results.
           </td>
         </tr>
+      </tbody>
+    );
+  }
+
+  // If the virtualizer still has no range (e.g. height still 0), render a capped
+  // non-virtual slice so the table is never blank on init.
+  if (virtualRows.length === 0) {
+    const fallbackRows = rows.slice(0, NON_VIRTUAL_FALLBACK_LIMIT);
+    return (
+      <tbody className="bg-background [&_tr:last-child]:border-0">
+        {fallbackRows.map((row, rowIndex) => (
+          <TradeTableBodyRow
+            key={row.id}
+            row={row}
+            rowIndex={rowIndex}
+            compact={compact}
+          />
+        ))}
       </tbody>
     );
   }

--- a/store/widgets/table-config-store.test.ts
+++ b/store/widgets/table-config-store.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TRADE_TABLE_PAGE_SIZE,
+  sanitizeTablePageSize,
+} from "./table-config-store";
+
+describe("sanitizeTablePageSize", () => {
+  it("returns fallback for zero, negative, and non-finite values", () => {
+    expect(sanitizeTablePageSize(0)).toBe(DEFAULT_TRADE_TABLE_PAGE_SIZE);
+    expect(sanitizeTablePageSize(-5)).toBe(DEFAULT_TRADE_TABLE_PAGE_SIZE);
+    expect(sanitizeTablePageSize(NaN)).toBe(DEFAULT_TRADE_TABLE_PAGE_SIZE);
+    expect(sanitizeTablePageSize(Infinity)).toBe(DEFAULT_TRADE_TABLE_PAGE_SIZE);
+    expect(sanitizeTablePageSize(undefined)).toBe(DEFAULT_TRADE_TABLE_PAGE_SIZE);
+    expect(sanitizeTablePageSize(null)).toBe(DEFAULT_TRADE_TABLE_PAGE_SIZE);
+    expect(sanitizeTablePageSize("0")).toBe(DEFAULT_TRADE_TABLE_PAGE_SIZE);
+  });
+
+  it("accepts positive page sizes and floors fractions", () => {
+    expect(sanitizeTablePageSize(1)).toBe(1);
+    expect(sanitizeTablePageSize(50)).toBe(50);
+    expect(sanitizeTablePageSize(10.9)).toBe(10);
+    expect(sanitizeTablePageSize("25")).toBe(25);
+  });
+
+  it("supports a custom fallback", () => {
+    expect(sanitizeTablePageSize(0, 10)).toBe(10);
+  });
+});

--- a/store/widgets/table-config-store.ts
+++ b/store/widgets/table-config-store.ts
@@ -10,6 +10,18 @@ export interface TableColumnConfig {
   order: number
 }
 
+export const DEFAULT_TRADE_TABLE_PAGE_SIZE = 50
+
+/** Coerce persisted/UI page sizes; 0 breaks TanStack pagination (empty page). */
+export function sanitizeTablePageSize(
+  pageSize: unknown,
+  fallback: number = DEFAULT_TRADE_TABLE_PAGE_SIZE,
+): number {
+  const n = typeof pageSize === 'number' ? pageSize : Number(pageSize)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  return Math.floor(n)
+}
+
 export interface TableConfig {
   id: string
   columns: TableColumnConfig[]
@@ -69,9 +81,26 @@ const defaultTradeTableConfig: TableConfig = {
   columnVisibility: {},
   sorting: [{ id: 'entryDate', desc: true }],
   columnFilters: [],
-  pageSize: 10,
+  pageSize: DEFAULT_TRADE_TABLE_PAGE_SIZE,
   groupingGranularity: 0,
   groupingMode: 'time',
+}
+
+function sanitizeTablesPageSizes(
+  tables: Record<string, TableConfig>,
+): Record<string, TableConfig> {
+  let changed = false
+  const next: Record<string, TableConfig> = {}
+  for (const [tableId, config] of Object.entries(tables)) {
+    const pageSize = sanitizeTablePageSize(config.pageSize)
+    if (pageSize !== config.pageSize) {
+      changed = true
+      next[tableId] = { ...config, pageSize }
+    } else {
+      next[tableId] = config
+    }
+  }
+  return changed ? next : tables
 }
 
 export const useTableConfigStore = create<TableConfigState>()(
@@ -246,7 +275,7 @@ export const useTableConfigStore = create<TableConfigState>()(
           ...state.tables,
           [tableId]: {
             ...state.tables[tableId],
-            pageSize,
+            pageSize: sanitizeTablePageSize(pageSize),
           },
         },
       })),
@@ -290,6 +319,26 @@ export const useTableConfigStore = create<TableConfigState>()(
     {
       name: 'table-config-store',
       storage: createJSONStorage(() => localStorage),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<TableConfigState> | undefined
+        const tables = sanitizeTablesPageSizes({
+          ...currentState.tables,
+          ...(persisted?.tables ?? {}),
+        })
+        return {
+          ...currentState,
+          ...persisted,
+          tables,
+        }
+      },
+      onRehydrateStorage: () => (state) => {
+        if (!state) return
+        state.migrateOldColumns()
+        const tables = sanitizeTablesPageSizes(state.tables)
+        if (tables !== state.tables) {
+          useTableConfigStore.setState({ tables })
+        }
+      },
     }
   )
 ) 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The trade review table could render with a trade count in the footer but **no rows** until the user clicked Reset Page Size, Increase Page Size, or Show All.

### Cause

1. **`pageSize: 0` persisted in `table-config-store`** — clicking Show All while `groupedTrades.length === 0` wrote `0` to localStorage. TanStack’s pagination then sliced to an empty page (`rows.slice(0, 0)`). Reset / increase / show-all all changed `pageSize` and reset the index, which matched the workaround.
2. **Virtualizer blank first paint** — when the flex scroll parent reported height `0` (or the scroll element wasn’t wired via state), `getVirtualItems()` returned `[]` while `rows.length > 0`, producing a blank body (not “No results.”).

### Fix

- Sanitize page sizes on store read/write/rehydrate (`sanitizeTablePageSize`); never persist `<= 0`
- Align default page size with Reset (50); Show All uses `Math.max(length, 50)`
- Clamp `pageIndex` when filtered data shrinks (`autoResetPageIndex: false`)
- Pass the scroll container as state (not only a ref) and fall back to a capped non-virtual render if the virtual range is empty

### Verification

- `bunx vitest run store/widgets/table-config-store.test.ts` — pass
- `bun run typecheck` — pass
- `OPENAI_API_KEY=dummy bun run build` — pass
- Full dashboard UI check blocked here (Docker/Postgres unavailable in this VM)

### Test plan

- [ ] Load dashboard with trades: table shows rows immediately (no Reset needed)
- [ ] Clear/corrupt `localStorage['table-config-store']` `pageSize` to `0`, reload: rows still show and size is corrected
- [ ] Show All with empty filters then add trades: table still shows rows
- [ ] Increase / Reset / Show All still work
- [ ] Pagination stays on a valid page after narrowing filters

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18d1e6b5-3701-4914-8414-49692022de66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18d1e6b5-3701-4914-8414-49692022de66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

