### PR TITLE
fix(teams): move invitation email out of the server action (unblocks team management on beta)

### DIFF
--- a/app/[locale]/dashboard/settings/actions.ts
+++ b/app/[locale]/dashboard/settings/actions.ts
@@ -4,9 +4,6 @@ import { prisma } from '@/lib/prisma'
 import auth from '@/locales/en/auth'
 import { createClient } from '@/server/auth'
 import { revalidatePath } from 'next/cache'
-import { Resend } from 'resend'
-import { render } from '@react-email/render'
-import TeamInvitationEmail from '@/components/emails/team-invitation'
 
 export async function createTeam(name: string) {
   try {
@@ -591,134 +588,9 @@ export async function addTraderToTeam(teamId: string, traderEmail: string) {
   }
 }
 
-export async function sendTeamInvitation(teamId: string, traderEmail: string) {
-  try {
-    const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user?.id) {
-      throw new Error('Unauthorized')
-    }
-
-    // Check if user is the owner or admin of this team
-    const team = await prisma.team.findUnique({
-      where: { id: teamId },
-    })
-
-    if (!team) {
-      throw new Error('Team not found')
-    }
-
-    // Check if current user is owner or admin manager
-    const isOwner = team.userId === user.id
-    const isAdminManager = await prisma.teamManager.findUnique({
-      where: {
-        teamId_managerId: {
-          teamId,
-          managerId: user.id,
-        }
-      }
-    })
-
-    if (!isOwner && (!isAdminManager || isAdminManager.access !== 'admin')) {
-      throw new Error('Unauthorized: Only team owners and admin managers can send invitations')
-    }
-
-    // Check if there's already a pending invitation
-    const existingInvitation = await prisma.teamInvitation.findUnique({
-      where: {
-        teamId_email: {
-          teamId,
-          email: traderEmail,
-        }
-      }
-    })
-
-    if (existingInvitation && existingInvitation.status === 'PENDING') {
-      throw new Error('An invitation has already been sent to this email')
-    }
-
-    // Check if user is already a trader in this team
-    const existingUser = await prisma.user.findUnique({
-      where: { email: traderEmail },
-    })
-
-    if (existingUser && team.traderIds.includes(existingUser.id)) {
-      throw new Error('User is already a member of this team')
-    }
-
-    // Create or update invitation
-    const invitation = await prisma.teamInvitation.upsert({
-      where: {
-        teamId_email: {
-          teamId,
-          email: traderEmail,
-        }
-      },
-      update: {
-        status: 'PENDING',
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-        invitedBy: user.id,
-      },
-      create: {
-        teamId,
-        email: traderEmail,
-        invitedBy: user.id,
-        status: 'PENDING',
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-      },
-    })
-
-    // Get inviter information
-    const inviter = await prisma.user.findUnique({
-      where: { id: user.id },
-    })
-
-    // Generate join URL
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 
-      (process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://deltalytix.app')
-    const joinUrl = `${baseUrl}/teams/join?invitation=${invitation.id}`
-
-    // Render email
-    const emailHtml = await render(
-      TeamInvitationEmail({
-        email: traderEmail,
-        teamName: team.name,
-        inviterName: inviter?.email?.split('@')[0] || 'trader',
-        inviterEmail: inviter?.email || 'trader@example.com',
-        joinUrl,
-        language: existingUser?.language || 'en'
-      })
-    )
-
-    // Send email
-    if (!process.env.RESEND_API_KEY) {
-      throw new Error('RESEND_API_KEY is not configured')
-    }
-
-    const resend = new Resend(process.env.RESEND_API_KEY)
-    const { error: emailError } = await resend.emails.send({
-      from: 'Deltalytix Team <team@eu.updates.deltalytix.app>',
-      to: traderEmail,
-      subject: existingUser?.language === 'fr' 
-        ? `Invitation à rejoindre ${team.name} sur Deltalytix`
-        : `Invitation to join ${team.name} on Deltalytix`,
-      html: emailHtml,
-      replyTo: 'hugo.demenez@deltalytix.app',
-    })
-
-    if (emailError) {
-      console.error('Error sending invitation email:', emailError)
-      throw new Error('Failed to send invitation email')
-    }
-
-    revalidatePath('/dashboard/settings')
-    revalidatePath('/teams/dashboard')
-    return { success: true, invitationId: invitation.id }
-  } catch (error) {
-    console.error('Error sending team invitation:', error)
-    return { success: false, error: error instanceof Error ? error.message : 'Failed to send invitation' }
-  }
-}
+// sendTeamInvitation moved to POST /api/team/invite. It rendered a React Email
+// here, and importing @react-email/render into a 'use server' module breaks every
+// action in this file on Turbopack builds. See app/api/team/invite/route.ts.
 
 export async function getTeamInvitations(teamId: string) {
   try {

--- a/app/[locale]/teams/components/team-management.tsx
+++ b/app/[locale]/teams/components/team-management.tsx
@@ -57,7 +57,6 @@ import {
   getUserTeamAccess,
   deleteTeam,
   renameTeam,
-  sendTeamInvitation,
   getTeamInvitations,
   removeTraderFromTeam,
   cancelTeamInvitation,
@@ -498,8 +497,22 @@ export function TeamManagement({
 
     setIsSubmitting(true)
     try {
-      const result = await sendTeamInvitation(selectedTeam.id, newTraderEmail.trim())
-      if (result.success) {
+      // Route Handler, not a server action: rendering the invitation email needs
+      // @react-email/render, which cannot be imported into a 'use server' module
+      // on Turbopack builds without breaking every other action in that file.
+      const response = await fetch('/api/team/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          teamId: selectedTeam.id,
+          email: newTraderEmail.trim(),
+        }),
+      })
+      const result = (await response.json().catch(() => ({}))) as {
+        success?: boolean
+        error?: string
+      }
+      if (response.ok && result.success) {
         toast.success(t('teams.invitations.sent'))
         setNewTraderEmail('')
         // Only reload pending invitations, no need to reload all team data

--- a/app/api/team/invite/route.ts
+++ b/app/api/team/invite/route.ts
@@ -1,53 +1,75 @@
-import { NextResponse } from "next/server"
-import { PrismaClient } from "@/prisma/generated/prisma/client"
-import { PrismaPg } from "@prisma/adapter-pg"
-import { Resend } from 'resend'
-import { createClient } from '@/server/auth'
-import TeamInvitationEmail from '@/components/emails/team-invitation'
 import { render } from "@react-email/render"
+import { revalidatePath } from "next/cache"
+import { NextResponse } from "next/server"
+import { Resend } from 'resend'
 
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-})
+import TeamInvitationEmail from '@/components/emails/team-invitation'
+import { prisma } from '@/lib/prisma'
+import { createClient } from '@/server/auth'
 
-const prisma = new PrismaClient({ adapter })
-const resend = new Resend(process.env.RESEND_API_KEY)
-
+// This lives in a Route Handler rather than a server action on purpose: on Next
+// 16.3-preview + Turbopack, importing @react-email/render from a 'use server'
+// module makes the bundler emit an unresolvable hashed external, which breaks
+// *every* action in the same route chunk. Route handlers bundle it correctly.
 export async function POST(req: Request) {
   try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
-    const { teamId, email, inviterId } = await req.json()
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+    }
 
-    console.log('Debug - Team ID:', teamId)
-    console.log('Debug - Trader Email:', email)
-    console.log('Debug - Inviter ID:', inviterId)
-
-    if (!teamId || !email || !inviterId) {
+    const { teamId, email } = (body ?? {}) as Record<string, unknown>
+    if (typeof teamId !== 'string' || typeof email !== 'string' || !email.trim()) {
       return NextResponse.json(
-        { error: 'Team ID, email, and inviter ID are required' },
+        { error: 'Team ID and email are required' },
+        { status: 400 }
+      )
+    }
+    const traderEmail = email.trim()
+
+    const team = await prisma.team.findUnique({ where: { id: teamId } })
+    if (!team) {
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 })
+    }
+
+    // Only owners and admin managers may invite. The previous version of this
+    // route read `inviterId` from the request body and never verified it, so any
+    // authenticated caller could invite to any team as anyone.
+    const isOwner = team.userId === user.id
+    const adminManager = await prisma.teamManager.findUnique({
+      where: { teamId_managerId: { teamId, managerId: user.id } },
+    })
+    if (!isOwner && adminManager?.access !== 'admin') {
+      return NextResponse.json(
+        {
+          error:
+            'Unauthorized: Only team owners and admin managers can send invitations',
+        },
+        { status: 403 }
+      )
+    }
+
+    const existingInvitation = await prisma.teamInvitation.findUnique({
+      where: { teamId_email: { teamId, email: traderEmail } },
+    })
+    if (existingInvitation?.status === 'PENDING') {
+      return NextResponse.json(
+        { error: 'An invitation has already been sent to this email' },
         { status: 400 }
       )
     }
 
-    // Check if user is the owner or admin of this team
-    const team = await prisma.team.findUnique({
-      where: { id: teamId },
-    })
-
-    console.log('Debug - Team:', team)
-
-    if (!team) {
-      return NextResponse.json(
-        { error: 'Team not found' },
-        { status: 404 }
-      )
-    }
-
-    // Check if user is already a trader in this team
     const existingUser = await prisma.user.findUnique({
-      where: { email },
+      where: { email: traderEmail },
     })
-
     if (existingUser && team.traderIds.includes(existingUser.id)) {
       return NextResponse.json(
         { error: 'User is already a member of this team' },
@@ -55,94 +77,72 @@ export async function POST(req: Request) {
       )
     }
 
-    // Check if there's already a pending invitation
-    const existingInvitation = await prisma.teamInvitation.findUnique({
-      where: {
-        teamId_email: {
-          teamId,
-          email,
-        }
-      }
-    })
-
-    if (existingInvitation && existingInvitation.status === 'PENDING') {
-      return NextResponse.json(
-        { error: 'An invitation has already been sent to this email' },
-        { status: 400 }
-      )
-    }
-
-    // Create or update invitation
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7 days
     const invitation = await prisma.teamInvitation.upsert({
-      where: {
-        teamId_email: {
-          teamId,
-          email,
-        }
-      },
-      update: {
-        status: 'PENDING',
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-        invitedBy: inviterId,
-      },
+      where: { teamId_email: { teamId, email: traderEmail } },
+      update: { status: 'PENDING', expiresAt, invitedBy: user.id },
       create: {
         teamId,
-        email,
-        invitedBy: inviterId,
+        email: traderEmail,
+        invitedBy: user.id,
         status: 'PENDING',
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
+        expiresAt,
       },
     })
 
-    // Get inviter information
-    const inviter = await prisma.user.findUnique({
-      where: { id: inviterId },
-    })
-
-    // Generate join URL
-    const joinUrl = `${process.env.NEXT_PUBLIC_APP_URL}/teams/join?invitation=${invitation.id}`
-
-    // Render email
-    const emailHtml = await render(
-      TeamInvitationEmail({
-        email,
-        teamName: team.name,
-        inviterName: inviter?.email?.split('@')[0] || 'trader',
-        inviterEmail: inviter?.email || 'trader@example.com',
-        joinUrl,
-        language: existingUser?.language || 'en'
-      })
-    )
-
-    // Send email
-    const { data, error } = await resend.emails.send({
-      from: 'Deltalytix Team <team@eu.updates.deltalytix.app>',
-      to: email,
-      subject: existingUser?.language === 'fr' 
-        ? `Invitation à rejoindre ${team.name} sur Deltalytix`
-        : `Invitation to join ${team.name} on Deltalytix`,
-      html: emailHtml,
-      replyTo: 'hugo.demenez@deltalytix.app',
-    })
-
-    if (error) {
-      console.error('Error sending invitation email:', error)
+    if (!process.env.RESEND_API_KEY) {
+      console.error('[Team invite] RESEND_API_KEY is not configured')
       return NextResponse.json(
         { error: 'Failed to send invitation email' },
         { status: 500 }
       )
     }
 
-    return NextResponse.json(
-      { success: true, invitationId: invitation.id },
-      { status: 200 }
+    const inviter = await prisma.user.findUnique({ where: { id: user.id } })
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      (process.env.NODE_ENV === 'development'
+        ? 'http://localhost:3000'
+        : 'https://deltalytix.app')
+    const joinUrl = `${baseUrl}/teams/join?invitation=${invitation.id}`
+
+    const emailHtml = await render(
+      TeamInvitationEmail({
+        email: traderEmail,
+        teamName: team.name,
+        inviterName: inviter?.email?.split('@')[0] || 'trader',
+        inviterEmail: inviter?.email || 'trader@example.com',
+        joinUrl,
+        language: existingUser?.language || 'en',
+      })
     )
 
+    const resend = new Resend(process.env.RESEND_API_KEY)
+    const { error: emailError } = await resend.emails.send({
+      from: 'Deltalytix Team <team@eu.updates.deltalytix.app>',
+      to: traderEmail,
+      subject:
+        existingUser?.language === 'fr'
+          ? `Invitation à rejoindre ${team.name} sur Deltalytix`
+          : `Invitation to join ${team.name} on Deltalytix`,
+      html: emailHtml,
+      replyTo: 'hugo.demenez@deltalytix.app',
+    })
+
+    if (emailError) {
+      console.error('[Team invite] Failed to send invitation email:', emailError)
+      return NextResponse.json(
+        { error: 'Failed to send invitation email' },
+        { status: 500 }
+      )
+    }
+
+    revalidatePath('/dashboard/settings')
+    revalidatePath('/teams/dashboard')
+
+    return NextResponse.json({ success: true, invitationId: invitation.id })
   } catch (error) {
-    console.error('Error sending team invitation:', error)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    console.error('[Team invite] Error sending team invitation:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
-} 
+}


### PR DESCRIPTION
Follow-up to #367 / #372, which hit the same root cause in the feedback feature.

## Root cause

On `beta` (`next@16.3.0-preview.6` + Turbopack), importing `@react-email/render` from a `'use server'` module makes the bundler emit an unresolvable hashed external:

```
Failed to load external module @react-email/render-<hash>
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@react-email/render-<hash>'
```

**Every action in that module fails**, not just the one that renders. Route Handlers bundle it correctly. `main` is unaffected (`next@^16.1.1`, webpack), so this only reproduces on beta and preview deploys — and **not locally**, where the package resolves from `node_modules`.

## Impact here is wider than email

`app/[locale]/dashboard/settings/actions.ts` imported the renderer for a single call inside `sendTeamInvitation` — line 682 of a 1003-line file. That one import poisons the whole module, so on beta these are all broken:

`createTeam`, `joinTeam`, `leaveTeam`, `getUserTeams`, `addManagerToTeam`, `removeManagerFromTeam`, `updateManagerAccess`, `getUserTeamAccess`, `deleteTeam`, `renameTeam`, `addTraderToTeam`, `sendTeamInvitation`, `getTeamInvitations`, `removeTraderFromTeam`, `cancelTeamInvitation`

Team management on beta, in other words — not an email edge case.

## Change

- `sendTeamInvitation` deleted from the action file, along with the `render` / `Resend` / `TeamInvitationEmail` imports.
- Work moves to `POST /api/team/invite`, which **already existed as dead code** duplicating the action with no callers.
- `team-management.tsx` calls the route instead of the action.

## Also fixes an access-control bug

The dead route took `inviterId` from the **request body and never verified it**, and had no owner/admin check at all — any authenticated caller could invite anyone to any team as any user. Now:

- the inviter is the session user, never the payload;
- the owner / admin-manager check from the action is carried over.

Worth noting this was latent, since nothing called the route.

## Not fixed here

Four admin actions have the same top-level import and are still broken on beta. They are admin-only tooling, and converting them means rewiring admin UI I cannot exercise, so they are deliberately left for a separate PR:

- `app/[locale]/admin/actions/weekly-recap.ts` — `renderEmail` (preview)
- `app/[locale]/admin/actions/welcome.ts` — `renderWelcomeEmailPreview`
- `app/[locale]/admin/actions/newsletter.ts` — `renderEmailPreview`, `sendNewsletter`, `sendTestNewsletter`
- `app/[locale]/admin/actions/send-email.ts` — `renderEmailPreview`, `sendEmailsToUsers`

Also unrelated but noticed: `beta` dropped `serverExternalPackages` entirely, while `main` still sets it for `playwright-core` and `@vercel/sandbox` — with a comment that playwright reads `browsers.json` at import time and must stay external and traced for cron scraping. That removal looks unintentional and may have broken cron scraping.

## Verification

- `tsc --noEmit` clean.
- `eslint` shows no new problems; the 5 errors in `team-management.tsx` are pre-existing on `beta` (verified against the untouched file).
- **Not exercised end to end.** Sending a real invitation needs a team plus owner credentials. Given this bug class is invisible locally, someone should send one invitation on the preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)