### PR TITLE
Fix connections account row alignment on mobile

### DIFF
--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-sync.tsx
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-sync.tsx
@@ -22,7 +22,11 @@ import {
 } from '@/components/ui/command'
 import { getDxFeedErrorToastContent } from '@/lib/dxfeed-client-messages'
 import { showToastWithCopy } from '@/lib/toast-copy'
-import { getEnabledDxFeedPropFirms } from '@/lib/dxfeed-propfirms'
+import {
+  getDxFeedPropFirm,
+  getDxFeedPropFirmByAuthName,
+  getEnabledDxFeedPropFirms,
+} from '@/lib/dxfeed-propfirms'
 import { useDxFeedSyncContext } from '@/context/dxfeed-sync-context'
 import { authenticateDxFeed } from './actions'
 import { DxFeedCredentialsManager } from './dxfeed-credentials-manager'
@@ -41,12 +45,31 @@ const configSelectClassName =
 const primaryButtonClassName =
   'inline-flex h-11 w-full items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-6 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]'
 
-function DxFeedConnectView({ onConnected }: { onConnected?: () => void }) {
+function resolvePrefillPropFirmId(propFirmName?: string) {
+  if (!propFirmName) return DEFAULT_PROP_FIRM_ID
+  return (
+    getDxFeedPropFirm(propFirmName)?.id ??
+    getDxFeedPropFirmByAuthName(propFirmName)?.id ??
+    DEFAULT_PROP_FIRM_ID
+  )
+}
+
+function DxFeedConnectView({
+  onConnected,
+  initialEmail,
+  initialPropFirmName,
+}: {
+  onConnected?: () => void
+  initialEmail?: string
+  initialPropFirmName?: string
+}) {
   const t = useI18n()
   const { loadAccounts } = useDxFeedSyncContext()
-  const [loginEmail, setLoginEmail] = useState('')
+  const [loginEmail, setLoginEmail] = useState(initialEmail ?? '')
   const [loginPassword, setLoginPassword] = useState('')
-  const [selectedPropFirmId, setSelectedPropFirmId] = useState(DEFAULT_PROP_FIRM_ID)
+  const [selectedPropFirmId, setSelectedPropFirmId] = useState(() =>
+    resolvePrefillPropFirmId(initialPropFirmName)
+  )
   const [isLoading, setIsLoading] = useState(false)
   const [propFirmOpen, setPropFirmOpen] = useState(false)
   const [propFirmSearch, setPropFirmSearch] = useState('')
@@ -292,6 +315,10 @@ function DxFeedConnectView({ onConnected }: { onConnected?: () => void }) {
 interface DxFeedSyncProps {
   /** When false, open on the connect form instead of the saved-accounts list. */
   initialShowAccountsManager?: boolean
+  /** Prefill login email when reconnecting. */
+  initialEmail?: string
+  /** Prefill prop firm (name or id) when reconnecting. */
+  initialPropFirmName?: string
   onConnected?: () => void
   /** Accepted for PlatformConfig customComponent compatibility; unused here. */
   setIsOpen?: Dispatch<SetStateAction<boolean>> | ((open: boolean) => void)
@@ -299,13 +326,21 @@ interface DxFeedSyncProps {
 
 export function DxFeedSync({
   initialShowAccountsManager = true,
+  initialEmail,
+  initialPropFirmName,
   onConnected,
   setIsOpen: _setIsOpen,
 }: DxFeedSyncProps = {}) {
   const t = useI18n()
 
   if (!initialShowAccountsManager) {
-    return <DxFeedConnectView onConnected={onConnected} />
+    return (
+      <DxFeedConnectView
+        onConnected={onConnected}
+        initialEmail={initialEmail}
+        initialPropFirmName={initialPropFirmName}
+      />
+    )
   }
 
   return (

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
@@ -39,12 +39,14 @@ const primaryButtonClassName =
 
 function RithmicProtocolConnectView({
   onConnected,
+  initialUsername,
 }: {
   onConnected?: () => void
+  initialUsername?: string
 }) {
   const t = useI18n()
   const { loadAccounts, performSyncForAccount } = useRithmicProtocolSyncContext()
-  const [username, setUsername] = useState('')
+  const [username, setUsername] = useState(initialUsername ?? '')
   const [password, setPassword] = useState('')
   const [historyStartDate, setHistoryStartDate] = useState('')
   const {
@@ -289,6 +291,8 @@ function RithmicProtocolConnectView({
 interface RithmicProtocolSyncProps {
   /** When false, open on the connect form instead of the saved-accounts list. */
   initialShowAccountsManager?: boolean
+  /** Prefill username when reconnecting. */
+  initialUsername?: string
   onConnected?: () => void
   /** Accepted for PlatformConfig customComponent compatibility; unused here. */
   setIsOpen?: Dispatch<SetStateAction<boolean>> | ((open: boolean) => void)
@@ -296,6 +300,7 @@ interface RithmicProtocolSyncProps {
 
 export function RithmicProtocolSync({
   initialShowAccountsManager = true,
+  initialUsername,
   onConnected,
   setIsOpen: _setIsOpen,
 }: RithmicProtocolSyncProps = {}) {
@@ -305,7 +310,10 @@ export function RithmicProtocolSync({
     <div className="flex h-full min-h-0 flex-col">
       <div className="min-h-0 flex-1 space-y-5 overflow-y-auto">
         {!initialShowAccountsManager ? (
-          <RithmicProtocolConnectView onConnected={onConnected} />
+          <RithmicProtocolConnectView
+            onConnected={onConnected}
+            initialUsername={initialUsername}
+          />
         ) : (
           <>
             <div className="flex min-w-0 flex-col gap-1.5">

--- a/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-sync-connection.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-sync-connection.tsx
@@ -48,11 +48,14 @@ interface RithmicSyncConnectionProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>> | ((open: boolean) => void)
   /** When false, open on the credentials form instead of the saved-credentials list. */
   initialShowCredentialsManager?: boolean
+  /** Prefill username when reconnecting. */
+  initialUsername?: string
 }
 
 export function RithmicSyncConnection({
   setIsOpen,
   initialShowCredentialsManager = true,
+  initialUsername,
 }: RithmicSyncConnectionProps) {
   const user = useUserStore(state => state.user)
   const { 
@@ -100,7 +103,7 @@ export function RithmicSyncConnection({
   }, [])
   
   const [credentials, setCredentials] = useState<RithmicCredentials>({
-    username: '',
+    username: initialUsername ?? '',
     password: '',
     server_type: 'Rithmic Paper Trading',
     location: 'Chicago Area',
@@ -379,7 +382,7 @@ export function RithmicSyncConnection({
     setShouldAutoConnect(false)
     setShowCredentialsManager(initialShowCredentialsManager)
     setCredentials({
-      username: '',
+      username: initialUsername ?? '',
       password: '',
       server_type: 'Rithmic Paper Trading',
       location: 'Chicago Area',
@@ -392,6 +395,7 @@ export function RithmicSyncConnection({
     setWsUrl,
     setStep,
     initialShowCredentialsManager,
+    initialUsername,
   ])
 
   // Close modal when processing is complete
@@ -791,11 +795,14 @@ interface RithmicSyncWrapperProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>> | ((open: boolean) => void)
   /** When false, open on the credentials form instead of the saved-credentials list. */
   initialShowCredentialsManager?: boolean
+  /** Prefill username when reconnecting. */
+  initialUsername?: string
 }
 
 export function RithmicSyncWrapper({
   setIsOpen,
   initialShowCredentialsManager = true,
+  initialUsername,
 }: RithmicSyncWrapperProps) {
   const t = useI18n()
   const showChromeTitle = initialShowCredentialsManager
@@ -811,6 +818,7 @@ export function RithmicSyncWrapper({
         <RithmicSyncConnection 
           setIsOpen={setIsOpen}
           initialShowCredentialsManager={initialShowCredentialsManager}
+          initialUsername={initialUsername}
         />
       </div>
       <div className="shrink-0 space-y-2 border-t border-black/10 pt-4 text-xs leading-relaxed text-black/45 dark:border-white/10 dark:text-white/45">

--- a/app/[locale]/dashboard/connections/components/connect-prefill.ts
+++ b/app/[locale]/dashboard/connections/components/connect-prefill.ts
@@ -1,0 +1,14 @@
+import type { ConnectionService } from '../actions'
+
+/**
+ * Optional values carried into the connect sheet when reconnecting an
+ * existing connection. Passwords are never prefilled.
+ */
+export type ConnectPrefill = {
+  service: ConnectionService
+  /** Login / external id (DxFeed email, Rithmic username, etc.). */
+  accountId?: string
+  /** Primary row label — used to resolve DxFeed prop firm by name. */
+  displayName?: string
+  environment?: string
+}

--- a/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
+++ b/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
@@ -14,18 +14,22 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { ServiceMonochromeLogo } from '@/components/monochrome-logo'
+import type { ConnectPrefill } from './connect-prefill'
 
 export function ConnectServiceModal({
   service,
+  prefill,
   onClose,
 }: {
   service: ConnectionService | null
+  prefill?: ConnectPrefill | null
   onClose: () => void
 }) {
   const t = useI18n()
   const open = service !== null
+  const isReconnect = !!prefill?.accountId
 
-  const title =
+  const addTitle =
     service === 'rithmic'
       ? t('connections.add.rithmic')
       : service === 'rithmic-protocol'
@@ -39,6 +43,8 @@ export function ConnectServiceModal({
               : service === 'etp'
                 ? t('connections.add.etp')
                 : t('connections.addConnection')
+
+  const title = isReconnect ? t('connections.reconnect') : addTitle
 
   return (
     <Sheet
@@ -70,6 +76,7 @@ export function ConnectServiceModal({
           {service === 'rithmic' && (
             <RithmicSyncWrapper
               initialShowCredentialsManager={false}
+              initialUsername={prefill?.accountId}
               setIsOpen={(next: boolean) => {
                 if (!next) onClose()
               }}
@@ -78,6 +85,7 @@ export function ConnectServiceModal({
           {service === 'rithmic-protocol' && (
             <RithmicProtocolSync
               initialShowAccountsManager={false}
+              initialUsername={prefill?.accountId}
               onConnected={onClose}
             />
           )}
@@ -90,6 +98,8 @@ export function ConnectServiceModal({
             <div className="min-h-0 flex-1 overflow-y-auto">
               <DxFeedSync
                 initialShowAccountsManager={false}
+                initialEmail={prefill?.accountId}
+                initialPropFirmName={prefill?.displayName}
                 onConnected={onClose}
               />
             </div>

--- a/app/[locale]/dashboard/connections/components/connections-page-chrome.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-chrome.tsx
@@ -53,7 +53,7 @@ export function ConnectionsPageChrome({ children }: { children: ReactNode }) {
 
 function ConnectionsPageChromeInner({ children }: { children: ReactNode }) {
   const t = useI18n()
-  const { refresh, connectService, openConnect, closeConnect } =
+  const { refresh, connectService, connectPrefill, openConnect, closeConnect } =
     useConnectionsRefresh()
   const [selectedImportPlatform, setSelectedImportPlatform] =
     useState<PlatformConfig | null>(null)
@@ -285,6 +285,7 @@ function ConnectionsPageChromeInner({ children }: { children: ReactNode }) {
 
       <ConnectServiceModal
         service={connectService}
+        prefill={connectPrefill}
         onClose={() => {
           closeConnect()
           refresh()

--- a/app/[locale]/dashboard/connections/components/connections-page-chrome.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-chrome.tsx
@@ -53,10 +53,8 @@ export function ConnectionsPageChrome({ children }: { children: ReactNode }) {
 
 function ConnectionsPageChromeInner({ children }: { children: ReactNode }) {
   const t = useI18n()
-  const { refresh } = useConnectionsRefresh()
-  const [connectService, setConnectService] = useState<ConnectionService | null>(
-    null
-  )
+  const { refresh, connectService, openConnect, closeConnect } =
+    useConnectionsRefresh()
   const [selectedImportPlatform, setSelectedImportPlatform] =
     useState<PlatformConfig | null>(null)
   const [importMenuOpen, setImportMenuOpen] = useState(false)
@@ -104,7 +102,7 @@ function ConnectionsPageChromeInner({ children }: { children: ReactNode }) {
                       onClick={() => {
                         setAddMenuOpen(false)
                         captureConnectionAddClicked(section.service)
-                        setConnectService(section.service)
+                        openConnect(section.service)
                       }}
                     >
                       <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
@@ -288,7 +286,7 @@ function ConnectionsPageChromeInner({ children }: { children: ReactNode }) {
       <ConnectServiceModal
         service={connectService}
         onClose={() => {
-          setConnectService(null)
+          closeConnect()
           refresh()
         }}
       />

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -105,9 +105,8 @@ function formatTradeDate(date: string | null | undefined, locale: string) {
 /**
  * Account rows:
  * - Mobile: account number, then one meta row — last trade (left) · trades (right).
- * - sm+: shared subgrid — account | last trade (left) | trade count (right).
- * Last trade uses a fixed-width date so it anchors the left; trade counts stay
- * right-aligned with tabular-nums for quick comparison.
+ * - sm+: shared subgrid — account | trade count | last trade (same row).
+ * Trade counts stay right-aligned with tabular-nums for quick comparison.
  */
 function AccountTradeList({
   accounts,
@@ -168,13 +167,23 @@ function AccountTradeList({
               {account.number}
             </span>
             <div className="flex min-w-0 items-baseline justify-between gap-3 sm:contents">
-              <span className={cn(metaClassName, 'sm:justify-self-start')}>
+              <span
+                className={cn(
+                  metaClassName,
+                  'order-2 text-right sm:order-1 sm:justify-self-end'
+                )}
+              >
+                {tradeCountLabel}
+              </span>
+              <span
+                className={cn(
+                  metaClassName,
+                  'order-1 sm:order-2 sm:justify-self-end'
+                )}
+              >
                 {lastTrade
                   ? t('connections.lastTrade', { date: lastTrade })
                   : null}
-              </span>
-              <span className={cn(metaClassName, 'text-right sm:justify-self-end')}>
-                {tradeCountLabel}
               </span>
             </div>
           </li>

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -234,14 +234,12 @@ function ConnectionStatusLight({
   syncFailed: boolean
 }) {
   const t = useI18n()
-  const effective: ConnectionStatus = syncFailed ? 'error' : status
+  const isError = syncFailed || status !== 'connected'
   const label = syncFailed
     ? t('connections.status.syncFailed')
-    : effective === 'connected'
-      ? t('connections.status.connected')
-      : effective === 'warning'
-        ? t('connections.status.warning')
-        : t('connections.status.error')
+    : isError
+      ? t('connections.status.error')
+      : t('connections.status.connected')
 
   return (
     <span
@@ -252,9 +250,7 @@ function ConnectionStatusLight({
       <span
         className={cn(
           'h-2 w-2 rounded-full',
-          effective === 'connected' && 'bg-emerald-500',
-          effective === 'warning' && 'bg-amber-500',
-          effective === 'error' && 'bg-red-500'
+          isError ? 'bg-red-500' : 'bg-emerald-500'
         )}
       />
     </span>
@@ -293,11 +289,8 @@ function ConnectionRow({
     connection.service === 'rithmic-protocol' &&
     isRithmicProtocolSyncing(connection.accountId)
   const rowSyncing = protocolSyncing || syncing
-  // Orange = expired token; red = missing/invalid auth (or last sync failed).
-  const needsReconnect =
-    syncFailed ||
-    connection.status === 'warning' ||
-    connection.status === 'error'
+  // Red = expired/missing auth, or the last sync attempt failed.
+  const needsReconnect = syncFailed || connection.status !== 'connected'
 
   const canSchedule = supportsDailySync(connection.service)
   const nextSyncAt = useMemo(
@@ -448,7 +441,12 @@ function ConnectionRow({
       return
     }
 
-    openConnect(connection.service as ConnectionService)
+    openConnect(connection.service as ConnectionService, {
+      service: connection.service as ConnectionService,
+      accountId: connection.accountId,
+      displayName: connection.displayName,
+      environment: connection.environment,
+    })
   }, [connection, openConnect, t, tradovateStore])
 
   const handleDelete = useCallback(async () => {
@@ -514,23 +512,24 @@ function ConnectionRow({
                 {t('connections.reconnect')}
               </button>
             )}
-            {(connection.service === 'tradovate' ||
-              connection.service === 'dxfeed' ||
-              connection.service === 'rithmic-protocol') && (
-              <button
-                type="button"
-                className={iconButtonClassName}
-                aria-label={t('connections.sync.now')}
-                disabled={rowSyncing || needsReconnect}
-                onClick={() => void handleSync()}
-              >
-                {rowSyncing ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <RefreshCw className="h-4 w-4" strokeWidth={1.75} />
-                )}
-              </button>
-            )}
+            {!needsReconnect &&
+              (connection.service === 'tradovate' ||
+                connection.service === 'dxfeed' ||
+                connection.service === 'rithmic-protocol') && (
+                <button
+                  type="button"
+                  className={iconButtonClassName}
+                  aria-label={t('connections.sync.now')}
+                  disabled={rowSyncing}
+                  onClick={() => void handleSync()}
+                >
+                  {rowSyncing ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4" strokeWidth={1.75} />
+                  )}
+                </button>
+              )}
             <button
               type="button"
               className={iconButtonClassName}
@@ -561,51 +560,42 @@ function ConnectionRow({
         </div>
         <p className="mt-1 pl-5 text-sm text-black/55 dark:text-white/55">
           {connection.loginLabel ? (
-            <span className="truncate">{connection.loginLabel}</span>
-          ) : null}
-          {connection.authError ? (
             <>
-              {connection.loginLabel ? ' · ' : null}
-              <span className="text-red-600 dark:text-red-400">
-                {connection.authError}
-              </span>
-            </>
-          ) : (
-            <>
-              {connection.loginLabel ? ' · ' : null}
-              {t('connections.lastSynced', {
-                time: formatRelative(
-                  connection.lastSyncedAt,
-                  t('connections.neverSynced')
-                ),
-              })}
-              {canSchedule && (
-                <>
-                  {' · '}
-                  <button
-                    type="button"
-                    className="underline decoration-black/20 underline-offset-2 transition-colors duration-150 hover:text-black dark:decoration-white/20 dark:hover:text-white"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      openScheduleDialog()
-                    }}
-                  >
-                    {nextSyncAt && nowMs != null
-                      ? t('connections.nextSyncIn', {
-                          time: formatCountdown(nextSyncAt, nowMs),
-                        })
-                      : t('connections.nextSyncSchedule')}
-                  </button>
-                </>
-              )}
+              <span className="truncate">{connection.loginLabel}</span>
               {' · '}
-              {connection.accounts.length === 1
-                ? t('connections.accountCount.one', { count: 1 })
-                : t('connections.accountCount.other', {
-                    count: connection.accounts.length,
-                  })}
+            </>
+          ) : null}
+          {t('connections.lastSynced', {
+            time: formatRelative(
+              connection.lastSyncedAt,
+              t('connections.neverSynced')
+            ),
+          })}
+          {canSchedule && (
+            <>
+              {' · '}
+              <button
+                type="button"
+                className="underline decoration-black/20 underline-offset-2 transition-colors duration-150 hover:text-black dark:decoration-white/20 dark:hover:text-white"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  openScheduleDialog()
+                }}
+              >
+                {nextSyncAt && nowMs != null
+                  ? t('connections.nextSyncIn', {
+                      time: formatCountdown(nextSyncAt, nowMs),
+                    })
+                  : t('connections.nextSyncSchedule')}
+              </button>
             </>
           )}
+          {' · '}
+          {connection.accounts.length === 1
+            ? t('connections.accountCount.one', { count: 1 })
+            : t('connections.accountCount.other', {
+                count: connection.accounts.length,
+              })}
         </p>
       </div>
       <div className="t-acc-panel">

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -96,9 +96,11 @@ function formatTradeDate(date: string | null | undefined, locale: string) {
 }
 
 /**
- * Account rows use a shared parent grid + subgrid so account number, trade
- * count, and last-trade date stay column-aligned across the list — including
- * on narrow mobile where the account id wraps onto its own line.
+ * Account rows:
+ * - Mobile: 3-row stack (account → trade count → last trade), meta right-aligned
+ *   so trade counts can be compared at a glance.
+ * - sm+: shared parent grid + subgrid keeps account / trades / last-trade
+ *   columns aligned across the list; trade counts stay right-aligned.
  */
 function AccountTradeList({
   accounts,
@@ -120,8 +122,8 @@ function AccountTradeList({
   return (
     <ul
       className={cn(
-        'grid grid-cols-[auto_auto] justify-items-start gap-x-3',
-        'sm:grid-cols-[minmax(0,1fr)_auto_auto]',
+        'grid grid-cols-1',
+        'sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:gap-x-4',
         !compact &&
           'border-y border-black/10 dark:border-white/10'
       )}
@@ -132,13 +134,14 @@ function AccountTradeList({
           <li
             key={account.id}
             className={cn(
-              'col-span-full grid grid-cols-subgrid items-baseline gap-y-1 border-t border-black/10 first:border-t-0 dark:border-white/10',
+              'grid grid-cols-1 gap-y-1 border-t border-black/10 first:border-t-0 dark:border-white/10',
+              'sm:col-span-full sm:grid-cols-subgrid sm:items-baseline',
               compact ? 'py-3 text-sm' : 'py-6 md:py-8'
             )}
           >
             <span
               className={cn(
-                'col-span-2 min-w-0 break-all tracking-tight sm:col-span-1 sm:truncate sm:break-normal',
+                'min-w-0 break-all tracking-tight sm:truncate sm:break-normal',
                 compact
                   ? 'font-medium'
                   : 'text-xl font-normal md:text-2xl'
@@ -148,7 +151,7 @@ function AccountTradeList({
             </span>
             <span
               className={cn(
-                'whitespace-nowrap text-black/45 dark:text-white/45 tabular-nums',
+                'whitespace-nowrap text-right text-black/45 dark:text-white/45 tabular-nums',
                 !compact && 'text-sm'
               )}
             >
@@ -160,7 +163,7 @@ function AccountTradeList({
             </span>
             <span
               className={cn(
-                'whitespace-nowrap text-black/45 dark:text-white/45 tabular-nums',
+                'whitespace-nowrap text-right text-black/45 dark:text-white/45 tabular-nums',
                 !compact && 'text-sm'
               )}
             >
@@ -421,7 +424,7 @@ function ConnectionRow({
         role="button"
         tabIndex={0}
         aria-expanded={open}
-        className="t-acc-head flex w-full cursor-pointer items-center justify-between gap-4 py-6 text-left md:py-8"
+        className="t-acc-head w-full cursor-pointer py-6 text-left md:py-8"
         onClick={() => setOpen((v) => !v)}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
@@ -430,7 +433,8 @@ function ConnectionRow({
           }
         }}
       >
-        <div className="min-w-0 flex-1">
+        {/* Title row: status + account number + actions share one alignment line */}
+        <div className="flex min-w-0 items-center justify-between gap-4">
           <div className="flex min-w-0 items-center gap-3">
             <ConnectionStatusLight
               status={connection.status}
@@ -440,101 +444,104 @@ function ConnectionRow({
               {connection.displayName}
             </div>
           </div>
-          <p className="mt-1 pl-5 text-sm text-black/55 dark:text-white/55">
-            {connection.loginLabel ? (
-              <span className="truncate">{connection.loginLabel}</span>
-            ) : null}
-            {connection.authError ? (
-              <>
-                {connection.loginLabel ? ' · ' : null}
-                <span className="text-red-600 dark:text-red-400">
-                  {connection.authError}
-                </span>
-              </>
-            ) : (
-              <>
-                {connection.loginLabel ? ' · ' : null}
-                {t('connections.lastSynced', {
-                  time: formatRelative(
-                    connection.lastSyncedAt,
-                    t('connections.neverSynced')
-                  ),
-                })}
-                {canSchedule && (
-                  <>
-                    {' · '}
-                    <button
-                      type="button"
-                      className="underline decoration-black/20 underline-offset-2 transition-colors duration-150 hover:text-black dark:decoration-white/20 dark:hover:text-white"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        openScheduleDialog()
-                      }}
-                    >
-                      {nextSyncAt && nowMs != null
-                        ? t('connections.nextSyncIn', {
-                            time: formatCountdown(nextSyncAt, nowMs),
-                          })
-                        : t('connections.nextSyncSchedule')}
-                    </button>
-                  </>
+          <div
+            className="flex shrink-0 items-center gap-1"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            {(connection.service === 'tradovate' ||
+              connection.service === 'dxfeed' ||
+              connection.service === 'rithmic-protocol') && (
+              <button
+                type="button"
+                className={iconButtonClassName}
+                aria-label={t('connections.sync.now')}
+                disabled={rowSyncing}
+                onClick={() => void handleSync()}
+              >
+                {rowSyncing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" strokeWidth={1.75} />
                 )}
-                {' · '}
-                {connection.accounts.length === 1
-                  ? t('connections.accountCount.one', { count: 1 })
-                  : t('connections.accountCount.other', {
-                      count: connection.accounts.length,
-                    })}
-              </>
+              </button>
             )}
-          </p>
-        </div>
-        <div
-          className="flex shrink-0 items-center gap-1"
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-        >
-          {(connection.service === 'tradovate' ||
-            connection.service === 'dxfeed' ||
-            connection.service === 'rithmic-protocol') && (
             <button
               type="button"
               className={iconButtonClassName}
-              aria-label={t('connections.sync.now')}
-              disabled={rowSyncing}
-              onClick={() => void handleSync()}
+              aria-label={t('connections.delete')}
+              disabled={deleting}
+              onClick={() => setDeleteOpen(true)}
             >
-              {rowSyncing ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <RefreshCw className="h-4 w-4" strokeWidth={1.75} />
-              )}
+              <Trash2 className="h-4 w-4" strokeWidth={1.75} />
             </button>
-          )}
-          <button
-            type="button"
-            className={iconButtonClassName}
-            aria-label={t('connections.delete')}
-            disabled={deleting}
-            onClick={() => setDeleteOpen(true)}
-          >
-            <Trash2 className="h-4 w-4" strokeWidth={1.75} />
-          </button>
-          <span
-            className={cn(iconButtonClassName, 't-acc-chevron pointer-events-none')}
-            aria-hidden
-          >
-            <svg
-              viewBox="0 0 16 16"
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
+            <span
+              className={cn(
+                iconButtonClassName,
+                't-acc-chevron pointer-events-none'
+              )}
+              aria-hidden
             >
-              <path d="M4 6.5L8 10.5L12 6.5" />
-            </svg>
-          </span>
+              <svg
+                viewBox="0 0 16 16"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <path d="M4 6.5L8 10.5L12 6.5" />
+              </svg>
+            </span>
+          </div>
         </div>
+        <p className="mt-1 pl-5 text-sm text-black/55 dark:text-white/55">
+          {connection.loginLabel ? (
+            <span className="truncate">{connection.loginLabel}</span>
+          ) : null}
+          {connection.authError ? (
+            <>
+              {connection.loginLabel ? ' · ' : null}
+              <span className="text-red-600 dark:text-red-400">
+                {connection.authError}
+              </span>
+            </>
+          ) : (
+            <>
+              {connection.loginLabel ? ' · ' : null}
+              {t('connections.lastSynced', {
+                time: formatRelative(
+                  connection.lastSyncedAt,
+                  t('connections.neverSynced')
+                ),
+              })}
+              {canSchedule && (
+                <>
+                  {' · '}
+                  <button
+                    type="button"
+                    className="underline decoration-black/20 underline-offset-2 transition-colors duration-150 hover:text-black dark:decoration-white/20 dark:hover:text-white"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      openScheduleDialog()
+                    }}
+                  >
+                    {nextSyncAt && nowMs != null
+                      ? t('connections.nextSyncIn', {
+                          time: formatCountdown(nextSyncAt, nowMs),
+                        })
+                      : t('connections.nextSyncSchedule')}
+                  </button>
+                </>
+              )}
+              {' · '}
+              {connection.accounts.length === 1
+                ? t('connections.accountCount.one', { count: 1 })
+                : t('connections.accountCount.other', {
+                    count: connection.accounts.length,
+                  })}
+            </>
+          )}
+        </p>
       </div>
       <div className="t-acc-panel">
         <div className="t-acc-panel-inner pb-6 md:pb-8">

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -41,7 +41,11 @@ import {
   type ConnectionsPageData,
   type ConnectionService,
 } from '../actions'
-import { handleTradovateCallback } from '@/app/[locale]/dashboard/components/import/tradovate/sync/actions'
+import {
+  handleTradovateCallback,
+  initiateTradovateOAuth,
+  type TradovateEnvironment,
+} from '@/app/[locale]/dashboard/components/import/tradovate/sync/actions'
 import { useTradovateSyncStore } from '@/store/tradovate-sync-store'
 import { useTradovateSyncContext } from '@/context/tradovate-sync-context'
 import { useDxFeedSyncContext } from '@/context/dxfeed-sync-context'
@@ -51,6 +55,9 @@ import { toast } from 'sonner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ServiceMonochromeLogo } from '@/components/monochrome-logo'
 import { useConnectionsRefresh } from './connections-refresh'
+
+const reconnectButtonClassName =
+  'inline-flex h-8 items-center justify-center rounded-sm border border-black/20 bg-transparent px-3 text-sm font-medium transition-[opacity,transform,background-color] duration-150 hover:bg-black/5 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:border-white/20 dark:hover:bg-white/5'
 
 const SERVICE_SECTIONS: {
   service: ConnectionService
@@ -268,11 +275,14 @@ function ConnectionRow({
   const [deleting, setDeleting] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [syncFailed, setSyncFailed] = useState(false)
+  const [reconnecting, setReconnecting] = useState(false)
   const [scheduleOpen, setScheduleOpen] = useState(false)
   const [dailySyncTime, setDailySyncTime] = useState('')
   const [savingSchedule, setSavingSchedule] = useState(false)
   // Countdown must not SSR with Date.now() — minute boundaries cause hydration mismatches.
   const [nowMs, setNowMs] = useState<number | null>(null)
+  const { openConnect } = useConnectionsRefresh()
+  const tradovateStore = useTradovateSyncStore()
   const { performSyncForAccount: syncTradovate } = useTradovateSyncContext()
   const { performSyncForAccount: syncDxFeed } = useDxFeedSyncContext()
   const {
@@ -283,6 +293,11 @@ function ConnectionRow({
     connection.service === 'rithmic-protocol' &&
     isRithmicProtocolSyncing(connection.accountId)
   const rowSyncing = protocolSyncing || syncing
+  // Orange = expired token; red = missing/invalid auth (or last sync failed).
+  const needsReconnect =
+    syncFailed ||
+    connection.status === 'warning' ||
+    connection.status === 'error'
 
   const canSchedule = supportsDailySync(connection.service)
   const nextSyncAt = useMemo(
@@ -398,6 +413,44 @@ function ConnectionRow({
     }
   }, [connection, onChanged, syncDxFeed, syncRithmicProtocol, syncTradovate, t])
 
+  const handleReconnect = useCallback(async () => {
+    // Tradovate can re-auth in place via OAuth without opening the add sheet.
+    if (connection.service === 'tradovate') {
+      setReconnecting(true)
+      try {
+        const environment: TradovateEnvironment =
+          connection.environment === 'live' ? 'live' : 'demo'
+        tradovateStore.setEnvironment(environment)
+        const result = await initiateTradovateOAuth(
+          connection.accountId,
+          environment
+        )
+        if (result.error || !result.authUrl || !result.state) {
+          toast.error(t('connections.reconnectFailed'))
+          return
+        }
+        tradovateStore.setOAuthState(result.state)
+        sessionStorage.setItem('tradovate_oauth_state', result.state)
+        sessionStorage.setItem(
+          'tradovate_oauth_pending',
+          JSON.stringify({
+            environment,
+            externalId: connection.accountId,
+          })
+        )
+        window.location.href = result.authUrl
+      } catch (error) {
+        console.error(error)
+        toast.error(t('connections.reconnectFailed'))
+      } finally {
+        setReconnecting(false)
+      }
+      return
+    }
+
+    openConnect(connection.service as ConnectionService)
+  }, [connection, openConnect, t, tradovateStore])
+
   const handleDelete = useCallback(async () => {
     setDeleting(true)
     try {
@@ -448,6 +501,19 @@ function ConnectionRow({
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
           >
+            {needsReconnect && (
+              <button
+                type="button"
+                className={reconnectButtonClassName}
+                disabled={reconnecting}
+                onClick={() => void handleReconnect()}
+              >
+                {reconnecting ? (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                {t('connections.reconnect')}
+              </button>
+            )}
             {(connection.service === 'tradovate' ||
               connection.service === 'dxfeed' ||
               connection.service === 'rithmic-protocol') && (
@@ -455,7 +521,7 @@ function ConnectionRow({
                 type="button"
                 className={iconButtonClassName}
                 aria-label={t('connections.sync.now')}
-                disabled={rowSyncing}
+                disabled={rowSyncing || needsReconnect}
                 onClick={() => void handleSync()}
               >
                 {rowSyncing ? (

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -95,6 +95,86 @@ function formatTradeDate(date: string | null | undefined, locale: string) {
   }).format(d)
 }
 
+/**
+ * Account rows use a shared parent grid + subgrid so account number, trade
+ * count, and last-trade date stay column-aligned across the list — including
+ * on narrow mobile where the account id wraps onto its own line.
+ */
+function AccountTradeList({
+  accounts,
+  locale,
+  density = 'compact',
+}: {
+  accounts: Array<{
+    id: string
+    number: string
+    tradeCount: number
+    lastTradeDate: string | null
+  }>
+  locale: string
+  density?: 'compact' | 'standalone'
+}) {
+  const t = useI18n()
+  const compact = density === 'compact'
+
+  return (
+    <ul
+      className={cn(
+        'grid grid-cols-[auto_auto] justify-items-start gap-x-3',
+        'sm:grid-cols-[minmax(0,1fr)_auto_auto]',
+        !compact &&
+          'border-y border-black/10 dark:border-white/10'
+      )}
+    >
+      {accounts.map((account) => {
+        const lastTrade = formatTradeDate(account.lastTradeDate, locale)
+        return (
+          <li
+            key={account.id}
+            className={cn(
+              'col-span-full grid grid-cols-subgrid items-baseline gap-y-1 border-t border-black/10 first:border-t-0 dark:border-white/10',
+              compact ? 'py-3 text-sm' : 'py-6 md:py-8'
+            )}
+          >
+            <span
+              className={cn(
+                'col-span-2 min-w-0 break-all tracking-tight sm:col-span-1 sm:truncate sm:break-normal',
+                compact
+                  ? 'font-medium'
+                  : 'text-xl font-normal md:text-2xl'
+              )}
+            >
+              {account.number}
+            </span>
+            <span
+              className={cn(
+                'whitespace-nowrap text-black/45 dark:text-white/45 tabular-nums',
+                !compact && 'text-sm'
+              )}
+            >
+              {account.tradeCount === 1
+                ? t('connections.tradeCount.one', { count: 1 })
+                : t('connections.tradeCount.other', {
+                    count: account.tradeCount,
+                  })}
+            </span>
+            <span
+              className={cn(
+                'whitespace-nowrap text-black/45 dark:text-white/45 tabular-nums',
+                !compact && 'text-sm'
+              )}
+            >
+              {lastTrade
+                ? t('connections.lastTrade', { date: lastTrade })
+                : null}
+            </span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
 function supportsDailySync(service: string) {
   return service === 'tradovate' || service === 'dxfeed'
 }
@@ -463,29 +543,11 @@ function ConnectionRow({
               {t('connections.noHostedAccounts')}
             </p>
           ) : (
-            <ul className="divide-y divide-black/10 dark:divide-white/10">
-              {connection.accounts.map((account) => (
-                <li
-                  key={account.id}
-                  className="flex items-center justify-between gap-4 py-3 text-sm"
-                >
-                  <span className="font-medium tracking-tight">{account.number}</span>
-                  <span className="text-black/45 dark:text-white/45 tabular-nums">
-                    {account.tradeCount === 1
-                      ? t('connections.tradeCount.one', { count: 1 })
-                      : t('connections.tradeCount.other', {
-                          count: account.tradeCount,
-                        })}
-                    {(() => {
-                      const lastTrade = formatTradeDate(account.lastTradeDate, locale)
-                      return lastTrade
-                        ? ` · ${t('connections.lastTrade', { date: lastTrade })}`
-                        : ''
-                    })()}
-                  </span>
-                </li>
-              ))}
-            </ul>
+            <AccountTradeList
+              accounts={connection.accounts}
+              locale={locale}
+              density="compact"
+            />
           )}
         </div>
       </div>
@@ -1206,31 +1268,11 @@ export function ConnectionsPageClient({
               {t('connections.standaloneHint')}
             </p>
           </div>
-          <ul className="divide-y divide-black/10 border-y border-black/10 dark:divide-white/10 dark:border-white/10">
-            {data!.standaloneAccounts.map((account) => (
-              <li
-                key={account.id}
-                className="flex items-center justify-between gap-4 py-6 md:py-8"
-              >
-                <div className="text-xl font-normal tracking-tight md:text-2xl">
-                  {account.number}
-                </div>
-                <span className="text-sm text-black/45 dark:text-white/45 tabular-nums">
-                  {account.tradeCount === 1
-                    ? t('connections.tradeCount.one', { count: 1 })
-                    : t('connections.tradeCount.other', {
-                        count: account.tradeCount,
-                      })}
-                  {(() => {
-                    const lastTrade = formatTradeDate(account.lastTradeDate, locale)
-                    return lastTrade
-                      ? ` · ${t('connections.lastTrade', { date: lastTrade })}`
-                      : ''
-                  })()}
-                </span>
-              </li>
-            ))}
-          </ul>
+          <AccountTradeList
+            accounts={data!.standaloneAccounts}
+            locale={locale}
+            density="standalone"
+          />
         </section>
       )}
     </div>

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -97,10 +97,10 @@ function formatTradeDate(date: string | null | undefined, locale: string) {
 
 /**
  * Account rows:
- * - Mobile: 3-row stack (account → trade count → last trade), meta right-aligned
- *   so trade counts can be compared at a glance.
- * - sm+: shared parent grid + subgrid keeps account / trades / last-trade
- *   columns aligned across the list; trade counts stay right-aligned.
+ * - Mobile: account number, then one meta row — last trade (left) · trades (right).
+ * - sm+: shared subgrid — account | last trade (left) | trade count (right).
+ * Last trade uses a fixed-width date so it anchors the left; trade counts stay
+ * right-aligned with tabular-nums for quick comparison.
  */
 function AccountTradeList({
   accounts,
@@ -118,6 +118,10 @@ function AccountTradeList({
 }) {
   const t = useI18n()
   const compact = density === 'compact'
+  const metaClassName = cn(
+    'whitespace-nowrap text-black/45 dark:text-white/45 tabular-nums',
+    !compact && 'text-sm'
+  )
 
   return (
     <ul
@@ -130,6 +134,13 @@ function AccountTradeList({
     >
       {accounts.map((account) => {
         const lastTrade = formatTradeDate(account.lastTradeDate, locale)
+        const tradeCountLabel =
+          account.tradeCount === 1
+            ? t('connections.tradeCount.one', { count: 1 })
+            : t('connections.tradeCount.other', {
+                count: account.tradeCount,
+              })
+
         return (
           <li
             key={account.id}
@@ -149,28 +160,16 @@ function AccountTradeList({
             >
               {account.number}
             </span>
-            <span
-              className={cn(
-                'whitespace-nowrap text-right text-black/45 dark:text-white/45 tabular-nums',
-                !compact && 'text-sm'
-              )}
-            >
-              {account.tradeCount === 1
-                ? t('connections.tradeCount.one', { count: 1 })
-                : t('connections.tradeCount.other', {
-                    count: account.tradeCount,
-                  })}
-            </span>
-            <span
-              className={cn(
-                'whitespace-nowrap text-right text-black/45 dark:text-white/45 tabular-nums',
-                !compact && 'text-sm'
-              )}
-            >
-              {lastTrade
-                ? t('connections.lastTrade', { date: lastTrade })
-                : null}
-            </span>
+            <div className="flex min-w-0 items-baseline justify-between gap-3 sm:contents">
+              <span className={cn(metaClassName, 'sm:justify-self-start')}>
+                {lastTrade
+                  ? t('connections.lastTrade', { date: lastTrade })
+                  : null}
+              </span>
+              <span className={cn(metaClassName, 'text-right sm:justify-self-end')}>
+                {tradeCountLabel}
+              </span>
+            </div>
           </li>
         )
       })}
@@ -795,12 +794,8 @@ function readOAuthPendingFromSession(
 function PendingTradovateConnectionRow({ title }: { title?: string }) {
   const t = useI18n()
   return (
-    <div
-      className="flex w-full items-center justify-between gap-4 py-6 md:py-8"
-      aria-busy="true"
-      aria-live="polite"
-    >
-      <div className="min-w-0 flex-1">
+    <div className="w-full py-6 md:py-8" aria-busy="true" aria-live="polite">
+      <div className="flex min-w-0 items-center justify-between gap-4">
         <div className="flex min-w-0 items-center gap-3">
           <span className="inline-flex shrink-0 items-center" aria-hidden>
             <span className="h-2 w-2 motion-safe:animate-pulse rounded-full bg-amber-500" />
@@ -809,15 +804,15 @@ function PendingTradovateConnectionRow({ title }: { title?: string }) {
             {title || t('connections.oauth.tradovate.connecting')}
           </div>
         </div>
-        <p className="mt-1 pl-5 text-sm text-black/55 dark:text-white/55">
-          {t('connections.oauth.tradovate.connectingHint')}
-        </p>
-        <div className="mt-3 space-y-2 pl-5">
-          <Skeleton className="h-3 w-48 rounded-sm bg-black/10 dark:bg-white/10" />
-          <Skeleton className="h-3 w-32 rounded-sm bg-black/10 dark:bg-white/10" />
-        </div>
+        <Loader2 className="h-5 w-5 shrink-0 animate-spin text-black/35 dark:text-white/35" />
       </div>
-      <Loader2 className="h-5 w-5 shrink-0 animate-spin text-black/35 dark:text-white/35" />
+      <p className="mt-1 pl-5 text-sm text-black/55 dark:text-white/55">
+        {t('connections.oauth.tradovate.connectingHint')}
+      </p>
+      <div className="mt-3 space-y-2 pl-5">
+        <Skeleton className="h-3 w-48 rounded-sm bg-black/10 dark:bg-white/10" />
+        <Skeleton className="h-3 w-32 rounded-sm bg-black/10 dark:bg-white/10" />
+      </div>
     </div>
   )
 }

--- a/app/[locale]/dashboard/connections/components/connections-refresh.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-refresh.tsx
@@ -5,14 +5,20 @@ import {
   useCallback,
   useContext,
   useRef,
+  useState,
   type ReactNode,
 } from 'react'
+import type { ConnectionService } from '../actions'
 
 type RefreshFn = () => void
 
 type ConnectionsRefreshContextValue = {
   refresh: () => void
   register: (fn: RefreshFn) => () => void
+  /** Open the connect/reconnect sheet for a service (from chrome or a row). */
+  connectService: ConnectionService | null
+  openConnect: (service: ConnectionService) => void
+  closeConnect: () => void
 }
 
 const ConnectionsRefreshContext =
@@ -20,7 +26,8 @@ const ConnectionsRefreshContext =
 
 /**
  * Lets the instant page chrome (header actions / import) ask the streamed
- * list to reload without remounting the Suspense boundary.
+ * list to reload without remounting the Suspense boundary, and lets rows
+ * open the shared ConnectServiceModal for reconnect.
  */
 export function ConnectionsRefreshProvider({
   children,
@@ -28,6 +35,8 @@ export function ConnectionsRefreshProvider({
   children: ReactNode
 }) {
   const fnRef = useRef<RefreshFn | null>(null)
+  const [connectService, setConnectService] =
+    useState<ConnectionService | null>(null)
 
   const register = useCallback((fn: RefreshFn) => {
     fnRef.current = fn
@@ -40,8 +49,24 @@ export function ConnectionsRefreshProvider({
     fnRef.current?.()
   }, [])
 
+  const openConnect = useCallback((service: ConnectionService) => {
+    setConnectService(service)
+  }, [])
+
+  const closeConnect = useCallback(() => {
+    setConnectService(null)
+  }, [])
+
   return (
-    <ConnectionsRefreshContext.Provider value={{ refresh, register }}>
+    <ConnectionsRefreshContext.Provider
+      value={{
+        refresh,
+        register,
+        connectService,
+        openConnect,
+        closeConnect,
+      }}
+    >
       {children}
     </ConnectionsRefreshContext.Provider>
   )

--- a/app/[locale]/dashboard/connections/components/connections-refresh.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-refresh.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from 'react'
 import type { ConnectionService } from '../actions'
+import type { ConnectPrefill } from './connect-prefill'
 
 type RefreshFn = () => void
 
@@ -17,7 +18,9 @@ type ConnectionsRefreshContextValue = {
   register: (fn: RefreshFn) => () => void
   /** Open the connect/reconnect sheet for a service (from chrome or a row). */
   connectService: ConnectionService | null
-  openConnect: (service: ConnectionService) => void
+  /** Prefill for reconnect; null when adding a new connection. */
+  connectPrefill: ConnectPrefill | null
+  openConnect: (service: ConnectionService, prefill?: ConnectPrefill) => void
   closeConnect: () => void
 }
 
@@ -37,6 +40,9 @@ export function ConnectionsRefreshProvider({
   const fnRef = useRef<RefreshFn | null>(null)
   const [connectService, setConnectService] =
     useState<ConnectionService | null>(null)
+  const [connectPrefill, setConnectPrefill] = useState<ConnectPrefill | null>(
+    null
+  )
 
   const register = useCallback((fn: RefreshFn) => {
     fnRef.current = fn
@@ -49,12 +55,17 @@ export function ConnectionsRefreshProvider({
     fnRef.current?.()
   }, [])
 
-  const openConnect = useCallback((service: ConnectionService) => {
-    setConnectService(service)
-  }, [])
+  const openConnect = useCallback(
+    (service: ConnectionService, prefill?: ConnectPrefill) => {
+      setConnectService(service)
+      setConnectPrefill(prefill ?? null)
+    },
+    []
+  )
 
   const closeConnect = useCallback(() => {
     setConnectService(null)
+    setConnectPrefill(null)
   }, [])
 
   return (
@@ -63,6 +74,7 @@ export function ConnectionsRefreshProvider({
         refresh,
         register,
         connectService,
+        connectPrefill,
         openConnect,
         closeConnect,
       }}

--- a/app/[locale]/dashboard/connections/data.ts
+++ b/app/[locale]/dashboard/connections/data.ts
@@ -47,15 +47,15 @@ function deriveConnectionStatus(
     return 'connected'
   }
 
-  if (!connection.token || parseConnectionAuthError(connection.token)) {
-    return 'error'
-  }
-
+  // Missing token, stored auth error, or expired token all mean reconnect.
+  // A single red state is clearer than orange (expired) vs red (error).
   if (
-    connection.tokenExpiresAt &&
-    connection.tokenExpiresAt.getTime() <= Date.now()
+    !connection.token ||
+    parseConnectionAuthError(connection.token) ||
+    (connection.tokenExpiresAt &&
+      connection.tokenExpiresAt.getTime() <= Date.now())
   ) {
-    return 'warning'
+    return 'error'
   }
 
   return 'connected'

--- a/app/[locale]/dashboard/connections/types.ts
+++ b/app/[locale]/dashboard/connections/types.ts
@@ -8,7 +8,7 @@ export type ConnectionService =
   | 'thor'
   | 'etp'
 
-export type ConnectionStatus = 'connected' | 'warning' | 'error'
+export type ConnectionStatus = 'connected' | 'error'
 
 export type ConnectionsPageAccount = {
   id: string

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -175,6 +175,8 @@ export default {
   "connections.status.warning": "Needs reconnect",
   "connections.status.error": "Disconnected",
   "connections.status.syncFailed": "Last sync failed",
+  "connections.reconnect": "Reconnect",
+  "connections.reconnectFailed": "Could not start reconnect",
   "connections.delete": "Delete connection",
   "connections.deleteConfirmTitle": "Delete this connection?",
   "connections.deleteConfirmDescription":

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -172,7 +172,6 @@ export default {
   "connections.sync.failed": "Sync failed",
   "connections.sync.manualOnly": "Sync this connection from its settings.",
   "connections.status.connected": "Connected",
-  "connections.status.warning": "Needs reconnect",
   "connections.status.error": "Disconnected",
   "connections.status.syncFailed": "Last sync failed",
   "connections.reconnect": "Reconnect",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -176,6 +176,8 @@ export default {
   "connections.status.warning": "Reconnecter",
   "connections.status.error": "Déconnecté",
   "connections.status.syncFailed": "Échec de la dernière sync",
+  "connections.reconnect": "Reconnecter",
+  "connections.reconnectFailed": "Impossible de démarrer la reconnexion",
   "connections.delete": "Supprimer la connexion",
   "connections.deleteConfirmTitle": "Supprimer cette connexion ?",
   "connections.deleteConfirmDescription":

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -173,7 +173,6 @@ export default {
   "connections.sync.failed": "Échec de la synchronisation",
   "connections.sync.manualOnly": "Synchronisez cette connexion depuis ses paramètres.",
   "connections.status.connected": "Connecté",
-  "connections.status.warning": "Reconnecter",
   "connections.status.error": "Déconnecté",
   "connections.status.syncFailed": "Échec de la dernière sync",
   "connections.reconnect": "Reconnecter",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Account rows use a grid: account number, then one meta row on mobile (**last trade left · trade count right**).
- **Desktop (sm+):** same row reads **trade count → last trade** (subgrid).
- Connection actions align with the connection name.
- Status is green or red only; when red, show Reconnect, hide sync, keep last-synced meta.
- Reconnect prefills non-secret fields (DxFeed: prop firm + email; Rithmic: username; Tradovate: OAuth).

## Screenshots

**Desktop — trades before last trade:**

![Desktop trades before last trade](https://cursor.com/artifacts/c/art-f460d16b-e69c-4c01-91e0-45dc4efcd49a)

**Mobile meta row:**

![Mobile meta row](https://cursor.com/artifacts/c/art-bde45ecd-9ada-40a7-a502-694d7ba41d34)

**DxFeed reconnect prefill:**

![DxFeed reconnect prefill](https://cursor.com/artifacts/c/art-09349d87-2e0d-40da-8fe6-6f3bee8a4851)

## Test plan
- [x] Desktop: trade count column appears before last trade on the same row
- [x] Mobile: last trade left, trade count right unchanged
- [x] Red connections: Reconnect shown, sync hidden
- [x] `bun run typecheck` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9de5-f900-7338-bc4e-0620664f748e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9de5-f900-7338-bc4e-0620664f748e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

