### PR TITLE
fix(dashboard): address Bugbot review on trade table page clamp & fallback

### DIFF
--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -592,15 +592,6 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
     return Array.from(groups.values());
   }, [trades, groupingGranularity, groupingMode, config?.groupTrades]);
 
-  // Keep pageIndex in range when filters/data shrink (autoResetPageIndex is off)
-  React.useEffect(() => {
-    const safePageSize = Math.max(pageSize, 1);
-    const pageCount = Math.max(1, Math.ceil(groupedTrades.length / safePageSize));
-    if (pageIndex > pageCount - 1) {
-      setPageIndex(Math.max(0, pageCount - 1));
-    }
-  }, [groupedTrades.length, pageSize, pageIndex]);
-
   // Initialize expanded state when expandByDefault is enabled
   React.useEffect(() => {
     if (config?.expandByDefault && groupedTrades.length > 0 && !hasInitializedExpanded) {
@@ -1254,6 +1245,17 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
       minSize: 100,
     },
   });
+
+  // Keep pageIndex in range when filters/data shrink (autoResetPageIndex is off).
+  // Uses the table's filtered page count so column filters are respected — clamping
+  // against the unfiltered groupedTrades length would leave pageIndex past the last
+  // visible page after filters narrow the row set, showing an empty body.
+  React.useEffect(() => {
+    const maxPageIndex = Math.max(0, table.getPageCount() - 1);
+    if (pageIndex > maxPageIndex) {
+      setPageIndex(maxPageIndex);
+    }
+  }, [table, groupedTrades.length, pageSize, pageIndex, columnFilters]);
 
   const currentPageTotals = calculateTotalsForRows(
     table.getPaginationRowModel().rows.map((row) => row.original),

--- a/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
@@ -114,6 +114,7 @@ export function TradeTableVirtualBody<TData>({
   // non-virtual slice so the table is never blank on init.
   if (virtualRows.length === 0) {
     const fallbackRows = rows.slice(0, NON_VIRTUAL_FALLBACK_LIMIT);
+    const hiddenRowCount = rows.length - fallbackRows.length;
     return (
       <tbody className="bg-background [&_tr:last-child]:border-0">
         {fallbackRows.map((row, rowIndex) => (
@@ -124,6 +125,17 @@ export function TradeTableVirtualBody<TData>({
             compact={compact}
           />
         ))}
+        {hiddenRowCount > 0 && (
+          <tr>
+            <td
+              colSpan={columnCount}
+              className="p-4 align-middle text-center text-sm text-muted-foreground"
+            >
+              Loading {hiddenRowCount} more{" "}
+              {hiddenRowCount === 1 ? "row" : "rows"}…
+            </td>
+          </tr>
+        )}
       </tbody>
     );
   }


### PR DESCRIPTION
## Summary

Follow-up to #365 addressing the two medium-severity issues Cursor Bugbot reported on that PR ([review](https://github.com/hugodemenez/deltalytix/pull/365#pullrequestreview-4767403460)).

### 1. Page clamp ignores column filters
`trade-table-review.tsx`

The `pageIndex` clamp computed page count from the **unfiltered** `groupedTrades.length`, while TanStack pagination and `getPageCount()` use the **filtered** row model. After column filters shrank the visible set, `pageIndex` could stay beyond the last filtered page — the body rendered no rows while pagination still looked valid.

- Clamp against `table.getPageCount()` (filtered) instead of recomputing from `groupedTrades.length`.
- Move the effect below the `useReactTable` call so the table instance is available, and add `columnFilters` to the dependency array so it re-runs when filters change.

### 2. Fallback hides rows above the cap
`trade-table-virtual-body.tsx`

When `getVirtualItems()` is still empty, the body renders a capped non-virtual `rows.slice(0, 100)`. On a large page (Show All with more than 100 trades) users could see at most 100 rows with **no indication** the rest of the page was omitted.

- Render a `Loading N more rows…` indicator row when the current page exceeds the fallback cap, so the omitted rows are visible rather than silently dropped. This only shows during the transient first paint before the virtualizer measures a real height.

### Verification

- `bun run typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsmmfVnoxpwBAva9wgULi1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsmmfVnoxpwBAva9wgULi1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard table pagination and transient virtual-render UX only; no auth, data, or API changes.
> 
> **Overview**
> Fixes two trade-table UX bugs from the prior pagination/virtualization work.
> 
> **Pagination:** `pageIndex` clamping now runs after `useReactTable` and uses **`table.getPageCount()`** (filtered row model) instead of page count from unfiltered `groupedTrades.length`. **`columnFilters`** is in the effect dependencies so tightening filters no longer leaves you on a page past the last visible page with an empty body.
> 
> **Virtual body:** When the virtualizer has not produced items yet and the body falls back to the first 100 rows, a footer row shows **“Loading N more rows…”** when the current page has more than 100 rows, so large “Show All” pages do not silently drop rows during the first paint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293740582cbdc90aeea5a9d8fd2364158ffe234e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->