### PR TITLE
Remove sensitive feedback analytics properties

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -83,22 +83,20 @@ export async function POST(request: Request) {
     page,
   }
 
-  // Two independent delivery channels. PostHog is the analytics/correlation
-  // layer; the support inbox is the durable one, since PostHog event retention
-  // is plan-limited.
+  // PostHog records only non-sensitive submission metadata. The support inbox
+  // is the sole durable channel for the message and the user's email address.
   //
   // consentGranted: the user typed this and pressed send, so it is a submission
   // fulfilling their own request rather than passive analytics. Same reasoning
   // as the Stripe webhook events.
-  const [capturedByPostHog, emailedToSupport] = await Promise.all([
+  const [, emailedToSupport] = await Promise.all([
     capturePostHogEvent({
       consentGranted: true,
       distinctId: user.id,
       event: 'feedback_submitted',
       properties: {
         feedback_type: type,
-        feedback_message: message,
-        email: user.email ?? null,
+        message_length: message.length,
         locale,
         page,
       },
@@ -106,9 +104,9 @@ export async function POST(request: Request) {
     sendFeedbackNotificationEmail(emailInput),
   ])
 
-  // Only a total failure loses the message. Surface that instead of reporting
-  // success; either channel landing means the team has the feedback.
-  if (!capturedByPostHog && !emailedToSupport) {
+  // Analytics no longer contains the message, so a support-email failure must
+  // be surfaced instead of reporting a successful submission.
+  if (!emailedToSupport) {
     return NextResponse.json(
       { error: 'Failed to deliver feedback' },
       { status: 502 },


### PR DESCRIPTION
## What changed

- removes raw `feedback_message` and `email` properties from the PostHog `feedback_submitted` event
- adds numeric `message_length` for aggregate feedback-quality analysis
- keeps `feedback_type`, `locale`, and the query/hash-stripped `page` property
- makes the support email the sole durable message-delivery channel, so an email failure is surfaced instead of silently succeeding with analytics metadata only

## Why

The live PostHog schema began receiving `feedback_submitted` today and exposed both raw feedback text and email addresses as event properties. Feedback can contain personal or sensitive content and does not need to be duplicated into analytics. The support inbox already receives the full message.

## Tracking contract

- Event: `feedback_submitted`
- Trigger: authenticated feedback submission
- Event properties:
  - `feedback_type: "bug" | "idea" | "other"`
  - `message_length: number`
  - `locale: "en" | "fr"`
  - `page: string | null` with query and hash removed
- Person properties: none
- Explicitly excluded: message text and email address

## PostHog acceptance check

For events ingested after deployment:

- `feedback_message` and `email` are not set
- `message_length` is numeric
- breakdowns by `feedback_type`, `locale`, and `page` remain available

## Validation

- ✅ `bun install`
- ✅ `bun run typecheck`
- ✅ `bunx eslint app/api/feedback/route.ts`
- ✅ `git diff --check`
- ❌ `bun run lint`: repository baseline reports 1,017 problems (414 errors, 603 warnings); the changed file has zero lint errors
- ⚠️ `OPENAI_API_KEY=dummy bun run build`: stopped during Prisma prebuild because the isolated checkout has no `DIRECT_URL`
- ⏭️ database push, seed, dev server, and health checks were not run without a safely verified local database configuration

This remains a draft until required project checks are resolved or rerun in a configured environment.