### PR TITLE
Track primary marketing CTA clicks

### DIFF
--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -5,6 +5,7 @@ import Link, { useLinkStatus } from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useTheme } from "@/context/theme-provider";
+import { captureMarketingCtaClicked } from "@/lib/marketing-analytics";
 
 function GetStartedLinkContent({ children }: { children: React.ReactNode }) {
   const { pending } = useLinkStatus();
@@ -101,6 +102,14 @@ export default function Hero() {
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
             <Link
               href={"/dashboard"}
+              onClick={() =>
+                captureMarketingCtaClicked({
+                  ctaId: "hero_get_started",
+                  destination: "/dashboard",
+                  locale,
+                  placement: "hero",
+                })
+              }
               className="inline-flex h-12 items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-6 text-sm font-medium text-white transition-[opacity,transform] hover:opacity-85 active:scale-[0.96] dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]"
             >
               <GetStartedLinkContent>{t("landing.cta")}</GetStartedLinkContent>

--- a/lib/marketing-analytics.ts
+++ b/lib/marketing-analytics.ts
@@ -1,0 +1,28 @@
+import posthog from "posthog-js";
+
+function canCapture() {
+  if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return false;
+  if (typeof window === "undefined") return false;
+  return !posthog.has_opted_out_capturing();
+}
+
+export function captureMarketingCtaClicked({
+  ctaId,
+  destination,
+  locale,
+  placement,
+}: {
+  ctaId: string;
+  destination: string;
+  locale: string;
+  placement: string;
+}) {
+  if (!canCapture()) return;
+
+  posthog.capture("marketing_cta_clicked", {
+    cta_id: ctaId,
+    destination,
+    locale,
+    placement,
+  });
+}


### PR DESCRIPTION
## What changed

- adds a consent-aware `marketing_cta_clicked` event for the primary homepage hero CTA
- records only controlled event properties: `cta_id`, `destination`, `locale`, and `placement`
- preserves the existing navigation behavior and captures no PII

## Why

PostHog currently shows landing traffic and signup outcomes, but no explicit signal between them because autocapture is disabled. This event enables a production-only funnel:

`$pageview → marketing_cta_clicked → user_signed_up`

It can be broken down by CTA, locale, placement, and host to separate marketing intent from beta, preview, local, and automated traffic.

## Event contract

- Event: `marketing_cta_clicked`
- Trigger: clicking the homepage hero “Get started” link, immediately before navigation
- Event properties:
  - `cta_id: "hero_get_started"`
  - `destination: "/dashboard"`
  - `locale: string`
  - `placement: "hero"`
- Person properties: none
- Privacy: no email, user-entered content, credentials, payment information, or other sensitive data

## Validation

- ✅ `bun install`
- ✅ `bun run typecheck`
- ✅ targeted ESLint for the two changed files: 0 errors (2 pre-existing `<img>` warnings in the hero)
- ❌ `bun run lint`: repository-wide baseline currently reports 1,028 problems (416 errors, 612 warnings); the changed files introduce no lint errors
- ⚠️ `OPENAI_API_KEY=dummy bun run build`: stopped in Prisma prebuild because the isolated checkout has no `DIRECT_URL`
- ⏭️ database push, seed, dev server, and health checks were not run because no safely verified local database configuration was available in the isolated checkout

This PR intentionally remains a draft until the required project checks are resolved or rerun in a configured local environment.