### PR TITLE
Fix dashboard tab bar gap under the navbar

### DIFF
--- a/app/[locale]/dashboard/(home)/dashboard-home-client.tsx
+++ b/app/[locale]/dashboard/(home)/dashboard-home-client.tsx
@@ -26,21 +26,21 @@ export default function DashboardHomeClient() {
     <>
       <TabsContent
         value="table"
-        className="h-[calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem)-16px)] min-w-0 p-2 sm:p-4"
+        className="h-[calc(100dvh-var(--navbar-height,4rem)-var(--tabs-height,3rem)-16px)] min-w-0 p-2 sm:p-4"
       >
         <TradeTableReview />
       </TabsContent>
 
       <TabsContent
         value="accounts"
-        className="h-[calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem)-16px)] min-w-0 mt-0"
+        className="h-[calc(100dvh-var(--navbar-height,4rem)-var(--tabs-height,3rem)-16px)] min-w-0 mt-0"
       >
         <AccountsOverview size="large" />
       </TabsContent>
 
       <TabsContent
         value="widgets"
-        className="min-w-0 overflow-hidden px-0 max-md:h-[calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem))] sm:px-4"
+        className="min-w-0 overflow-hidden px-0 max-md:h-[calc(100dvh-var(--navbar-height,4rem)-var(--tabs-height,3rem))] sm:px-4"
       >
         <WidgetCanvas />
       </TabsContent>

--- a/app/[locale]/dashboard/components/dashboard-home-chrome.tsx
+++ b/app/[locale]/dashboard/components/dashboard-home-chrome.tsx
@@ -21,43 +21,49 @@ export function DashboardHomeChrome({ children }: { children: ReactNode }) {
   const [tab, setTab] = useState('widgets')
 
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout
+    let timeoutId: NodeJS.Timeout | undefined
+
+    const applyHeights = () => {
+      const navbar = document.querySelector(
+        'nav[class*="sticky"]'
+      ) as HTMLElement | null
+      // Match navbar.tsx: h-16 (4rem). Avoid the old 96/5rem fallback that
+      // left a visible strip between sticky nav and fixed tabs.
+      const navbarHeight = navbar?.offsetHeight || 64
+
+      const tabsList = tabsListRef.current
+      const tabsListHeight = tabsList?.offsetHeight || 48
+      const tabsWrapperBottom = navbarHeight + tabsListHeight
+
+      const main = mainRef.current
+      const mainTop = main?.getBoundingClientRect().top || 0
+      const calculatedPaddingTop = tabsWrapperBottom - mainTop
+
+      document.documentElement.style.setProperty(
+        '--navbar-height',
+        `${navbarHeight}px`
+      )
+      document.documentElement.style.setProperty(
+        '--tabs-height',
+        `${tabsListHeight}px`
+      )
+      document.documentElement.style.setProperty(
+        '--calculated-padding-top',
+        `${calculatedPaddingTop}px`
+      )
+    }
 
     const calculateHeight = () => {
       if (timeoutId) {
         clearTimeout(timeoutId)
       }
 
-      timeoutId = setTimeout(() => {
-        const navbar = document.querySelector(
-          'nav[class*="sticky"]'
-        ) as HTMLElement
-        const navbarHeight = navbar?.offsetHeight || 96
-
-        const tabsList = tabsListRef.current
-        const tabsListHeight = tabsList?.offsetHeight || 0
-        const tabsWrapperBottom = navbarHeight + tabsListHeight
-
-        const main = mainRef.current
-        const mainTop = main?.getBoundingClientRect().top || 0
-        const calculatedPaddingTop = tabsWrapperBottom - mainTop
-
-        document.documentElement.style.setProperty(
-          '--navbar-height',
-          `${navbarHeight}px`
-        )
-        document.documentElement.style.setProperty(
-          '--tabs-height',
-          `${tabsListHeight}px`
-        )
-        document.documentElement.style.setProperty(
-          '--calculated-padding-top',
-          `${calculatedPaddingTop}px`
-        )
-      }, 100)
+      // Debounce resize/mutation noise only — first paint must be immediate
+      // so Instant Nav does not flash the old 5rem gap.
+      timeoutId = setTimeout(applyHeights, 100)
     }
 
-    calculateHeight()
+    applyHeights()
     window.addEventListener('resize', calculateHeight)
 
     const resizeObserver = new ResizeObserver(calculateHeight)
@@ -125,7 +131,7 @@ export function DashboardHomeChrome({ children }: { children: ReactNode }) {
       >
         <div
           ref={tabsListRef}
-          className="fixed inset-x-0 top-(--navbar-height,5rem) z-30 w-full overflow-x-auto border-b bg-background shadow-xs"
+          className="fixed inset-x-0 top-(--navbar-height,4rem) z-30 w-full overflow-x-auto border-b bg-background shadow-xs"
         >
           <TabsList className="h-12 w-full min-w-max max-w-none rounded-none bg-muted/70 sm:min-w-0">
             <TabsTrigger value="widgets">

--- a/app/[locale]/dashboard/components/dashboard-home-skeleton.tsx
+++ b/app/[locale]/dashboard/components/dashboard-home-skeleton.tsx
@@ -9,7 +9,7 @@ import { MOBILE_CAROUSEL_HEIGHT } from '@/lib/widget-carousel'
 export function DashboardHomeContentSkeleton() {
   return (
     <div
-      className="min-w-0 overflow-hidden px-0 max-md:h-[calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem))] sm:px-4"
+      className="min-w-0 overflow-hidden px-0 max-md:h-[calc(100dvh-var(--navbar-height,4rem)-var(--tabs-height,3rem))] sm:px-4"
       aria-busy="true"
       aria-live="polite"
     >
@@ -40,7 +40,7 @@ export function WidgetCanvasSkeleton() {
 
       {/* Desktop: one full-page placeholder (no fake widget tiles) */}
       <div className="relative hidden w-full md:mt-6 md:block md:min-h-screen md:pb-16">
-        <Skeleton className="min-h-[min(70vh,40rem)] w-full rounded-lg md:min-h-[calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem)-6rem)]" />
+        <Skeleton className="min-h-[min(70vh,40rem)] w-full rounded-lg md:min-h-[calc(100dvh-var(--navbar-height,4rem)-var(--tabs-height,3rem)-6rem)]" />
       </div>
     </div>
   )

--- a/app/[locale]/dashboard/components/widget-canvas.tsx
+++ b/app/[locale]/dashboard/components/widget-canvas.tsx
@@ -844,7 +844,7 @@ export default function WidgetCanvas() {
         // Before viewport is known: mobile-sized shell that expands on md+
         // so we never paint the desktop grid on a phone for a frame.
         !isLayoutReady &&
-          "overflow-hidden md:mt-6 md:min-h-screen md:overflow-visible md:pb-16 max-md:[height:calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem)-var(--mobile-toolbar-top,5.5rem))]",
+          "overflow-hidden md:mt-6 md:min-h-screen md:overflow-visible md:pb-16 max-md:[height:calc(100dvh-var(--navbar-height,4rem)-var(--tabs-height,3rem)-var(--mobile-toolbar-top,5.5rem))]",
         isLayoutReady && useMobileCarousel && "mt-0 overflow-hidden",
         isLayoutReady && !useMobileCarousel && "mt-6 pb-16 min-h-screen",
       )}

--- a/app/[locale]/shared/[slug]/shared-widget-canvas.tsx
+++ b/app/[locale]/shared/[slug]/shared-widget-canvas.tsx
@@ -179,7 +179,7 @@ export function SharedWidgetCanvas() {
       className={cn(
         "relative",
         !isLayoutReady &&
-          "overflow-hidden md:mt-6 max-md:[height:calc(100dvh-var(--navbar-height,5rem)-var(--tabs-height,3rem))]",
+          "overflow-hidden md:mt-6 max-md:[height:calc(100dvh-var(--navbar-height,4rem)-var(--tabs-height,3rem))]",
         isLayoutReady && useMobileCarousel && "mt-0 overflow-hidden",
         isLayoutReady && !useMobileCarousel && "mt-6",
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,6 +197,10 @@
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
     --radius: 0.5rem;
+    /* Dashboard sticky nav is h-16 (4rem) + optional iOS safe-area inset.
+       Fixed tab chrome uses this before JS measures the real nav height. */
+    --navbar-height: calc(4rem + env(safe-area-inset-top, 0px));
+    --tabs-height: 3rem;
     --sidebar-background: 0 0% var(--theme-intensity, 98%);
     --sidebar-foreground: 240 5.3% 26.1%;
     --sidebar-primary: 240 5.9% 10%;

--- a/lib/widget-carousel.ts
+++ b/lib/widget-carousel.ts
@@ -2,10 +2,10 @@ import { WIDGET_REGISTRY } from "@/app/[locale]/dashboard/config/widget-registry
 import { Widget, WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
 
 export const MOBILE_CAROUSEL_VIEWPORT_HEIGHT =
-  "calc(100dvh - var(--navbar-height, 5rem) - var(--tabs-height, 3rem))"
+  "calc(100dvh - var(--navbar-height, 4rem) - var(--tabs-height, 3rem))"
 
 export const MOBILE_CAROUSEL_HEIGHT =
-  "calc(100dvh - var(--navbar-height, 5rem) - var(--tabs-height, 3rem) - var(--mobile-toolbar-top, 5.5rem))"
+  "calc(100dvh - var(--navbar-height, 4rem) - var(--tabs-height, 3rem) - var(--mobile-toolbar-top, 5.5rem))"
 
 /** Pick the largest allowed size so widgets fill the carousel slide. */
 export function getCarouselWidgetSize(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On Instant Nav / first paint, the Widgets · Table · Accounts bar sat ~16px below the sticky navbar, leaving a strip of page background between them. Visible on preview deployments (e.g. the Rithmic account-linking preview) before JS measured the real nav height.

## Cause

Safari safe-area work (#342) made the dashboard nav `h-16` (**4rem**) with padding inside the row. The fixed tab chrome still used `top: var(--navbar-height, **5rem**)`, and measurement ran only after a 100ms debounce.

## Fix

- Default `--navbar-height` to `calc(4rem + env(safe-area-inset-top, 0px))` in `:root`
- Change tab `top` / height fallbacks from `5rem` → `4rem`
- Measure navbar height on first paint (debounce only resize/mutations); JS fallback `96` → `64`

## Verify

- Open `/dashboard`: tab bar flush under the navbar (only the 1px border between them)
- Soft-navigate Dashboard ↔ Connections: no Instant Nav flash gap
- With active filter tags expanding the nav, tabs still track measured height

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3fb45f5-f901-4488-a525-02d6b7cf2a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3fb45f5-f901-4488-a525-02d6b7cf2a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

