### PR TITLE
Add responsive drawer layout for calendar modals on mobile

### DIFF
--- a/app/[locale]/dashboard/components/calendar/daily-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-modal.tsx
@@ -11,22 +11,21 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { ScrollArea } from "@/components/ui/scroll-area";
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { cn, parsePositionTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { Trade } from "@/prisma/generated/prisma/browser";
 import { CalendarEntry } from "@/app/[locale]/dashboard/types/calendar";
 import { Charts } from "./charts";
 import { useI18n, useCurrentLocale } from "@/locales/client";
 import { DailyStats } from "./daily-stats";
 import { DailyComment } from "./daily-comment";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { useUserStore } from "../../../../../store/user-store";
 import { TradeTableReview } from "../tables/trade-table-review";
 import StatisticsWidget from "../statistics/statistics-widget";
@@ -39,19 +38,90 @@ interface CalendarModalProps {
   isLoading: boolean;
 }
 
-interface GroupedTrades {
-  [accountNumber: string]: Trade[];
+interface DailyTabsProps {
+  selectedDate: Date;
+  dayData: CalendarEntry | undefined;
+  isLoading: boolean;
+  layout: "dialog" | "drawer";
 }
 
-function groupTradesByAccount(trades: Trade[]): GroupedTrades {
-  return trades.reduce((acc: GroupedTrades, trade) => {
-    const account = trade.accountNumber || "Unknown Account";
-    if (!acc[account]) {
-      acc[account] = [];
-    }
-    acc[account].push(trade);
-    return acc;
-  }, {});
+const formatSignedCurrency = (value: number) => {
+  const formatted = Math.abs(value).toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  return value < 0 ? `-${formatted}` : `+${formatted}`;
+};
+
+function DailyTabs({ selectedDate, dayData, isLoading, layout }: DailyTabsProps) {
+  const t = useI18n();
+  const isDrawer = layout === "drawer";
+  // On mobile the drawer should be glanceable first: land on the read-only
+  // analysis tab instead of opening straight into the journal editor.
+  const [activeTab, setActiveTab] = useState(isDrawer ? "analysis" : "comment");
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={setActiveTab}
+      className="grow flex flex-col overflow-hidden min-h-0"
+    >
+      <TabsList
+        className={cn(
+          "shrink-0",
+          isDrawer ? "mx-4 grid w-auto grid-cols-3" : "px-6",
+        )}
+      >
+        <TabsTrigger value="comment">{t("calendar.modal.comment")}</TabsTrigger>
+        <TabsTrigger value="table">{t("calendar.modal.table")}</TabsTrigger>
+        <TabsTrigger value="analysis">
+          {t("calendar.modal.analysis")}
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent
+        value="comment"
+        className={cn(
+          "grow overflow-hidden h-full flex flex-col min-h-0",
+          isDrawer ? "px-4 pt-2 pb-4" : "p-6 pt-2",
+        )}
+        data-vaul-no-drag
+      >
+        <DailyComment dayData={dayData} selectedDate={selectedDate} />
+      </TabsContent>
+      <TabsContent
+        value="table"
+        className="grow overflow-hidden flex flex-col min-h-0"
+        data-vaul-no-drag
+      >
+        {dayData && dayData.trades?.length > 0 ? (
+          <div className="h-full w-full overflow-hidden">
+            <TradeTableReview tradesParam={dayData.trades as Trade[]} />
+          </div>
+        ) : (
+          <p className={cn(isDrawer ? "px-4 pt-2" : "p-6 pt-2")}>
+            {t("calendar.modal.noTrades")}
+          </p>
+        )}
+      </TabsContent>
+      <TabsContent
+        value="analysis"
+        className={cn(
+          "grow overflow-y-auto overscroll-contain space-y-4 min-h-0",
+          isDrawer ? "px-4 pt-2 pb-6" : "p-6 pt-2",
+        )}
+        data-vaul-no-drag
+      >
+        {dayData && dayData.trades?.length > 0 && (
+          <StatisticsWidget dayData={dayData} size="medium" />
+        )}
+        <DailyStats dayData={dayData} isWeekly={false} />
+        {/* <DailyMood dayData={dayData} isWeekly={false} selectedDate={selectedDate} /> */}
+        <Charts dayData={dayData} isLoading={isLoading} />
+      </TabsContent>
+    </Tabs>
+  );
 }
 
 export function CalendarModal({
@@ -65,7 +135,7 @@ export function CalendarModal({
   const locale = useCurrentLocale();
   const timezone = useUserStore((state) => state.timezone);
   const dateLocale = locale === "fr" ? fr : enUS;
-  const [activeTab, setActiveTab] = useState("comment");
+  const isDesktop = useMediaQuery("(min-width: 640px)");
   const [formattedDate, setFormattedDate] = useState<string>("");
 
   React.useEffect(() => {
@@ -80,59 +150,62 @@ export function CalendarModal({
 
   if (!selectedDate) return null;
 
+  if (!isDesktop) {
+    const tradeCount = dayData?.tradeNumber ?? 0;
+
+    return (
+      <Drawer open={isOpen} onOpenChange={onOpenChange}>
+        <DrawerContent className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col">
+          <DrawerHeader className="shrink-0 px-4 pt-3 pb-2 text-left">
+            <div className="flex items-baseline justify-between gap-3">
+              <DrawerTitle className="text-base capitalize truncate">
+                {formattedDate}
+              </DrawerTitle>
+              {dayData && (
+                <span
+                  className={cn(
+                    "text-sm font-semibold shrink-0",
+                    dayData.pnl >= 0
+                      ? "text-green-600 dark:text-green-400"
+                      : "text-red-600 dark:text-red-400",
+                  )}
+                >
+                  {formatSignedCurrency(dayData.pnl)}
+                </span>
+              )}
+            </div>
+            <DrawerDescription className="text-xs">
+              {tradeCount > 0
+                ? `${tradeCount} ${tradeCount > 1 ? t("calendar.trades") : t("calendar.trade")}`
+                : t("calendar.modal.noTrades")}
+            </DrawerDescription>
+          </DrawerHeader>
+          <DailyTabs
+            selectedDate={selectedDate}
+            dayData={dayData}
+            isLoading={isLoading}
+            layout="drawer"
+          />
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl w-full h-dvh sm:h-[80vh] p-0 flex flex-col">
+      <DialogContent className="max-w-4xl w-full h-[80vh] p-0 flex flex-col">
         <DialogHeader className="p-6 pb-2">
           <DialogTitle>{formattedDate}</DialogTitle>
           <DialogDescription>
             {t("calendar.modal.tradeDetails")}
           </DialogDescription>
         </DialogHeader>
-        <Tabs
-          value={activeTab}
-          onValueChange={setActiveTab}
-          className="grow flex flex-col overflow-hidden"
-        >
-          <TabsList className="px-6">
-            <TabsTrigger value="comment">
-              {t("calendar.modal.comment")}
-            </TabsTrigger>
-            <TabsTrigger value="table">{t("calendar.modal.table")}</TabsTrigger>
-            <TabsTrigger value="analysis">
-              {t("calendar.modal.analysis")}
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent
-            value="comment"
-            className="grow overflow-hidden p-6 pt-2 h-full flex flex-col"
-          >
-            <DailyComment dayData={dayData} selectedDate={selectedDate} />
-          </TabsContent>
-          <TabsContent
-            value="table"
-            className="grow overflow-hidden flex flex-col min-h-0"
-          >
-            {dayData && dayData.trades?.length > 0 ? (
-              <div className="h-full w-full overflow-hidden">
-                <TradeTableReview tradesParam={dayData.trades as Trade[]} />
-              </div>
-            ) : (
-              <p className="p-6 pt-2">{t("calendar.modal.noTrades")}</p>
-            )}
-          </TabsContent>
-          <TabsContent
-            value="analysis"
-            className="grow overflow-auto p-6 pt-2 space-y-4"
-          >
-            {dayData && dayData.trades?.length > 0 && (
-              <StatisticsWidget dayData={dayData} size="medium" />
-            )}
-            <DailyStats dayData={dayData} isWeekly={false} />
-            {/* <DailyMood dayData={dayData} isWeekly={false} selectedDate={selectedDate} /> */}
-            <Charts dayData={dayData} isLoading={isLoading} />
-          </TabsContent>
-        </Tabs>
+        <DailyTabs
+          selectedDate={selectedDate}
+          dayData={dayData}
+          isLoading={isLoading}
+          layout="dialog"
+        />
       </DialogContent>
     </Dialog>
   );

--- a/app/[locale]/dashboard/components/calendar/daily-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-modal.tsx
@@ -66,7 +66,7 @@ function DailyTabs({ selectedDate, dayData, isLoading, layout }: DailyTabsProps)
     <Tabs
       value={activeTab}
       onValueChange={setActiveTab}
-      className="grow flex flex-col overflow-hidden min-h-0"
+      className="flex-1 flex flex-col overflow-hidden min-h-0"
     >
       <TabsList
         className={cn(
@@ -83,7 +83,7 @@ function DailyTabs({ selectedDate, dayData, isLoading, layout }: DailyTabsProps)
       <TabsContent
         value="comment"
         className={cn(
-          "grow overflow-hidden h-full flex flex-col min-h-0",
+          "flex-1 overflow-hidden flex flex-col min-h-0",
           isDrawer ? "px-4 pt-2 pb-4" : "p-6 pt-2",
         )}
         data-vaul-no-drag
@@ -92,7 +92,7 @@ function DailyTabs({ selectedDate, dayData, isLoading, layout }: DailyTabsProps)
       </TabsContent>
       <TabsContent
         value="table"
-        className="grow overflow-hidden flex flex-col min-h-0"
+        className="flex-1 overflow-hidden flex flex-col min-h-0"
         data-vaul-no-drag
       >
         {dayData && dayData.trades?.length > 0 ? (
@@ -108,7 +108,7 @@ function DailyTabs({ selectedDate, dayData, isLoading, layout }: DailyTabsProps)
       <TabsContent
         value="analysis"
         className={cn(
-          "grow overflow-y-auto overscroll-contain space-y-4 min-h-0",
+          "flex-1 overflow-y-auto overscroll-contain space-y-4 min-h-0",
           isDrawer ? "px-4 pt-2 pb-6" : "p-6 pt-2",
         )}
         data-vaul-no-drag

--- a/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
@@ -46,14 +46,14 @@ function WeeklyTabs({
   const [activeTab, setActiveTab] = useState("charts")
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab} className="grow flex flex-col overflow-hidden min-h-0">
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col overflow-hidden min-h-0">
       <TabsList className={cn("shrink-0", isDrawer ? "mx-4 grid w-auto grid-cols-1" : "px-6")}>
         <TabsTrigger value="charts">{t('calendar.modal.charts')}</TabsTrigger>
       </TabsList>
       <TabsContent
         value="charts"
         className={cn(
-          "grow overflow-y-auto overscroll-contain min-h-0",
+          "flex-1 overflow-y-auto overscroll-contain min-h-0",
           isDrawer ? "px-4 pt-2 pb-6" : "p-6 pt-2"
         )}
         data-vaul-no-drag

--- a/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
@@ -4,12 +4,15 @@ import React, { useState } from "react"
 import { format, startOfWeek, endOfWeek } from "date-fns"
 import { fr, enUS } from 'date-fns/locale'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { ScrollArea } from "@/components/ui/scroll-area"
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "@/components/ui/drawer"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { CalendarData } from "@/app/[locale]/dashboard/types/calendar"
+import { CalendarData, CalendarEntry } from "@/app/[locale]/dashboard/types/calendar"
+import { Trade } from "@/prisma/generated/prisma/browser"
 import { Charts } from "./charts"
 import { useI18n, useCurrentLocale } from "@/locales/client"
 import { calendarDateKeyFromZoned } from "@/lib/calendar-timezone"
+import { useMediaQuery } from "@/hooks/use-media-query"
+import { cn } from "@/lib/utils"
 
 interface WeeklyModalProps {
   isOpen: boolean;
@@ -17,6 +20,48 @@ interface WeeklyModalProps {
   selectedDate: Date | null;
   calendarData: CalendarData;
   isLoading: boolean;
+}
+
+const formatSignedCurrency = (value: number) => {
+  const formatted = Math.abs(value).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+  return value < 0 ? `-${formatted}` : `+${formatted}`
+}
+
+function WeeklyTabs({
+  weeklyData,
+  isLoading,
+  layout,
+}: {
+  weeklyData: CalendarEntry;
+  isLoading: boolean;
+  layout: 'dialog' | 'drawer';
+}) {
+  const t = useI18n()
+  const isDrawer = layout === 'drawer'
+  const [activeTab, setActiveTab] = useState("charts")
+
+  return (
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="grow flex flex-col overflow-hidden min-h-0">
+      <TabsList className={cn("shrink-0", isDrawer ? "mx-4 grid w-auto grid-cols-1" : "px-6")}>
+        <TabsTrigger value="charts">{t('calendar.modal.charts')}</TabsTrigger>
+      </TabsList>
+      <TabsContent
+        value="charts"
+        className={cn(
+          "grow overflow-y-auto overscroll-contain min-h-0",
+          isDrawer ? "px-4 pt-2 pb-6" : "p-6 pt-2"
+        )}
+        data-vaul-no-drag
+      >
+        <Charts dayData={weeklyData} isWeekly={true} isLoading={isLoading} />
+      </TabsContent>
+    </Tabs>
+  )
 }
 
 export function WeeklyModal({
@@ -30,13 +75,13 @@ export function WeeklyModal({
   const locale = useCurrentLocale()
   const dateLocale = locale === 'fr' ? fr : enUS
   const weekStartsOnMonday = locale === 'fr'
-  const [activeTab, setActiveTab] = useState("charts")
+  const isDesktop = useMediaQuery("(min-width: 640px)")
 
   // Aggregate weekly data
-  const weeklyData = React.useMemo(() => {
+  const weeklyData = React.useMemo<CalendarEntry>(() => {
     if (!selectedDate) return { trades: [], tradeNumber: 0, pnl: 0, longNumber: 0, shortNumber: 0 }
 
-    const trades: any[] = []
+    const trades: Trade[] = []
     const weekStartsOn = weekStartsOnMonday ? 1 : 0
     const weekStart = startOfWeek(selectedDate, { weekStartsOn })
     const weekEnd = endOfWeek(selectedDate, { weekStartsOn })
@@ -46,7 +91,7 @@ export function WeeklyModal({
     // Collect all trades for the week
     for (const [dateString, dayData] of Object.entries(calendarData)) {
       if (dateString >= weekStartKey && dateString <= weekEndKey && dayData.trades) {
-        trades.push(...(dayData.trades as any[]))
+        trades.push(...dayData.trades)
       }
     }
 
@@ -71,24 +116,45 @@ export function WeeklyModal({
   const weekEnd = endOfWeek(selectedDate, { weekStartsOn })
   const dateRange = `${format(weekStart, 'MMMM d', { locale: dateLocale })} - ${format(weekEnd, 'MMMM d, yyyy', { locale: dateLocale })}`
 
+  if (!isDesktop) {
+    return (
+      <Drawer open={isOpen} onOpenChange={onOpenChange}>
+        <DrawerContent className="h-[85dvh] max-h-[85dvh] p-0 flex flex-col">
+          <DrawerHeader className="shrink-0 px-4 pt-3 pb-2 text-left">
+            <div className="flex items-baseline justify-between gap-3">
+              <DrawerTitle className="text-base capitalize truncate">{dateRange}</DrawerTitle>
+              <span className={cn(
+                "text-sm font-semibold shrink-0",
+                weeklyData.pnl >= 0
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-red-600 dark:text-red-400"
+              )}>
+                {formatSignedCurrency(weeklyData.pnl)}
+              </span>
+            </div>
+            <DrawerDescription className="text-xs">
+              {weeklyData.tradeNumber > 0
+                ? `${weeklyData.tradeNumber} ${weeklyData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`
+                : t('calendar.modal.noTrades')}
+            </DrawerDescription>
+          </DrawerHeader>
+          <WeeklyTabs weeklyData={weeklyData} isLoading={isLoading} layout="drawer" />
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl w-full h-dvh sm:h-[90vh] p-0 flex flex-col">
+      <DialogContent className="max-w-4xl w-full h-[90vh] p-0 flex flex-col">
         <DialogHeader className="p-6 pb-2">
           <DialogTitle>{dateRange}</DialogTitle>
           <DialogDescription>
             {t('calendar.modal.weeklyDetails')}
           </DialogDescription>
         </DialogHeader>
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="grow flex flex-col overflow-hidden">
-          <TabsList className="px-6">
-            <TabsTrigger value="charts">{t('calendar.modal.charts')}</TabsTrigger>
-          </TabsList>
-          <TabsContent value="charts" className="grow overflow-auto p-6 pt-2">
-            <Charts dayData={weeklyData} isWeekly={true} isLoading={isLoading} />
-          </TabsContent>
-        </Tabs>
+        <WeeklyTabs weeklyData={weeklyData} isLoading={isLoading} layout="dialog" />
       </DialogContent>
     </Dialog>
   )
-} 
+}

--- a/components/consent-banner.tsx
+++ b/components/consent-banner.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Drawer,
@@ -103,6 +103,7 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
   })
 
   const isDesktop = useMediaQuery("(min-width: 768px)")
+  const bannerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const sharedAnalyticsConsent = getSharedAnalyticsConsent()
@@ -166,6 +167,23 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
     return () => window.removeEventListener('keydown', handleKeyPress)
   }, [])
 
+  // Radix (and vaul on top of it) decides an interaction happened "outside" an
+  // open dialog from a document-level pointerdown listener, and closes on it.
+  // A React onPointerDown cannot stop that: React delegates handlers to the
+  // root container, so its stopPropagation runs on the same node as Radix's
+  // listener and therefore too late. Stopping the event on the banner element
+  // itself keeps it from ever reaching document, so choosing a consent option
+  // no longer tears down whatever modal the user had open.
+  useEffect(() => {
+    const node = bannerRef.current
+    if (!node) return
+
+    const stop = (event: Event) => event.stopPropagation()
+    const events = ["pointerdown", "mousedown", "touchstart"] as const
+    events.forEach((type) => node.addEventListener(type, stop))
+    return () => events.forEach((type) => node.removeEventListener(type, stop))
+  }, [isVisible])
+
   // Add/remove data attribute when banner visibility changes
   useEffect(() => {
     if (isVisible) {
@@ -218,8 +236,17 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
 
   return (
     <AnimatePresence>
-      <motion.div 
-        className="fixed bottom-0 left-0 right-0 z-9999 p-4 -m-4"
+      <motion.div
+        // The banner outlives any modal on the page, so it has to survive what
+        // Radix does to the rest of the document while a dialog/drawer is open:
+        // - body gets `pointer-events: none`, which the banner inherits, hence
+        //   the explicit `pointer-events-auto`;
+        // - `hideOthers()` marks every other body child `aria-hidden`, and it
+        //   only spares `[aria-live]` nodes, hence the live region.
+        // Without these, an open drawer leaves the banner visible but dead.
+        ref={bannerRef}
+        className="fixed bottom-0 left-0 right-0 z-9999 p-4 -m-4 pointer-events-auto"
+        aria-live="polite"
         initial={{ y: 100 }}
         animate={{ y: 0 }}
         exit={{ y: 100 }}

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -48,7 +48,9 @@ const DrawerContent = React.forwardRef<
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {/* shrink-0: the grip is a flex item, so tall content would otherwise
+          shave pixels off it when the sheet has to distribute shrinkage. */}
+      <div className="mx-auto mt-4 h-2 w-[100px] shrink-0 rounded-full bg-muted" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>


### PR DESCRIPTION
## Summary
This PR adds responsive mobile support to the calendar modals by implementing a drawer-based layout for screens smaller than 640px, while maintaining the existing dialog layout for desktop. The changes improve the mobile user experience by using a bottom sheet drawer that's more suitable for smaller screens.

## Key Changes

- **Responsive Modal Layouts**: Both daily and weekly calendar modals now use `Drawer` component on mobile (< 640px) and `Dialog` on desktop, detected via `useMediaQuery` hook
- **Extracted Tab Components**: Created `DailyTabs` and `WeeklyTabs` components to share tab logic between dialog and drawer layouts, with layout-specific styling
- **Mobile-Optimized UX**: 
  - Drawer defaults to "analysis" tab on mobile for quick glanceable content, while dialog defaults to "comment"
  - Added PnL display in drawer headers for quick reference
  - Adjusted padding and spacing for drawer vs dialog layouts
- **Removed Unused Code**: Removed `parsePositionTime` import and `groupTradesByAccount` function that were no longer used
- **Fixed Consent Banner Interaction**: Added event listeners to prevent pointer events from bubbling to document level, preventing modals from closing when interacting with the consent banner
- **Drawer Grip Styling**: Added `shrink-0` class to drawer grip to prevent it from being compressed by tall content

## Implementation Details

- Mobile drawer uses 85dvh (85% of dynamic viewport height) for better usability
- Consistent `formatSignedCurrency` utility added to both daily and weekly modals for PnL display
- Tab content uses `data-vaul-no-drag` attribute to prevent accidental drawer dragging when interacting with tabs
- Drawer headers display trade count and PnL in a compact format suitable for mobile
- All responsive breakpoints use Tailwind's `sm:` (640px) breakpoint for consistency

https://claude.ai/code/session_01HDx5HqcQEGcL4xfjoC9zPX