### PR TITLE
docs: refocus README as a product hub and fix drifted setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
   <h3>Open-source trading journal and analytics for futures and prop-firm traders</h3>
 
   [![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc/4.0/)
-  [![Next.js](https://img.shields.io/badge/Next.js-15-black)](https://nextjs.org/)
+  [![Next.js](https://img.shields.io/badge/Next.js-16-black)](https://nextjs.org/)
+  [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev/)
+  [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue)](https://www.typescriptlang.org/)
   [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/a5YVF5Ec2n)
 
   <a href="https://trustmrr.com/startup/deltalytix" target="_blank"><img src="https://trustmrr.com/api/embed/deltalytix?format=svg" alt="TrustMRR verified revenue badge" width="220" height="90" /></a>
@@ -26,15 +28,37 @@ Use it hosted at [deltalytix.app](https://deltalytix.app), or run the whole thin
 
 ## What it does
 
-**Get your trades in.** Direct sync for Rithmic, Tradovate, Thor, and DXfeed. File and statement import for Interactive Brokers PDFs, ATAS, FTMO, TradeZella, Quantower, Topstep, and NinjaTrader. Manual entry with commissions inferred from your history. For anything not on that list, AI field mapping reads an arbitrary CSV and works out the columns.
+### Get your trades in
 
-**See what happened.** Drag-and-drop dashboard of PnL, decile statistics, and per-account breakdowns, filterable by instrument, weekday, and date range. Calendar view with daily statistics and trade-by-trade review.
+Direct sync for Rithmic, Tradovate, Thor, and DXfeed. File and statement import for Interactive Brokers PDFs, ATAS, FTMO, TradeZella, Quantower, Topstep, and NinjaTrader. Manual entry with commissions inferred from your history. For anything not on that list, AI field mapping reads an arbitrary CSV and works out the columns.
 
-**Write it down.** A rich journal editor with tables, resizable images, and session tags, plus AI-assisted entries that focus on the mistakes and the things that went right.
+<div align="center">
+  <img src="public/updates/pr-249/en/import-from-mobile.png" alt="Import dialog listing direct account sync options for Rithmic, Thor, Tradovate and DxFeed, plus AI-mapped CSV import" width="320" />
+</div>
 
-**Trade together.** Team accounts with combined performance across every trader, and a prop-firm catalogue with aggregated payout and pass-rate statistics.
+### See what happened
 
-Available in English and French.
+A drag-and-drop dashboard of PnL, win rate, trade distribution, average time in position, and per-account breakdowns — filterable by instrument, weekday, and date range. Calendar view with daily statistics, and a trade table you can sort, group, and bulk-edit.
+
+<div align="center">
+  <img src="public/updates/pr-288/en/responsive-calendar-analytics-charts.png" alt="Dashboard widgets showing daily PnL charts, trading statistics, average PnL by hour, and a monthly calendar" width="700" />
+  <br /><br />
+  <img src="public/updates/pr-249/en/trade-table-mobile-and-show-all.png" alt="Trade review table listing entry and exit prices, direction, position time and instrument per trade" width="700" />
+</div>
+
+### Write it down
+
+A rich journal editor with tables, resizable images, and session tags, plus an AI coach that reads your entries alongside your fills and names the patterns costing you money.
+
+<div align="center">
+  <img src="public/updates/pr-316/en/landing-ai-coach-demo.png" alt="AI coach chat identifying a revenge-trading pattern with a 73% loss rate after consecutive losses" width="700" />
+</div>
+
+### Trade together
+
+Team accounts with combined performance across every trader, and a prop-firm catalogue with aggregated payout and pass-rate statistics.
+
+Available in English and French. More screenshots accompany each release in the [release notes](https://deltalytix.app/updates).
 
 ## Run it yourself
 
@@ -61,7 +85,9 @@ Then open <http://localhost:3000/dashboard>. The quickstart starts Postgres, wri
 
 ## Built with
 
-Next.js 15 (App Router) and React 19 on TypeScript, Tailwind, and Radix UI. Postgres through Prisma, with Supabase for auth and storage. Zustand for client state, Server Actions for mutations. Stripe for billing, OpenAI for the AI features, Bun as the package manager.
+Next.js 16 (App Router, currently tracking the `16.3.0-preview` channel) and React 19.2 on TypeScript 5.9, Tailwind CSS 4, and Radix UI. Postgres through Prisma 7, with Supabase for auth and storage. Zustand for client state, Server Actions for mutations. Stripe for billing, OpenAI for the AI features, Bun as the package manager.
+
+Because Next.js 16 is a preview release, its APIs and conventions differ from Next.js 15 in ways that may not match what you (or an AI assistant) expect — check `node_modules/next/dist/docs/` before reaching for a familiar pattern.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -28,37 +28,15 @@ Use it hosted at [deltalytix.app](https://deltalytix.app), or run the whole thin
 
 ## What it does
 
-### Get your trades in
+**Get your trades in.** Direct sync for Rithmic, Tradovate, Thor, and DXfeed. File and statement import for Interactive Brokers PDFs, ATAS, FTMO, TradeZella, Quantower, Topstep, and NinjaTrader. Manual entry with commissions inferred from your history. For anything not on that list, AI field mapping reads an arbitrary CSV and works out the columns.
 
-Direct sync for Rithmic, Tradovate, Thor, and DXfeed. File and statement import for Interactive Brokers PDFs, ATAS, FTMO, TradeZella, Quantower, Topstep, and NinjaTrader. Manual entry with commissions inferred from your history. For anything not on that list, AI field mapping reads an arbitrary CSV and works out the columns.
+**See what happened.** A drag-and-drop dashboard of PnL, win rate, trade distribution, average time in position, and per-account breakdowns — filterable by instrument, weekday, and date range. Calendar view with daily statistics, and a trade table you can sort, group, and bulk-edit.
 
-<div align="center">
-  <img src="public/updates/pr-249/en/import-from-mobile.png" alt="Import dialog listing direct account sync options for Rithmic, Thor, Tradovate and DxFeed, plus AI-mapped CSV import" width="320" />
-</div>
+**Write it down.** A rich journal editor with tables, resizable images, and session tags, plus an AI coach that reads your entries alongside your fills and names the patterns costing you money.
 
-### See what happened
+**Trade together.** Team accounts with combined performance across every trader, and a prop-firm catalogue with aggregated payout and pass-rate statistics.
 
-A drag-and-drop dashboard of PnL, win rate, trade distribution, average time in position, and per-account breakdowns — filterable by instrument, weekday, and date range. Calendar view with daily statistics, and a trade table you can sort, group, and bulk-edit.
-
-<div align="center">
-  <img src="public/updates/pr-288/en/responsive-calendar-analytics-charts.png" alt="Dashboard widgets showing daily PnL charts, trading statistics, average PnL by hour, and a monthly calendar" width="700" />
-  <br /><br />
-  <img src="public/updates/pr-249/en/trade-table-mobile-and-show-all.png" alt="Trade review table listing entry and exit prices, direction, position time and instrument per trade" width="700" />
-</div>
-
-### Write it down
-
-A rich journal editor with tables, resizable images, and session tags, plus an AI coach that reads your entries alongside your fills and names the patterns costing you money.
-
-<div align="center">
-  <img src="public/updates/pr-316/en/landing-ai-coach-demo.png" alt="AI coach chat identifying a revenge-trading pattern with a 73% loss rate after consecutive losses" width="700" />
-</div>
-
-### Trade together
-
-Team accounts with combined performance across every trader, and a prop-firm catalogue with aggregated payout and pass-rate statistics.
-
-Available in English and French. More screenshots accompany each release in the [release notes](https://deltalytix.app/updates).
+Available in English and French.
 
 ## Run it yourself
 

--- a/README.md
+++ b/README.md
@@ -2,465 +2,101 @@
 
 <div align="center">
   <img src="public/apple-icon.png" alt="Deltalytix Logo" width="120" height="120">
-  
-  <h3>Open-source trading analytics platform for professional traders</h3>
-  
+
+  <h3>Open-source trading journal and analytics for futures and prop-firm traders</h3>
+
   [![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc/4.0/)
   [![Next.js](https://img.shields.io/badge/Next.js-15-black)](https://nextjs.org/)
-  [![React](https://img.shields.io/badge/React-19-blue)](https://reactjs.org/)
-  [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue)](https://www.typescriptlang.org/)
   [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/a5YVF5Ec2n)
-  
+
   <a href="https://trustmrr.com/startup/deltalytix" target="_blank"><img src="https://trustmrr.com/api/embed/deltalytix?format=svg" alt="TrustMRR verified revenue badge" width="220" height="90" /></a>
-  
-  [🚀 Live Demo](https://deltalytix.app) • [💬 Discord Community](https://discord.gg/a5YVF5Ec2n) • [🐛 Report Bug](https://github.com/hugodemenez/deltalytix/issues)
+
+  [🚀 Live app](https://deltalytix.app) • [💬 Discord](https://discord.gg/a5YVF5Ec2n) • [🐛 Report a bug](https://github.com/hugodemenez/deltalytix/issues)
 </div>
 
 ---
 
-## Self-hosting
+Deltalytix pulls your fills out of your broker, turns them into a performance record you can actually read, and helps you work out which of your habits are making money and which are costing it. It is built for traders juggling several funded and live accounts, where the hard part is not placing the trade but keeping an honest account of what happened afterwards.
 
-For AI agents and local bootstrap, start with [`AGENTS.md`](./AGENTS.md).
+Use it hosted at [deltalytix.app](https://deltalytix.app), or run the whole thing yourself.
 
-For the full runbook, read [`SELF_HOSTING.md`](./SELF_HOSTING.md).
-
-It includes:
-- dashboard-only local auth bypass mode
-- deterministic demo data seeding for default layout charts
-- copy/paste health checks and deploy checklist
-
----
-
-## ✨ Key Features
-
-  <div align="center">
-  <img src="public/dashboard-overview.gif" alt="Dashboard overview GIF" width="650" style="margin-bottom: 1.5rem;" />
+<div align="center">
+  <img src="public/dashboard-overview.gif" alt="Deltalytix dashboard overview" width="650" />
 </div>
 
-### 📊 Advanced Trading Analytics
+## What it does
 
-- **Real-time PnL tracking** with customizable performance metrics
-- **Interactive dashboards** with drag-and-drop widget layouts
-- **Comprehensive trade analysis** with decile statistics and pattern recognition
-- **Customizable chart views** supporting multiple timeframes and indicators
+**Get your trades in.** Direct sync for Rithmic, Tradovate, Thor, and DXfeed. File and statement import for Interactive Brokers PDFs, ATAS, FTMO, TradeZella, Quantower, Topstep, and NinjaTrader. Manual entry with commissions inferred from your history. For anything not on that list, AI field mapping reads an arbitrary CSV and works out the columns.
 
-<!-- TODO: Add GIF showing dashboard overview with customizable widgets -->
+**See what happened.** Drag-and-drop dashboard of PnL, decile statistics, and per-account breakdowns, filterable by instrument, weekday, and date range. Calendar view with daily statistics and trade-by-trade review.
 
-### 🔗 Multi-Broker Integration
+**Write it down.** A rich journal editor with tables, resizable images, and session tags, plus AI-assisted entries that focus on the mistakes and the things that went right.
 
-- **Tradovate sync** for real-time trade data synchronization
-- **Rithmic sync** via proprietary service integration
-- **Built-in integrations** for FTMO, ProjectX, ATAS, and Interactive Brokers (IBKR)
-- **AI-powered file parsing** for any broker format when specific integration doesn't exist yet
+**Trade together.** Team accounts with combined performance across every trader, and a prop-firm catalogue with aggregated payout and pass-rate statistics.
 
-<!-- TODO: Add GIF showing CSV import flow with AI field mapping -->
+Available in English and French.
 
-### 🤖 AI-Powered Insights
+## Run it yourself
 
-- **Intelligent field mapping** for seamless data imports
-- **Sentiment analysis** of trading patterns and market conditions
-- **Automated trade journal** with AI-generated insights
-- **Pattern recognition** for identifying trading opportunities
-- **Rich text editor** with image resizing and table support for structured journaling
-
-<!-- TODO: Add GIF showing AI chat assistant helping with trade analysis -->
-
-### 🌍 Internationalization
-
-- **Full i18n support** with English and French translations
-- **Extensible translation system** using next-international
-- **Locale-aware formatting** for dates, numbers, and currencies
-- **RTL language support** ready for future expansion
-
-### ⚡ Modern Technology Stack
-
-- **Next.js 15** with App Router for optimal performance
-- **React 19** with latest concurrent features
-- **TypeScript** for type-safe development
-- **Prisma ORM** for database operations
-- **Supabase** for authentication and real-time features
-
-<!-- TODO: Add GIF showing dark/light theme switching and mobile responsive design -->
-
----
-
-## 🛠️ Tech Stack & Architecture
-
-### Frontend
-
-- **Framework**: Next.js 15 (App Router)
-- **UI Library**: React 19 with TypeScript
-- **Styling**: Tailwind CSS with custom design system
-- **Animations**: Framer Motion with performance optimizations
-- **State Management**: Zustand stores + React Context
-- **Internationalization**: next-international
-
-### Backend
-
-- **API**: Next.js API Routes + Server Actions
-- **Database**: PostgreSQL via Supabase
-- **ORM**: Prisma with type-safe queries
-- **Authentication**: Supabase Auth (Discord OAuth, Email)
-- **Real-time**: WebSocket connections for live data
-
-### External Services
-
-- **Payments**: Stripe integration with webhooks
-- **AI/ML**: OpenAI API for analysis and field mapping
-- **Storage**: Supabase Storage for file uploads
-- **Broker Syncs**: Tradovate API, Rithmic proprietary service
-- **Platform Integrations**: FTMO, ProjectX, ATAS, Interactive Brokers (IBKR)
-- **Deployment**: Vercel-optimized with edge functions
-
-### Development Tools
-
-- **Package Manager**: Bun (recommended) or npm
-- **Linting**: ESLint with Next.js config
-- **Type Checking**: TypeScript strict mode
-- **Database Migrations**: Prisma migrations
-
----
-
-## 📋 Prerequisites
-
-Before you begin, ensure you have the following:
-
-### Required Software
-
-- **Node.js 20+** or **Bun** (latest version recommended)
-- **Git** for version control
-- **PostgreSQL** database (or use Supabase free tier)
-
-### Required Accounts
-
-- **Supabase account** ([free tier available](https://supabase.com))
-- **Stripe account** (for payment processing)
-- **OpenAI API key** (for AI features)
-- **Discord application** (for OAuth authentication)
-
----
-
-## 🚀 Installation & Setup
-
-### Step 1: Clone and Install
+Requires [Bun](https://bun.sh) and Docker.
 
 ```bash
-git clone https://github.com/hugodemenez/deltalytix.git
-cd deltalytix
-npm install  # or bun install
+bash scripts/self-host-quickstart.sh
+bash scripts/dev.sh
 ```
 
-### Step 2: Environment Variables
+Then open <http://localhost:3000/dashboard>. The quickstart starts Postgres, writes a `.env.local` with local auth bypass enabled, and seeds a demo account so the dashboard has something to draw.
 
-Create a `.env.local` file in the root directory with the following variables:
+**[→ Full self-hosting runbook](./SELF_HOSTING.md)** — manual bootstrap, Docker deployment, health checks, and production notes. Copy [`.env.example`](./.env.example) for the complete list of environment variables; only `DATABASE_URL` and `DIRECT_URL` are needed for local dashboard work.
 
-```env
-# Supabase Configuration
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+## Documentation
 
-# Database
-DATABASE_URL=your_postgresql_connection_string
+| | |
+|---|---|
+| [`SELF_HOSTING.md`](./SELF_HOSTING.md) | Deployment, configuration, and health checks |
+| [`AGENTS.md`](./AGENTS.md) | Build commands, conventions, and PR checklist — for contributors and AI agents alike |
+| [`SECURITY.md`](./SECURITY.md) | Reporting a vulnerability |
+| [`agents/skills/`](./agents/skills/) | Shared skill library for AI coding agents |
+| [deltalytix.app/updates](https://deltalytix.app/updates) | Release notes |
 
-# OpenAI
-OPENAI_API_KEY=your_openai_api_key
+## Built with
 
-# Stripe
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key
-STRIPE_SECRET_KEY=your_stripe_secret_key
-STRIPE_WEBHOOK_SECRET=your_stripe_webhook_secret
+Next.js 15 (App Router) and React 19 on TypeScript, Tailwind, and Radix UI. Postgres through Prisma, with Supabase for auth and storage. Zustand for client state, Server Actions for mutations. Stripe for billing, OpenAI for the AI features, Bun as the package manager.
 
-# Discord OAuth
-DISCORD_CLIENT_ID=your_discord_client_id
-DISCORD_CLIENT_SECRET=your_discord_client_secret
+## Roadmap
 
-# Application
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-```
+**In development**
 
-### Step 3: Database Setup
+- [ ] **Mobile optimisation** — fully responsive design with mobile-specific behaviour
+- [ ] **On-premise deployment** — Dockerised self-hosting with a bundled Postgres container
+
+**Next (Q2–Q3 2026)**
+
+- [ ] **Deeper journaling** — session-based analysis with automated insight on recurring patterns
+- [ ] **Market data** — Databento integration for real-time market context alongside your fills
+
+Shipped work lives in the [release notes](https://deltalytix.app/updates). Longer-term ideas are tracked in [GitHub issues](https://github.com/hugodemenez/deltalytix/issues).
+
+## Contributing
+
+Contributions are welcome. Open pull requests against **`beta`**, not `main` — `main` is production and feature work lands on `beta` first.
 
 ```bash
-# Generate Prisma client
-npx prisma generate
-
-# Push schema to database (for development)
-npx prisma db push
-
-# Or run migrations (for production)
-npx prisma migrate dev
-
-# Seed the database (optional)
-npx prisma db seed
+bun install
+bunx prisma generate
+bun run typecheck && bun run lint
+OPENAI_API_KEY=dummy bun run build
 ```
 
-### Step 4: Run Development Server
+Read [`AGENTS.md`](./AGENTS.md) before your first PR: it covers the local environment, the definition of done, and the pre-PR checklist. Keep user-facing strings in [`locales/`](./locales/) and include both English and French.
 
-```bash
-npm run dev
-# or
-bun dev
-```
+Bug reports and feature ideas belong in [GitHub issues](https://github.com/hugodemenez/deltalytix/issues); questions are best asked on [Discord](https://discord.gg/a5YVF5Ec2n).
 
-Open [http://localhost:3000](http://localhost:3000) to view the application.
+## License
 
----
+[Creative Commons Attribution-NonCommercial 4.0 International](./LICENSE) (CC BY-NC 4.0).
 
-## ⚙️ Configuration Guide
-
-### Supabase Setup
-
-1. Create a new Supabase project
-2. Enable Discord OAuth provider in Authentication settings
-3. Configure Row Level Security (RLS) policies
-4. Set up storage buckets for file uploads
-5. Configure real-time subscriptions for live data
-
-### Stripe Configuration
-
-1. Create a Stripe account and get API keys
-2. Set up webhook endpoints for payment processing
-3. Configure products and pricing plans
-4. Test webhook integration in development
-
-### Discord OAuth Setup
-
-1. Create a Discord application in the [Discord Developer Portal](https://discord.com/developers/applications)
-2. Navigate to OAuth2 settings and add redirect URI: `http://localhost:3000/api/auth/callback/discord`
-3. Copy Client ID and Client Secret to environment variables
-4. Enable the `identify` and `email` scopes for user authentication
-
-### OpenAI Integration
-
-1. Get an API key from OpenAI
-2. Configure usage limits and billing
-3. Test API connectivity with the field mapping feature
-
----
-
-## 📁 Project Structure
-
-```
-deltalytix/
-├── app/                    # Next.js App Router
-│   ├── [locale]/          # Internationalized routes
-│   │   ├── dashboard/     # Main dashboard pages
-│   │   ├── admin/         # Admin panel
-│   │   ├── business/      # Business features
-│   │   └── (landing)/     # Marketing pages
-│   └── api/               # API routes
-│       ├── ai/           # AI-powered endpoints
-│       ├── auth/         # Authentication
-│       ├── stripe/       # Payment processing
-│       └── cron/         # Scheduled tasks
-├── components/            # Reusable React components
-│   ├── ui/               # Base UI components (Radix UI)
-│   ├── ai-elements/      # AI-powered components
-│   ├── emails/           # Email templates
-│   ├── tiptap/           # TipTap editor components
-│   └── magicui/          # Custom UI components
-├── server/               # Server-side business logic
-├── store/                # Zustand state management
-├── prisma/               # Database schema and migrations
-├── locales/              # Internationalization files (EN/FR)
-├── lib/                  # Utility functions
-├── hooks/                # Custom React hooks
-├── context/              # React Context providers
-├── docs/                 # Feature documentation
-│   └── JOURNAL_EDITOR.md # Journal editor feature guide
-└── content/              # MDX content for updates
-```
-
----
-
-## 🧑‍💻 Development Guidelines
-
-### Code Style
-
-- Use TypeScript strict mode
-- Follow Next.js best practices
-- Implement proper error handling
-- Write self-documenting code
-
-### Translation System
-
-Use the `useI18n` hook for all user-facing text:
-
-```typescript
-import { useI18n } from "@/locales/client"
-
-const t = useI18n()
-
-// Basic translation
-<CardTitle>{t('propFirm.title')}</CardTitle>
-
-// Translation with variables
-<DialogTitle>{t('propFirm.configurator.title', { accountNumber: account.accountNumber })}</DialogTitle>
-```
-
-### State Management
-
-- Use Zustand stores for client-side state
-- Use React Context for complex mutations
-- Prefer Server Actions for data mutations
-- Use API routes for public data with caching
-
-### API Design
-
-- **API Routes**: For public data that benefits from caching
-- **Server Actions**: For mutations and private operations
-- **Real-time**: Use Supabase subscriptions for live updates
-
----
-
-## 🤝 Contributing
-
-We welcome contributions to Deltalytix! Here's how you can help:
-
-### Getting Started
-
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/amazing-feature`
-3. Make your changes and test thoroughly
-4. Commit your changes: `git commit -m 'Add amazing feature'`
-5. Push to the branch: `git push origin feature/amazing-feature`
-6. Open a Pull Request
-
-### Development Workflow
-
-- Follow the existing code style and conventions
-- Add tests for new features
-- Update documentation as needed
-- Ensure all translations are included
-- Test on both desktop and mobile
-
-### Reporting Issues
-
-- Use GitHub Issues for bug reports
-- Include steps to reproduce
-- Provide system information
-- Add screenshots if applicable
-
-### Feature Requests
-
-- Use GitHub Discussions for feature ideas
-- Check existing issues before creating new ones
-- Provide detailed use cases and benefits
-
----
-
-## 📄 License
-
-This project is licensed under the **Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0)**.
-
-### Key Points:
-
-- ✅ **You can use, modify, and distribute this software for non-commercial purposes**
-- ✅ **You must give appropriate credit and provide a link to the license**
-- ✅ **You can create derivative works for non-commercial use**
-- ❌ **You cannot use this software for commercial purposes**
-- ❌ **You cannot distribute this software commercially without permission**
-
-### What This Means:
-
-This license allows you to use Deltalytix for personal, educational, and non-commercial purposes. You can modify and share the code as long as you give proper attribution and don't use it commercially.
-
-**For commercial licensing options, please contact us.**
-
-Read the full license text in the [LICENSE](LICENSE) file.
-
----
-
-## 🆘 Support & Community
-
-### Get Help
-
-- 💬 **Discord Community**: [Join our Discord](https://discord.gg/a5YVF5Ec2n) for real-time support
-- 📚 **GitHub Discussions**: Ask questions and share ideas
-- 🐛 **Issue Tracker**: Report bugs and request features
-- 📖 **Documentation**: Check our comprehensive guides
-
-### Stay Updated
-
-- ⭐ **Star the repository** to show your support
-- 👀 **Watch for releases** to get notified of updates
-- 🐦 **Follow us on social media** for announcements
-
----
-
-## 🙏 Acknowledgments
-
-### Contributors
-
-Thank you to all the contributors who help make Deltalytix better!
-
-### Open Source Projects
-
-This project builds upon many excellent open source libraries:
-
-- [Next.js](https://nextjs.org/) - The React framework
-- [Supabase](https://supabase.com/) - Backend as a service
-- [Prisma](https://prisma.io/) - Database toolkit
-- [Tailwind CSS](https://tailwindcss.com/) - Utility-first CSS
-- [Framer Motion](https://framer.com/motion/) - Animation library
-- [Radix UI](https://radix-ui.com/) - Accessible component primitives
-
-### Inspiration
-
-Deltalytix was inspired by the need for better trading analytics tools in the open source community.
-
----
-
-## 🗺️ Roadmap
-
-### ✅ Recently Completed
-
-- [x] **Custom Dashboard Layout** - Drag-and-drop widgets with flexible workspace customization
-- [x] **AI-Powered Data Import** - Intelligent field mapping for seamless CSV processing
-- [x] **Enhanced Data Processing** - Multi-platform support with encryption and accurate commission calculations
-- [x] **Automatic Rithmic Integration** - Direct API connection with hourly data synchronization
-- [x] **Tradovate Synchronization** - Real-time trade data sync with automated import
-- [x] **Interactive Brokers Integration** - PDF statement import system for comprehensive trade data
-- [x] **AMP Integration** - Connected through Rithmic sync for seamless data flow
-- [x] **Subscription Plans** - Flexible pricing tiers for different trader needs
-- [x] **Bulk Trade Editing** - Edit multiple trades at once with bulk operations or modify individual trades directly in the table
-- [x] **Journal with Image Resizing and Tables** - Enhanced journal editor with draggable image resizing, table creation, and session-based tag application
-- [x] **Teams Platform** - Create trading teams, invite members, and view combined performance analytics across all team traders
-- [x] **Manual Trade Entry** - Enter trades manually with intelligent auto-commission calculation based on historical data
-- [x] **Prop Firms Catalogue** - Browse prop trading firms with aggregated statistics on account counts, payout rates, and success metrics
-- [x] **Accounts Table View** - Enhanced accounts overview with table view option and improved account management
-- [x] **Multi-Day Weekday Filters** - Select multiple days at once for filtering charts and analytics
-- [x] **Calendar Modal Enhancements** - Daily statistics widget and improved trade review in calendar modal
-- [x] **Account Configurator Improvements** - Search functionality for prop firms, reset date consideration, and group management
-- [x] **Automated Journaling System** - AI-assisted trade journaling that focuses on mistakes and successes
-- [x] **Collaborative AI Assistant** - AI Trading Coach with data-aware conversations, pattern recognition, and behavioral insights
-
-### 🔄 Currently In Development
-
-- [ ] **Mobile Optimization** - Fully responsive design with mobile-specific Enhancements
-- [ ] **On premise deployment** - Dockerized version for self-hosting (uses postgres container)
-
-### 📋 Upcoming Features (Q2-Q3 2026)
-
-- [ ] **Enhanced Journaling Experience** - Session-based analysis with automated insights on trading patterns
-- [ ] **Market Data Integration** - Databento connection for real-time market insights and context
-
-### 🚀 Long-term Vision (2027+)
-
-- [ ] **Third-Party Dashboard Licensing** - Prop firms can embed Deltalytix directly into their platforms
-- [ ] **Interactive Brokers API Integration** - Direct sync replacing PDF imports for real-time data
-- [ ] **Advanced Market Analytics** - Deep market insights powered by Databento data feeds
-- [ ] **White-Label Solutions** - Customizable platform for trading firms and educational institutions
-- [ ] **Advanced Risk Management** - Real-time alerts and automated risk monitoring
-- [ ] **Portfolio Optimization Tools** - Modern portfolio theory and risk-adjusted returns
-
-### 🎯 Strategic Focus Areas
-
-- **Trader-Centric Development** - All features designed specifically for individual traders
-- **AI-Human Collaboration** - Seamless integration of AI insights into natural trading workflow
-- **Automated Learning** - Systems that help traders identify and learn from their patterns
-- **Market Context Integration** - Connecting trading performance to broader market conditions
+You may use, modify, and share Deltalytix for personal, educational, and other non-commercial purposes, with attribution. Commercial use and commercial distribution require a separate licence — get in touch.
 
 ---
 
@@ -472,4 +108,3 @@ Deltalytix was inspired by the need for better trading analytics tools in the op
     <a href="https://deltalytix.app">Website</a>
   </p>
 </div>
-


### PR DESCRIPTION
Cuts the README from **475 to 114 lines** and repairs instructions and version numbers that had drifted away from the repo.

## Why

Length was the symptom; duplication and drift were the cause. Three of the largest sections re-told what a dedicated file already owned better — setup (`SELF_HOSTING.md`), dev workflow (`AGENTS.md`), and shipped work (the release notes). Because those copies were maintained by hand, they went stale.

## Factual corrections

Each of these was verified against the code, not just reworded:

| Claim in old README | Reality |
|---|---|
| **Next.js 15** (badge and prose) | `package.json` pins **`next@16.3.0-preview.6`** — a full major behind |
| React 19, TypeScript 5, Prisma/Tailwind unversioned | React 19.2.1, TypeScript 5.9.3, Prisma 7.8.0, Tailwind CSS 4 |
| `npm install`, `npx prisma …` | Repo is Bun-only (`bun.lock`, no `package-lock.json`); `AGENTS.md` mandates Bun |
| `npx prisma db seed` | No seed configured in `package.json` or `prisma.config.ts`; the real script is `bun run seed:self-host` |
| `SUPABASE_SERVICE_ROLE_KEY`, `DISCORD_CLIENT_ID`/`_SECRET`, `NEXT_PUBLIC_APP_URL` | Do not exist. Real names in `.env.example` are `DISCORD_ID`/`DISCORD_SECRET`/`REDIRECT_URL`; required `ENCRYPTION_KEY` and `DIRECT_URL` were missing entirely |
| Project structure lists `docs/JOURNAL_EDITOR.md` | `docs/` does not exist |
| "Open a PR from a feature branch" | `AGENTS.md:124` requires PRs against `beta` |
| Integrations include **ProjectX** | No ProjectX code anywhere in the import config |
| Integration list omits Thor, DXfeed, TradeZella, Quantower, Topstep, NinjaTrader | All six ship today per `app/[locale]/dashboard/components/import/config/platforms.tsx` |

The env block now defers to `.env.example` and every version was read from `package.json`, so neither can drift silently again. The stack section also flags that Next.js 16 preview diverges from 15 — mirroring the warning `next dev` writes into `AGENTS.md` — so contributors don't reach for Next 15 patterns.

## Structure

Product-first hub: what it is, who it's for, the dashboard overview GIF, then a three-line quickstart that links `SELF_HOSTING.md`, and a docs table routing to `AGENTS.md` / `SECURITY.md` / `agents/skills/` / release notes. Features became four prose blocks instead of twenty nested bullets; tech stack collapsed from three subsections to one paragraph.

The GIF is the only product visual. Still screenshots were tried and pulled back out — the release-note media in `public/updates/` shows older UI states.

Roadmap keeps **In development** and **Next**, and drops the twenty "Recently Completed" entries in favour of a link to the release notes, which already track shipped work.

## Reviewer notes

Two judgement calls worth a second opinion:

1. **Positioning.** The tagline is now "for futures and prop-firm traders," narrower than the previous "professional traders." That's a positioning decision rather than a documentation one — easy to revert if it's wrong.
2. **Dropped sections.** *Long-term Vision (2027+)* and *Strategic Focus Areas* are gone. They read as investor-facing rather than reader-facing, but the third-party licensing and white-label items are real strategy and can come back as a compact "Later" block if you'd rather keep them public.

All relative links and image paths were verified to resolve. Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)