### PR TITLE
Run daily connection syncs from a cron, and enable them for Rithmic Protocol

### DIFF
--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
@@ -222,13 +222,15 @@ export async function authenticateRithmicProtocol(
   }
 }
 
-export async function storeRithmicProtocolToken(
+/**
+ * Writes credentials for an already-resolved user. Kept module-private so the
+ * exported action can never be handed a caller-supplied userId.
+ */
+async function persistRithmicProtocolCredentials(
+  userId: string,
   tokenJson: string,
   accountId: string,
 ) {
-  const userId = await getUserId()
-  if (!userId) throw new Error('Not authenticated')
-
   const encryptedToken = encryptConnectionToken(tokenJson)
 
   const connection = await prisma.connection.upsert({
@@ -255,6 +257,16 @@ export async function storeRithmicProtocolToken(
 
   await invalidateConnectionsPageCache(userId)
   return connection
+}
+
+export async function storeRithmicProtocolToken(
+  tokenJson: string,
+  accountId: string,
+) {
+  const userId = await getUserId()
+  if (!userId) throw new Error('Not authenticated')
+
+  return persistRithmicProtocolCredentials(userId, tokenJson, accountId)
 }
 
 export async function getRithmicProtocolToken(accountId: string) {
@@ -403,7 +415,8 @@ export async function getRithmicProtocolTrades(
       credentials.accountIds = resolvedAccountIds
       credentials.fcmId = listed.fcmId ?? credentials.fcmId
       credentials.ibId = listed.ibId ?? credentials.ibId
-      await storeRithmicProtocolToken(
+      await persistRithmicProtocolCredentials(
+        userId,
         JSON.stringify(credentials),
         credentials.username,
       )
@@ -452,6 +465,18 @@ export async function getRithmicProtocolTrades(
     syncStats.closedTrades = trades.length
     syncStats.openTradesSkipped = openSkipped
 
+    // Stamped before saving: the fills were fetched, so the connection has synced
+    // even when every trade turns out to be a duplicate. Leaving it unstamped made
+    // the daily-sync cron re-run this connection on every tick.
+    await prisma.connection.updateMany({
+      where: {
+        userId,
+        service: SERVICE,
+        externalId: credentials.username,
+      },
+      data: { lastSyncedAt: new Date() },
+    })
+
     let savedCount = 0
     if (trades.length > 0) {
       const saveResult = await saveTradesAction(trades, { userId })
@@ -467,15 +492,6 @@ export async function getRithmicProtocolTrades(
       }
       savedCount = saveResult.numberOfTradesAdded
     }
-
-    await prisma.connection.updateMany({
-      where: {
-        userId,
-        service: SERVICE,
-        externalId: credentials.username,
-      },
-      data: { lastSyncedAt: new Date() },
-    })
 
     return {
       processedTrades: trades,

--- a/app/[locale]/dashboard/connections/actions.ts
+++ b/app/[locale]/dashboard/connections/actions.ts
@@ -6,6 +6,7 @@ import {
   getConnectionsPageDataFresh,
   invalidateConnectionsPageCache,
 } from './data'
+import { supportsDailySync } from './daily-sync-services'
 import type { ConnectionsPageData } from './types'
 
 export type {
@@ -65,7 +66,7 @@ export async function updateConnectionDailySyncTimeAction(
     return { error: 'NOT_FOUND' }
   }
 
-  if (existing.service !== 'tradovate' && existing.service !== 'dxfeed') {
+  if (!supportsDailySync(existing.service)) {
     return { error: 'UNSUPPORTED_SERVICE' }
   }
 

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -41,6 +41,7 @@ import {
   type ConnectionsPageData,
   type ConnectionService,
 } from '../actions'
+import { supportsDailySync } from '../daily-sync-services'
 import {
   handleTradovateCallback,
   initiateTradovateOAuth,
@@ -191,10 +192,6 @@ function AccountTradeList({
       })}
     </ul>
   )
-}
-
-function supportsDailySync(service: string) {
-  return service === 'tradovate' || service === 'dxfeed'
 }
 
 function getNextDailySyncAt(

--- a/app/[locale]/dashboard/connections/daily-sync-services.ts
+++ b/app/[locale]/dashboard/connections/daily-sync-services.ts
@@ -1,0 +1,19 @@
+/**
+ * Services whose connections can carry a `dailySyncTime`.
+ *
+ * A service belongs here only once two things exist: the schedule dialog on the
+ * connections page can save it, and `/api/cron/daily-sync` knows how to run an
+ * unattended sync for it. Adding a service to this list without the cron side
+ * ships a time picker that never fires.
+ */
+export const DAILY_SYNC_SERVICES = [
+  'tradovate',
+  'dxfeed',
+  'rithmic-protocol',
+] as const
+
+export type DailySyncService = (typeof DAILY_SYNC_SERVICES)[number]
+
+export function supportsDailySync(service: string): service is DailySyncService {
+  return (DAILY_SYNC_SERVICES as readonly string[]).includes(service)
+}

--- a/app/api/cron/daily-sync/route.ts
+++ b/app/api/cron/daily-sync/route.ts
@@ -1,0 +1,141 @@
+// app/api/cron/daily-sync/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { decryptConnectionToken } from '@/lib/connection-token-crypto'
+import { isDailySyncDue } from '@/lib/daily-sync-schedule'
+import { getDxFeedTrades } from '@/app/[locale]/dashboard/components/import/dxfeed/sync/actions'
+import { getRithmicProtocolTrades } from '@/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions'
+import { invalidateConnectionsPageCache } from '@/app/[locale]/dashboard/connections/data'
+
+export const maxDuration = 300
+
+/**
+ * Services this cron can sync unattended. Tradovate is deliberately absent: its
+ * schedule is already driven by /api/cron/renew-tradovate-token, which has to
+ * refresh the OAuth token in the same pass.
+ */
+const SYNCABLE_SERVICES = ['dxfeed', 'rithmic-protocol'] as const
+
+/** Stop starting new syncs past this point so the function returns before its limit. */
+const WALL_CLOCK_BUDGET_MS = 240_000
+
+/** The broker was reached and the connection is up to date — not a failure. */
+const DUPLICATE_TRADES = 'DUPLICATE_TRADES'
+
+async function syncConnection(connection: {
+  service: string
+  userId: string
+  externalId: string
+  token: string | null
+}): Promise<{ ok: boolean; reason?: string }> {
+  const storedTokenJson = decryptConnectionToken(connection.token)
+  if (!storedTokenJson) {
+    return { ok: false, reason: 'NO_TOKEN' }
+  }
+
+  const error =
+    connection.service === 'dxfeed'
+      ? (
+          await getDxFeedTrades(storedTokenJson, {
+            userId: connection.userId,
+            accountId: connection.externalId,
+          })
+        ).error
+      : (
+          await getRithmicProtocolTrades(storedTokenJson, {
+            userId: connection.userId,
+          })
+        ).error
+
+  if (!error || error === DUPLICATE_TRADES) return { ok: true }
+  return { ok: false, reason: error }
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization')
+  if (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const startedAt = Date.now()
+  const now = new Date()
+
+  try {
+    const connections = await prisma.connection.findMany({
+      where: {
+        service: { in: [...SYNCABLE_SERVICES] },
+        token: { not: null },
+        dailySyncTime: { not: null },
+        // DxFeed stamps an epoch expiry when the broker rejects a token; without
+        // this the cron would retry a dead connection on every tick until the
+        // catch-up window closes. Rithmic Protocol stores credentials, not a
+        // token with an expiry, so its rows carry null here.
+        OR: [{ tokenExpiresAt: null }, { tokenExpiresAt: { gt: now } }],
+      },
+      select: {
+        id: true,
+        userId: true,
+        service: true,
+        externalId: true,
+        token: true,
+        dailySyncTime: true,
+        lastSyncedAt: true,
+      },
+    })
+
+    const due = connections.filter((connection) =>
+      isDailySyncDue(connection.dailySyncTime, connection.lastSyncedAt, now),
+    )
+
+    let synced = 0
+    let failed = 0
+    let deferred = 0
+    const touchedUserIds = new Set<string>()
+
+    // Sequential on purpose: a Rithmic Protocol sync opens a gateway session and
+    // pulls up to 30-day fill windows. Running these in parallel starves the
+    // function and trips broker-side rate limits.
+    for (const connection of due) {
+      if (Date.now() - startedAt > WALL_CLOCK_BUDGET_MS) {
+        // Still inside the catch-up window, so the next tick picks these up.
+        deferred = due.length - (synced + failed)
+        break
+      }
+
+      try {
+        const result = await syncConnection(connection)
+        if (result.ok) {
+          synced++
+          touchedUserIds.add(connection.userId)
+        } else {
+          failed++
+          console.warn(
+            `[CRON daily-sync] ${connection.service}/${connection.id} failed: ${result.reason}`,
+          )
+        }
+      } catch (error) {
+        failed++
+        console.error(
+          `[CRON daily-sync] ${connection.service}/${connection.id} threw:`,
+          error,
+        )
+      }
+    }
+
+    await Promise.allSettled(
+      [...touchedUserIds].map((userId) => invalidateConnectionsPageCache(userId)),
+    )
+
+    return NextResponse.json({
+      success: true,
+      candidates: connections.length,
+      due: due.length,
+      synced,
+      failed,
+      deferred,
+    })
+  } catch (error) {
+    console.error('[CRON daily-sync] job error:', error)
+    return NextResponse.json({ error: 'Cron job failed' }, { status: 500 })
+  }
+}

--- a/lib/daily-sync-schedule.test.ts
+++ b/lib/daily-sync-schedule.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CATCH_UP_WINDOW_MS,
+  isDailySyncDue,
+  lastOccurrenceOf,
+} from './daily-sync-schedule'
+
+/** Only the UTC time-of-day matters; the date is whatever day the user saved on. */
+function scheduleAt(hours: number, minutes = 0): Date {
+  return new Date(Date.UTC(2020, 0, 1, hours, minutes, 0, 0))
+}
+
+const HOUR = 60 * 60 * 1000
+
+describe('lastOccurrenceOf', () => {
+  it('returns today when the time has already passed', () => {
+    const now = new Date('2026-07-26T14:00:00.000Z')
+    expect(lastOccurrenceOf(scheduleAt(9), now).toISOString()).toBe(
+      '2026-07-26T09:00:00.000Z',
+    )
+  })
+
+  it('rolls back to yesterday when the time is still ahead', () => {
+    const now = new Date('2026-07-26T06:00:00.000Z')
+    expect(lastOccurrenceOf(scheduleAt(9), now).toISOString()).toBe(
+      '2026-07-25T09:00:00.000Z',
+    )
+  })
+
+  it('ignores the date component of the stored timestamp', () => {
+    const storedLongAgo = new Date('2023-02-11T22:30:00.000Z')
+    const now = new Date('2026-07-26T23:00:00.000Z')
+    expect(lastOccurrenceOf(storedLongAgo, now).toISOString()).toBe(
+      '2026-07-26T22:30:00.000Z',
+    )
+  })
+
+  it('rolls back across a month boundary', () => {
+    const now = new Date('2026-08-01T01:00:00.000Z')
+    expect(lastOccurrenceOf(scheduleAt(23), now).toISOString()).toBe(
+      '2026-07-31T23:00:00.000Z',
+    )
+  })
+})
+
+describe('isDailySyncDue', () => {
+  it('is never due without a configured time', () => {
+    const now = new Date('2026-07-26T09:05:00.000Z')
+    expect(isDailySyncDue(null, new Date('2026-07-25T00:00:00.000Z'), now)).toBe(
+      false,
+    )
+  })
+
+  it('fires once the scheduled time has passed', () => {
+    const now = new Date('2026-07-26T09:05:00.000Z')
+    const lastSynced = new Date('2026-07-25T09:02:00.000Z')
+    expect(isDailySyncDue(scheduleAt(9), lastSynced, now)).toBe(true)
+  })
+
+  it('does not fire before the scheduled time', () => {
+    const now = new Date('2026-07-26T08:55:00.000Z')
+    const lastSynced = new Date('2026-07-25T09:02:00.000Z')
+    expect(isDailySyncDue(scheduleAt(9), lastSynced, now)).toBe(false)
+  })
+
+  it('does not fire twice for the same occurrence', () => {
+    const schedule = scheduleAt(9)
+    const now = new Date('2026-07-26T09:05:00.000Z')
+    const afterFirstRun = new Date('2026-07-26T09:05:30.000Z')
+
+    expect(isDailySyncDue(schedule, new Date('2026-07-25T09:02:00.000Z'), now)).toBe(
+      true,
+    )
+    // Next cron tick, 15 minutes later: already synced past the occurrence.
+    expect(
+      isDailySyncDue(schedule, afterFirstRun, new Date('2026-07-26T09:20:00.000Z')),
+    ).toBe(false)
+  })
+
+  it('skips when the user already synced manually after the occurrence', () => {
+    const now = new Date('2026-07-26T11:00:00.000Z')
+    const manualSync = new Date('2026-07-26T10:30:00.000Z')
+    expect(isDailySyncDue(scheduleAt(9), manualSync, now)).toBe(false)
+  })
+
+  it('still fires when a manual sync happened before the occurrence', () => {
+    const now = new Date('2026-07-26T09:30:00.000Z')
+    const manualSync = new Date('2026-07-26T07:00:00.000Z')
+    expect(isDailySyncDue(scheduleAt(9), manualSync, now)).toBe(true)
+  })
+
+  it('catches up on a missed tick within the window', () => {
+    const now = new Date('2026-07-26T13:00:00.000Z') // 4h late
+    const lastSynced = new Date('2026-07-25T09:02:00.000Z')
+    expect(isDailySyncDue(scheduleAt(9), lastSynced, now)).toBe(true)
+  })
+
+  it('gives up once the catch-up window has elapsed', () => {
+    const now = new Date('2026-07-26T16:00:00.000Z') // 7h late
+    const lastSynced = new Date('2026-07-25T09:02:00.000Z')
+    expect(isDailySyncDue(scheduleAt(9), lastSynced, now)).toBe(false)
+  })
+
+  it('treats the catch-up boundary as inclusive', () => {
+    const occurrence = new Date('2026-07-26T09:00:00.000Z')
+    const lastSynced = new Date('2026-07-25T09:02:00.000Z')
+    expect(
+      isDailySyncDue(
+        scheduleAt(9),
+        lastSynced,
+        new Date(occurrence.getTime() + CATCH_UP_WINDOW_MS),
+      ),
+    ).toBe(true)
+    expect(
+      isDailySyncDue(
+        scheduleAt(9),
+        lastSynced,
+        new Date(occurrence.getTime() + CATCH_UP_WINDOW_MS + 1),
+      ),
+    ).toBe(false)
+  })
+
+  it('handles a schedule set just after midnight UTC', () => {
+    const now = new Date('2026-07-26T00:10:00.000Z')
+    const lastSynced = new Date('2026-07-25T00:05:00.000Z')
+    expect(isDailySyncDue(scheduleAt(0, 5), lastSynced, now)).toBe(true)
+  })
+
+  it('does not replay a schedule the user just set for earlier today', () => {
+    // User sets 08:00 at 20:00 local-UTC; the 12h-old occurrence is out of window.
+    const now = new Date('2026-07-26T20:00:00.000Z')
+    const lastSynced = new Date('2026-07-24T08:00:00.000Z')
+    expect(isDailySyncDue(scheduleAt(8), lastSynced, now)).toBe(false)
+    // ...and it fires normally at the next day's occurrence.
+    expect(
+      isDailySyncDue(scheduleAt(8), lastSynced, new Date('2026-07-27T08:05:00.000Z')),
+    ).toBe(true)
+  })
+
+  it('respects a caller-supplied catch-up window', () => {
+    const now = new Date('2026-07-26T10:00:00.000Z')
+    const lastSynced = new Date('2026-07-25T09:02:00.000Z')
+    expect(isDailySyncDue(scheduleAt(9), lastSynced, now, 2 * HOUR)).toBe(true)
+    expect(isDailySyncDue(scheduleAt(9), lastSynced, now, 30 * 60 * 1000)).toBe(false)
+  })
+})

--- a/lib/daily-sync-schedule.ts
+++ b/lib/daily-sync-schedule.ts
@@ -1,0 +1,54 @@
+/**
+ * Scheduling maths for the daily connection sync cron.
+ *
+ * `Connection.dailySyncTime` is stored as a full timestamp, but only its UTC
+ * hours/minutes carry meaning — the date part is whatever day the user happened
+ * to save it on.
+ */
+
+/**
+ * How long after a missed occurrence we still catch up. Covers deploys and cron
+ * hiccups without replaying a schedule the user set hours ago.
+ */
+export const CATCH_UP_WINDOW_MS = 6 * 60 * 60 * 1000
+
+/** Most recent moment the configured time-of-day elapsed, in UTC. */
+export function lastOccurrenceOf(dailySyncTime: Date, now: Date): Date {
+  const occurrence = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      dailySyncTime.getUTCHours(),
+      dailySyncTime.getUTCMinutes(),
+      0,
+      0,
+    ),
+  )
+  if (occurrence.getTime() > now.getTime()) {
+    occurrence.setUTCDate(occurrence.getUTCDate() - 1)
+  }
+  return occurrence
+}
+
+/**
+ * A connection is due when its latest scheduled occurrence has passed, is still
+ * within the catch-up window, and no sync (manual or scheduled) has landed since.
+ *
+ * Anchoring on `lastSyncedAt` rather than a fixed ± window around the configured
+ * time makes the job idempotent: it fires exactly once per occurrence no matter
+ * how often the cron ticks, and a missed tick is retried instead of skipped.
+ */
+export function isDailySyncDue(
+  dailySyncTime: Date | null,
+  lastSyncedAt: Date,
+  now: Date,
+  catchUpWindowMs: number = CATCH_UP_WINDOW_MS,
+): boolean {
+  if (!dailySyncTime) return false
+
+  const occurrence = lastOccurrenceOf(dailySyncTime, now)
+  if (now.getTime() - occurrence.getTime() > catchUpWindowMs) return false
+
+  return lastSyncedAt.getTime() < occurrence.getTime()
+}

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/renew-tradovate-token",
       "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/cron/daily-sync",
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Why

Daily sync schedules were only offered for Tradovate and DxFeed, gated by two hardcoded allowlists. Rithmic Protocol already had the `dailySyncTime` column, the context field, and even an `updateRithmicProtocolDailySyncTimeAction` — but no way to reach any of it. The allowlists were never extended when Rithmic Protocol was wired into Connections.

Digging in turned up something bigger: **only Tradovate's schedule ever executed.** The one cron that reads `dailySyncTime` queries `service: 'tradovate'`. A DxFeed user could pick a sync time, see a countdown, and nothing would ever fire — the only thing actually syncing was the client-side interval timer, which needs the dashboard tab open.

So this both unblocks the UI and makes the feature real.

## What changed

**UI unblocked.** The two allowlists become one shared `DAILY_SYNC_SERVICES` constant in `app/[locale]/dashboard/connections/daily-sync-services.ts`, used by the client gate and the save action. `rithmic-protocol` joins the list. The dialog, countdown, and time presets were already service-agnostic, so nothing else needed touching.

**Schedules now execute.** New `/api/cron/daily-sync`, registered in `vercel.json` at `*/15`, covering `dxfeed` and `rithmic-protocol`. Tradovate keeps its existing cron, which has to renew the OAuth token in the same pass.

## The due check

I did not copy Tradovate's "±15 minutes of the configured time" test — at a 10-minute cadence that fires two or three times per schedule. Instead the check compares `lastSyncedAt` against the most recent occurrence of the configured time (`lib/daily-sync-schedule.ts`):

- exactly one sync per occurrence, whatever the cron cadence
- a missed tick is retried rather than skipped (6h catch-up window)
- no run if the user already synced manually after the scheduled time

16 tests in `lib/daily-sync-schedule.test.ts` cover the boundaries, month rollover, and the double-fire case.

Other operational details the cron needed:

- **Sequential, with a 240s wall-clock budget.** A Rithmic Protocol sync opens a gateway session and pulls 30-day fill windows; parallelism starves the function and trips broker rate limits. Leftovers get picked up next tick.
- **Skips tokens DxFeed has marked expired** (`tokenExpiresAt: new Date(0)`), otherwise a dead connection retries every tick for six hours.
- **`DUPLICATE_TRADES` counts as success** — the broker was reached, there was just nothing new.

## Bug fixed along the way

`getRithmicProtocolTrades` stamped `lastSyncedAt` only *after* saving, so the `DUPLICATE_TRADES` early return left it untouched. The connection looked never-synced and would have re-run on every cron tick. Moved the stamp before the save, matching what DxFeed already does.

`storeRithmicProtocolToken` is split into a module-private `persistRithmicProtocolCredentials(userId, …)` plus a session-resolving export, so the cron's credential-refresh path works headlessly without adding a caller-supplied `userId` to an exported server action.

## Follow-up (not in this PR)

`getDxFeedTrades` and `getRithmicProtocolTrades` already accept `options.userId` and are exported from `'use server'` files, which makes them reachable as action endpoints regardless of whether any client imports them. Pre-existing, not widened here, but worth closing separately.

## Verification

- `bun run typecheck` — clean
- `bunx vitest run` — 108 passed
- eslint clean on all new files (the 5 errors in `connections-page-client.tsx` are pre-existing at lines 1119/1128; identical count on the unmodified file)

`bun run build` could **not** run: this worktree has no `.env`, so `prisma generate` fails on a missing `DIRECT_URL` before Next even starts. Given the past trouble with server actions under the beta bundler, **the cron route is worth a check on the deployed preview** — hit it with the `CRON_SECRET` bearer token and confirm the JSON counters. A route handler importing `'use server'` modules is exactly the shape that broke before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)