### PR TITLE
Add Interactive Brokers sync via the Flex Web Service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,22 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY='your_stripe_publishable_key_here'
 STRIPE_SECRET_KEY='your_stripe_secret_key_here'
 STRIPE_WEBHOOK_SECRET='your_stripe_webhook_secret_here'
 
+# Interactive Brokers Flex Web Service
+# No app-level credentials: each user supplies their own Flex token + query ID.
+# Overrides below are only needed to point at a different host or tune polling.
+# IBKR_FLEX_BASE_URL='https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService'
+# IBKR requires a User-Agent on every request
+# IBKR_FLEX_USER_AGENT='Deltalytix/1.0'
+# Delay between GetStatement polls while IBKR generates the report (default 3000)
+# IBKR_FLEX_POLL_DELAY_MS=3000
+# How many times to poll before giving up (default 5)
+# IBKR_FLEX_MAX_ATTEMPTS=5
+# Per-request timeout in ms (default 30000)
+# IBKR_FLEX_TIMEOUT_MS=30000
+# Deep link shown in the setup guide (defaults to the Client Portal home)
+# NEXT_PUBLIC_IBKR_FLEX_PORTAL_URL='https://www.interactivebrokers.com/portal'
+# NEXT_PUBLIC_IBKR_SYNC_TUTORIAL_VIDEO='your_video_url_here'
+
 # DxFeed Configuration
 DXFEED_AUTH_URL='https://authdxfeed.volumetricatrading.com/api/auth/token'
 DXFEED_PLATFORM_KEY='your_dxfeed_platform_key_here'

--- a/app/[locale]/dashboard/components/import/components/import-dialog-footer.tsx
+++ b/app/[locale]/dashboard/components/import/components/import-dialog-footer.tsx
@@ -68,7 +68,8 @@ export function ImportDialogFooter({
             currentStepIndex === 0 &&
               (importType === 'rithmic-sync' ||
                 importType === 'tradovate-sync' ||
-                importType === 'dxfeed-sync') &&
+                importType === 'dxfeed-sync' ||
+                importType === 'ibkr-sync') &&
               "invisible"
           )}
         >
@@ -95,7 +96,7 @@ export function ImportDialogFooter({
           onClick={onNext}
           className={cn(
             "w-fit min-w-[80px] sm:min-w-[100px]",
-            (currentStepIndex === 0 && (importType === 'rithmic-sync' || importType === 'rithmic-protocol-sync' || importType === 'tradovate-sync' || importType === 'dxfeed-sync')) && "invisible"
+            (currentStepIndex === 0 && (importType === 'rithmic-sync' || importType === 'rithmic-protocol-sync' || importType === 'tradovate-sync' || importType === 'dxfeed-sync' || importType === 'ibkr-sync')) && "invisible"
           )}
           disabled={isNextDisabled || isSaving}
         >

--- a/app/[locale]/dashboard/components/import/config/platforms.tsx
+++ b/app/[locale]/dashboard/components/import/config/platforms.tsx
@@ -3,6 +3,7 @@ import { Trade } from '@/prisma/generated/prisma/browser'
 import { ThorSync } from '../thor/thor-sync'
 import { TradovateSync } from '../tradovate/sync/tradovate-sync'
 import { DxFeedSync } from '../dxfeed/sync/dxfeed-sync'
+import { IbkrSync } from '../ibkr/sync/ibkr-sync'
 import { RithmicSyncWrapper } from '../rithmic/sync/rithmic-sync-connection'
 import { RithmicProtocolSync } from '../rithmic-protocol/sync/rithmic-protocol-sync'
 import type { ComponentType } from 'react'
@@ -128,6 +129,7 @@ type StepComponent =
   | typeof ThorSync
   | typeof TradovateSync
   | typeof DxFeedSync
+  | typeof IbkrSync
   | typeof PdfUpload
   | typeof PdfProcessing
   | typeof AtasFileUpload
@@ -740,6 +742,35 @@ export const platforms: PlatformConfig[] = [
         title: 'import.steps.connectAccount',
         description: 'import.steps.connectAccountDescription',
         component: DxFeedSync,
+        isLastStep: true
+      }
+    ]
+  },
+  {
+    platformName: 'ibkr-sync',
+    type: 'ibkr-sync',
+    name: 'import.type.ibkrSync.name',
+    description: 'import.type.ibkrSync.description',
+    category: 'Direct Account Sync',
+    videoUrl: process.env.NEXT_PUBLIC_IBKR_SYNC_TUTORIAL_VIDEO || '',
+    details: 'import.type.ibkrSync.details',
+    logo: {
+      path: '/logos/ibkr.png',
+      alt: 'Interactive Brokers Logo'
+    },
+    customComponent: IbkrSync,
+    steps: [
+      {
+        id: 'select-import-type',
+        title: 'import.steps.selectPlatform',
+        description: 'import.steps.selectPlatformDescription',
+        component: ImportTypeSelection
+      },
+      {
+        id: 'complete',
+        title: 'import.steps.connectAccount',
+        description: 'import.steps.connectAccountDescription',
+        component: IbkrSync,
         isLastStep: true
       }
     ]

--- a/app/[locale]/dashboard/components/import/ibkr/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/ibkr/sync/actions.ts
@@ -1,0 +1,421 @@
+'use server'
+
+import { Trade } from '@/prisma/generated/prisma/client'
+import { prisma } from '@/lib/prisma'
+import { getUserId } from '@/server/auth'
+import { saveTradesAction } from '@/server/database'
+import { ensureConnection, upsertAccountsForNumbers } from '@/server/connections'
+import { decryptConnectionToken } from '@/lib/connection-token-crypto'
+import { createTradeWithDefaults } from '@/lib/trade-factory'
+import { generateDeterministicTradeId } from '@/lib/trade-id-utils'
+import { capturePostHogEvent } from '@/lib/posthog-server'
+import { invalidateConnectionsPageCache } from '@/app/[locale]/dashboard/connections/data'
+import { fetchFlexStatement } from '@/lib/ibkr-flex-client'
+import { IbkrErrorCode, type IbkrErrorCodeValue, type IbkrErrorParams } from '@/lib/ibkr-flex-errors'
+import {
+  isValidFlexQueryId,
+  isValidFlexToken,
+  parseIbkrCredentialsInput,
+} from '@/lib/ibkr-flex-credentials'
+import {
+  matchExecutionsFifo,
+  parseFlexStatement,
+  type FlexMatchedTrade,
+} from '@/lib/ibkr-flex-trades'
+import type {
+  IbkrConnectResult,
+  IbkrStoredCredentials,
+  IbkrSyncStats,
+  IbkrTradesResult,
+} from './ibkr-types'
+
+const SERVICE = 'ibkr'
+
+const logger = {
+  info: (message: string) => console.log(`[IBKR] ${message}`),
+  error: (message: string, error?: unknown) =>
+    console.error(`[IBKR] ${message}`, error instanceof Error ? error.message : ''),
+}
+
+function parseStoredCredentials(tokenField: string | null): IbkrStoredCredentials | null {
+  if (!tokenField) return null
+  try {
+    const decrypted = decryptConnectionToken(tokenField)
+    if (!decrypted) return null
+    const parsed = JSON.parse(decrypted) as Partial<IbkrStoredCredentials>
+    if (typeof parsed.token === 'string' && typeof parsed.queryId === 'string') {
+      return parsed as IbkrStoredCredentials
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+type LoadResult =
+  | { ok: true; trades: FlexMatchedTrade[]; stats: IbkrSyncStats }
+  | { ok: false; error: IbkrErrorCodeValue; errorParams?: IbkrErrorParams }
+
+/**
+ * Runs the Flex exchange and turns the statement into matched round-turns.
+ * Shared by the connect preview and the sync itself so both see the same data.
+ */
+async function loadFlexTrades(credentials: IbkrStoredCredentials): Promise<LoadResult> {
+  const statement = await fetchFlexStatement(credentials.token, credentials.queryId)
+  if (!statement.ok) {
+    return { ok: false, error: statement.error, errorParams: statement.errorParams }
+  }
+
+  const { executions, stats: parseStats } = parseFlexStatement(statement.xml)
+
+  // No Trade rows at all means the query has no Trades section — a config
+  // problem the user has to fix in Client Portal, not a transient failure.
+  if (parseStats.tradeRows === 0) {
+    return { ok: false, error: IbkrErrorCode.QUERY_HAS_NO_TRADES_SECTION }
+  }
+
+  // Rows exist but every one was undatable: the query's date format is one we
+  // refuse to guess at. Tell the user exactly that instead of "no trades".
+  if (executions.length === 0 && parseStats.skippedUnparseableDate > 0) {
+    return {
+      ok: false,
+      error: IbkrErrorCode.QUERY_UNPARSEABLE_DATES,
+      errorParams: { count: parseStats.skippedUnparseableDate },
+    }
+  }
+
+  const trades = matchExecutionsFifo(executions)
+
+  return {
+    ok: true,
+    trades,
+    stats: {
+      tradeRows: parseStats.tradeRows,
+      executionRows: parseStats.executionRows,
+      closedLotRows: parseStats.closedLotRows,
+      matchedTrades: trades.length,
+      skippedUnparseableDate: parseStats.skippedUnparseableDate,
+      skippedIncomplete: parseStats.skippedIncomplete,
+      currencies: parseStats.currencies,
+      accountIds: parseStats.accountIds,
+    },
+  }
+}
+
+function toPrismaTrades(trades: FlexMatchedTrade[], userId: string): Trade[] {
+  return trades.map((trade) => {
+    const identity = {
+      accountNumber: trade.accountId,
+      entryId: trade.entryId,
+      closeId: trade.closeId,
+      instrument: trade.instrument,
+      entryPrice: trade.entryPrice.toString(),
+      closePrice: trade.closePrice.toString(),
+      entryDate: trade.entryDate,
+      closeDate: trade.closeDate,
+      quantity: trade.quantity,
+      side: trade.side,
+      userId,
+    }
+
+    return createTradeWithDefaults({
+      id: generateDeterministicTradeId(identity),
+      accountNumber: trade.accountId,
+      quantity: trade.quantity,
+      entryId: trade.entryId,
+      closeId: trade.closeId,
+      instrument: trade.instrument,
+      entryPrice: trade.entryPrice.toString(),
+      closePrice: trade.closePrice.toString(),
+      entryDate: trade.entryDate,
+      closeDate: trade.closeDate,
+      pnl: trade.pnl,
+      commission: trade.commission,
+      timeInPosition: trade.timeInPosition,
+      side: trade.side,
+      userId,
+      tags: ['ibkr'],
+    })
+  })
+}
+
+/**
+ * Writes matched round-turns, returning how many were new.
+ *
+ * Re-syncs deliberately overlap, so `DUPLICATE_TRADES` from the save layer is a
+ * normal outcome and reported as "nothing new", not as a failure.
+ */
+interface PersistResult {
+  savedCount: number
+  tradesCount: number
+  error?: IbkrErrorCodeValue
+  errorParams?: IbkrErrorParams
+}
+
+async function persistTrades(
+  trades: FlexMatchedTrade[],
+  userId: string,
+  connectionId: string,
+): Promise<PersistResult> {
+  const processedTrades = toPrismaTrades(trades, userId)
+  const saveResult = await saveTradesAction(processedTrades, { userId, connectionId })
+
+  if (saveResult.error) {
+    if (saveResult.error === 'DUPLICATE_TRADES') {
+      return { savedCount: 0, tradesCount: processedTrades.length }
+    }
+    return {
+      savedCount: 0,
+      tradesCount: processedTrades.length,
+      error: IbkrErrorCode.SAVE_TRADES_FAILED,
+      errorParams: { detail: String(saveResult.error) },
+    }
+  }
+
+  return { savedCount: saveResult.numberOfTradesAdded, tradesCount: processedTrades.length }
+}
+
+/**
+ * Validates a pasted token/query ID against the live Flex service, saves it,
+ * and imports whatever the statement contained.
+ *
+ * Importing here rather than on a follow-up click is both one step fewer and
+ * one Flex round-trip fewer — IBKR allows only 10 requests per minute per
+ * token, and each statement costs several.
+ */
+export async function connectIbkrFlexAccount(rawInput: string): Promise<IbkrConnectResult> {
+  let userId: string
+  try {
+    userId = await getUserId()
+  } catch {
+    return { error: IbkrErrorCode.USER_NOT_AUTHENTICATED }
+  }
+
+  const { token, queryId } = parseIbkrCredentialsInput(rawInput)
+
+  if (!token && !queryId) return { error: IbkrErrorCode.CREDENTIALS_REQUIRED }
+  if (!token || !isValidFlexToken(token)) return { error: IbkrErrorCode.TOKEN_MALFORMED }
+  if (!queryId || !isValidFlexQueryId(queryId)) {
+    return { error: IbkrErrorCode.QUERY_ID_MALFORMED }
+  }
+
+  const existing = await prisma.connection.findUnique({
+    where: { userId_service_externalId: { userId, service: SERVICE, externalId: queryId } },
+    select: { id: true },
+  })
+
+  const result = await loadFlexTrades({ token, queryId })
+  if (!result.ok) {
+    return { error: result.error, errorParams: result.errorParams }
+  }
+
+  const credentials: IbkrStoredCredentials = {
+    token,
+    queryId,
+    accountNumbers: result.stats.accountIds,
+    currencies: result.stats.currencies,
+  }
+
+  const connection = await ensureConnection({
+    userId,
+    service: SERVICE,
+    externalId: queryId,
+    token: JSON.stringify(credentials),
+    // Flex never reports a token's expiry, so we clear any "rejected" marker
+    // here and let a future 1012/1015 response set it again.
+    tokenExpiresAt: null,
+  })
+
+  // Register the IBKR account numbers so trades land against real accounts.
+  if (result.stats.accountIds.length > 0) {
+    await upsertAccountsForNumbers(userId, result.stats.accountIds, connection.id)
+  }
+
+  const saved =
+    result.trades.length > 0
+      ? await persistTrades(result.trades, userId, connection.id)
+      : { savedCount: 0, tradesCount: 0 }
+
+  // The connection itself is good even if saving hit a problem; report the
+  // save failure but keep the credentials so the user can retry the sync.
+  if (saved.error) {
+    return {
+      success: true,
+      accountId: queryId,
+      stats: result.stats,
+      savedCount: 0,
+      tradesCount: saved.tradesCount,
+      error: saved.error,
+      errorParams: saved.errorParams,
+    }
+  }
+
+  await capturePostHogEvent({
+    distinctId: userId,
+    event: 'integration_connected',
+    properties: {
+      integration: 'ibkr',
+      is_first_connection: !existing,
+      matched_trades: result.stats.matchedTrades,
+      saved_trades: saved.savedCount,
+      account_count: result.stats.accountIds.length,
+    },
+  })
+
+  await invalidateConnectionsPageCache(userId)
+
+  logger.info(
+    `Connected query ${queryId}: imported ${saved.savedCount}/${result.stats.matchedTrades} trades across ${result.stats.accountIds.length} account(s)`,
+  )
+
+  return {
+    success: true,
+    accountId: queryId,
+    stats: result.stats,
+    savedCount: saved.savedCount,
+    tradesCount: saved.tradesCount,
+  }
+}
+
+export async function syncIbkrAccount(
+  accountId: string,
+  options?: { userId?: string },
+): Promise<IbkrTradesResult> {
+  let userId = options?.userId
+  if (!userId) {
+    try {
+      userId = await getUserId()
+    } catch {
+      return { error: IbkrErrorCode.USER_NOT_AUTHENTICATED }
+    }
+  }
+  const resolvedUserId = userId
+
+  const connection = await prisma.connection.findUnique({
+    where: {
+      userId_service_externalId: {
+        userId: resolvedUserId,
+        service: SERVICE,
+        externalId: accountId,
+      },
+    },
+  })
+
+  if (!connection) return { error: IbkrErrorCode.NO_CREDENTIALS_RECONNECT }
+
+  const credentials = parseStoredCredentials(connection.token)
+  if (!credentials) return { error: IbkrErrorCode.INVALID_STORED_CREDENTIALS }
+
+  const result = await loadFlexTrades(credentials)
+  if (!result.ok) {
+    if (
+      result.error === IbkrErrorCode.FLEX_TOKEN_EXPIRED ||
+      result.error === IbkrErrorCode.FLEX_TOKEN_INVALID
+    ) {
+      // A past expiry is how the rest of the app reads "needs reconnecting".
+      await prisma.connection.updateMany({
+        where: { userId: resolvedUserId, service: SERVICE, externalId: accountId },
+        data: { tokenExpiresAt: new Date(0) },
+      })
+    }
+    return { error: result.error, errorParams: result.errorParams }
+  }
+
+  // Refresh the cached display data and the sync timestamp even when the
+  // statement was empty — the connection is healthy, it just had no activity.
+  await ensureConnection({
+    userId: resolvedUserId,
+    service: SERVICE,
+    externalId: accountId,
+    token: JSON.stringify({
+      ...credentials,
+      accountNumbers: result.stats.accountIds,
+      currencies: result.stats.currencies,
+    }),
+    tokenExpiresAt: null,
+  })
+
+  if (result.stats.accountIds.length > 0) {
+    await upsertAccountsForNumbers(resolvedUserId, result.stats.accountIds, connection.id)
+  }
+
+  if (result.trades.length === 0) {
+    const error =
+      result.stats.executionRows > 0
+        ? IbkrErrorCode.OPEN_POSITIONS_ONLY
+        : IbkrErrorCode.NO_TRADES_IN_RANGE
+    return { savedCount: 0, tradesCount: 0, stats: result.stats, error }
+  }
+
+  const saved = await persistTrades(result.trades, resolvedUserId, connection.id)
+
+  if (saved.error) {
+    logger.error(`Failed to save trades for query ${accountId}: ${saved.errorParams?.detail}`)
+    return {
+      error: saved.error,
+      errorParams: saved.errorParams,
+      tradesCount: saved.tradesCount,
+      stats: result.stats,
+    }
+  }
+
+  logger.info(
+    `Synced query ${accountId}: saved ${saved.savedCount}/${saved.tradesCount} trades`,
+  )
+
+  return {
+    savedCount: saved.savedCount,
+    tradesCount: saved.tradesCount,
+    stats: result.stats,
+  }
+}
+
+export async function getIbkrConnections() {
+  try {
+    const userId = await getUserId()
+    const connections = await prisma.connection.findMany({
+      where: { userId, service: SERVICE },
+      orderBy: { lastSyncedAt: 'desc' },
+    })
+    return { connections }
+  } catch (error) {
+    logger.error('Failed to list connections', error)
+    return { error: IbkrErrorCode.LOAD_SYNCHRONIZATIONS_FAILED }
+  }
+}
+
+export async function removeIbkrConnection(accountId: string) {
+  try {
+    const userId = await getUserId()
+    await prisma.connection.deleteMany({
+      where: { userId, service: SERVICE, externalId: accountId },
+    })
+    return { success: true }
+  } catch (error) {
+    logger.error('Failed to remove connection', error)
+    return { error: IbkrErrorCode.DELETE_SYNC_FAILED }
+  }
+}
+
+/**
+ * Sets the daily sync time. IBKR statements cover a rolling window rather than
+ * only today, so this is a convenience rather than a requirement — a missed run
+ * is picked up by the next one.
+ */
+export async function updateIbkrDailySyncTimeAction(
+  accountId: string,
+  utcTimeString: string | null,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const userId = await getUserId()
+    await prisma.connection.updateMany({
+      where: { userId, service: SERVICE, externalId: accountId },
+      data: { dailySyncTime: utcTimeString ? new Date(utcTimeString) : null },
+    })
+    await invalidateConnectionsPageCache(userId)
+    return { success: true }
+  } catch (error) {
+    logger.error('Failed to update daily sync time', error)
+    return { success: false, error: IbkrErrorCode.UPDATE_SYNC_TIME_FAILED }
+  }
+}

--- a/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-connect-form.tsx
+++ b/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-connect-form.tsx
@@ -17,8 +17,10 @@ import type { IbkrSyncStats } from './ibkr-types'
 const primaryButtonClassName =
   'inline-flex h-11 w-full items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-6 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]'
 
+// text-base on mobile keeps the paste field at 16px, below which iOS Safari
+// zooms the page on focus; sm+ drops back to the app's field size.
 const fieldClassName =
-  'rounded-sm border-black/10 bg-transparent font-mono text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+  'rounded-sm border-black/10 bg-transparent font-mono text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
 
 /** Shows only the last few characters so the user can confirm what we detected
  *  without the full secret sitting on screen. */

--- a/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-connect-form.tsx
+++ b/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-connect-form.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { AlertTriangle, Check, Loader2 } from 'lucide-react'
+import { useI18n } from '@/locales/client'
+import { useData } from '@/context/data-provider'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { showToastWithCopy } from '@/lib/toast-copy'
+import { getIbkrErrorToastContent } from '@/lib/ibkr-client-messages'
+import { captureConnectionCreated } from '@/lib/connection-analytics'
+import { parseIbkrCredentialsInput } from '@/lib/ibkr-flex-credentials'
+import { useIbkrSyncContext } from '@/context/ibkr-sync-context'
+import { IbkrSetupGuide } from './ibkr-setup-guide'
+import type { IbkrSyncStats } from './ibkr-types'
+
+const primaryButtonClassName =
+  'inline-flex h-11 w-full items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-6 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]'
+
+const fieldClassName =
+  'rounded-sm border-black/10 bg-transparent font-mono text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+
+/** Shows only the last few characters so the user can confirm what we detected
+ *  without the full secret sitting on screen. */
+function maskToken(token: string): string {
+  if (token.length <= 4) return '•'.repeat(token.length)
+  return `${'•'.repeat(Math.min(token.length - 4, 12))}${token.slice(-4)}`
+}
+
+function DetectedRow({ found, label, value }: { found: boolean; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      {found ? (
+        <Check className="h-3.5 w-3.5 shrink-0 text-green-600 dark:text-green-500" />
+      ) : (
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-500" />
+      )}
+      <span className="text-black/45 dark:text-white/45">{label}</span>
+      <span className="font-mono">{value}</span>
+    </div>
+  )
+}
+
+/**
+ * The whole connect flow: the Client Portal walkthrough, a single paste field,
+ * and a live verification against IBKR before anything is saved.
+ *
+ * Verification is the point. IBKR gives no way to provision a Flex Query for
+ * the user, so the only defence against a mis-clicked setting is to fetch a
+ * real statement and show them what came back.
+ */
+export function IbkrConnectForm({
+  onConnected,
+}: {
+  onConnected?: (accountId: string) => void
+}) {
+  const t = useI18n()
+  const { loadAccounts } = useIbkrSyncContext()
+  const { refreshTradesOnly } = useData()
+
+  const [pastedCredentials, setPastedCredentials] = useState('')
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [preview, setPreview] = useState<{
+    accountId: string
+    stats: IbkrSyncStats
+    savedCount: number
+  } | null>(null)
+
+  // Parsed live as the user types, so the form can confirm both values were
+  // found before they commit to a round-trip against IBKR.
+  const detected = useMemo(
+    () => parseIbkrCredentialsInput(pastedCredentials),
+    [pastedCredentials],
+  )
+  const canConnect = !!detected.token && !!detected.queryId && !isConnecting
+
+  const handleConnect = useCallback(async () => {
+    setIsConnecting(true)
+    setPreview(null)
+
+    try {
+      const response = await fetch('/api/ibkr/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input: pastedCredentials }),
+      })
+      const payload = await response.json()
+
+      if (!response.ok || !payload?.success) {
+        const { title, description } = getIbkrErrorToastContent(
+          t,
+          payload?.message,
+          payload?.errorParams,
+        )
+        showToastWithCopy('error', title, { description, copyLabel: t('common.copy') })
+        return
+      }
+
+      // Connecting already imported the statement, so surface a save failure
+      // here rather than pretending the import succeeded.
+      if (payload.message) {
+        const { title, description } = getIbkrErrorToastContent(
+          t,
+          payload.message,
+          payload.errorParams,
+        )
+        showToastWithCopy('error', title, { description, copyLabel: t('common.copy') })
+      }
+
+      // Stay on the form and show what IBKR returned: the counts are the proof
+      // the setup worked, and closing immediately would hide them.
+      setPreview({
+        accountId: payload.accountId,
+        stats: payload.stats as IbkrSyncStats,
+        savedCount: payload.savedCount ?? 0,
+      })
+      captureConnectionCreated('ibkr')
+      await loadAccounts()
+      await refreshTradesOnly({ force: false })
+    } catch (error) {
+      console.error('IBKR connect error:', error)
+      const { title, description } = getIbkrErrorToastContent(t, 'UNKNOWN')
+      showToastWithCopy('error', title, { description, copyLabel: t('common.copy') })
+    } finally {
+      setIsConnecting(false)
+    }
+  }, [pastedCredentials, t, loadAccounts, refreshTradesOnly])
+
+  const handleDone = useCallback(() => {
+    if (!preview) return
+    const { accountId } = preview
+    setPastedCredentials('')
+    setPreview(null)
+    onConnected?.(accountId)
+  }, [preview, onConnected])
+
+  if (preview) {
+    const { stats, savedCount } = preview
+    return (
+      <div className="flex flex-col space-y-5">
+        <div className="space-y-2 border-y border-black/10 py-4 dark:border-white/10">
+          <p className="flex items-center gap-2 text-sm font-medium">
+            <Check className="h-4 w-4 text-green-600 dark:text-green-500" aria-hidden="true" />
+            {t('ibkrSync.connect.verifiedTitle')}
+          </p>
+          <p className="text-sm leading-relaxed text-black/55 dark:text-white/55">
+            {savedCount > 0
+              ? t('ibkrSync.connect.importedTrades', {
+                  savedCount,
+                  tradesCount: stats.matchedTrades,
+                })
+              : t('ibkrSync.connect.nothingNew', { tradesCount: stats.matchedTrades })}
+          </p>
+          {stats.accountIds.length > 0 && (
+            <p className="font-mono text-xs text-black/55 dark:text-white/55">
+              {stats.accountIds.join(', ')}
+            </p>
+          )}
+          {stats.skippedUnparseableDate > 0 && (
+            <p className="text-xs text-amber-600 dark:text-amber-500">
+              {t('ibkrSync.sync.skippedDatesWarning', {
+                count: stats.skippedUnparseableDate,
+              })}
+            </p>
+          )}
+          {stats.currencies.length > 1 && (
+            <p className="text-xs text-amber-600 dark:text-amber-500">
+              {t('ibkrSync.sync.multiCurrencyWarning', {
+                currencies: stats.currencies.join(', '),
+              })}
+            </p>
+          )}
+        </div>
+        <button type="button" className={primaryButtonClassName} onClick={handleDone}>
+          {t('ibkrSync.connect.done')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <form
+      className="flex flex-col space-y-5"
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (canConnect) void handleConnect()
+      }}
+    >
+      <IbkrSetupGuide />
+
+      <div className="space-y-2">
+        <Label
+          htmlFor="ibkr-credentials"
+          className="text-sm text-black/55 dark:text-white/55"
+        >
+          {t('ibkrSync.connect.pasteLabel')}
+        </Label>
+        <Textarea
+          id="ibkr-credentials"
+          value={pastedCredentials}
+          onChange={(e) => setPastedCredentials(e.target.value)}
+          placeholder={t('ibkrSync.connect.pastePlaceholder')}
+          rows={3}
+          className={fieldClassName}
+          spellCheck={false}
+        />
+        <p className="text-xs leading-relaxed text-black/45 dark:text-white/45">
+          {t('ibkrSync.connect.pasteHint')}
+        </p>
+
+        {pastedCredentials.trim().length > 0 && (
+          <div className="space-y-1 rounded-sm border border-black/10 p-2 text-xs dark:border-white/10">
+            <DetectedRow
+              found={!!detected.token}
+              label={t('ibkrSync.connect.detectedToken')}
+              value={
+                detected.token
+                  ? maskToken(detected.token)
+                  : t('ibkrSync.connect.notDetected')
+              }
+            />
+            <DetectedRow
+              found={!!detected.queryId}
+              label={t('ibkrSync.connect.detectedQueryId')}
+              value={detected.queryId ?? t('ibkrSync.connect.notDetected')}
+            />
+          </div>
+        )}
+      </div>
+
+      <button type="submit" disabled={!canConnect} className={primaryButtonClassName}>
+        {isConnecting ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            {t('ibkrSync.connect.verifying')}
+          </>
+        ) : (
+          t('ibkrSync.connect.verifyAndConnect')
+        )}
+      </button>
+    </form>
+  )
+}

--- a/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-credentials-manager.tsx
@@ -1,0 +1,346 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { AlertTriangle, Loader2, MoreVertical, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useI18n } from '@/locales/client'
+import { useIbkrSyncContext } from '@/context/ibkr-sync-context'
+import { updateIbkrDailySyncTimeAction } from './actions'
+import { IbkrConnectForm } from './ibkr-connect-form'
+
+export function IbkrCredentialsManager() {
+  const { accounts, loadAccounts, deleteAccount, performSyncForAccount, performSyncForAllAccounts } =
+    useIbkrSyncContext()
+  const t = useI18n()
+
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
+  const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false)
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null)
+  const [actionsMenuAccountId, setActionsMenuAccountId] = useState<string | null>(null)
+
+  const [syncingId, setSyncingId] = useState<string | null>(null)
+  const [isReloading, setIsReloading] = useState(false)
+  const [dailySyncTime, setDailySyncTime] = useState('')
+  const [isSavingTime, setIsSavingTime] = useState(false)
+
+  const handleRemove = useCallback(
+    async (accountId: string) => {
+      try {
+        await deleteAccount(accountId)
+        setIsRemoveDialogOpen(false)
+        toast.success(t('ibkrSync.manage.connectionRemoved', { accountId }))
+      } catch (error) {
+        console.error('IBKR remove error:', error)
+        toast.error(t('ibkrSync.manage.removeError', { accountId }))
+      }
+    },
+    [deleteAccount, t],
+  )
+
+  const handleReload = useCallback(async () => {
+    setIsReloading(true)
+    try {
+      await loadAccounts()
+      toast.success(t('ibkrSync.manage.reloaded'))
+    } finally {
+      setIsReloading(false)
+    }
+  }, [loadAccounts, t])
+
+  const handleSaveDailySyncTime = useCallback(async () => {
+    if (!selectedAccountId) return
+    setIsSavingTime(true)
+    try {
+      let utcTimeString: string | null = null
+      if (dailySyncTime) {
+        const [hours, minutes] = dailySyncTime.split(':').map(Number)
+        const localDate = new Date()
+        localDate.setHours(hours, minutes, 0, 0)
+        utcTimeString = localDate.toISOString()
+      }
+
+      const result = await updateIbkrDailySyncTimeAction(selectedAccountId, utcTimeString)
+      if (result.success) {
+        toast.success(t('ibkrSync.manage.dailySyncTimeUpdated'))
+        setIsTimeDialogOpen(false)
+        await loadAccounts()
+      } else {
+        toast.error(t('ibkrSync.manage.dailySyncTimeUpdateError'))
+      }
+    } finally {
+      setIsSavingTime(false)
+    }
+  }, [selectedAccountId, dailySyncTime, loadAccounts, t])
+
+  function formatLocalTime(date: Date | null): string | null {
+    if (!date) return null
+    const local = new Date(date)
+    return `${local.getHours().toString().padStart(2, '0')}:${local
+      .getMinutes()
+      .toString()
+      .padStart(2, '0')}`
+  }
+
+  return (
+    <div className="space-y-4 min-w-0 w-full">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2 min-w-0">
+          <h3 className="text-sm sm:text-base font-semibold truncate">
+            {t('ibkrSync.manage.savedConnections')}
+          </h3>
+          <Button
+            onClick={handleReload}
+            size="sm"
+            variant="ghost"
+            disabled={isReloading}
+            className="h-8 w-8 p-0 shrink-0"
+          >
+            {isReloading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2 shrink-0">
+          {accounts.length > 0 && (
+            <Button
+              onClick={() => performSyncForAllAccounts()}
+              size="sm"
+              variant="outline"
+              disabled={syncingId !== null}
+              className="h-8 flex-1 sm:flex-none"
+            >
+              <RefreshCw className="h-4 w-4 mr-2" />
+              <span className="truncate">{t('ibkrSync.manage.syncAll')}</span>
+            </Button>
+          )}
+          <Button
+            onClick={() => setIsAddDialogOpen(true)}
+            size="sm"
+            className="h-8 flex-1 sm:flex-none"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            {t('ibkrSync.manage.addNew')}
+          </Button>
+        </div>
+      </div>
+
+      {accounts.length === 0 ? (
+        <div className="border rounded-lg px-4 py-8 text-center text-muted-foreground text-sm">
+          {t('ibkrSync.manage.noConnections')}
+        </div>
+      ) : (
+        <ul className="rounded-lg border divide-y">
+          {accounts.map((connection) => {
+            const isConnected = connection.hasToken && !connection.tokenExpired
+            return (
+              <li key={connection.accountId} className="flex min-w-0 items-start gap-2 px-3 py-2.5">
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <p className="truncate text-sm font-medium">
+                      {t('ibkrSync.manage.queryLabel', { queryId: connection.accountId })}
+                    </p>
+                    <span
+                      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium leading-none ${
+                        isConnected
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                          : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                      }`}
+                    >
+                      {isConnected
+                        ? t('ibkrSync.manage.connected')
+                        : t('ibkrSync.manage.expired')}
+                    </span>
+                  </div>
+                  {connection.accountNumbers.length > 0 && (
+                    <p className="truncate font-mono text-xs text-muted-foreground">
+                      {connection.accountNumbers.join(', ')}
+                    </p>
+                  )}
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                    <span>
+                      {t('ibkrSync.manage.lastSync')}:{' '}
+                      <span className="text-foreground/75">
+                        {connection.lastSyncedAt.toLocaleString()}
+                      </span>
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      {t('ibkrSync.manage.dailySync')}:
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="sm"
+                        className="h-auto p-0 text-[11px] font-normal"
+                        onClick={() => {
+                          setSelectedAccountId(connection.accountId)
+                          setDailySyncTime(formatLocalTime(connection.dailySyncTime) ?? '')
+                          setIsTimeDialogOpen(true)
+                        }}
+                      >
+                        {formatLocalTime(connection.dailySyncTime) ??
+                          t('ibkrSync.manage.scheduleSync')}
+                      </Button>
+                    </span>
+                  </div>
+                  {connection.currencies.length > 1 && (
+                    <p className="flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-500">
+                      <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden="true" />
+                      {t('ibkrSync.manage.multiCurrency', {
+                        currencies: connection.currencies.join(', '),
+                      })}
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-center gap-0.5">
+                  {!isConnected && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsAddDialogOpen(true)}
+                      className="h-7 px-2 text-xs"
+                    >
+                      {t('ibkrSync.manage.reconnect')}
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={async () => {
+                      setSyncingId(connection.accountId)
+                      await performSyncForAccount(connection.accountId)
+                      setSyncingId(null)
+                    }}
+                    disabled={syncingId !== null || !isConnected}
+                    className="h-7 w-7 p-0 shrink-0"
+                    title={t('ibkrSync.manage.syncNow')}
+                  >
+                    {syncingId === connection.accountId ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground" />
+                    )}
+                  </Button>
+                  <Popover
+                    modal
+                    open={actionsMenuAccountId === connection.accountId}
+                    onOpenChange={(open) =>
+                      setActionsMenuAccountId(open ? connection.accountId : null)
+                    }
+                  >
+                    <PopoverTrigger asChild>
+                      <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0">
+                        <MoreVertical className="h-3.5 w-3.5" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-52 p-2" align="end">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="w-full justify-start text-destructive hover:text-destructive"
+                        onClick={() => {
+                          setActionsMenuAccountId(null)
+                          setSelectedAccountId(connection.accountId)
+                          setIsRemoveDialogOpen(true)
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        {t('ibkrSync.manage.removeConnection')}
+                      </Button>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t('ibkrSync.connect.title')}</DialogTitle>
+            <DialogDescription>{t('ibkrSync.connect.description')}</DialogDescription>
+          </DialogHeader>
+          <IbkrConnectForm onConnected={() => setIsAddDialogOpen(false)} />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isRemoveDialogOpen} onOpenChange={setIsRemoveDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('ibkrSync.manage.removeConnection')}</DialogTitle>
+            <DialogDescription>
+              {t('ibkrSync.manage.removeConfirm', { accountId: selectedAccountId ?? '' })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end space-x-2 mt-4">
+            <Button variant="outline" onClick={() => setIsRemoveDialogOpen(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => selectedAccountId && handleRemove(selectedAccountId)}
+            >
+              {t('ibkrSync.manage.remove')}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isTimeDialogOpen} onOpenChange={setIsTimeDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('ibkrSync.manage.dailySyncTimeTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('ibkrSync.manage.dailySyncTimeDescription')}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-4">
+            <div className="space-y-2">
+              <Label htmlFor="ibkr-sync-time">{t('ibkrSync.manage.dailySyncTimeLabel')}</Label>
+              <Input
+                id="ibkr-sync-time"
+                type="time"
+                value={dailySyncTime}
+                onChange={(e) => setDailySyncTime(e.target.value)}
+              />
+              <p className="text-sm text-muted-foreground">
+                {t('ibkrSync.manage.dailySyncTimeTimezoneNote', {
+                  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+                })}
+              </p>
+            </div>
+            <div className="flex justify-end space-x-2">
+              <Button variant="outline" onClick={() => setIsTimeDialogOpen(false)}>
+                {t('common.cancel')}
+              </Button>
+              <Button onClick={handleSaveDailySyncTime} disabled={isSavingTime}>
+                {isSavingTime ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    {t('common.saving')}
+                  </>
+                ) : (
+                  t('common.save')
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-setup-guide.tsx
+++ b/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-setup-guide.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Check, Copy, ExternalLink, Info } from 'lucide-react'
+import { useI18n } from '@/locales/client'
+import { cn } from '@/lib/utils'
+
+/**
+ * Client Portal entry point. Overridable so the exact Flex Queries deep link can
+ * be swapped in without a code change once verified against a live account.
+ */
+const IBKR_PORTAL_URL =
+  process.env.NEXT_PUBLIC_IBKR_FLEX_PORTAL_URL || 'https://www.interactivebrokers.com/portal'
+
+/** The query settings the sync depends on, kept in one place so the guide,
+ *  the copyable summary and the error hints cannot drift apart. */
+export const IBKR_REQUIRED_QUERY_SETTINGS = {
+  section: 'Trades',
+  period: 'Last 365 Calendar Days',
+  format: 'XML',
+  dateFormat: 'yyyyMMdd',
+  timeFormat: 'HHmmss',
+} as const
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-7 gap-1.5 px-2 text-xs"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(value)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 2000)
+        } catch {
+          // Clipboard denied (insecure context or permission): the value is
+          // visible on screen, so selecting it by hand still works.
+        }
+      }}
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {label}
+    </Button>
+  )
+}
+
+function Step({
+  index,
+  title,
+  children,
+}: {
+  index: number
+  title: string
+  children?: React.ReactNode
+}) {
+  return (
+    <li className="flex gap-3">
+      <span
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold tabular-nums"
+        aria-hidden="true"
+      >
+        {index}
+      </span>
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <p className="text-sm leading-snug">{title}</p>
+        {children}
+      </div>
+    </li>
+  )
+}
+
+/**
+ * Walks the user through the Client Portal setup that the Flex Web Service
+ * requires. IBKR gives no way to provision a query on the user's behalf, so the
+ * next best thing is to make every step unambiguous and pre-fill what we can.
+ */
+export function IbkrSetupGuide({ className }: { className?: string }) {
+  const t = useI18n()
+
+  const settingsSummary = [
+    `${t('ibkrSync.setup.summarySection')}: ${IBKR_REQUIRED_QUERY_SETTINGS.section}`,
+    `${t('ibkrSync.setup.summaryPeriod')}: ${IBKR_REQUIRED_QUERY_SETTINGS.period}`,
+    `${t('ibkrSync.setup.summaryFormat')}: ${IBKR_REQUIRED_QUERY_SETTINGS.format}`,
+    `${t('ibkrSync.setup.summaryDateFormat')}: ${IBKR_REQUIRED_QUERY_SETTINGS.dateFormat} / ${IBKR_REQUIRED_QUERY_SETTINGS.timeFormat}`,
+  ].join('\n')
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="text-sm font-medium">{t('ibkrSync.setup.title')}</h4>
+        <Button type="button" variant="outline" size="sm" className="h-8 gap-1.5" asChild>
+          <a href={IBKR_PORTAL_URL} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="h-3.5 w-3.5" />
+            {t('ibkrSync.setup.openPortal')}
+          </a>
+        </Button>
+      </div>
+
+      <ol className="space-y-3">
+        <Step index={1} title={t('ibkrSync.setup.step1')} />
+        <Step index={2} title={t('ibkrSync.setup.step2')}>
+          <p className="text-xs text-muted-foreground">{t('ibkrSync.setup.step2Hint')}</p>
+        </Step>
+        <Step index={3} title={t('ibkrSync.setup.step3')}>
+          <p className="text-xs text-muted-foreground">{t('ibkrSync.setup.step3Hint')}</p>
+        </Step>
+        <Step index={4} title={t('ibkrSync.setup.step4')}>
+          <div className="rounded-md border bg-muted/40 p-2">
+            <dl className="space-y-0.5 text-xs">
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">
+                  {t('ibkrSync.setup.summarySection')}
+                </dt>
+                <dd className="font-mono">{IBKR_REQUIRED_QUERY_SETTINGS.section}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">
+                  {t('ibkrSync.setup.summaryPeriod')}
+                </dt>
+                <dd className="font-mono">{IBKR_REQUIRED_QUERY_SETTINGS.period}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">
+                  {t('ibkrSync.setup.summaryFormat')}
+                </dt>
+                <dd className="font-mono">{IBKR_REQUIRED_QUERY_SETTINGS.format}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">
+                  {t('ibkrSync.setup.summaryDateFormat')}
+                </dt>
+                <dd className="font-mono">
+                  {IBKR_REQUIRED_QUERY_SETTINGS.dateFormat} /{' '}
+                  {IBKR_REQUIRED_QUERY_SETTINGS.timeFormat}
+                </dd>
+              </div>
+            </dl>
+            <div className="mt-1.5 flex justify-end">
+              <CopyButton value={settingsSummary} label={t('common.copy')} />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">{t('ibkrSync.setup.step4Hint')}</p>
+        </Step>
+        <Step index={5} title={t('ibkrSync.setup.step5')} />
+      </ol>
+
+      <Alert variant="info" role="note">
+        <Info className="h-4 w-4" aria-hidden="true" />
+        <AlertDescription className="text-xs">
+          {t('ibkrSync.setup.readOnlyNote')}
+        </AlertDescription>
+      </Alert>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-sync.tsx
+++ b/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-sync.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import type { Dispatch, SetStateAction } from 'react'
+import { useI18n } from '@/locales/client'
+import { IbkrConnectForm } from './ibkr-connect-form'
+import { IbkrCredentialsManager } from './ibkr-credentials-manager'
+
+interface IbkrSyncProps {
+  /** When false, open on the connect form instead of the saved-connections list. */
+  initialShowAccountsManager?: boolean
+  onConnected?: () => void
+  /** Accepted for PlatformConfig customComponent compatibility; unused here. */
+  setIsOpen?: Dispatch<SetStateAction<boolean>> | ((open: boolean) => void)
+}
+
+export function IbkrSync({
+  initialShowAccountsManager = true,
+  onConnected,
+  setIsOpen: _setIsOpen,
+}: IbkrSyncProps = {}) {
+  const t = useI18n()
+
+  if (!initialShowAccountsManager) {
+    return <IbkrConnectForm onConnected={() => onConnected?.()} />
+  }
+
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-4 p-0 sm:gap-6 sm:p-1">
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <h2 className="text-xl font-normal tracking-tight md:text-2xl">
+          {t('ibkrSync.title')}
+        </h2>
+        <p className="text-sm leading-relaxed text-black/55 dark:text-white/55">
+          {t('ibkrSync.description')}
+        </p>
+      </div>
+      <IbkrCredentialsManager />
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-types.ts
+++ b/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-types.ts
@@ -1,0 +1,70 @@
+import type { IbkrErrorCodeValue, IbkrErrorParams } from '@/lib/ibkr-flex-errors'
+
+/**
+ * Shape stored as JSON in `Synchronization.token`.
+ *
+ * The Flex Web Service needs both values on every call, and the Synchronization
+ * model has a single token column, so they travel together — the same approach
+ * the DxFeed integration uses for its credential bundle.
+ */
+export interface IbkrStoredCredentials {
+  token: string
+  queryId: string
+  /** IBKR account IDs seen in the last statement, for display only. */
+  accountNumbers?: string[]
+  /** Currencies seen in the last statement; more than one needs a warning. */
+  currencies?: string[]
+}
+
+export interface IbkrSyncStats {
+  /** Total <Trade> rows in the statement, at every level of detail. */
+  tradeRows: number
+  executionRows: number
+  closedLotRows: number
+  /** Round-turns produced by FIFO matching. */
+  matchedTrades: number
+  /** Rows dropped because their date could not be read unambiguously. */
+  skippedUnparseableDate: number
+  /** Rows dropped for missing side/quantity/price. */
+  skippedIncomplete: number
+  currencies: string[]
+  accountIds: string[]
+}
+
+export interface IbkrActionResult {
+  error?: IbkrErrorCodeValue
+  errorParams?: IbkrErrorParams
+}
+
+export interface IbkrConnectResult extends IbkrActionResult {
+  success?: boolean
+  accountId?: string
+  stats?: IbkrSyncStats
+  /** Trades written on the connecting call; connecting imports immediately. */
+  savedCount?: number
+  /** Round-turns found, whether or not they were new. */
+  tradesCount?: number
+}
+
+export interface IbkrTradesResult extends IbkrActionResult {
+  savedCount?: number
+  tradesCount?: number
+  stats?: IbkrSyncStats
+}
+
+/** Client-safe view of a Synchronization row — credentials never leave the server. */
+export interface IbkrSyncAccount {
+  id: string
+  userId: string
+  service: string
+  /** The Flex query ID; unique per connection for a user. */
+  accountId: string
+  hasToken: boolean
+  tokenExpired: boolean
+  accountNumbers: string[]
+  currencies: string[]
+  lastSyncedAt: Date
+  dailySyncTime: Date | null
+  createdAt: Date
+  updatedAt: Date
+}

--- a/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
+++ b/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
@@ -4,6 +4,7 @@ import { RithmicSyncWrapper } from '@/app/[locale]/dashboard/components/import/r
 import { RithmicProtocolSync } from '@/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync'
 import { TradovateSync } from '@/app/[locale]/dashboard/components/import/tradovate/sync/tradovate-sync'
 import { DxFeedSync } from '@/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-sync'
+import { IbkrSync } from '@/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-sync'
 import { ThorSync } from '@/app/[locale]/dashboard/components/import/thor/thor-sync'
 import type { ConnectionService } from '../actions'
 import { useI18n } from '@/locales/client'
@@ -38,6 +39,8 @@ export function ConnectServiceModal({
           ? t('connections.add.tradovate')
           : service === 'dxfeed'
             ? t('connections.add.dxfeed')
+            : service === 'ibkr'
+              ? t('connections.add.ibkr')
             : service === 'thor'
               ? t('connections.add.thor')
               : service === 'etp'
@@ -100,6 +103,14 @@ export function ConnectServiceModal({
                 initialShowAccountsManager={false}
                 initialEmail={prefill?.accountId}
                 initialPropFirmName={prefill?.displayName}
+                onConnected={onClose}
+              />
+            </div>
+          )}
+          {service === 'ibkr' && (
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <IbkrSync
+                initialShowAccountsManager={false}
                 onConnected={onClose}
               />
             </div>

--- a/app/[locale]/dashboard/connections/components/connections-page-chrome.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-chrome.tsx
@@ -42,6 +42,7 @@ const SERVICE_SECTIONS: {
   },
   { service: 'tradovate', labelKey: 'connections.sections.tradovate' },
   { service: 'dxfeed', labelKey: 'connections.sections.dxfeed' },
+  { service: 'ibkr', labelKey: 'connections.sections.ibkr' },
   { service: 'thor', labelKey: 'connections.sections.thor' },
 ]
 

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -50,6 +50,7 @@ import {
 import { useTradovateSyncStore } from '@/store/tradovate-sync-store'
 import { useTradovateSyncContext } from '@/context/tradovate-sync-context'
 import { useDxFeedSyncContext } from '@/context/dxfeed-sync-context'
+import { useIbkrSyncContext } from '@/context/ibkr-sync-context'
 import { useRithmicSyncContext } from '@/context/rithmic-sync-context'
 import { useRithmicProtocolSyncContext } from '@/context/rithmic-protocol-sync-context'
 import { toast } from 'sonner'
@@ -76,6 +77,7 @@ const SERVICE_SECTIONS: {
   },
   { service: 'tradovate', labelKey: 'connections.sections.tradovate' },
   { service: 'dxfeed', labelKey: 'connections.sections.dxfeed' },
+  { service: 'ibkr', labelKey: 'connections.sections.ibkr' },
   { service: 'thor', labelKey: 'connections.sections.thor' },
 ]
 
@@ -88,6 +90,7 @@ const SYNCABLE_SERVICES = new Set<string>([
   'rithmic-protocol',
   'tradovate',
   'dxfeed',
+  'ibkr',
 ])
 
 const iconButtonClassName =
@@ -367,6 +370,7 @@ function ConnectionRow({
   const tradovateStore = useTradovateSyncStore()
   const { performSyncForAccount: syncTradovate } = useTradovateSyncContext()
   const { performSyncForAccount: syncDxFeed } = useDxFeedSyncContext()
+  const { performSyncForAccount: syncIbkr } = useIbkrSyncContext()
   const {
     performSyncForAccount: syncRithmicProtocol,
     isAccountSyncing: isRithmicProtocolSyncing,
@@ -381,6 +385,7 @@ function ConnectionRow({
   const canSyncRow =
     connection.service === 'tradovate' ||
     connection.service === 'dxfeed' ||
+    connection.service === 'ibkr' ||
     connection.service === 'rithmic-protocol'
 
   const canSchedule = supportsDailySync(connection.service)
@@ -470,6 +475,8 @@ function ConnectionRow({
         result = await syncTradovate(connection.accountId)
       } else if (connection.service === 'dxfeed') {
         result = await syncDxFeed(connection.accountId)
+      } else if (connection.service === 'ibkr') {
+        result = await syncIbkr(connection.accountId)
       } else if (connection.service === 'rithmic-protocol') {
         // Loading/error feedback comes from Protocol sync context (row spinner).
         result = await syncRithmicProtocol(connection.accountId)
@@ -495,7 +502,7 @@ function ConnectionRow({
     } finally {
       if (usesLocalSyncState) setSyncing(false)
     }
-  }, [connection, onChanged, syncDxFeed, syncRithmicProtocol, syncTradovate, t])
+  }, [connection, onChanged, syncDxFeed, syncIbkr, syncRithmicProtocol, syncTradovate, t])
 
   const handleReconnect = useCallback(async () => {
     // Tradovate can re-auth in place via OAuth without opening the add sheet.
@@ -1054,6 +1061,7 @@ export function ConnectionsPageClient({
     loadAccounts: loadDxFeed,
     performSyncForAccount: syncDxFeed,
   } = useDxFeedSyncContext()
+  const { performSyncForAccount: syncIbkr } = useIbkrSyncContext()
   const { performSyncForCredential: syncRithmic } = useRithmicSyncContext()
   const { performSyncForAccount: syncRithmicProtocol } =
     useRithmicProtocolSyncContext()
@@ -1312,6 +1320,8 @@ export function ConnectionsPageClient({
             result = await syncTradovate(connection.accountId)
           } else if (connection.service === 'dxfeed') {
             result = await syncDxFeed(connection.accountId)
+          } else if (connection.service === 'ibkr') {
+            result = await syncIbkr(connection.accountId)
           } else if (connection.service === 'rithmic-protocol') {
             result = await syncRithmicProtocol(connection.accountId)
           } else {
@@ -1338,6 +1348,7 @@ export function ConnectionsPageClient({
   }, [
     load,
     syncDxFeed,
+    syncIbkr,
     syncRithmic,
     syncRithmicProtocol,
     syncTradovate,

--- a/app/[locale]/dashboard/connections/daily-sync-services.ts
+++ b/app/[locale]/dashboard/connections/daily-sync-services.ts
@@ -10,6 +10,7 @@ export const DAILY_SYNC_SERVICES = [
   'tradovate',
   'dxfeed',
   'rithmic-protocol',
+  'ibkr',
 ] as const
 
 export type DailySyncService = (typeof DAILY_SYNC_SERVICES)[number]

--- a/app/[locale]/dashboard/connections/types.ts
+++ b/app/[locale]/dashboard/connections/types.ts
@@ -5,6 +5,7 @@ export type ConnectionService =
   | 'rithmic-protocol'
   | 'tradovate'
   | 'dxfeed'
+  | 'ibkr'
   | 'thor'
   | 'etp'
 

--- a/app/[locale]/dashboard/layout.tsx
+++ b/app/[locale]/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { RithmicSyncContextProvider } from "@/context/rithmic-sync-context";
 import { TradovateSyncContextProvider } from "@/context/tradovate-sync-context";
 import { DxFeedSyncContextProvider } from "@/context/dxfeed-sync-context";
+import { IbkrSyncContextProvider } from "@/context/ibkr-sync-context";
 import { RithmicProtocolSyncContextProvider } from "@/context/rithmic-protocol-sync-context";
 import { ConsentBanner } from "@/components/consent-banner";
 import { PostHogIdentity } from "@/components/posthog-identity";
@@ -65,11 +66,13 @@ export default function RootLayout({
               <RithmicProtocolSyncContextProvider>
                 <TradovateSyncContextProvider>
                   <DxFeedSyncContextProvider>
-                    <RithmicSyncNotifications />
-                    <Toaster />
-                    <Navbar />
-                    {children}
-                    <Modals />
+                    <IbkrSyncContextProvider>
+                      <RithmicSyncNotifications />
+                      <Toaster />
+                      <Navbar />
+                      {children}
+                      <Modals />
+                    </IbkrSyncContextProvider>
                   </DxFeedSyncContextProvider>
                 </TradovateSyncContextProvider>
               </RithmicProtocolSyncContextProvider>

--- a/app/api/cron/daily-sync/route.ts
+++ b/app/api/cron/daily-sync/route.ts
@@ -5,6 +5,7 @@ import { decryptConnectionToken } from '@/lib/connection-token-crypto'
 import { isDailySyncDue } from '@/lib/daily-sync-schedule'
 import { getDxFeedTrades } from '@/app/[locale]/dashboard/components/import/dxfeed/sync/actions'
 import { getRithmicProtocolTrades } from '@/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions'
+import { syncIbkrAccount } from '@/app/[locale]/dashboard/components/import/ibkr/sync/actions'
 import { invalidateConnectionsPageCache } from '@/app/[locale]/dashboard/connections/data'
 
 export const maxDuration = 300
@@ -14,7 +15,13 @@ export const maxDuration = 300
  * schedule is already driven by /api/cron/renew-tradovate-token, which has to
  * refresh the OAuth token in the same pass.
  */
-const SYNCABLE_SERVICES = ['dxfeed', 'rithmic-protocol'] as const
+const SYNCABLE_SERVICES = ['dxfeed', 'rithmic-protocol', 'ibkr'] as const
+
+/**
+ * IBKR statements cover a rolling window rather than only the latest day, so a
+ * run that finds nothing new is a healthy no-op, not a failure to report.
+ */
+const IBKR_EMPTY_RESULTS = new Set(['NO_TRADES_IN_RANGE', 'OPEN_POSITIONS_ONLY'])
 
 /** Stop starting new syncs past this point so the function returns before its limit. */
 const WALL_CLOCK_BUDGET_MS = 240_000
@@ -34,20 +41,30 @@ async function syncConnection(connection: {
     return { ok: false, reason: 'NO_TOKEN' }
   }
 
-  const error =
-    connection.service === 'dxfeed'
-      ? (
-          await getDxFeedTrades(storedTokenJson, {
-            userId: connection.userId,
-            accountId: connection.externalId,
-          })
-        ).error
-      : (
-          await getRithmicProtocolTrades(storedTokenJson, {
-            userId: connection.userId,
-            connectionId: connection.id,
-          })
-        ).error
+  let error: string | undefined
+
+  if (connection.service === 'dxfeed') {
+    error = (
+      await getDxFeedTrades(storedTokenJson, {
+        userId: connection.userId,
+        accountId: connection.externalId,
+      })
+    ).error
+  } else if (connection.service === 'ibkr') {
+    // IBKR re-reads and decrypts the bundle itself; the check above is only a
+    // cheap guard against scheduling a connection with no credentials left.
+    const result = await syncIbkrAccount(connection.externalId, {
+      userId: connection.userId,
+    })
+    error = result.error && !IBKR_EMPTY_RESULTS.has(result.error) ? result.error : undefined
+  } else {
+    error = (
+      await getRithmicProtocolTrades(storedTokenJson, {
+        userId: connection.userId,
+        connectionId: connection.id,
+      })
+    ).error
+  }
 
   if (!error || error === DUPLICATE_TRADES) return { ok: true }
   return { ok: false, reason: error }

--- a/app/api/ibkr/connect/route.ts
+++ b/app/api/ibkr/connect/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectIbkrFlexAccount } from '@/app/[locale]/dashboard/components/import/ibkr/sync/actions'
+import { IbkrErrorCode } from '@/lib/ibkr-flex-errors'
+
+/**
+ * Connecting validates the credentials against the live Flex service, which
+ * involves waiting for IBKR to generate the report, so this needs more than the
+ * default execution budget.
+ */
+export const maxDuration = 60
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const input = typeof body?.input === 'string' ? body.input : ''
+
+    if (!input.trim()) {
+      return NextResponse.json(
+        { success: false, message: IbkrErrorCode.CREDENTIALS_REQUIRED },
+        { status: 400 },
+      )
+    }
+
+    const result = await connectIbkrFlexAccount(input)
+
+    if (!result.success) {
+      return NextResponse.json(
+        { success: false, message: result.error, errorParams: result.errorParams },
+        { status: 400 },
+      )
+    }
+
+    // The connection can be stored successfully and still carry an error from
+    // the import that followed it, so `message` rides along with success.
+    return NextResponse.json({
+      success: true,
+      accountId: result.accountId,
+      stats: result.stats,
+      savedCount: result.savedCount ?? 0,
+      tradesCount: result.tradesCount ?? 0,
+      message: result.error,
+      errorParams: result.errorParams,
+    })
+  } catch (error) {
+    console.error('Error connecting IBKR Flex account:', error)
+    return NextResponse.json(
+      { success: false, message: IbkrErrorCode.UNKNOWN },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/ibkr/sync/route.ts
+++ b/app/api/ibkr/sync/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { syncIbkrAccount } from '@/app/[locale]/dashboard/components/import/ibkr/sync/actions'
+import { IbkrErrorCode } from '@/lib/ibkr-flex-errors'
+
+/** Flex report generation is asynchronous; allow time for the polling loop. */
+export const maxDuration = 60
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const accountId = typeof body?.accountId === 'string' ? body.accountId : undefined
+
+    if (!accountId) {
+      return NextResponse.json(
+        { success: false, message: IbkrErrorCode.ACCOUNT_ID_REQUIRED },
+        { status: 400 },
+      )
+    }
+
+    const result = await syncIbkrAccount(accountId)
+
+    if (result.error) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: result.error,
+          errorParams: result.errorParams,
+          stats: result.stats,
+        },
+        { status: 400 },
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      savedCount: result.savedCount ?? 0,
+      tradesCount: result.tradesCount ?? 0,
+      stats: result.stats,
+    })
+  } catch (error) {
+    console.error('Error performing IBKR sync:', error)
+    return NextResponse.json(
+      { success: false, message: IbkrErrorCode.SYNC_FAILED },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/ibkr/synchronizations/route.ts
+++ b/app/api/ibkr/synchronizations/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  getIbkrConnections,
+  removeIbkrConnection,
+} from '@/app/[locale]/dashboard/components/import/ibkr/sync/actions'
+import { IbkrErrorCode } from '@/lib/ibkr-flex-errors'
+import { decryptConnectionToken } from '@/lib/connection-token-crypto'
+import type { IbkrStoredCredentials } from '@/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-types'
+
+export async function GET() {
+  try {
+    const result = await getIbkrConnections()
+    if (result.error) {
+      return NextResponse.json({ success: false, message: result.error }, { status: 400 })
+    }
+
+    // The stored token is a credential bundle and must never reach the client;
+    // only the derived display fields do.
+    const sanitized = (result.connections ?? []).map(
+      ({ token, tokenExpiresAt, externalId, ...rest }) => {
+        let accountNumbers: string[] = []
+        let currencies: string[] = []
+
+        if (token) {
+          try {
+            const parsed = JSON.parse(
+              decryptConnectionToken(token) ?? '{}',
+            ) as Partial<IbkrStoredCredentials>
+            if (Array.isArray(parsed.accountNumbers)) accountNumbers = parsed.accountNumbers
+            if (Array.isArray(parsed.currencies)) currencies = parsed.currencies
+          } catch {
+            // Unreadable bundle: surfaced as a disconnected row below.
+          }
+        }
+
+        // Flex never reports a token's expiry, so a past `tokenExpiresAt` only
+        // ever means "IBKR rejected this token on the last attempt".
+        const tokenExpired = !!tokenExpiresAt && tokenExpiresAt.getTime() <= Date.now()
+
+        return {
+          ...rest,
+          // The client keys connections by the Flex query ID.
+          accountId: externalId,
+          hasToken: !!token && !tokenExpired,
+          tokenExpired,
+          accountNumbers,
+          currencies,
+        }
+      },
+    )
+
+    return NextResponse.json({ success: true, data: sanitized })
+  } catch (error) {
+    console.error('Error fetching IBKR connections:', error)
+    return NextResponse.json(
+      { success: false, message: IbkrErrorCode.LOAD_SYNCHRONIZATIONS_FAILED },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const accountId = typeof body?.accountId === 'string' ? body.accountId : undefined
+
+    if (!accountId) {
+      return NextResponse.json(
+        { success: false, message: IbkrErrorCode.ACCOUNT_ID_REQUIRED },
+        { status: 400 },
+      )
+    }
+
+    const result = await removeIbkrConnection(accountId)
+    if (result.error) {
+      return NextResponse.json({ success: false, message: result.error }, { status: 400 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error deleting IBKR connection:', error)
+    return NextResponse.json(
+      { success: false, message: IbkrErrorCode.DELETE_SYNC_FAILED },
+      { status: 500 },
+    )
+  }
+}

--- a/components/monochrome-logo.tsx
+++ b/components/monochrome-logo.tsx
@@ -6,6 +6,7 @@ const SERVICE_SLUGS = {
   'rithmic-protocol': 'rithmic',
   tradovate: 'tradovate',
   dxfeed: 'dxfeed',
+  ibkr: 'ibkr',
   thor: 'thor',
   etp: 'thor',
 } as const

--- a/context/ibkr-sync-context.tsx
+++ b/context/ibkr-sync-context.tsx
@@ -1,0 +1,284 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useData } from '@/context/data-provider'
+import { useI18n } from '@/locales/client'
+import { IbkrErrorCode } from '@/lib/ibkr-flex-errors'
+import { formatIbkrError, getIbkrErrorToastContent } from '@/lib/ibkr-client-messages'
+import { runToastWithCopy, showToastWithCopy } from '@/lib/toast-copy'
+import type {
+  IbkrSyncAccount,
+  IbkrSyncStats,
+} from '@/app/[locale]/dashboard/components/import/ibkr/sync/ibkr-types'
+
+interface IbkrSyncApiPayload {
+  success?: boolean
+  message?: string
+  errorParams?: Record<string, string | number>
+  savedCount?: number
+  tradesCount?: number
+  stats?: IbkrSyncStats
+}
+
+/**
+ * Chooses the message for a successful call, which may still have imported
+ * nothing. "Synced 0 trades" is useless on its own — the user needs to know
+ * whether that means no activity, only open positions, or rows we dropped.
+ */
+function buildSyncSuccessToast(
+  t: unknown,
+  accountId: string,
+  payload: IbkrSyncApiPayload,
+): { title: string; description?: string } {
+  const translate = t as (key: string, params?: Record<string, string | number>) => string
+  const savedCount = payload.savedCount ?? 0
+  const tradesCount = payload.tradesCount ?? 0
+  const stats = payload.stats
+
+  const warnings: string[] = []
+  if (stats && stats.currencies.length > 1) {
+    warnings.push(
+      translate('ibkrSync.sync.multiCurrencyWarning', {
+        currencies: stats.currencies.join(', '),
+      }),
+    )
+  }
+  if (stats && stats.skippedUnparseableDate > 0) {
+    warnings.push(
+      translate('ibkrSync.sync.skippedDatesWarning', {
+        count: stats.skippedUnparseableDate,
+      }),
+    )
+  }
+  const description = warnings.length > 0 ? warnings.join(' ') : undefined
+
+  if (savedCount > 0) {
+    return {
+      title: translate('ibkrSync.sync.completeForAccount', {
+        savedCount,
+        tradesCount,
+        accountId,
+      }),
+      description,
+    }
+  }
+
+  return {
+    title: translate('ibkrSync.sync.noNewTradesForAccount', { tradesCount, accountId }),
+    description,
+  }
+}
+
+/** Wire shape of `GET /api/ibkr/synchronizations`: dates arrive as ISO strings. */
+interface IbkrConnectionPayload {
+  id: string
+  userId: string
+  service: string
+  accountId: string
+  hasToken?: boolean
+  tokenExpired?: boolean
+  accountNumbers?: string[]
+  currencies?: string[]
+  lastSyncedAt?: string | null
+  dailySyncTime?: string | null
+  createdAt?: string | null
+  updatedAt?: string | null
+}
+
+interface IbkrSyncContextType {
+  performSyncForAccount: (
+    accountId: string,
+  ) => Promise<{ success: boolean; message: string } | undefined>
+  performSyncForAllAccounts: () => Promise<void>
+  isAutoSyncing: boolean
+  accounts: IbkrSyncAccount[]
+  loadAccounts: () => Promise<void>
+  deleteAccount: (accountId: string) => Promise<void>
+}
+
+const IbkrSyncContext = createContext<IbkrSyncContextType | undefined>(undefined)
+
+export function IbkrSyncContextProvider({ children }: { children: ReactNode }) {
+  const [isAutoSyncing, setIsAutoSyncing] = useState(false)
+  const isAutoSyncingRef = useRef(false)
+  const [accounts, setAccounts] = useState<IbkrSyncAccount[]>([])
+
+  const t = useI18n()
+  const { refreshTradesOnly } = useData()
+
+  /** The API sends dates as ISO strings; rebuild them as Date objects. */
+  const normalizeSynchronization = useCallback(
+    (sync: IbkrConnectionPayload): IbkrSyncAccount => ({
+      id: sync.id,
+      userId: sync.userId,
+      service: sync.service,
+      accountId: sync.accountId,
+      hasToken: !!sync.hasToken,
+      tokenExpired: !!sync.tokenExpired,
+      accountNumbers: Array.isArray(sync.accountNumbers) ? sync.accountNumbers : [],
+      currencies: Array.isArray(sync.currencies) ? sync.currencies : [],
+      lastSyncedAt: sync.lastSyncedAt ? new Date(sync.lastSyncedAt) : new Date(),
+      dailySyncTime: sync.dailySyncTime ? new Date(sync.dailySyncTime) : null,
+      createdAt: sync.createdAt ? new Date(sync.createdAt) : new Date(),
+      updatedAt: sync.updatedAt ? new Date(sync.updatedAt) : new Date(),
+    }),
+    [],
+  )
+
+  const loadAccounts = useCallback(async () => {
+    try {
+      const response = await fetch('/api/ibkr/synchronizations', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      if (!response.ok) throw new Error('Failed to fetch IBKR synchronizations')
+
+      const result = await response.json()
+      const data = Array.isArray(result.data) ? result.data : []
+      setAccounts(data.map(normalizeSynchronization))
+    } catch (error) {
+      console.warn('Failed to load IBKR connections:', error)
+      showToastWithCopy(
+        'error',
+        formatIbkrError(t, IbkrErrorCode.LOAD_SYNCHRONIZATIONS_FAILED),
+        { copyLabel: t('common.copy') },
+      )
+    }
+  }, [normalizeSynchronization, t])
+
+  const deleteAccount = useCallback(async (accountId: string) => {
+    setAccounts((prev) => prev.filter((acc) => acc.accountId !== accountId))
+    await fetch('/api/ibkr/synchronizations', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountId }),
+    })
+  }, [])
+
+  const performSyncForAccount = useCallback(
+    async (accountId: string) => {
+      const account = accounts.find((acc) => acc.accountId === accountId)
+      if (!account) {
+        return { success: false, message: formatIbkrError(t, IbkrErrorCode.ACCOUNT_ID_REQUIRED) }
+      }
+      if (!account.hasToken || account.tokenExpired) {
+        return {
+          success: false,
+          message: formatIbkrError(t, IbkrErrorCode.NO_CREDENTIALS_RECONNECT),
+        }
+      }
+
+      try {
+        const message = await runToastWithCopy(
+          async () => {
+            const response = await fetch('/api/ibkr/sync', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ accountId }),
+            })
+
+            const payload = (await response.json()) as IbkrSyncApiPayload
+
+            if (!response.ok || !payload?.success) {
+              const err = new Error(payload?.message || IbkrErrorCode.SYNC_FAILED) as Error & {
+                errorParams?: Record<string, string | number>
+              }
+              err.errorParams = payload?.errorParams
+              throw err
+            }
+
+            await loadAccounts()
+            await refreshTradesOnly({ force: false })
+
+            return buildSyncSuccessToast(t, accountId, payload)
+          },
+          {
+            loading: t('ibkrSync.sync.inProgress', { accountId }),
+            success: (result) => result,
+            error: (e) => {
+              const code = e instanceof Error ? e.message : IbkrErrorCode.SYNC_FAILED
+              const params =
+                e instanceof Error && 'errorParams' in e
+                  ? (e as Error & { errorParams?: Record<string, string | number> }).errorParams
+                  : undefined
+              if (
+                code === IbkrErrorCode.FLEX_TOKEN_EXPIRED ||
+                code === IbkrErrorCode.FLEX_TOKEN_INVALID
+              ) {
+                void loadAccounts()
+              }
+              return getIbkrErrorToastContent(t, code, params)
+            },
+            copyLabel: t('common.copy'),
+          },
+        )
+
+        return { success: true, message: message.title }
+      } catch (error) {
+        const code = error instanceof Error ? error.message : IbkrErrorCode.SYNC_FAILED
+        console.error('IBKR sync error:', error)
+        return { success: false, message: formatIbkrError(t, code) }
+      }
+    },
+    [accounts, t, refreshTradesOnly, loadAccounts],
+  )
+
+  const performSyncForAllAccounts = useCallback(async () => {
+    if (isAutoSyncingRef.current) return
+
+    isAutoSyncingRef.current = true
+    setIsAutoSyncing(true)
+
+    try {
+      const validAccounts = accounts.filter((acc) => acc.hasToken && !acc.tokenExpired)
+
+      for (const account of validAccounts) {
+        await performSyncForAccount(account.accountId)
+        // Flex allows 10 requests per minute per token; each sync already makes
+        // several, so pace the loop rather than trip error 1018.
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+      }
+    } catch (error) {
+      console.error('Error during bulk IBKR sync:', error)
+    } finally {
+      isAutoSyncingRef.current = false
+      setIsAutoSyncing(false)
+    }
+  }, [accounts, performSyncForAccount])
+
+  useEffect(() => {
+    loadAccounts()
+  }, [loadAccounts])
+
+  return (
+    <IbkrSyncContext.Provider
+      value={{
+        performSyncForAccount,
+        performSyncForAllAccounts,
+        isAutoSyncing,
+        accounts,
+        loadAccounts,
+        deleteAccount,
+      }}
+    >
+      {children}
+    </IbkrSyncContext.Provider>
+  )
+}
+
+export function useIbkrSyncContext() {
+  const context = useContext(IbkrSyncContext)
+  if (context === undefined) {
+    throw new Error('useIbkrSyncContext must be used within an IbkrSyncContextProvider')
+  }
+  return context
+}

--- a/lib/ibkr-client-messages.ts
+++ b/lib/ibkr-client-messages.ts
@@ -1,0 +1,87 @@
+import { IbkrErrorCode, isIbkrErrorCode } from '@/lib/ibkr-flex-errors'
+
+/** Loose translator; useI18n `t` is cast internally for next-international strict keys. */
+type TranslateFn = (key: string, params?: Record<string, string | number>) => string
+
+function asTranslateFn(t: unknown): TranslateFn {
+  return t as TranslateFn
+}
+
+/** Errors the user fixes by editing the Flex Query in Client Portal. */
+const QUERY_HINT_CODES: Set<string> = new Set([
+  IbkrErrorCode.FLEX_QUERY_INVALID,
+  IbkrErrorCode.FLEX_LEGACY_QUERY,
+  IbkrErrorCode.QUERY_HAS_NO_TRADES_SECTION,
+  IbkrErrorCode.QUERY_MISSING_FIELDS,
+  IbkrErrorCode.NO_TRADES_IN_RANGE,
+])
+
+/** Errors the user fixes by generating a fresh Flex token. */
+const TOKEN_HINT_CODES: Set<string> = new Set([
+  IbkrErrorCode.FLEX_TOKEN_EXPIRED,
+  IbkrErrorCode.FLEX_TOKEN_INVALID,
+  IbkrErrorCode.FLEX_SERVICE_INACTIVE,
+  IbkrErrorCode.NO_CREDENTIALS_RECONNECT,
+  IbkrErrorCode.INVALID_STORED_CREDENTIALS,
+])
+
+/** Transient errors where waiting and retrying is the right move. */
+const RETRY_HINT_CODES: Set<string> = new Set([
+  IbkrErrorCode.FLEX_RATE_LIMITED,
+  IbkrErrorCode.FLEX_STATEMENT_TIMEOUT,
+  IbkrErrorCode.FLEX_UNREACHABLE,
+  IbkrErrorCode.FLEX_STATEMENT_FAILED,
+])
+
+export function formatIbkrError(
+  t: unknown,
+  error?: string | null,
+  errorParams?: Record<string, string | number>,
+): string {
+  const translate = asTranslateFn(t)
+
+  if (!error) return translate('ibkrSync.errors.UNKNOWN')
+
+  if (isIbkrErrorCode(error)) {
+    return translate(`ibkrSync.errors.${error}`, errorParams)
+  }
+
+  return translate('ibkrSync.errors.UNKNOWN')
+}
+
+/**
+ * Pairs the message with the one action that actually resolves it. Flex failures
+ * are almost always a config mistake in Client Portal, so a bare error string
+ * would leave the user with nowhere to go.
+ */
+export function getIbkrErrorToastContent(
+  t: unknown,
+  error?: string | null,
+  errorParams?: Record<string, string | number>,
+): { title: string; description?: string } {
+  const translate = asTranslateFn(t)
+  const code = error && isIbkrErrorCode(error) ? error : null
+  const title = formatIbkrError(t, error, errorParams)
+
+  if (code && QUERY_HINT_CODES.has(code)) {
+    return { title, description: translate('ibkrSync.errors.hintEditQuery') }
+  }
+
+  if (code && TOKEN_HINT_CODES.has(code)) {
+    return { title, description: translate('ibkrSync.errors.hintRegenerateToken') }
+  }
+
+  if (code && RETRY_HINT_CODES.has(code)) {
+    return { title, description: translate('ibkrSync.errors.hintRetryShortly') }
+  }
+
+  if (code === IbkrErrorCode.QUERY_UNPARSEABLE_DATES) {
+    return { title, description: translate('ibkrSync.errors.hintDateFormat') }
+  }
+
+  if (code === IbkrErrorCode.FLEX_IP_RESTRICTED) {
+    return { title, description: translate('ibkrSync.errors.hintIpRestriction') }
+  }
+
+  return { title }
+}

--- a/lib/ibkr-flex-client.ts
+++ b/lib/ibkr-flex-client.ts
@@ -1,0 +1,190 @@
+/**
+ * IBKR Flex Web Service v3 client.
+ *
+ * Two-step protocol: SendRequest returns a reference code identifying a report
+ * instance IBKR generates asynchronously; GetStatement fetches it once ready.
+ *
+ * Docs: https://www.interactivebrokers.com/campus/ibkr-api-page/flex-web-service/
+ * Error codes: https://www.ibkrguides.com/clientportal/flex3.htm
+ */
+
+import {
+  IbkrErrorCode,
+  isFlexRetryableError,
+  mapFlexNumericError,
+  type IbkrErrorCodeValue,
+  type IbkrErrorParams,
+} from './ibkr-flex-errors'
+import { extractText } from './ibkr-flex-xml'
+
+const FLEX_BASE_URL =
+  process.env.IBKR_FLEX_BASE_URL ??
+  'https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService'
+
+/** IBKR rejects requests without a User-Agent. */
+const USER_AGENT = process.env.IBKR_FLEX_USER_AGENT ?? 'Deltalytix/1.0'
+
+/**
+ * Flex allows 1 request/second and 10/minute per token (error 1018). The report
+ * also needs a moment to generate, so we poll GetStatement on a delay.
+ */
+const STATEMENT_POLL_DELAY_MS = Math.max(
+  1000,
+  Number(process.env.IBKR_FLEX_POLL_DELAY_MS ?? '3000'),
+)
+const STATEMENT_MAX_ATTEMPTS = Math.max(
+  1,
+  Number(process.env.IBKR_FLEX_MAX_ATTEMPTS ?? '5'),
+)
+const REQUEST_TIMEOUT_MS = Math.max(
+  5000,
+  Number(process.env.IBKR_FLEX_TIMEOUT_MS ?? '30000'),
+)
+
+const logger = {
+  info: (message: string) => console.log(`[IBKR-FLEX] ${message}`),
+  warn: (message: string) => console.warn(`[IBKR-FLEX] ${message}`),
+  error: (message: string, error?: unknown) =>
+    console.error(`[IBKR-FLEX] ${message}`, error instanceof Error ? error.message : ''),
+}
+
+export interface FlexFailure {
+  error: IbkrErrorCodeValue
+  errorParams?: IbkrErrorParams
+}
+
+export type FlexResult<T> = ({ ok: true } & T) | ({ ok: false } & FlexFailure)
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Reads the `<Status>Fail</Status>` envelope both endpoints share. Returns null
+ * when the payload is not an error.
+ */
+function readFlexError(xml: string): FlexFailure | null {
+  const status = extractText(xml, 'Status')
+  if (status && status.toLowerCase() !== 'fail') return null
+
+  const errorCode = extractText(xml, 'ErrorCode')
+  const errorMessage = extractText(xml, 'ErrorMessage')
+
+  // A success payload has no Status element at all (GetStatement returns the
+  // report directly), so only treat this as an error if IBKR said so.
+  if (!status && !errorCode) return null
+
+  return {
+    error: mapFlexNumericError(errorCode),
+    errorParams: {
+      code: errorCode ?? 'unknown',
+      detail: errorMessage ?? 'No detail provided',
+    },
+  }
+}
+
+async function flexFetch(url: string): Promise<FlexResult<{ body: string }>> {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        // Mandatory: IBKR blocks requests without it.
+        'User-Agent': USER_AGENT,
+        Accept: 'text/xml, application/xml, */*',
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      cache: 'no-store',
+    })
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: IbkrErrorCode.FLEX_HTTP_ERROR,
+        errorParams: { status: response.status },
+      }
+    }
+
+    return { ok: true, body: await response.text() }
+  } catch (error) {
+    logger.error('Flex request failed', error)
+    return { ok: false, error: IbkrErrorCode.FLEX_UNREACHABLE }
+  }
+}
+
+/** Step 1: ask IBKR to generate a report instance for this query. */
+export async function sendFlexRequest(
+  token: string,
+  queryId: string,
+): Promise<FlexResult<{ referenceCode: string }>> {
+  const url = `${FLEX_BASE_URL}/SendRequest?t=${encodeURIComponent(token)}&q=${encodeURIComponent(queryId)}&v=3`
+  const response = await flexFetch(url)
+  if (!response.ok) return response
+
+  const failure = readFlexError(response.body)
+  if (failure) {
+    logger.warn(`SendRequest rejected: ${failure.error} (${failure.errorParams?.code})`)
+    return { ok: false, ...failure }
+  }
+
+  const referenceCode = extractText(response.body, 'ReferenceCode')
+  if (!referenceCode) {
+    logger.warn('SendRequest returned no reference code')
+    return { ok: false, error: IbkrErrorCode.FLEX_MALFORMED_RESPONSE }
+  }
+
+  return { ok: true, referenceCode }
+}
+
+/**
+ * Step 2: fetch the generated report, polling while IBKR reports it is still
+ * being built (error 1019).
+ */
+export async function getFlexStatement(
+  token: string,
+  referenceCode: string,
+): Promise<FlexResult<{ xml: string }>> {
+  const url = `${FLEX_BASE_URL}/GetStatement?t=${encodeURIComponent(token)}&q=${encodeURIComponent(referenceCode)}&v=3`
+
+  let lastFailure: FlexFailure = { error: IbkrErrorCode.FLEX_STATEMENT_TIMEOUT }
+
+  for (let attempt = 0; attempt < STATEMENT_MAX_ATTEMPTS; attempt++) {
+    // IBKR needs time to build the report; requesting immediately reliably
+    // returns 1019, so wait before every attempt including the first.
+    await sleep(STATEMENT_POLL_DELAY_MS)
+
+    const response = await flexFetch(url)
+    if (!response.ok) {
+      lastFailure = response
+      // A transport failure will not resolve itself by polling.
+      break
+    }
+
+    const failure = readFlexError(response.body)
+    if (!failure) {
+      return { ok: true, xml: response.body }
+    }
+
+    lastFailure = failure
+    if (!isFlexRetryableError(String(failure.errorParams?.code ?? ''))) {
+      logger.warn(`GetStatement rejected: ${failure.error} (${failure.errorParams?.code})`)
+      break
+    }
+
+    logger.info(
+      `Statement still generating, retrying (${attempt + 1}/${STATEMENT_MAX_ATTEMPTS})`,
+    )
+  }
+
+  return { ok: false, ...lastFailure }
+}
+
+/** Runs the full two-step Flex exchange and returns the report XML. */
+export async function fetchFlexStatement(
+  token: string,
+  queryId: string,
+): Promise<FlexResult<{ xml: string }>> {
+  const request = await sendFlexRequest(token, queryId)
+  if (!request.ok) return request
+
+  return getFlexStatement(token, request.referenceCode)
+}

--- a/lib/ibkr-flex-credentials.test.ts
+++ b/lib/ibkr-flex-credentials.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isValidFlexQueryId,
+  isValidFlexToken,
+  parseIbkrCredentialsInput,
+} from './ibkr-flex-credentials'
+
+describe('parseIbkrCredentialsInput', () => {
+  it('splits a token and query ID pasted on separate lines', () => {
+    expect(parseIbkrCredentialsInput('123456789012345\n987654')).toEqual({
+      token: '123456789012345',
+      queryId: '987654',
+    })
+  })
+
+  it('splits values pasted on one line in either order', () => {
+    expect(parseIbkrCredentialsInput('123456789012345 987654')).toEqual({
+      token: '123456789012345',
+      queryId: '987654',
+    })
+    expect(parseIbkrCredentialsInput('987654 123456789012345')).toEqual({
+      token: '123456789012345',
+      queryId: '987654',
+    })
+  })
+
+  it('honours labels from Client Portal', () => {
+    const input = 'Token: 111122223333444\nQuery ID: 555666'
+    expect(parseIbkrCredentialsInput(input)).toEqual({
+      token: '111122223333444',
+      queryId: '555666',
+    })
+  })
+
+  it('honours labels even when the shape heuristic would disagree', () => {
+    // Both values are long enough to look like tokens; the labels decide.
+    const input = 'queryid=12345678 token=987654321098765'
+    expect(parseIbkrCredentialsInput(input)).toEqual({
+      token: '987654321098765',
+      queryId: '12345678',
+    })
+  })
+
+  it('reports the missing half when only one value is pasted', () => {
+    expect(parseIbkrCredentialsInput('123456789012345')).toEqual({
+      token: '123456789012345',
+      queryId: null,
+    })
+    expect(parseIbkrCredentialsInput('987654')).toEqual({
+      token: null,
+      queryId: '987654',
+    })
+  })
+
+  it('ignores surrounding prose', () => {
+    const input = 'Here is my token 123456789012345 and the query is 987654, thanks'
+    expect(parseIbkrCredentialsInput(input)).toEqual({
+      token: '123456789012345',
+      queryId: '987654',
+    })
+  })
+
+  it('returns nulls for empty input', () => {
+    expect(parseIbkrCredentialsInput('')).toEqual({ token: null, queryId: null })
+    expect(parseIbkrCredentialsInput('   ')).toEqual({ token: null, queryId: null })
+  })
+})
+
+describe('flex credential validators', () => {
+  it('accepts realistic values', () => {
+    expect(isValidFlexToken('123456789012345')).toBe(true)
+    expect(isValidFlexQueryId('987654')).toBe(true)
+  })
+
+  it('rejects short tokens and non-numeric input', () => {
+    expect(isValidFlexToken('12345')).toBe(false)
+    expect(isValidFlexToken('abcdefghijkl')).toBe(false)
+    expect(isValidFlexQueryId('12')).toBe(false)
+    expect(isValidFlexQueryId('1234567890')).toBe(false)
+  })
+})

--- a/lib/ibkr-flex-credentials.ts
+++ b/lib/ibkr-flex-credentials.ts
@@ -1,0 +1,77 @@
+/**
+ * Credential extraction for the IBKR Flex connection form.
+ *
+ * The Flex Web Service needs two values that live on different screens of
+ * Client Portal: a long numeric token and a short numeric query ID. Rather than
+ * make the user label them correctly across two inputs, the connect form takes
+ * one paste and we work out which is which — they are trivially separable by
+ * length, and labelled text is honoured when present.
+ */
+
+export interface IbkrFlexCredentials {
+  token: string
+  queryId: string
+}
+
+/** Flex tokens are long numeric strings; query IDs are short ones. */
+const MIN_TOKEN_LENGTH = 10
+const MIN_QUERY_ID_LENGTH = 4
+const MAX_QUERY_ID_LENGTH = 9
+
+function findLabelled(input: string, labels: string[]): string | null {
+  for (const label of labels) {
+    // e.g. "Query ID: 1234567", "token=987...", "Token   987..."
+    const pattern = new RegExp(`${label}\\s*[:=]?\\s*(\\d{${MIN_QUERY_ID_LENGTH},})`, 'i')
+    const match = input.match(pattern)
+    if (match) return match[1]
+  }
+  return null
+}
+
+export function isValidFlexToken(value: string): boolean {
+  return /^\d+$/.test(value) && value.length >= MIN_TOKEN_LENGTH
+}
+
+export function isValidFlexQueryId(value: string): boolean {
+  return (
+    /^\d+$/.test(value) &&
+    value.length >= MIN_QUERY_ID_LENGTH &&
+    value.length <= MAX_QUERY_ID_LENGTH
+  )
+}
+
+/**
+ * Pulls a token and query ID out of free-form pasted text.
+ *
+ * Accepts the two values on separate lines, space-separated, or with the labels
+ * Client Portal shows next to them. Returns null for whichever value cannot be
+ * identified so the caller can ask for just that one.
+ */
+export function parseIbkrCredentialsInput(raw: string): {
+  token: string | null
+  queryId: string | null
+} {
+  const input = (raw ?? '').trim()
+  if (!input) return { token: null, queryId: null }
+
+  const labelledToken = findLabelled(input, ['token'])
+  const labelledQueryId = findLabelled(input, ['query\\s*id', 'queryid', 'query'])
+
+  let token = labelledToken && isValidFlexToken(labelledToken) ? labelledToken : null
+  let queryId = labelledQueryId && isValidFlexQueryId(labelledQueryId) ? labelledQueryId : null
+
+  if (token && queryId) return { token, queryId }
+
+  // Fall back to shape: the longest numeric run is the token, the longest of
+  // the rest that fits a query ID is the query ID.
+  const numbers = (input.match(/\d+/g) ?? []).slice().sort((a, b) => b.length - a.length)
+
+  if (!token) {
+    token = numbers.find((n) => isValidFlexToken(n) && n !== queryId) ?? null
+  }
+  if (!queryId) {
+    queryId = numbers.find((n) => isValidFlexQueryId(n) && n !== token) ?? null
+  }
+
+  return { token, queryId }
+}

--- a/lib/ibkr-flex-date.test.ts
+++ b/lib/ibkr-flex-date.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { parseFlexDateTime } from './ibkr-flex-date'
+
+describe('parseFlexDateTime', () => {
+  it('parses the Flex default yyyyMMdd;HHmmss form', () => {
+    expect(parseFlexDateTime('20250115;093000')).toBe('2025-01-15T09:30:00.000+00:00')
+  })
+
+  it('parses a colon-separated time', () => {
+    expect(parseFlexDateTime('20250115;09:30:00')).toBe('2025-01-15T09:30:00.000+00:00')
+  })
+
+  it('parses space- and T-separated forms', () => {
+    expect(parseFlexDateTime('2025-01-15 09:30:00')).toBe('2025-01-15T09:30:00.000+00:00')
+    expect(parseFlexDateTime('2025-01-15T09:30:00')).toBe('2025-01-15T09:30:00.000+00:00')
+  })
+
+  it('parses a date-only value as midnight UTC', () => {
+    expect(parseFlexDateTime('20250115')).toBe('2025-01-15T00:00:00.000+00:00')
+  })
+
+  it('combines separate tradeDate and tradeTime attributes', () => {
+    expect(parseFlexDateTime('20250115', '093000')).toBe('2025-01-15T09:30:00.000+00:00')
+  })
+
+  it('prefers an explicit time argument over one embedded in the same string', () => {
+    expect(parseFlexDateTime('20250115;000000', '143000')).toBe(
+      '2025-01-15T14:30:00.000+00:00',
+    )
+  })
+
+  it('applies a numeric UTC offset', () => {
+    expect(parseFlexDateTime('20250115;093000 -05:00')).toBe('2025-01-15T14:30:00.000+00:00')
+    expect(parseFlexDateTime('20250115;093000 +0100')).toBe('2025-01-15T08:30:00.000+00:00')
+  })
+
+  it('applies a named timezone abbreviation', () => {
+    expect(parseFlexDateTime('20250115;093000 EST')).toBe('2025-01-15T14:30:00.000+00:00')
+    expect(parseFlexDateTime('20250115;093000 UTC')).toBe('2025-01-15T09:30:00.000+00:00')
+  })
+
+  it('refuses ambiguous slash dates rather than guessing day/month order', () => {
+    expect(parseFlexDateTime('03/04/2025')).toBeNull()
+    expect(parseFlexDateTime('03/04/2025;093000')).toBeNull()
+  })
+
+  it('rejects impossible calendar dates instead of rolling them over', () => {
+    expect(parseFlexDateTime('20250231')).toBeNull()
+    expect(parseFlexDateTime('20251301')).toBeNull()
+  })
+
+  it('rejects a present-but-unreadable time instead of falling back to midnight', () => {
+    expect(parseFlexDateTime('20250115;9999')).toBeNull()
+    expect(parseFlexDateTime('20250115;25:00:00')).toBeNull()
+  })
+
+  it('returns null for empty and missing input', () => {
+    expect(parseFlexDateTime(null)).toBeNull()
+    expect(parseFlexDateTime(undefined)).toBeNull()
+    expect(parseFlexDateTime('')).toBeNull()
+  })
+})

--- a/lib/ibkr-flex-date.ts
+++ b/lib/ibkr-flex-date.ts
@@ -1,0 +1,187 @@
+/**
+ * Date/time parsing for IBKR Flex statements.
+ *
+ * Flex lets the user choose the date and time format when they build the query,
+ * so the same field can arrive as `20250115;093000`, `2025-01-15 09:30:00`, or
+ * `15/01/2025`. We accept every unambiguous form and explicitly refuse the
+ * ambiguous ones rather than guessing — a silently mis-parsed `03/04/2025` puts
+ * a trade on the wrong day and quietly corrupts the journal.
+ *
+ * When the statement carries no timezone the instant is read as UTC. That is
+ * what IBKR's own default (no "Display Time Zone" column) implies, and it keeps
+ * a trade's calendar day stable regardless of where the sync runs.
+ */
+
+/** Timezone abbreviations Flex emits when "Display Time Zone" is enabled. */
+const TIMEZONE_OFFSETS_MINUTES: Record<string, number> = {
+  UTC: 0,
+  GMT: 0,
+  EST: -300,
+  EDT: -240,
+  CST: -360,
+  CDT: -300,
+  MST: -420,
+  MDT: -360,
+  PST: -480,
+  PDT: -420,
+  CET: 60,
+  CEST: 120,
+  BST: 60,
+  JST: 540,
+  HKT: 480,
+  SGT: 480,
+  AEST: 600,
+  AEDT: 660,
+}
+
+interface DateParts {
+  year: number
+  month: number
+  day: number
+}
+
+interface TimeParts {
+  hour: number
+  minute: number
+  second: number
+}
+
+function parseDatePart(value: string): DateParts | null {
+  const compact = value.match(/^(\d{4})(\d{2})(\d{2})$/)
+  if (compact) {
+    return {
+      year: Number(compact[1]),
+      month: Number(compact[2]),
+      day: Number(compact[3]),
+    }
+  }
+
+  // yyyy-MM-dd / yyyy/MM/dd — unambiguous because the year leads.
+  const dashed = value.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/)
+  if (dashed) {
+    return {
+      year: Number(dashed[1]),
+      month: Number(dashed[2]),
+      day: Number(dashed[3]),
+    }
+  }
+
+  // dd/MM/yyyy and MM/dd/yyyy are indistinguishable for days <= 12, so we
+  // refuse the whole shape instead of coin-flipping on which one it is.
+  return null
+}
+
+function parseTimePart(value: string): TimeParts | null {
+  const compact = value.match(/^(\d{2})(\d{2})(\d{2})$/)
+  if (compact) {
+    return {
+      hour: Number(compact[1]),
+      minute: Number(compact[2]),
+      second: Number(compact[3]),
+    }
+  }
+
+  const colonned = value.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/)
+  if (colonned) {
+    return {
+      hour: Number(colonned[1]),
+      minute: Number(colonned[2]),
+      second: colonned[3] ? Number(colonned[3]) : 0,
+    }
+  }
+
+  return null
+}
+
+function isValidDate(date: DateParts): boolean {
+  if (date.month < 1 || date.month > 12) return false
+  if (date.day < 1 || date.day > 31) return false
+  if (date.year < 1970 || date.year > 2200) return false
+  // Reject e.g. 31 February, which Date.UTC would silently roll over.
+  const probe = new Date(Date.UTC(date.year, date.month - 1, date.day))
+  return probe.getUTCMonth() === date.month - 1 && probe.getUTCDate() === date.day
+}
+
+function isValidTime(time: TimeParts): boolean {
+  return (
+    time.hour >= 0 &&
+    time.hour <= 23 &&
+    time.minute >= 0 &&
+    time.minute <= 59 &&
+    time.second >= 0 &&
+    time.second <= 59
+  )
+}
+
+/**
+ * Splits a trailing timezone off the value, returning its offset in minutes.
+ * Recognises `+01:00`, `-0500`, `Z`, and the abbreviations above.
+ */
+function extractTimezone(value: string): { rest: string; offsetMinutes: number } {
+  const trimmed = value.trim()
+
+  const numeric = trimmed.match(/^(.*?)\s*([+-])(\d{2}):?(\d{2})$/)
+  if (numeric) {
+    const sign = numeric[2] === '-' ? -1 : 1
+    const offset = sign * (Number(numeric[3]) * 60 + Number(numeric[4]))
+    return { rest: numeric[1].trim(), offsetMinutes: offset }
+  }
+
+  const named = trimmed.match(/^(.*?)\s+([A-Z]{1,4})$/)
+  if (named && named[2] in TIMEZONE_OFFSETS_MINUTES) {
+    return { rest: named[1].trim(), offsetMinutes: TIMEZONE_OFFSETS_MINUTES[named[2]] }
+  }
+
+  if (/Z$/.test(trimmed) && /\d/.test(trimmed.slice(0, -1))) {
+    return { rest: trimmed.slice(0, -1).trim(), offsetMinutes: 0 }
+  }
+
+  return { rest: trimmed, offsetMinutes: 0 }
+}
+
+/**
+ * Parses a Flex date/time into an ISO-8601 instant in `+00:00` form, matching
+ * the timestamp convention the rest of the app stores.
+ *
+ * Accepts a combined value (`20250115;093000`) or a separate date and time
+ * (`tradeDate` + `tradeTime`). Returns null when the input is absent, malformed,
+ * or ambiguous.
+ */
+export function parseFlexDateTime(
+  dateTimeValue: string | null | undefined,
+  timeValue?: string | null,
+): string | null {
+  if (!dateTimeValue) return null
+
+  const { rest, offsetMinutes } = extractTimezone(dateTimeValue)
+  if (!rest) return null
+
+  // The date and time may be joined by ';', 'T', or whitespace, or supplied
+  // as two separate attributes.
+  let datePortion = rest
+  let timePortion = timeValue?.trim() ?? ''
+
+  const separatorMatch = rest.match(/^(.*?)[;T\s]+(.*)$/)
+  if (separatorMatch) {
+    datePortion = separatorMatch[1]
+    // An explicit time argument wins over one embedded in the same string.
+    if (!timePortion) timePortion = separatorMatch[2]
+  }
+
+  const date = parseDatePart(datePortion.trim())
+  if (!date || !isValidDate(date)) return null
+
+  let time: TimeParts = { hour: 0, minute: 0, second: 0 }
+  if (timePortion) {
+    const parsed = parseTimePart(timePortion.trim())
+    // A present-but-unreadable time is a malformed row, not a midnight row.
+    if (!parsed || !isValidTime(parsed)) return null
+    time = parsed
+  }
+
+  const epochMs =
+    Date.UTC(date.year, date.month - 1, date.day, time.hour, time.minute, time.second) -
+    offsetMinutes * 60_000
+
+  return new Date(epochMs).toISOString().replace('Z', '+00:00')
+}

--- a/lib/ibkr-flex-errors.ts
+++ b/lib/ibkr-flex-errors.ts
@@ -1,0 +1,105 @@
+/**
+ * Stable error codes returned by IBKR Flex server actions / API routes.
+ * The client maps these to localized messages via formatIbkrError().
+ */
+
+export const IbkrErrorCode = {
+  USER_NOT_AUTHENTICATED: 'USER_NOT_AUTHENTICATED',
+
+  // Credential input
+  CREDENTIALS_REQUIRED: 'CREDENTIALS_REQUIRED',
+  TOKEN_MALFORMED: 'TOKEN_MALFORMED',
+  QUERY_ID_MALFORMED: 'QUERY_ID_MALFORMED',
+  INVALID_STORED_CREDENTIALS: 'INVALID_STORED_CREDENTIALS',
+  NO_CREDENTIALS_RECONNECT: 'NO_CREDENTIALS_RECONNECT',
+  DUPLICATE_CONNECTION: 'DUPLICATE_CONNECTION',
+
+  // Flex Web Service transport
+  FLEX_HTTP_ERROR: 'FLEX_HTTP_ERROR',
+  FLEX_UNREACHABLE: 'FLEX_UNREACHABLE',
+  FLEX_MALFORMED_RESPONSE: 'FLEX_MALFORMED_RESPONSE',
+  FLEX_STATEMENT_TIMEOUT: 'FLEX_STATEMENT_TIMEOUT',
+
+  // Flex Web Service documented failures (mapped from numeric ErrorCode)
+  FLEX_TOKEN_EXPIRED: 'FLEX_TOKEN_EXPIRED',
+  FLEX_TOKEN_INVALID: 'FLEX_TOKEN_INVALID',
+  FLEX_IP_RESTRICTED: 'FLEX_IP_RESTRICTED',
+  FLEX_QUERY_INVALID: 'FLEX_QUERY_INVALID',
+  FLEX_REFERENCE_INVALID: 'FLEX_REFERENCE_INVALID',
+  FLEX_ACCOUNT_INVALID: 'FLEX_ACCOUNT_INVALID',
+  FLEX_SERVICE_INACTIVE: 'FLEX_SERVICE_INACTIVE',
+  FLEX_RATE_LIMITED: 'FLEX_RATE_LIMITED',
+  FLEX_LEGACY_QUERY: 'FLEX_LEGACY_QUERY',
+  FLEX_STATEMENT_FAILED: 'FLEX_STATEMENT_FAILED',
+  FLEX_UNKNOWN_ERROR: 'FLEX_UNKNOWN_ERROR',
+
+  // Query shape problems the user must fix in Client Portal
+  QUERY_HAS_NO_TRADES_SECTION: 'QUERY_HAS_NO_TRADES_SECTION',
+  QUERY_MISSING_FIELDS: 'QUERY_MISSING_FIELDS',
+  QUERY_UNPARSEABLE_DATES: 'QUERY_UNPARSEABLE_DATES',
+
+  // Sync outcomes
+  NO_TRADES_IN_RANGE: 'NO_TRADES_IN_RANGE',
+  OPEN_POSITIONS_ONLY: 'OPEN_POSITIONS_ONLY',
+  DUPLICATE_TRADES: 'DUPLICATE_TRADES',
+  SAVE_TRADES_FAILED: 'SAVE_TRADES_FAILED',
+  SYNC_FAILED: 'SYNC_FAILED',
+
+  // Plumbing
+  ACCOUNT_ID_REQUIRED: 'ACCOUNT_ID_REQUIRED',
+  LOAD_SYNCHRONIZATIONS_FAILED: 'LOAD_SYNCHRONIZATIONS_FAILED',
+  DELETE_SYNC_FAILED: 'DELETE_SYNC_FAILED',
+  UPDATE_SYNC_TIME_FAILED: 'UPDATE_SYNC_TIME_FAILED',
+  UNKNOWN: 'UNKNOWN',
+} as const
+
+export type IbkrErrorCodeValue = (typeof IbkrErrorCode)[keyof typeof IbkrErrorCode]
+
+export type IbkrErrorParams = Record<string, string | number>
+
+export function isIbkrErrorCode(value: string): value is IbkrErrorCodeValue {
+  return Object.values(IbkrErrorCode).includes(value as IbkrErrorCodeValue)
+}
+
+/**
+ * Flex Web Service v3 numeric error codes.
+ * Source: https://www.ibkrguides.com/clientportal/flex3.htm
+ *
+ * Anything not listed here surfaces as FLEX_UNKNOWN_ERROR carrying IBKR's own
+ * message, so an undocumented code is still actionable for the user.
+ */
+const FLEX_NUMERIC_ERRORS: Record<string, IbkrErrorCodeValue> = {
+  '1001': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1003': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1004': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1005': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1006': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1007': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1008': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1009': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1010': IbkrErrorCode.FLEX_LEGACY_QUERY,
+  '1011': IbkrErrorCode.FLEX_SERVICE_INACTIVE,
+  '1012': IbkrErrorCode.FLEX_TOKEN_EXPIRED,
+  '1013': IbkrErrorCode.FLEX_IP_RESTRICTED,
+  '1014': IbkrErrorCode.FLEX_QUERY_INVALID,
+  '1015': IbkrErrorCode.FLEX_TOKEN_INVALID,
+  '1016': IbkrErrorCode.FLEX_ACCOUNT_INVALID,
+  '1017': IbkrErrorCode.FLEX_REFERENCE_INVALID,
+  '1018': IbkrErrorCode.FLEX_RATE_LIMITED,
+  '1019': IbkrErrorCode.FLEX_STATEMENT_TIMEOUT,
+  '1020': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+  '1021': IbkrErrorCode.FLEX_STATEMENT_FAILED,
+}
+
+export function mapFlexNumericError(code: string | null | undefined): IbkrErrorCodeValue {
+  if (!code) return IbkrErrorCode.FLEX_UNKNOWN_ERROR
+  return FLEX_NUMERIC_ERRORS[code.trim()] ?? IbkrErrorCode.FLEX_UNKNOWN_ERROR
+}
+
+/**
+ * Code 1019 ("statement generation in progress") is the only one where retrying
+ * the same reference code is the correct response.
+ */
+export function isFlexRetryableError(code: string | null | undefined): boolean {
+  return code?.trim() === '1019'
+}

--- a/lib/ibkr-flex-trades.test.ts
+++ b/lib/ibkr-flex-trades.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest'
+import {
+  matchExecutionsFifo,
+  parseFlexStatement,
+  type FlexExecution,
+} from './ibkr-flex-trades'
+
+function statement(trades: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="Deltalytix" type="AF">
+<FlexStatements count="1">
+<FlexStatement accountId="U1234567" fromDate="20250101" toDate="20250131">
+<Trades>
+${trades}
+</Trades>
+</FlexStatement>
+</FlexStatements>
+</FlexQueryResponse>`
+}
+
+function execution(overrides: Partial<FlexExecution> = {}): FlexExecution {
+  return {
+    accountId: 'U1234567',
+    tradeId: 'T1',
+    rawSymbol: 'MESZ5',
+    instrument: 'MES',
+    assetCategory: 'FUT',
+    currency: 'USD',
+    multiplier: 5,
+    side: 'BUY',
+    quantity: 1,
+    price: 5000,
+    commission: 0,
+    timestamp: '2025-01-15T09:30:00.000+00:00',
+    ...overrides,
+  }
+}
+
+describe('parseFlexStatement', () => {
+  it('reads execution rows into normalized executions', () => {
+    const xml = statement(
+      `<Trade accountId="U1234567" currency="USD" assetCategory="FUT" symbol="MESZ5" underlyingSymbol="MES" multiplier="5" tradeID="111" dateTime="20250115;093000" buySell="BUY" quantity="2" tradePrice="5000.25" ibCommission="-1.24" levelOfDetail="EXECUTION" />`,
+    )
+
+    const { executions, stats } = parseFlexStatement(xml)
+
+    expect(executions).toHaveLength(1)
+    expect(executions[0]).toMatchObject({
+      accountId: 'U1234567',
+      tradeId: '111',
+      rawSymbol: 'MESZ5',
+      instrument: 'MES',
+      multiplier: 5,
+      side: 'BUY',
+      quantity: 2,
+      price: 5000.25,
+      // Flex reports commissions as negative; we store the magnitude.
+      commission: 1.24,
+      timestamp: '2025-01-15T09:30:00.000+00:00',
+    })
+    expect(stats.accountIds).toEqual(['U1234567'])
+    expect(stats.currencies).toEqual(['USD'])
+  })
+
+  it('uses the plain symbol for equities and the underlying for futures', () => {
+    const xml = statement(
+      `<Trade assetCategory="STK" symbol="AAPL" underlyingSymbol="" tradeID="1" dateTime="20250115;093000" buySell="BUY" quantity="10" tradePrice="200" levelOfDetail="EXECUTION" />
+       <Trade assetCategory="FUT" symbol="MESZ5" underlyingSymbol="MES" tradeID="2" dateTime="20250115;093100" buySell="BUY" quantity="1" tradePrice="5000" levelOfDetail="EXECUTION" />`,
+    )
+
+    const { executions } = parseFlexStatement(xml)
+    expect(executions.map((e) => e.instrument)).toEqual(['AAPL', 'MES'])
+  })
+
+  it('ignores CLOSED_LOT and ORDER rows so positions are not double counted', () => {
+    const xml = statement(
+      `<Trade symbol="MESZ5" underlyingSymbol="MES" assetCategory="FUT" tradeID="1" dateTime="20250115;093000" buySell="BUY" quantity="1" tradePrice="5000" levelOfDetail="EXECUTION" />
+       <Trade symbol="MESZ5" underlyingSymbol="MES" assetCategory="FUT" tradeID="1" dateTime="20250115;093000" buySell="BUY" quantity="1" tradePrice="5000" levelOfDetail="ORDER" />
+       <Trade symbol="MESZ5" underlyingSymbol="MES" assetCategory="FUT" tradeID="1" dateTime="20250115;093000" buySell="BUY" quantity="1" tradePrice="5000" levelOfDetail="CLOSED_LOT" />`,
+    )
+
+    const { executions, stats } = parseFlexStatement(xml)
+    expect(executions).toHaveLength(1)
+    expect(stats.closedLotRows).toBe(1)
+    expect(stats.tradeRows).toBe(3)
+  })
+
+  it('counts rows it cannot date instead of importing them at the wrong time', () => {
+    const xml = statement(
+      `<Trade symbol="AAPL" assetCategory="STK" tradeID="1" dateTime="03/04/2025" buySell="BUY" quantity="1" tradePrice="200" levelOfDetail="EXECUTION" />`,
+    )
+
+    const { executions, stats } = parseFlexStatement(xml)
+    expect(executions).toHaveLength(0)
+    expect(stats.skippedUnparseableDate).toBe(1)
+  })
+
+  it('sorts executions oldest first regardless of document order', () => {
+    const xml = statement(
+      `<Trade symbol="AAPL" assetCategory="STK" tradeID="2" dateTime="20250115;120000" buySell="SELL" quantity="1" tradePrice="210" levelOfDetail="EXECUTION" />
+       <Trade symbol="AAPL" assetCategory="STK" tradeID="1" dateTime="20250115;093000" buySell="BUY" quantity="1" tradePrice="200" levelOfDetail="EXECUTION" />`,
+    )
+
+    const { executions } = parseFlexStatement(xml)
+    expect(executions.map((e) => e.tradeId)).toEqual(['1', '2'])
+  })
+
+  it('treats a quoted attribute containing > as data, not as the end of the tag', () => {
+    const xml = statement(
+      `<Trade symbol="AAPL" assetCategory="STK" description="A &gt; B" tradeID="1" dateTime="20250115;093000" buySell="BUY" quantity="1" tradePrice="200" levelOfDetail="EXECUTION" />`,
+    )
+
+    const { executions } = parseFlexStatement(xml)
+    expect(executions).toHaveLength(1)
+    expect(executions[0].tradeId).toBe('1')
+  })
+})
+
+describe('matchExecutionsFifo', () => {
+  it('pairs a simple long round-turn and applies the multiplier', () => {
+    const trades = matchExecutionsFifo([
+      execution({ tradeId: 'A', side: 'BUY', quantity: 1, price: 5000 }),
+      execution({
+        tradeId: 'B',
+        side: 'SELL',
+        quantity: 1,
+        price: 5010,
+        timestamp: '2025-01-15T10:00:00.000+00:00',
+      }),
+    ])
+
+    expect(trades).toHaveLength(1)
+    expect(trades[0]).toMatchObject({
+      side: 'Long',
+      quantity: 1,
+      entryPrice: 5000,
+      closePrice: 5010,
+      // 10 points x 1 contract x $5 multiplier
+      pnl: 50,
+      timeInPosition: 1800,
+      entryId: 'A',
+      closeId: 'B',
+    })
+  })
+
+  it('signs a short round-turn correctly', () => {
+    const trades = matchExecutionsFifo([
+      execution({ tradeId: 'A', side: 'SELL', quantity: 1, price: 5010 }),
+      execution({
+        tradeId: 'B',
+        side: 'BUY',
+        quantity: 1,
+        price: 5000,
+        timestamp: '2025-01-15T10:00:00.000+00:00',
+      }),
+    ])
+
+    expect(trades).toHaveLength(1)
+    expect(trades[0]).toMatchObject({ side: 'Short', pnl: 50 })
+  })
+
+  it('splits a closing execution across several open lots in FIFO order', () => {
+    const trades = matchExecutionsFifo([
+      execution({ tradeId: 'A', side: 'BUY', quantity: 1, price: 5000 }),
+      execution({
+        tradeId: 'B',
+        side: 'BUY',
+        quantity: 1,
+        price: 5020,
+        timestamp: '2025-01-15T09:45:00.000+00:00',
+      }),
+      execution({
+        tradeId: 'C',
+        side: 'SELL',
+        quantity: 2,
+        price: 5010,
+        timestamp: '2025-01-15T10:00:00.000+00:00',
+      }),
+    ])
+
+    expect(trades).toHaveLength(2)
+    // Oldest lot closes first: +10 points, then -10 points.
+    expect(trades[0]).toMatchObject({ entryId: 'A', entryPrice: 5000, pnl: 50 })
+    expect(trades[1]).toMatchObject({ entryId: 'B', entryPrice: 5020, pnl: -50 })
+  })
+
+  it('prorates commission across a partially matched execution', () => {
+    const trades = matchExecutionsFifo([
+      execution({ tradeId: 'A', side: 'BUY', quantity: 2, price: 5000, commission: 2 }),
+      execution({
+        tradeId: 'B',
+        side: 'SELL',
+        quantity: 1,
+        price: 5010,
+        commission: 1,
+        timestamp: '2025-01-15T10:00:00.000+00:00',
+      }),
+    ])
+
+    expect(trades).toHaveLength(1)
+    // Half of the 2.00 entry commission plus all of the 1.00 exit commission.
+    expect(trades[0].commission).toBe(2)
+    expect(trades[0].quantity).toBe(1)
+  })
+
+  it('closes the outstanding position before opening the other side on a flip', () => {
+    const trades = matchExecutionsFifo([
+      execution({ tradeId: 'A', side: 'BUY', quantity: 1, price: 5000 }),
+      execution({
+        tradeId: 'B',
+        side: 'SELL',
+        quantity: 3,
+        price: 5010,
+        timestamp: '2025-01-15T10:00:00.000+00:00',
+      }),
+      execution({
+        tradeId: 'C',
+        side: 'BUY',
+        quantity: 2,
+        price: 5005,
+        timestamp: '2025-01-15T11:00:00.000+00:00',
+      }),
+    ])
+
+    // One long round-turn, then the 2-lot short opened by the flip and closed by C.
+    expect(trades).toHaveLength(2)
+    expect(trades[0]).toMatchObject({ side: 'Long', quantity: 1 })
+    expect(trades[1]).toMatchObject({ side: 'Short', quantity: 2, pnl: 50 })
+  })
+
+  it('does not emit anything for a position that is still open', () => {
+    expect(matchExecutionsFifo([execution({ side: 'BUY', quantity: 1 })])).toEqual([])
+  })
+
+  it('keeps different contracts and accounts in separate FIFO queues', () => {
+    const trades = matchExecutionsFifo([
+      execution({ tradeId: 'A', rawSymbol: 'MESZ5', side: 'BUY', quantity: 1, price: 5000 }),
+      execution({
+        tradeId: 'B',
+        rawSymbol: 'MNQZ5',
+        side: 'SELL',
+        quantity: 1,
+        price: 18000,
+        timestamp: '2025-01-15T10:00:00.000+00:00',
+      }),
+    ])
+
+    // Opposite sides, but different contracts — nothing should pair.
+    expect(trades).toEqual([])
+  })
+})

--- a/lib/ibkr-flex-trades.ts
+++ b/lib/ibkr-flex-trades.ts
@@ -1,0 +1,263 @@
+/**
+ * Maps an IBKR Flex statement into Deltalytix trades.
+ *
+ * We read the Trades section at EXECUTION level and pair executions ourselves
+ * with FIFO. Flex can also emit CLOSED_LOT rows carrying IBKR's own
+ * `fifoPnlRealized`, but those rows do not reliably carry the opening price and
+ * time that the journal needs, and requiring them would add another checkbox to
+ * the user's query setup. Executions carry everything, so one section with its
+ * default options is enough — which is the whole point of this integration.
+ *
+ * P&L is computed as (exit - entry) x quantity x multiplier, signed by
+ * direction. That is exact for futures, options and equities alike, because
+ * Flex reports the contract multiplier per execution.
+ */
+
+import { parseFlexDateTime } from './ibkr-flex-date'
+import { extractElements } from './ibkr-flex-xml'
+
+export interface FlexExecution {
+  accountId: string
+  /** IBKR's per-execution ID; used to build stable entry/close IDs. */
+  tradeId: string
+  /** Symbol as traded, e.g. "MESZ5" — the FIFO grouping key. */
+  rawSymbol: string
+  /** Display symbol, e.g. "MES" for futures, "AAPL" for equities. */
+  instrument: string
+  assetCategory: string
+  currency: string
+  multiplier: number
+  side: 'BUY' | 'SELL'
+  quantity: number
+  price: number
+  /** Always non-negative; Flex reports commissions as negative numbers. */
+  commission: number
+  timestamp: string
+}
+
+export interface FlexParseStats {
+  tradeRows: number
+  executionRows: number
+  closedLotRows: number
+  skippedUnparseableDate: number
+  skippedIncomplete: number
+  currencies: string[]
+  accountIds: string[]
+}
+
+export interface FlexParseResult {
+  executions: FlexExecution[]
+  stats: FlexParseStats
+}
+
+/** Futures and their options report the tradeable root on `underlyingSymbol`. */
+const UNDERLYING_ASSET_CATEGORIES = new Set(['FUT', 'FOP', 'OPT', 'CFD'])
+
+function toNumber(value: string | undefined, fallback = 0): number {
+  if (value === undefined || value.trim() === '') return fallback
+  // Flex emits thousands separators in some locale configurations.
+  const parsed = Number(value.replace(/,/g, ''))
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function normalizeSide(value: string | undefined): 'BUY' | 'SELL' | null {
+  const upper = (value ?? '').trim().toUpperCase()
+  // Cancellations arrive as "BUY (Ca.)" / "SELL (Ca.)".
+  if (upper.startsWith('BUY')) return 'BUY'
+  if (upper.startsWith('SELL')) return 'SELL'
+  return null
+}
+
+function resolveInstrument(row: Record<string, string>): string {
+  const assetCategory = (row.assetCategory ?? '').toUpperCase()
+  const underlying = (row.underlyingSymbol ?? '').trim()
+  const symbol = (row.symbol ?? '').trim()
+
+  if (UNDERLYING_ASSET_CATEGORIES.has(assetCategory) && underlying) {
+    return underlying.toUpperCase()
+  }
+  return (symbol || underlying).toUpperCase()
+}
+
+/**
+ * Reads the Trades section of a Flex statement into normalized executions,
+ * sorted oldest first so FIFO matching is well-defined.
+ */
+export function parseFlexStatement(xml: string): FlexParseResult {
+  const statements = extractElements(xml, 'FlexStatement')
+  const rows = extractElements(xml, 'Trade')
+
+  const executions: FlexExecution[] = []
+  const currencies = new Set<string>()
+  const accountIds = new Set<string>()
+
+  let executionRows = 0
+  let closedLotRows = 0
+  let skippedUnparseableDate = 0
+  let skippedIncomplete = 0
+
+  for (const statement of statements) {
+    if (statement.accountId) accountIds.add(statement.accountId)
+  }
+
+  for (const row of rows) {
+    const levelOfDetail = (row.levelOfDetail ?? '').toUpperCase()
+
+    if (levelOfDetail === 'CLOSED_LOT') {
+      closedLotRows += 1
+      continue
+    }
+    // ORDER rows are aggregates of the executions we already read; counting
+    // both would double every position.
+    if (levelOfDetail === 'ORDER') continue
+
+    executionRows += 1
+
+    const side = normalizeSide(row.buySell)
+    const quantity = Math.abs(toNumber(row.quantity))
+    const price = toNumber(row.tradePrice, Number.NaN)
+    const instrument = resolveInstrument(row)
+    const rawSymbol = (row.symbol ?? '').trim() || instrument
+
+    if (!side || quantity <= 0 || !Number.isFinite(price) || !instrument) {
+      skippedIncomplete += 1
+      continue
+    }
+
+    const timestamp =
+      parseFlexDateTime(row.dateTime) ??
+      parseFlexDateTime(row.tradeDate, row.tradeTime) ??
+      parseFlexDateTime(row.tradeDate)
+
+    if (!timestamp) {
+      skippedUnparseableDate += 1
+      continue
+    }
+
+    if (row.currency) currencies.add(row.currency.toUpperCase())
+    if (row.accountId) accountIds.add(row.accountId)
+
+    executions.push({
+      accountId: (row.accountId ?? '').trim() || statements[0]?.accountId || 'IBKR',
+      tradeId: (row.tradeID ?? row.transactionID ?? row.ibExecID ?? '').trim(),
+      rawSymbol,
+      instrument,
+      assetCategory: (row.assetCategory ?? '').toUpperCase(),
+      currency: (row.currency ?? '').toUpperCase(),
+      // A missing multiplier means a 1:1 instrument (equities, cash).
+      multiplier: toNumber(row.multiplier, 1) || 1,
+      side,
+      quantity,
+      price,
+      commission: Math.abs(toNumber(row.ibCommission)),
+      timestamp,
+    })
+  }
+
+  executions.sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+
+  return {
+    executions,
+    stats: {
+      tradeRows: rows.length,
+      executionRows,
+      closedLotRows,
+      skippedUnparseableDate,
+      skippedIncomplete,
+      currencies: Array.from(currencies).sort(),
+      accountIds: Array.from(accountIds).sort(),
+    },
+  }
+}
+
+/** A round-turn produced by pairing an opening execution with a closing one. */
+export interface FlexMatchedTrade {
+  accountId: string
+  instrument: string
+  currency: string
+  side: 'Long' | 'Short'
+  quantity: number
+  entryId: string
+  closeId: string
+  entryPrice: number
+  closePrice: number
+  entryDate: string
+  closeDate: string
+  pnl: number
+  commission: number
+  timeInPosition: number
+}
+
+interface OpenLot {
+  execution: FlexExecution
+  /** Quantity still open on this execution. */
+  remaining: number
+}
+
+/**
+ * Pairs executions into round-turns using FIFO, per account and per contract.
+ *
+ * Positions that flip through zero are handled by closing the outstanding lots
+ * first and opening the remainder in the new direction. Executions left open at
+ * the end of the statement are simply not emitted — an open position is not a
+ * trade yet.
+ */
+export function matchExecutionsFifo(executions: FlexExecution[]): FlexMatchedTrade[] {
+  const openLotsByKey = new Map<string, OpenLot[]>()
+  const trades: FlexMatchedTrade[] = []
+
+  for (const execution of executions) {
+    const key = `${execution.accountId}::${execution.rawSymbol}`
+    const openLots = openLotsByKey.get(key) ?? []
+    let unmatched = execution.quantity
+
+    while (unmatched > 0 && openLots.length > 0 && openLots[0].execution.side !== execution.side) {
+      const lot = openLots[0]
+      const matchedQuantity = Math.min(lot.remaining, unmatched)
+
+      const isLong = lot.execution.side === 'BUY'
+      const entryPrice = lot.execution.price
+      const closePrice = execution.price
+      const multiplier = lot.execution.multiplier || 1
+
+      const grossPnl =
+        (closePrice - entryPrice) * matchedQuantity * multiplier * (isLong ? 1 : -1)
+
+      // Commission is reported per execution, so charge the matched slice of each.
+      const entryCommission =
+        (lot.execution.commission / lot.execution.quantity) * matchedQuantity
+      const closeCommission = (execution.commission / execution.quantity) * matchedQuantity
+
+      const entryMs = new Date(lot.execution.timestamp).getTime()
+      const closeMs = new Date(execution.timestamp).getTime()
+
+      trades.push({
+        accountId: execution.accountId,
+        instrument: execution.instrument,
+        currency: execution.currency || lot.execution.currency,
+        side: isLong ? 'Long' : 'Short',
+        quantity: matchedQuantity,
+        entryId: lot.execution.tradeId,
+        closeId: execution.tradeId,
+        entryPrice,
+        closePrice,
+        entryDate: lot.execution.timestamp,
+        closeDate: execution.timestamp,
+        pnl: Number(grossPnl.toFixed(2)),
+        commission: Number((entryCommission + closeCommission).toFixed(2)),
+        timeInPosition: Math.max(0, Math.round((closeMs - entryMs) / 1000)),
+      })
+
+      lot.remaining -= matchedQuantity
+      unmatched -= matchedQuantity
+      if (lot.remaining <= 0) openLots.shift()
+    }
+
+    if (unmatched > 0) {
+      openLots.push({ execution, remaining: unmatched })
+    }
+    openLotsByKey.set(key, openLots)
+  }
+
+  return trades
+}

--- a/lib/ibkr-flex-xml.ts
+++ b/lib/ibkr-flex-xml.ts
@@ -1,0 +1,134 @@
+/**
+ * Minimal XML reader for IBKR Flex Web Service responses.
+ *
+ * Flex responses are a narrow, well-defined shape: a shallow element tree whose
+ * payload lives entirely in attributes (`<Trade symbol="MESZ5" quantity="2" .../>`),
+ * plus a handful of text-only status elements. That is small enough to read
+ * directly, which keeps a brokerage-data path free of a general-purpose XML
+ * dependency.
+ *
+ * Deliberately NOT a general XML parser: no namespaces, no mixed content, no
+ * DTD/entity expansion (so no billion-laughs surface). Unknown constructs are
+ * skipped rather than guessed at.
+ */
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+}
+
+/** Decodes the XML entities IBKR actually emits, plus numeric character refs. */
+export function decodeXmlEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, entity: string) => {
+    if (entity.startsWith('#x') || entity.startsWith('#X')) {
+      const codePoint = Number.parseInt(entity.slice(2), 16)
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint)
+    }
+    if (entity.startsWith('#')) {
+      const codePoint = Number.parseInt(entity.slice(1), 10)
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint)
+    }
+    return NAMED_ENTITIES[entity] ?? match
+  })
+}
+
+/** Strips comments and CDATA so they can never be mistaken for markup. */
+function stripNonMarkup(xml: string): string {
+  return xml.replace(/<!--[\s\S]*?-->/g, '').replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
+}
+
+/**
+ * Reads the attributes of an element's opening tag, starting just past the
+ * element name. Returns the attribute map and the index right after the tag.
+ *
+ * Quote-aware, so a `>` inside an attribute value does not end the tag early.
+ */
+function readAttributes(
+  xml: string,
+  startIndex: number,
+): { attributes: Record<string, string>; endIndex: number } | null {
+  const attributes: Record<string, string> = {}
+  let i = startIndex
+
+  while (i < xml.length) {
+    const char = xml[i]
+
+    if (char === '>') {
+      return { attributes, endIndex: i + 1 }
+    }
+    if (char === '/' && xml[i + 1] === '>') {
+      return { attributes, endIndex: i + 2 }
+    }
+    if (/\s/.test(char)) {
+      i += 1
+      continue
+    }
+
+    // attribute name
+    const nameStart = i
+    while (i < xml.length && !/[\s=/>]/.test(xml[i])) i += 1
+    const name = xml.slice(nameStart, i)
+    if (!name) return null
+
+    while (i < xml.length && /\s/.test(xml[i])) i += 1
+
+    // Valueless attribute — not emitted by Flex, but skip it rather than break.
+    if (xml[i] !== '=') {
+      attributes[name] = ''
+      continue
+    }
+    i += 1
+    while (i < xml.length && /\s/.test(xml[i])) i += 1
+
+    const quote = xml[i]
+    if (quote !== '"' && quote !== "'") return null
+    i += 1
+    const valueStart = i
+    while (i < xml.length && xml[i] !== quote) i += 1
+    if (i >= xml.length) return null
+
+    attributes[name] = decodeXmlEntities(xml.slice(valueStart, i))
+    i += 1
+  }
+
+  return null
+}
+
+/**
+ * Returns the attribute map of every `<tagName ...>` element in the document,
+ * in document order. Both self-closing and paired elements are matched; only
+ * the opening tag's attributes are read.
+ */
+export function extractElements(xml: string, tagName: string): Record<string, string>[] {
+  const source = stripNonMarkup(xml)
+  const results: Record<string, string>[] = []
+  // `<Trade` must not also match `<TradeConfirm`, hence the delimiter check.
+  const opening = new RegExp(`<${tagName}(?=[\\s/>])`, 'g')
+
+  let match: RegExpExecArray | null
+  while ((match = opening.exec(source)) !== null) {
+    const parsed = readAttributes(source, match.index + tagName.length + 1)
+    if (parsed) {
+      results.push(parsed.attributes)
+      opening.lastIndex = parsed.endIndex
+    }
+  }
+
+  return results
+}
+
+/**
+ * Returns the trimmed text content of the first `<tagName>text</tagName>`,
+ * or null when the element is absent or empty.
+ */
+export function extractText(xml: string, tagName: string): string | null {
+  const source = stripNonMarkup(xml)
+  const pattern = new RegExp(`<${tagName}(?:\\s[^>]*)?>([\\s\\S]*?)</${tagName}>`)
+  const match = source.match(pattern)
+  if (!match) return null
+  const text = decodeXmlEntities(match[1]).trim()
+  return text.length > 0 ? text : null
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -139,12 +139,14 @@ export default {
   "connections.sections.rithmicProtocol": "Rithmic Protocol",
   "connections.sections.tradovate": "Tradovate",
   "connections.sections.dxfeed": "DxFeed",
+  "connections.sections.ibkr": "Interactive Brokers",
   "connections.sections.thor": "Thor",
   "connections.sections.standalone": "Standalone accounts",
   "connections.add.rithmic": "Add Rithmic connection",
   "connections.add.rithmicProtocol": "Add Rithmic Protocol connection",
   "connections.add.tradovate": "Add Tradovate connection",
   "connections.add.dxfeed": "Add DxFeed connection",
+  "connections.add.ibkr": "Add Interactive Brokers connection",
   "connections.add.thor": "Add Thor connection",
   "connections.add.etp": "Add ETP connection",
   "connections.emptySection": "No connections yet. Use + to add one.",
@@ -2356,6 +2358,171 @@ export default {
       },
     },
   },
+  ibkrSync: {
+    title: "Interactive Brokers Sync",
+    description:
+      "Import your IBKR trade history automatically using a Flex Query. Set it up once in Client Portal and paste the two values below.",
+    setup: {
+      title: "Set up in IBKR Client Portal",
+      openPortal: "Open Client Portal",
+      step1: "Sign in to IBKR Client Portal and go to Performance & Reports → Flex Queries.",
+      step2:
+        "Under Flex Web Service Configuration, turn the service on and copy the token.",
+      step2Hint:
+        "When asked how long the token should last, choose one year. Shorter tokens stop the sync silently when they expire.",
+      step3:
+        'Create a new Activity Flex Query, name it "Deltalytix", and add the Trades section.',
+      step3Hint:
+        "Click the Trades section header to select every field at once — no need to pick them one by one.",
+      step4: "Set the delivery options to match these, then save the query.",
+      step4Hint:
+        "Any date format other than yyyyMMdd is ambiguous, so we refuse to guess and skip those rows instead of importing them on the wrong day.",
+      step5: "Copy the query ID shown next to the saved query, then paste both values below.",
+      summarySection: "Section",
+      summaryPeriod: "Period",
+      summaryFormat: "Format",
+      summaryDateFormat: "Date / time",
+      readOnlyNote:
+        "The Flex Web Service is read-only: it can download reports and nothing else. It cannot place, modify or cancel orders, and it cannot move funds.",
+    },
+    connect: {
+      title: "Connect Interactive Brokers",
+      description:
+        "Create the Flex Query once, then paste your token and query ID together — we work out which is which.",
+      pasteLabel: "Token and query ID",
+      pastePlaceholder: "Paste both values here, in any order",
+      pasteHint:
+        "You can paste them on separate lines, side by side, or with the labels from Client Portal.",
+      detectedToken: "Token",
+      detectedQueryId: "Query ID",
+      notDetected: "not found yet",
+      verifyAndConnect: "Verify and connect",
+      verifying: "Checking with IBKR...",
+      verifiedTitle: "Connection verified",
+      importedTrades:
+        "Imported {savedCount} new trade(s) out of {tradesCount} found.",
+      nothingNew:
+        "Found {tradesCount} completed trade(s); all of them were already in your journal.",
+      done: "Done",
+    },
+    manage: {
+      savedConnections: "Saved connections",
+      addNew: "Add new",
+      syncAll: "Sync all",
+      syncNow: "Sync now",
+      noConnections: "No Interactive Brokers connection yet",
+      queryLabel: "Flex Query {queryId}",
+      connected: "Connected",
+      expired: "Needs reconnecting",
+      reconnect: "Reconnect",
+      lastSync: "Last sync",
+      dailySync: "Daily sync",
+      scheduleSync: "Schedule",
+      multiCurrency:
+        "Trades in several currencies ({currencies}). P&L is stored as reported, without conversion.",
+      removeConnection: "Remove connection",
+      removeConfirm:
+        'Remove the connection for Flex Query "{accountId}"? Trades already imported stay in your journal.',
+      remove: "Remove",
+      connectionRemoved: "Connection {accountId} removed.",
+      removeError: "Could not remove connection {accountId}.",
+      reloaded: "Connections reloaded",
+      dailySyncTimeTitle: "Set daily sync time",
+      dailySyncTimeDescription:
+        "Pick a time and we import each day automatically. IBKR statements cover a rolling window, so a missed run is picked up by the next one. Leave empty to sync manually only.",
+      dailySyncTimeLabel: "Sync time (local time)",
+      dailySyncTimeTimezoneNote: "Time is in your local timezone ({timezone})",
+      dailySyncTimeUpdated: "Daily sync time updated",
+      dailySyncTimeUpdateError: "Could not update the daily sync time",
+    },
+    sync: {
+      inProgress: "Syncing Flex Query {accountId}...",
+      completeForAccount:
+        "Imported {savedCount} new trade(s) out of {tradesCount} found for {accountId}.",
+      noNewTradesForAccount:
+        "Checked {accountId}: {tradesCount} trade(s) found, all already in your journal.",
+      multiCurrencyWarning:
+        "This statement mixes currencies ({currencies}); P&L is stored as reported, without conversion.",
+      skippedDatesWarning:
+        "{count} row(s) were skipped because their date format was ambiguous — set the query's date format to yyyyMMdd.",
+    },
+    errors: {
+      UNKNOWN:
+        "Something went wrong. Try again, or contact Support if the problem continues.",
+      USER_NOT_AUTHENTICATED:
+        "You must be signed in to connect Interactive Brokers. Sign in and try again.",
+      CREDENTIALS_REQUIRED: "Paste your Flex token and query ID to continue.",
+      TOKEN_MALFORMED:
+        "We could not find a Flex token in what you pasted. It is a long number from the Flex Web Service Configuration panel.",
+      QUERY_ID_MALFORMED:
+        "We could not find a query ID in what you pasted. It is the short number shown next to your saved Flex Query.",
+      INVALID_STORED_CREDENTIALS:
+        "The saved connection data could not be read. Remove the connection and add it again.",
+      NO_CREDENTIALS_RECONNECT:
+        "This connection has no saved credentials. Add it again with a fresh token and query ID.",
+      DUPLICATE_CONNECTION: "This Flex Query is already connected.",
+      FLEX_HTTP_ERROR:
+        "Interactive Brokers returned an unexpected response (HTTP {status}). Try again shortly.",
+      FLEX_UNREACHABLE:
+        "We could not reach Interactive Brokers. Check your connection and try again.",
+      FLEX_MALFORMED_RESPONSE:
+        "Interactive Brokers returned a response we could not read. Try again shortly.",
+      FLEX_STATEMENT_TIMEOUT:
+        "Interactive Brokers is still generating the report. Try again in a minute.",
+      FLEX_TOKEN_EXPIRED:
+        "Your Flex token has expired. Generate a new one in Client Portal and reconnect.",
+      FLEX_TOKEN_INVALID:
+        "Interactive Brokers rejected this Flex token. Generate a new one and reconnect.",
+      FLEX_IP_RESTRICTED:
+        "This Flex token is restricted to a specific IP address, so our servers cannot use it.",
+      FLEX_QUERY_INVALID:
+        "Interactive Brokers does not recognise this query ID. Check it against the saved query in Client Portal.",
+      FLEX_REFERENCE_INVALID:
+        "The report reference expired before we could download it. Try again.",
+      FLEX_ACCOUNT_INVALID:
+        "The account on this Flex Query is not valid. Check the query's account selection in Client Portal.",
+      FLEX_SERVICE_INACTIVE:
+        "The Flex Web Service is switched off for this account. Turn it back on in Client Portal.",
+      FLEX_RATE_LIMITED:
+        "Interactive Brokers is rate limiting this token (max 10 requests per minute). Wait a minute and try again.",
+      FLEX_LEGACY_QUERY:
+        "This is a legacy Flex Query, which IBKR no longer supports. Create a new Activity Flex Query instead.",
+      FLEX_STATEMENT_FAILED:
+        "Interactive Brokers could not generate the report ({code}): {detail}",
+      FLEX_UNKNOWN_ERROR:
+        "Interactive Brokers returned error {code}: {detail}",
+      QUERY_HAS_NO_TRADES_SECTION:
+        "This Flex Query returned no trade data. Edit it in Client Portal and add the Trades section.",
+      QUERY_MISSING_FIELDS:
+        "This Flex Query is missing fields we need. Open the Trades section and select all of its fields.",
+      QUERY_UNPARSEABLE_DATES:
+        "None of the {count} rows in this statement had a date we could read unambiguously.",
+      NO_TRADES_IN_RANGE:
+        "The statement came back empty. Check the query's period covers the days you traded.",
+      OPEN_POSITIONS_ONLY:
+        "This statement only contains positions that are still open, so there is nothing to import yet.",
+      DUPLICATE_TRADES: "These trades are already in your journal.",
+      SAVE_TRADES_FAILED:
+        "Trades were downloaded but could not be saved: {detail}",
+      SYNC_FAILED: "The sync failed. Try again in a few minutes.",
+      ACCOUNT_ID_REQUIRED:
+        "Connection identifier is missing. Refresh the page and try again.",
+      LOAD_SYNCHRONIZATIONS_FAILED:
+        "Could not load your saved Interactive Brokers connections. Refresh the page.",
+      DELETE_SYNC_FAILED: "Could not remove this connection. Try again.",
+      UPDATE_SYNC_TIME_FAILED: "Could not update the daily sync time. Try again.",
+      hintEditQuery:
+        "Open Client Portal → Performance & Reports → Flex Queries, edit your query, and check the Trades section and period.",
+      hintRegenerateToken:
+        "Open Client Portal → Performance & Reports → Flex Queries → Flex Web Service Configuration, generate a new token, then reconnect here.",
+      hintRetryShortly:
+        "This is usually temporary. Wait a minute and run the sync again.",
+      hintDateFormat:
+        "In your Flex Query's delivery settings, set the date format to yyyyMMdd and the time format to HHmmss.",
+      hintIpRestriction:
+        "Generate the token again without an IP restriction, or allow our servers' address.",
+    },
+  },
   rithmicProtocolSync: {
     title: "Rithmic Protocol Sync",
     description:
@@ -2441,6 +2608,11 @@ export default {
     "Direct account synchronization with DxFeed",
   "import.type.dxfeedSync.details":
     "Import closed trades from your prop firm (DxFeed / Volumetrica). Select your firm, then sign in with your platform credentials.",
+  "import.type.ibkrSync.name": "Interactive Brokers",
+  "import.type.ibkrSync.description":
+    "Direct account synchronization with Interactive Brokers",
+  "import.type.ibkrSync.details":
+    "Import your IBKR trade history automatically using a Flex Query. You create the query once in Client Portal, paste the token and query ID here, and we keep it in sync.",
   "import.type.atas.name": "ATAS",
   "import.type.atas.description": "ATAS Excel file",
   "import.type.atas.details":

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -140,12 +140,14 @@ export default {
   "connections.sections.rithmicProtocol": "Rithmic Protocol",
   "connections.sections.tradovate": "Tradovate",
   "connections.sections.dxfeed": "DxFeed",
+  "connections.sections.ibkr": "Interactive Brokers",
   "connections.sections.thor": "Thor",
   "connections.sections.standalone": "Comptes autonomes",
   "connections.add.rithmic": "Ajouter une connexion Rithmic",
   "connections.add.rithmicProtocol": "Ajouter une connexion Rithmic Protocol",
   "connections.add.tradovate": "Ajouter une connexion Tradovate",
   "connections.add.dxfeed": "Ajouter une connexion DxFeed",
+  "connections.add.ibkr": "Ajouter une connexion Interactive Brokers",
   "connections.add.thor": "Ajouter une connexion Thor",
   "connections.add.etp": "Ajouter une connexion ETP",
   "connections.emptySection": "Aucune connexion. Utilisez + pour en ajouter une.",
@@ -2487,6 +2489,174 @@ export default {
       },
     },
   },
+  ibkrSync: {
+    title: "Synchronisation Interactive Brokers",
+    description:
+      "Importez automatiquement votre historique de trades IBKR via une Flex Query. Configurez-la une fois dans le Client Portal et collez les deux valeurs ci-dessous.",
+    setup: {
+      title: "Configuration dans le Client Portal IBKR",
+      openPortal: "Ouvrir le Client Portal",
+      step1:
+        "Connectez-vous au Client Portal IBKR et allez dans Performance & Reports → Flex Queries.",
+      step2:
+        "Dans Flex Web Service Configuration, activez le service et copiez le token.",
+      step2Hint:
+        "Quand la durée de validité vous est demandée, choisissez un an. Un token plus court interrompt la synchronisation sans prévenir à son expiration.",
+      step3:
+        'Créez une nouvelle Activity Flex Query, nommez-la « Deltalytix » et ajoutez la section Trades.',
+      step3Hint:
+        "Cliquez sur l'en-tête de la section Trades pour sélectionner tous les champs d'un coup — inutile de les cocher un par un.",
+      step4:
+        "Réglez les options de livraison comme ci-dessous, puis enregistrez la requête.",
+      step4Hint:
+        "Tout format de date autre que yyyyMMdd est ambigu : nous refusons de deviner et ignorons ces lignes plutôt que de les importer au mauvais jour.",
+      step5:
+        "Copiez l'ID de requête affiché à côté de la requête enregistrée, puis collez les deux valeurs ci-dessous.",
+      summarySection: "Section",
+      summaryPeriod: "Période",
+      summaryFormat: "Format",
+      summaryDateFormat: "Date / heure",
+      readOnlyNote:
+        "Le Flex Web Service est en lecture seule : il ne peut que télécharger des rapports. Il ne peut ni passer, modifier ou annuler d'ordres, ni déplacer de fonds.",
+    },
+    connect: {
+      title: "Connecter Interactive Brokers",
+      description:
+        "Créez la Flex Query une fois, puis collez votre token et votre ID de requête ensemble — nous identifions lequel est lequel.",
+      pasteLabel: "Token et ID de requête",
+      pastePlaceholder: "Collez les deux valeurs ici, dans n'importe quel ordre",
+      pasteHint:
+        "Vous pouvez les coller sur deux lignes, côte à côte, ou avec les libellés du Client Portal.",
+      detectedToken: "Token",
+      detectedQueryId: "ID de requête",
+      notDetected: "pas encore trouvé",
+      verifyAndConnect: "Vérifier et connecter",
+      verifying: "Vérification auprès d'IBKR...",
+      verifiedTitle: "Connexion vérifiée",
+      importedTrades:
+        "{savedCount} nouveau(x) trade(s) importé(s) sur {tradesCount} trouvé(s).",
+      nothingNew:
+        "{tradesCount} trade(s) clôturé(s) trouvé(s) ; tous étaient déjà dans votre journal.",
+      done: "Terminé",
+    },
+    manage: {
+      savedConnections: "Connexions enregistrées",
+      addNew: "Ajouter",
+      syncAll: "Tout synchroniser",
+      syncNow: "Synchroniser",
+      noConnections: "Aucune connexion Interactive Brokers pour le moment",
+      queryLabel: "Flex Query {queryId}",
+      connected: "Connecté",
+      expired: "À reconnecter",
+      reconnect: "Reconnecter",
+      lastSync: "Dernière synchro",
+      dailySync: "Synchro quotidienne",
+      scheduleSync: "Planifier",
+      multiCurrency:
+        "Trades en plusieurs devises ({currencies}). Le P&L est enregistré tel quel, sans conversion.",
+      removeConnection: "Supprimer la connexion",
+      removeConfirm:
+        'Supprimer la connexion pour la Flex Query « {accountId} » ? Les trades déjà importés restent dans votre journal.',
+      remove: "Supprimer",
+      connectionRemoved: "Connexion {accountId} supprimée.",
+      removeError: "Impossible de supprimer la connexion {accountId}.",
+      reloaded: "Connexions rechargées",
+      dailySyncTimeTitle: "Définir l'heure de synchronisation quotidienne",
+      dailySyncTimeDescription:
+        "Choisissez une heure et nous importons chaque jour automatiquement. Les relevés IBKR couvrent une fenêtre glissante : une exécution manquée est rattrapée par la suivante. Laissez vide pour synchroniser manuellement.",
+      dailySyncTimeLabel: "Heure de synchronisation (heure locale)",
+      dailySyncTimeTimezoneNote: "L'heure est dans votre fuseau horaire ({timezone})",
+      dailySyncTimeUpdated: "Heure de synchronisation mise à jour",
+      dailySyncTimeUpdateError: "Impossible de mettre à jour l'heure de synchronisation",
+    },
+    sync: {
+      inProgress: "Synchronisation de la Flex Query {accountId}...",
+      completeForAccount:
+        "{savedCount} nouveau(x) trade(s) importé(s) sur {tradesCount} trouvé(s) pour {accountId}.",
+      noNewTradesForAccount:
+        "{accountId} vérifié : {tradesCount} trade(s) trouvé(s), tous déjà dans votre journal.",
+      multiCurrencyWarning:
+        "Ce relevé mélange plusieurs devises ({currencies}) ; le P&L est enregistré tel quel, sans conversion.",
+      skippedDatesWarning:
+        "{count} ligne(s) ignorée(s) car leur format de date était ambigu — réglez le format de date de la requête sur yyyyMMdd.",
+    },
+    errors: {
+      UNKNOWN:
+        "Une erreur est survenue. Réessayez ou contactez le support si le problème persiste.",
+      USER_NOT_AUTHENTICATED:
+        "Vous devez être connecté pour lier Interactive Brokers. Connectez-vous et réessayez.",
+      CREDENTIALS_REQUIRED: "Collez votre token Flex et votre ID de requête pour continuer.",
+      TOKEN_MALFORMED:
+        "Aucun token Flex trouvé dans ce que vous avez collé. C'est le long nombre affiché dans le panneau Flex Web Service Configuration.",
+      QUERY_ID_MALFORMED:
+        "Aucun ID de requête trouvé dans ce que vous avez collé. C'est le nombre court affiché à côté de votre Flex Query enregistrée.",
+      INVALID_STORED_CREDENTIALS:
+        "Les données de connexion enregistrées sont illisibles. Supprimez la connexion et recréez-la.",
+      NO_CREDENTIALS_RECONNECT:
+        "Cette connexion n'a plus d'identifiants enregistrés. Recréez-la avec un nouveau token et un ID de requête.",
+      DUPLICATE_CONNECTION: "Cette Flex Query est déjà connectée.",
+      FLEX_HTTP_ERROR:
+        "Interactive Brokers a renvoyé une réponse inattendue (HTTP {status}). Réessayez dans un instant.",
+      FLEX_UNREACHABLE:
+        "Impossible de joindre Interactive Brokers. Vérifiez votre connexion et réessayez.",
+      FLEX_MALFORMED_RESPONSE:
+        "Interactive Brokers a renvoyé une réponse illisible. Réessayez dans un instant.",
+      FLEX_STATEMENT_TIMEOUT:
+        "Interactive Brokers génère encore le rapport. Réessayez dans une minute.",
+      FLEX_TOKEN_EXPIRED:
+        "Votre token Flex a expiré. Générez-en un nouveau dans le Client Portal et reconnectez-vous.",
+      FLEX_TOKEN_INVALID:
+        "Interactive Brokers a rejeté ce token Flex. Générez-en un nouveau et reconnectez-vous.",
+      FLEX_IP_RESTRICTED:
+        "Ce token Flex est restreint à une adresse IP précise, nos serveurs ne peuvent donc pas l'utiliser.",
+      FLEX_QUERY_INVALID:
+        "Interactive Brokers ne reconnaît pas cet ID de requête. Vérifiez-le dans le Client Portal.",
+      FLEX_REFERENCE_INVALID:
+        "La référence du rapport a expiré avant que nous puissions le télécharger. Réessayez.",
+      FLEX_ACCOUNT_INVALID:
+        "Le compte de cette Flex Query n'est pas valide. Vérifiez la sélection de comptes de la requête dans le Client Portal.",
+      FLEX_SERVICE_INACTIVE:
+        "Le Flex Web Service est désactivé pour ce compte. Réactivez-le dans le Client Portal.",
+      FLEX_RATE_LIMITED:
+        "Interactive Brokers limite ce token (10 requêtes par minute maximum). Attendez une minute et réessayez.",
+      FLEX_LEGACY_QUERY:
+        "Il s'agit d'une Flex Query héritée, qu'IBKR ne prend plus en charge. Créez une nouvelle Activity Flex Query.",
+      FLEX_STATEMENT_FAILED:
+        "Interactive Brokers n'a pas pu générer le rapport ({code}) : {detail}",
+      FLEX_UNKNOWN_ERROR: "Interactive Brokers a renvoyé l'erreur {code} : {detail}",
+      QUERY_HAS_NO_TRADES_SECTION:
+        "Cette Flex Query n'a renvoyé aucune donnée de trade. Modifiez-la dans le Client Portal et ajoutez la section Trades.",
+      QUERY_MISSING_FIELDS:
+        "Il manque des champs à cette Flex Query. Ouvrez la section Trades et sélectionnez tous ses champs.",
+      QUERY_UNPARSEABLE_DATES:
+        "Aucune des {count} lignes de ce relevé n'avait de date lisible sans ambiguïté.",
+      NO_TRADES_IN_RANGE:
+        "Le relevé est vide. Vérifiez que la période de la requête couvre bien vos jours de trading.",
+      OPEN_POSITIONS_ONLY:
+        "Ce relevé ne contient que des positions encore ouvertes : il n'y a rien à importer pour l'instant.",
+      DUPLICATE_TRADES: "Ces trades sont déjà dans votre journal.",
+      SAVE_TRADES_FAILED:
+        "Les trades ont été téléchargés mais n'ont pas pu être enregistrés : {detail}",
+      SYNC_FAILED: "La synchronisation a échoué. Réessayez dans quelques minutes.",
+      ACCOUNT_ID_REQUIRED:
+        "Identifiant de connexion manquant. Actualisez la page et réessayez.",
+      LOAD_SYNCHRONIZATIONS_FAILED:
+        "Impossible de charger vos connexions Interactive Brokers. Actualisez la page.",
+      DELETE_SYNC_FAILED: "Impossible de supprimer cette connexion. Réessayez.",
+      UPDATE_SYNC_TIME_FAILED:
+        "Impossible de mettre à jour l'heure de synchronisation. Réessayez.",
+      hintEditQuery:
+        "Ouvrez Client Portal → Performance & Reports → Flex Queries, modifiez votre requête et vérifiez la section Trades et la période.",
+      hintRegenerateToken:
+        "Ouvrez Client Portal → Performance & Reports → Flex Queries → Flex Web Service Configuration, générez un nouveau token, puis reconnectez-vous ici.",
+      hintRetryShortly:
+        "C'est généralement temporaire. Attendez une minute et relancez la synchronisation.",
+      hintDateFormat:
+        "Dans les options de livraison de votre Flex Query, réglez le format de date sur yyyyMMdd et le format d'heure sur HHmmss.",
+      hintIpRestriction:
+        "Régénérez le token sans restriction d'IP, ou autorisez l'adresse de nos serveurs.",
+    },
+  },
   rithmicProtocolSync: {
     title: "Synchronisation Rithmic Protocol",
     description:
@@ -2580,6 +2750,11 @@ export default {
     "Synchronisation directe de compte avec DxFeed",
   "import.type.dxfeedSync.details":
     "Importez vos trades clôturés depuis votre propfirm (DxFeed / Volumetrica). Sélectionnez la propfirm, puis connectez-vous avec vos identifiants plateforme.",
+  "import.type.ibkrSync.name": "Interactive Brokers",
+  "import.type.ibkrSync.description":
+    "Synchronisation directe de compte avec Interactive Brokers",
+  "import.type.ibkrSync.details":
+    "Importez automatiquement votre historique de trades IBKR via une Flex Query. Vous créez la requête une fois dans le Client Portal, collez le token et l'ID de requête ici, et nous gardons tout synchronisé.",
   "import.type.atas.name": "ATAS",
   "import.type.atas.description": "Fichier Excel ATAS",
   "import.type.atas.details":


### PR DESCRIPTION
## Summary

Connects IBKR accounts using Flex Queries — the only IBKR access path that works for a hosted app without a compliance-gated partnership.

The alternative, the Web API OAuth 1.0a flow, needs third-party onboarding, an enhanced due-diligence review, and a signed agreement before any code can run, and its trades endpoint only returns 7 days of history. Flex needs no approval and returns a full rolling year, so it is both the faster path and the better data source. The tradeoff is setup burden, which this PR spends most of its effort on.

## How it works

Trade history is read from the Trades section at execution level and paired into round-turns with FIFO. Flex can also emit `CLOSED_LOT` rows carrying IBKR's own `fifoPnlRealized`, but those rows do not reliably carry the opening price and time the journal needs, and requiring them adds another checkbox to the user's query setup. Executions carry everything, so **one section with its default options is enough**.

P&L is computed as `(exit − entry) × quantity × multiplier`, signed by direction — exact for futures, options and equities alike, since Flex reports the contract multiplier per execution.

## Reducing the setup steps

IBKR offers no API to provision a Flex Query on a user's behalf, so the ~13 manual actions in Client Portal are unavoidable. The flow attacks everything around them:

- **One paste field**, not two — the token and query ID are identified by shape, with Client Portal's labels honoured when present
- **Live parse feedback** — the form confirms both values were found before the user commits to a round-trip
- **In-app walkthrough** with the exact delivery settings, copyable in one click, and a tip to select all Trades fields via the section header rather than one by one
- **Verification on connect** — fetches a real statement and reports the accounts and trades actually found, so a mis-clicked setting surfaces immediately instead of as a silent empty sync tomorrow
- **Connecting imports immediately** — one click fewer, and one Flex round-trip fewer against IBKR's limit of 10 requests per minute per token

## Notable decisions

- **Ambiguous dates are refused, not guessed.** Flex lets users pick the date format, and `03/04/2025` is undecidable between dd/MM and MM/dd. Guessing wrong puts a trade on the wrong calendar day and quietly corrupts the journal, so those rows are skipped, counted, and surfaced with the setting that fixes them.
- **A small purpose-built XML reader** instead of a general parser. Flex responses are shallow and attribute-only; this keeps a brokerage-data path free of a general parser's dependency and entity-expansion surface. It is quote-aware, decodes entities, and skips comments and CDATA.
- **Credentials are stored encrypted** as a bundle in `Connection.token` via the existing `ensureConnection` path, and never reach the client — the API returns only derived display fields.
- **Multi-currency statements import but are flagged**, since `Trade.pnl` has no currency column and nothing is converted.
- **All 22 documented Flex error codes are mapped** to actionable messages paired with the one action that resolves them (edit the query / regenerate the token / wait and retry). Code 1019 is the only one retried, since it means the report is still generating.

## Surfaces touched

Registers `ibkr` as a connection service across the connections page, the connect modal, and the legacy import dialog.

Scheduled syncs run from the shared `/api/cron/daily-sync` rather than a service-specific cron, so IBKR inherits its wall-clock budget, its `lastSyncedAt` catch-up and its cache invalidation. `ibkr` is added to both `DAILY_SYNC_SERVICES` and the cron's `SYNCABLE_SERVICES`, which is the contract `daily-sync-services.ts` documents — a service in the first list without the second ships a time picker that never fires. Empty statements are reported as healthy no-ops, since an IBKR window that overlaps the previous run legitimately finds nothing new.

## Testing

34 new unit tests, all passing (185 total), covering date formats and timezone offsets, credential extraction, XML attribute parsing, and FIFO matching — including position flips through zero, partial fills, and commission proration.

- `bun run typecheck` — clean
- `bun run build` — clean, 342/342 static pages, with `/api/ibkr/connect`, `/api/ibkr/sync` and `/api/ibkr/synchronizations` registered
- Lint on `app/[locale]/dashboard/connections` is byte-identical before and after this branch (8 problems either way), so nothing new was introduced to the files this PR touches

Two pre-existing conditions unchanged by this PR: two test *files* (`lib/pdf/statement.test.ts`, `lib/rithmic-protocol/fills-to-trades.test.ts`) fail to load identically on clean `beta` because vitest has no `@/` alias configured; and builds intermittently time out prerendering marketing changelog MDX pages, a different page each run.

## Before merging

- `ENCRYPTION_KEY` must be set — `ensureConnection` throws without it
- The Client Portal link is the portal home rather than a deep link to Flex Queries, which I could not verify. It is overridable via `NEXT_PUBLIC_IBKR_FLEX_PORTAL_URL` with no code change.
- Nothing has run against a real Flex statement. The parser is tested against XML constructed from IBKR's documented field names; the stats panel is designed to make any field-name drift visible on first connection rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gt7Jzqyu6JkpbHfk4GBC6