### PR TITLE
Add consent-aware Google Ads tracking

### DIFF
--- a/app/[locale]/(authentication)/components/user-auth-form.tsx
+++ b/app/[locale]/(authentication)/components/user-auth-form.tsx
@@ -33,6 +33,7 @@ import { Badge } from "@/components/ui/badge"
 // Link removed; unauthenticated users can't reach settings
 import { useAuthPreferenceStore } from "@/store/auth-preference-store"
 import { openMailbox } from "@/lib/open-mailbox"
+import { signupRedirectPath } from "@/lib/signup-redirect"
 
 const formSchema = z.object({
     email: z.string().email(),
@@ -231,10 +232,12 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
         setIsLoading(true)
         setAuthMethod('email')
         try {
-            await signInWithPasswordAction(values.email, values.password || '')
+            const result = await signInWithPasswordAction(values.email, values.password || '')
             toast.success(t('success'), { description: t('auth.signIn') })
             router.refresh()
-            router.push(nextUrl || '/dashboard')
+            // This action doubles as registration when the account does not
+            // exist yet, so it can legitimately return a brand-new user.
+            router.push(signupRedirectPath(nextUrl, result?.isNewUser ?? false))
             setLastAuthPreference('password')
         } catch (error) {
             console.error(error)
@@ -274,10 +277,7 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
                 description: "Successfully verified. Redirecting...",
             })
             router.refresh()
-            const fallbackUrl = result?.isNewUser
-              ? '/dashboard?signup=success'
-              : '/dashboard'
-            router.push(nextUrl || fallbackUrl)
+            router.push(signupRedirectPath(nextUrl, result?.isNewUser ?? false))
         } catch (error) {
             console.error(error)
             toast.error("Error", {

--- a/app/[locale]/(authentication)/components/user-auth-form.tsx
+++ b/app/[locale]/(authentication)/components/user-auth-form.tsx
@@ -269,12 +269,15 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
         setIsLoading(true)
         try {
             const email = form.getValues('email')
-            await verifyOtp(email, values.otp)
+            const result = await verifyOtp(email, values.otp)
             toast.success("Successfully verified. Redirecting...", {
                 description: "Successfully verified. Redirecting...",
             })
             router.refresh()
-            router.push(nextUrl || '/dashboard')
+            const fallbackUrl = result?.isNewUser
+              ? '/dashboard?signup=success'
+              : '/dashboard'
+            router.push(nextUrl || fallbackUrl)
         } catch (error) {
             console.error(error)
             toast.error("Error", {

--- a/app/[locale]/(landing)/types/gtag.d.ts
+++ b/app/[locale]/(landing)/types/gtag.d.ts
@@ -1,10 +1,4 @@
 interface Window {
-  gtag: (
-    command: 'consent',
-    action: 'update' | 'default',
-    settings: {
-      [key: string]: 'granted' | 'denied'
-    }
-  ) => void;
-  dataLayer: any[];
-} 
+  gtag?: (...args: unknown[]) => void;
+  dataLayer: unknown[];
+}

--- a/app/[locale]/(landing)/types/gtag.d.ts
+++ b/app/[locale]/(landing)/types/gtag.d.ts
@@ -1,4 +1,18 @@
+type GtagConsentValue = 'granted' | 'denied';
+
 interface Window {
-  gtag?: (...args: unknown[]) => void;
-  dataLayer: unknown[];
+  // Overloads keep the consent calls type-checked while still allowing the
+  // initialisation commands the Google tag loader needs.
+  gtag?: {
+    (
+      command: 'consent',
+      action: 'default' | 'update',
+      settings: Record<string, GtagConsentValue>,
+    ): void;
+    (command: 'js', date: Date): void;
+    (command: 'config', targetId: string, config?: Record<string, unknown>): void;
+    (command: 'event', eventName: string, params?: Record<string, unknown>): void;
+  };
+  // Present only once the tag (or its queue stub) has initialised it.
+  dataLayer?: unknown[];
 }

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -26,6 +26,7 @@ export async function GET(request: Request) {
 
   // Redirect to the decoded 'next' URL if it exists, otherwise to the homepage
   let decodedNext: string | null = null;
+  let isNewUser = false;
   if (next) {
     decodedNext = decodeURIComponent(next)
   }
@@ -53,17 +54,19 @@ export async function GET(request: Request) {
         try {
           const { data: { user } } = await supabase.auth.getUser()
           if (user) {
-            await ensureUserInDatabase(user, locale)
+            const databaseUser = await ensureUserInDatabase(user, locale)
+            isNewUser = Date.now() - databaseUser.createdAt.getTime() < 60_000
           }
         } catch (e) {
           console.error('Auth callback ensureUserInDatabase error:', e)
           // Non-fatal: continue redirect
         }
 
-        if (decodedNext) {
-          return NextResponse.redirect(new URL(decodedNext, requestOrigin))
+        const redirectUrl = new URL(decodedNext ?? next ?? '/dashboard', requestOrigin)
+        if (isNewUser && redirectUrl.pathname.includes('/dashboard')) {
+          redirectUrl.searchParams.set('signup', 'success')
         }
-        return NextResponse.redirect(new URL(next ?? '/dashboard', requestOrigin))
+        return NextResponse.redirect(redirectUrl)
       } else {
         console.log('Auth callback error:', error)
       }

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,6 +1,7 @@
 'use server'
 import { createClient, ensureUserInDatabase } from '@/server/auth'
 import { getRequestOrigin } from '@/lib/site-url'
+import { applySignupSuccess, resolveInternalDestination } from '@/lib/signup-redirect'
 import { NextResponse } from 'next/server'
 // The client you created from the Server-Side Auth instructions
 
@@ -62,10 +63,8 @@ export async function GET(request: Request) {
           // Non-fatal: continue redirect
         }
 
-        const redirectUrl = new URL(decodedNext ?? next ?? '/dashboard', requestOrigin)
-        if (isNewUser && redirectUrl.pathname.includes('/dashboard')) {
-          redirectUrl.searchParams.set('signup', 'success')
-        }
+        const redirectUrl = resolveInternalDestination(decodedNext, requestOrigin)
+        applySignupSuccess(redirectUrl, isNewUser)
         return NextResponse.redirect(redirectUrl)
       } else {
         console.log('Auth callback error:', error)

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -54,8 +54,8 @@ export async function GET(request: Request) {
         try {
           const { data: { user } } = await supabase.auth.getUser()
           if (user) {
-            const databaseUser = await ensureUserInDatabase(user, locale)
-            isNewUser = Date.now() - databaseUser.createdAt.getTime() < 60_000
+            const ensureResult = await ensureUserInDatabase(user, locale)
+            isNewUser = ensureResult.isNewUser
           }
         } catch (e) {
           console.error('Auth callback ensureUserInDatabase error:', e)

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -6,8 +6,27 @@ import { stripe } from "@/server/stripe";
 import { getSubscriptionDetails } from "@/server/subscription";
 import { getReferralBySlug } from "@/server/referral";
 import { capturePostHogEvent, hasAnalyticsConsent } from "@/lib/posthog-server";
+import { applySignupSuccess, hasSignupSuccess } from "@/lib/signup-redirect";
 
-async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: string, referral?: string | null, promo_code?: string | null) {
+// This endpoint renders no page of ours — it redirects straight to Stripe — so
+// a signup marker arriving here would never reach the Google tag. Forward it to
+// every URL that brings the user back instead. The account already exists at
+// this point, so the signal is owed regardless of how checkout ends.
+function buildReturnUrl(
+    websiteURL: string,
+    path: string,
+    params: Record<string, string>,
+    signupSuccess: boolean,
+) {
+    const url = new URL(path, websiteURL);
+    for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+    }
+    applySignupSuccess(url, signupSuccess);
+    return url.toString();
+}
+
+async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: string, referral?: string | null, promo_code?: string | null, signupSuccess = false) {
     const subscriptionDetails = await getSubscriptionDetails();
     
     // If referral code is provided, validate it (but don't block checkout if invalid)
@@ -30,7 +49,7 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
 
     if (subscriptionDetails?.isActive) {
         return NextResponse.redirect(
-            `${websiteURL}dashboard?error=already_subscribed`,
+            buildReturnUrl(websiteURL, 'dashboard', { error: 'already_subscribed' }, signupSuccess),
             303
         );
     }
@@ -113,8 +132,15 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
                 quantity: 1,
             },
         ],
-        success_url: `${websiteURL}dashboard?success=true&referral_applied=${referral ? 'true' : 'false'}`,
-        cancel_url: `${websiteURL}pricing?canceled=true`,
+        success_url: buildReturnUrl(
+            websiteURL,
+            'dashboard',
+            { success: 'true', referral_applied: referral ? 'true' : 'false' },
+            signupSuccess,
+        ),
+        // Abandoning checkout does not undo the registration, so the marker
+        // rides the cancel path too.
+        cancel_url: buildReturnUrl(websiteURL, 'pricing', { canceled: 'true' }, signupSuccess),
         allow_promotion_codes: true,
     };
 
@@ -175,7 +201,7 @@ export async function POST(req: Request) {
         );
     }
 
-    return handleCheckoutSession(lookup_key, user, websiteURL, referral, promo_code);
+    return handleCheckoutSession(lookup_key, user, websiteURL, referral, promo_code, false);
 }
 
 export async function GET(req: Request) {
@@ -201,5 +227,12 @@ export async function GET(req: Request) {
         );
     }
 
-    return handleCheckoutSession(lookup_key, user, websiteURL, referral, promo_code);
+    return handleCheckoutSession(
+        lookup_key,
+        user,
+        websiteURL,
+        referral,
+        promo_code,
+        hasSignupSuccess(searchParams),
+    );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { ScrollLockFix } from "@/components/scroll-lock-fix";
 import { getSiteOrigin, siteUrl } from "@/lib/site-url";
 import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 import { cn } from "@/lib/utils";
+import { GoogleTag } from "@/components/google-tag";
 
 const inter = Inter({ subsets: ["latin"] });
 const metadataBase = new URL(getSiteOrigin());
@@ -348,6 +349,7 @@ export default function RootLayout({
         className={cn(inter.className, "antialiased [font-synthesis:none]")}
       >
         <ScrollLockFix />
+        <GoogleTag />
         <SpeedInsights />
         <Analytics />
         {children}

--- a/components/consent-banner.tsx
+++ b/components/consent-banner.tsx
@@ -22,6 +22,7 @@ import { Label } from "@/components/ui/label"
 import { motion, AnimatePresence } from "framer-motion"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useI18n } from "@/locales/client"
+import type { ConsentSettings } from "@/lib/consent-settings"
 import posthog from "posthog-js"
 
 const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent"
@@ -76,17 +77,6 @@ function syncPostHogConsent(analyticsEnabled: boolean) {
     }
   }
 }
-
-interface ConsentSettings {
-  analytics_storage: boolean;
-  ad_storage: boolean;
-  ad_user_data: boolean;
-  ad_personalization: boolean;
-  functionality_storage: boolean;
-  personalization_storage: boolean;
-  security_storage: boolean;
-}
-
 
 type ConsentTranslator = ReturnType<typeof useI18n>
 
@@ -221,18 +211,11 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
   const saveConsent = (consentSettings: ConsentSettings) => {
     localStorage.setItem("cookieConsent", JSON.stringify(consentSettings))
     syncPostHogConsent(consentSettings.analytics_storage)
+    // <GoogleTag /> owns everything Google-side: it loads the tag on first
+    // consent and relays later changes, so the banner only has to announce.
     window.dispatchEvent(new CustomEvent(CONSENT_UPDATED_EVENT, {
       detail: consentSettings,
     }))
-    window.gtag?.("consent", "update", {
-      analytics_storage: consentSettings.analytics_storage ? "granted" : "denied",
-      ad_storage: consentSettings.ad_storage ? "granted" : "denied",
-      ad_user_data: consentSettings.ad_user_data ? "granted" : "denied",
-      ad_personalization: consentSettings.ad_personalization ? "granted" : "denied",
-      functionality_storage: consentSettings.functionality_storage ? "granted" : "denied",
-      personalization_storage: consentSettings.personalization_storage ? "granted" : "denied",
-      security_storage: consentSettings.security_storage ? "granted" : "denied",
-    })
     setIsVisible(false)
   }
 

--- a/components/consent-banner.tsx
+++ b/components/consent-banner.tsx
@@ -26,6 +26,7 @@ import posthog from "posthog-js"
 
 const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent"
 const CONSENT_EVENT = "deltalytix:analytics-consent"
+const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated"
 
 function isDeltalytixHost() {
   const host = window.location.hostname
@@ -220,6 +221,9 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
   const saveConsent = (consentSettings: ConsentSettings) => {
     localStorage.setItem("cookieConsent", JSON.stringify(consentSettings))
     syncPostHogConsent(consentSettings.analytics_storage)
+    window.dispatchEvent(new CustomEvent(CONSENT_UPDATED_EVENT, {
+      detail: consentSettings,
+    }))
     window.gtag?.("consent", "update", {
       analytics_storage: consentSettings.analytics_storage ? "granted" : "denied",
       ad_storage: consentSettings.ad_storage ? "granted" : "denied",

--- a/components/google-tag.tsx
+++ b/components/google-tag.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect } from "react";
+
+const GOOGLE_ANALYTICS_ID = "G-PYK62LTZRQ";
+const GOOGLE_ADS_ID = "AW-16864609071";
+const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated";
+
+interface ConsentSettings {
+  analytics_storage: boolean;
+  ad_storage: boolean;
+  ad_user_data: boolean;
+  ad_personalization: boolean;
+  functionality_storage: boolean;
+  personalization_storage: boolean;
+  security_storage: boolean;
+}
+
+function isProductionHost() {
+  return (
+    window.location.hostname === "deltalytix.app" ||
+    window.location.hostname === "www.deltalytix.app"
+  );
+}
+
+function readConsentSettings(): ConsentSettings | null {
+  const storedConsent = window.localStorage.getItem("cookieConsent");
+  if (!storedConsent) return null;
+
+  try {
+    return JSON.parse(storedConsent) as ConsentSettings;
+  } catch {
+    return null;
+  }
+}
+
+function toGoogleConsent(settings: ConsentSettings) {
+  return {
+    analytics_storage: settings.analytics_storage ? "granted" : "denied",
+    ad_storage: settings.ad_storage ? "granted" : "denied",
+    ad_user_data: settings.ad_user_data ? "granted" : "denied",
+    ad_personalization: settings.ad_personalization ? "granted" : "denied",
+    functionality_storage: settings.functionality_storage
+      ? "granted"
+      : "denied",
+    personalization_storage: settings.personalization_storage
+      ? "granted"
+      : "denied",
+    security_storage: settings.security_storage ? "granted" : "denied",
+  } as const;
+}
+
+function configureGoogleTag(settings: ConsentSettings) {
+  if (!isProductionHost()) return;
+
+  const measurementAllowed = settings.analytics_storage;
+
+  if (!measurementAllowed) {
+    window.gtag?.("consent", "update", toGoogleConsent(settings));
+    return;
+  }
+
+  const existingScript = document.querySelector(
+    `script[data-google-tag="${GOOGLE_ADS_ID}"]`,
+  );
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function gtag() {
+    // Google Tag's command queue expects the function's arguments object.
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer.push(arguments);
+  };
+
+  if (!existingScript) {
+    window.gtag("consent", "default", toGoogleConsent(settings));
+    window.gtag("js", new Date());
+    window.gtag("config", GOOGLE_ANALYTICS_ID);
+    window.gtag("config", GOOGLE_ADS_ID);
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`;
+    script.dataset.googleTag = GOOGLE_ADS_ID;
+    document.head.appendChild(script);
+  } else {
+    window.gtag("consent", "update", toGoogleConsent(settings));
+  }
+}
+
+export function GoogleTag() {
+  useEffect(() => {
+    const initialSettings = readConsentSettings();
+    if (initialSettings) configureGoogleTag(initialSettings);
+
+    const handleConsentUpdate = (event: Event) => {
+      const settings = (event as CustomEvent<ConsentSettings>).detail;
+      if (settings) configureGoogleTag(settings);
+    };
+
+    window.addEventListener(CONSENT_UPDATED_EVENT, handleConsentUpdate);
+    return () =>
+      window.removeEventListener(CONSENT_UPDATED_EVENT, handleConsentUpdate);
+  }, []);
+
+  return null;
+}

--- a/components/google-tag.tsx
+++ b/components/google-tag.tsx
@@ -2,19 +2,15 @@
 
 import { useEffect } from "react";
 
+import {
+  type ConsentSettings,
+  isGoogleTagAllowed,
+  toGoogleConsent,
+} from "@/lib/consent-settings";
+
 const GOOGLE_ANALYTICS_ID = "G-PYK62LTZRQ";
 const GOOGLE_ADS_ID = "AW-16864609071";
 const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated";
-
-interface ConsentSettings {
-  analytics_storage: boolean;
-  ad_storage: boolean;
-  ad_user_data: boolean;
-  ad_personalization: boolean;
-  functionality_storage: boolean;
-  personalization_storage: boolean;
-  security_storage: boolean;
-}
 
 function isProductionHost() {
   return (
@@ -34,28 +30,12 @@ function readConsentSettings(): ConsentSettings | null {
   }
 }
 
-function toGoogleConsent(settings: ConsentSettings) {
-  return {
-    analytics_storage: settings.analytics_storage ? "granted" : "denied",
-    ad_storage: settings.ad_storage ? "granted" : "denied",
-    ad_user_data: settings.ad_user_data ? "granted" : "denied",
-    ad_personalization: settings.ad_personalization ? "granted" : "denied",
-    functionality_storage: settings.functionality_storage
-      ? "granted"
-      : "denied",
-    personalization_storage: settings.personalization_storage
-      ? "granted"
-      : "denied",
-    security_storage: settings.security_storage ? "granted" : "denied",
-  } as const;
-}
-
 function configureGoogleTag(settings: ConsentSettings) {
   if (!isProductionHost()) return;
 
-  const measurementAllowed = settings.analytics_storage;
-
-  if (!measurementAllowed) {
+  // Without consent the tag is never injected, so there is nothing to load and
+  // at most an already-loaded tag to notify of the withdrawal.
+  if (!isGoogleTagAllowed(settings)) {
     window.gtag?.("consent", "update", toGoogleConsent(settings));
     return;
   }
@@ -64,27 +44,30 @@ function configureGoogleTag(settings: ConsentSettings) {
     `script[data-google-tag="${GOOGLE_ADS_ID}"]`,
   );
 
-  window.dataLayer = window.dataLayer || [];
-  window.gtag = window.gtag || function gtag() {
-    // Google Tag's command queue expects the function's arguments object.
-    // eslint-disable-next-line prefer-rest-params
-    window.dataLayer.push(arguments);
-  };
+  const dataLayer = (window.dataLayer = window.dataLayer || []);
+  window.gtag =
+    window.gtag ||
+    function gtag() {
+      // Google Tag's command queue expects the function's arguments object.
+      // eslint-disable-next-line prefer-rest-params
+      dataLayer.push(arguments);
+    };
 
-  if (!existingScript) {
-    window.gtag("consent", "default", toGoogleConsent(settings));
-    window.gtag("js", new Date());
-    window.gtag("config", GOOGLE_ANALYTICS_ID);
-    window.gtag("config", GOOGLE_ADS_ID);
-
-    const script = document.createElement("script");
-    script.async = true;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`;
-    script.dataset.googleTag = GOOGLE_ADS_ID;
-    document.head.appendChild(script);
-  } else {
+  if (existingScript) {
     window.gtag("consent", "update", toGoogleConsent(settings));
+    return;
   }
+
+  window.gtag("consent", "default", toGoogleConsent(settings));
+  window.gtag("js", new Date());
+  window.gtag("config", GOOGLE_ANALYTICS_ID);
+  window.gtag("config", GOOGLE_ADS_ID);
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`;
+  script.dataset.googleTag = GOOGLE_ADS_ID;
+  document.head.appendChild(script);
 }
 
 export function GoogleTag() {

--- a/lib/consent-settings.test.ts
+++ b/lib/consent-settings.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConsentSettings,
+  isGoogleTagAllowed,
+  toGoogleConsent,
+} from "./consent-settings";
+
+const denyAll: ConsentSettings = {
+  analytics_storage: false,
+  ad_storage: false,
+  ad_user_data: false,
+  ad_personalization: false,
+  functionality_storage: false,
+  personalization_storage: false,
+  security_storage: false,
+};
+
+describe("toGoogleConsent", () => {
+  it("maps every category to Google's vocabulary", () => {
+    expect(toGoogleConsent({ ...denyAll, analytics_storage: true })).toEqual({
+      analytics_storage: "granted",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+      functionality_storage: "denied",
+      personalization_storage: "denied",
+      security_storage: "denied",
+    });
+  });
+
+  it("denies categories missing from a legacy payload", () => {
+    expect(toGoogleConsent({ analytics_storage: true })).toMatchObject({
+      analytics_storage: "granted",
+      ad_user_data: "denied",
+      security_storage: "denied",
+    });
+  });
+});
+
+describe("isGoogleTagAllowed", () => {
+  it("allows the tag on analytics consent alone", () => {
+    expect(isGoogleTagAllowed({ ...denyAll, analytics_storage: true })).toBe(true);
+  });
+
+  it("allows the tag on ad consent alone, so Ads conversions still fire", () => {
+    expect(isGoogleTagAllowed({ ...denyAll, ad_storage: true })).toBe(true);
+  });
+
+  it("blocks the tag when both are refused", () => {
+    expect(
+      isGoogleTagAllowed({ ...denyAll, functionality_storage: true }),
+    ).toBe(false);
+  });
+});

--- a/lib/consent-settings.ts
+++ b/lib/consent-settings.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared consent vocabulary for the cookie banner and the Google tag.
+ *
+ * Both sides have to agree on the exact key set: the banner persists it to
+ * localStorage, the tag replays it to Google. Keeping one definition here stops
+ * the two from drifting apart when a category is added.
+ */
+
+export interface ConsentSettings {
+  analytics_storage: boolean;
+  ad_storage: boolean;
+  ad_user_data: boolean;
+  ad_personalization: boolean;
+  functionality_storage: boolean;
+  personalization_storage: boolean;
+  security_storage: boolean;
+}
+
+export type GoogleConsentValue = "granted" | "denied";
+
+export type GoogleConsentState = Record<
+  keyof ConsentSettings,
+  GoogleConsentValue
+>;
+
+const CONSENT_KEYS = [
+  "analytics_storage",
+  "ad_storage",
+  "ad_user_data",
+  "ad_personalization",
+  "functionality_storage",
+  "personalization_storage",
+  "security_storage",
+] as const satisfies readonly (keyof ConsentSettings)[];
+
+/**
+ * Translates the banner's booleans into Google's granted/denied vocabulary.
+ * Missing keys — a payload written by an older banner version — degrade to
+ * "denied" rather than being sent as undefined.
+ */
+export function toGoogleConsent(
+  settings: Partial<ConsentSettings>,
+): GoogleConsentState {
+  return CONSENT_KEYS.reduce((state, key) => {
+    state[key] = settings[key] ? "granted" : "denied";
+    return state;
+  }, {} as GoogleConsentState);
+}
+
+/**
+ * Whether the Google tag may load at all.
+ *
+ * Analytics and Ads are served by the same tag, so consenting to either one is
+ * enough to justify loading it — gating on analytics alone silently drops Ads
+ * conversions for anyone who accepts ad storage but declines analytics.
+ */
+export function isGoogleTagAllowed(
+  settings: Partial<ConsentSettings>,
+): boolean {
+  return Boolean(settings.analytics_storage || settings.ad_storage);
+}

--- a/lib/signup-redirect.test.ts
+++ b/lib/signup-redirect.test.ts
@@ -49,6 +49,8 @@ describe("resolveInternalDestination", () => {
     "https://evil.example/steal",
     "//evil.example/steal",
     "http://deltalytix.app.evil.example/steal",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
   ])("refuses the off-origin destination %s", (target) => {
     expect(resolveInternalDestination(target, ORIGIN).href).toBe(
       `${ORIGIN}/dashboard`,
@@ -83,9 +85,21 @@ describe("signupRedirectPath", () => {
     );
   });
 
-  it("never marks an off-origin destination", () => {
-    expect(signupRedirectPath("https://evil.example/steal", true)).toBe(
-      "https://evil.example/steal",
-    );
+  it("keeps a relative next such as the checkout endpoint", () => {
+    expect(
+      signupRedirectPath("api/stripe/create-checkout-session?lookup_key=x", true),
+    ).toBe("/api/stripe/create-checkout-session?lookup_key=x&signup=success");
+  });
+
+  // The result goes to router.push, so an unrecognised target must never
+  // survive: `javascript:` parses as a URL and would otherwise be navigated to.
+  it.each([
+    "https://evil.example/steal",
+    "//evil.example/steal",
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+  ])("refuses to navigate to %s", (target) => {
+    expect(signupRedirectPath(target, true)).toBe("/dashboard?signup=success");
   });
 });

--- a/lib/signup-redirect.test.ts
+++ b/lib/signup-redirect.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applySignupSuccess,
+  resolveInternalDestination,
+  signupRedirectPath,
+} from "./signup-redirect";
+
+const ORIGIN = "https://deltalytix.app";
+
+describe("applySignupSuccess", () => {
+  it("marks a new user's destination", () => {
+    const url = applySignupSuccess(new URL("/dashboard", ORIGIN), true);
+    expect(url.searchParams.get("signup")).toBe("success");
+  });
+
+  it("leaves a returning user's destination untouched", () => {
+    const url = applySignupSuccess(new URL("/dashboard", ORIGIN), false);
+    expect(url.searchParams.has("signup")).toBe(false);
+  });
+
+  it("preserves existing query parameters", () => {
+    const url = applySignupSuccess(
+      new URL("/dashboard?tab=trades", ORIGIN),
+      true,
+    );
+    expect(url.searchParams.get("tab")).toBe("trades");
+    expect(url.searchParams.get("signup")).toBe("success");
+  });
+});
+
+describe("resolveInternalDestination", () => {
+  it.each(["/dashboard", "/fr/dashboard", "/dashboard/settings?tab=billing"])(
+    "keeps the internal destination %s",
+    (target) => {
+      expect(resolveInternalDestination(target, ORIGIN).pathname).toBe(
+        new URL(target, ORIGIN).pathname,
+      );
+    },
+  );
+
+  it.each([null, undefined, ""])("falls back to the dashboard for %s", (target) => {
+    expect(resolveInternalDestination(target, ORIGIN).href).toBe(
+      `${ORIGIN}/dashboard`,
+    );
+  });
+
+  it.each([
+    "https://evil.example/steal",
+    "//evil.example/steal",
+    "http://deltalytix.app.evil.example/steal",
+  ])("refuses the off-origin destination %s", (target) => {
+    expect(resolveInternalDestination(target, ORIGIN).href).toBe(
+      `${ORIGIN}/dashboard`,
+    );
+  });
+});
+
+describe("signupRedirectPath", () => {
+  it("defaults a new user to the marked dashboard", () => {
+    expect(signupRedirectPath(null, true)).toBe("/dashboard?signup=success");
+  });
+
+  it("defaults a returning user to the plain dashboard", () => {
+    expect(signupRedirectPath(null, false)).toBe("/dashboard");
+  });
+
+  it("marks an explicit next destination rather than dropping it", () => {
+    expect(signupRedirectPath("/dashboard/billing", true)).toBe(
+      "/dashboard/billing?signup=success",
+    );
+  });
+
+  it("keeps locale-prefixed destinations", () => {
+    expect(signupRedirectPath("/fr/dashboard", true)).toBe(
+      "/fr/dashboard?signup=success",
+    );
+  });
+
+  it("preserves query and hash", () => {
+    expect(signupRedirectPath("/dashboard?tab=trades#recent", true)).toBe(
+      "/dashboard?tab=trades&signup=success#recent",
+    );
+  });
+
+  it("never marks an off-origin destination", () => {
+    expect(signupRedirectPath("https://evil.example/steal", true)).toBe(
+      "https://evil.example/steal",
+    );
+  });
+});

--- a/lib/signup-redirect.test.ts
+++ b/lib/signup-redirect.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   applySignupSuccess,
+  hasSignupSuccess,
   resolveInternalDestination,
   signupRedirectPath,
 } from "./signup-redirect";
@@ -26,6 +27,29 @@ describe("applySignupSuccess", () => {
     );
     expect(url.searchParams.get("tab")).toBe("trades");
     expect(url.searchParams.get("signup")).toBe("success");
+  });
+});
+
+describe("hasSignupSuccess", () => {
+  it("recognises the marker so checkout can forward it", () => {
+    const { searchParams } = new URL(
+      "/api/stripe/create-checkout-session?lookup_key=pro&signup=success",
+      ORIGIN,
+    );
+    expect(hasSignupSuccess(searchParams)).toBe(true);
+  });
+
+  it.each(["", "?lookup_key=pro", "?signup=", "?signup=true"])(
+    "rejects %s",
+    (query) => {
+      const { searchParams } = new URL(`/checkout${query}`, ORIGIN);
+      expect(hasSignupSuccess(searchParams)).toBe(false);
+    },
+  );
+
+  it("round-trips what applySignupSuccess writes", () => {
+    const url = applySignupSuccess(new URL("/checkout", ORIGIN), true);
+    expect(hasSignupSuccess(url.searchParams)).toBe(true);
   });
 });
 

--- a/lib/signup-redirect.ts
+++ b/lib/signup-redirect.ts
@@ -1,0 +1,76 @@
+/**
+ * Post-authentication redirect targets.
+ *
+ * Newly created accounts land on a URL carrying `?signup=success`. Nothing in
+ * the app reads it — it exists so Google Ads can match a completed signup on a
+ * URL it could not otherwise distinguish from an ordinary sign-in.
+ *
+ * The marker is applied to any *internal* destination rather than to
+ * `/dashboard` alone: `next` legitimately points at checkout and team surfaces,
+ * locale-prefixed paths (`/fr/dashboard`) are equally valid landings, and a
+ * signup is a signup wherever the user ends up. External destinations are never
+ * tagged, so the marker cannot leak off-origin.
+ */
+
+export const SIGNUP_SUCCESS_PARAM = "signup";
+export const SIGNUP_SUCCESS_VALUE = "success";
+
+const DEFAULT_DESTINATION = "/dashboard";
+
+// Sentinel origin used only to resolve relative paths on the client, where
+// there is no request origin to resolve against.
+const RELATIVE_BASE = "http://signup-redirect.invalid";
+
+/** Tags a destination as a completed signup. No-op for returning users. */
+export function applySignupSuccess(url: URL, isNewUser: boolean): URL {
+  if (isNewUser) {
+    url.searchParams.set(SIGNUP_SUCCESS_PARAM, SIGNUP_SUCCESS_VALUE);
+  }
+  return url;
+}
+
+/**
+ * Resolves an untrusted `next` value to a URL on this origin.
+ *
+ * Anything that resolves off-origin — an absolute URL, a protocol-relative
+ * `//host/path`, or a malformed value — falls back to the dashboard, so the
+ * callback cannot be used as an open redirect.
+ */
+export function resolveInternalDestination(
+  target: string | null | undefined,
+  origin: string,
+): URL {
+  const fallback = new URL(DEFAULT_DESTINATION, origin);
+  if (!target) return fallback;
+
+  try {
+    const url = new URL(target, origin);
+    return url.origin === fallback.origin ? url : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Client-side counterpart: takes a relative path and returns it with the signup
+ * marker applied, preserving any query string and hash already on it. External
+ * or unparseable targets are returned untouched.
+ */
+export function signupRedirectPath(
+  target: string | null | undefined,
+  isNewUser: boolean,
+): string {
+  const destination = target || DEFAULT_DESTINATION;
+
+  let url: URL;
+  try {
+    url = new URL(destination, RELATIVE_BASE);
+  } catch {
+    return destination;
+  }
+
+  if (url.origin !== RELATIVE_BASE) return destination;
+
+  applySignupSuccess(url, isNewUser);
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/lib/signup-redirect.ts
+++ b/lib/signup-redirect.ts
@@ -33,6 +33,17 @@ export function applySignupSuccess(url: URL, isNewUser: boolean): URL {
 }
 
 /**
+ * Whether a request carries the signup marker.
+ *
+ * Used to hand the marker across a hop that renders no page of ours — the
+ * checkout endpoint redirects straight to Stripe, so it has to forward the
+ * marker to the URLs Stripe sends the user back to.
+ */
+export function hasSignupSuccess(params: URLSearchParams): boolean {
+  return params.get(SIGNUP_SUCCESS_PARAM) === SIGNUP_SUCCESS_VALUE;
+}
+
+/**
  * Resolves an untrusted `next` value to a URL on this origin.
  *
  * Anything that resolves off-origin — an absolute URL, a protocol-relative

--- a/lib/signup-redirect.ts
+++ b/lib/signup-redirect.ts
@@ -8,8 +8,11 @@
  * The marker is applied to any *internal* destination rather than to
  * `/dashboard` alone: `next` legitimately points at checkout and team surfaces,
  * locale-prefixed paths (`/fr/dashboard`) are equally valid landings, and a
- * signup is a signup wherever the user ends up. External destinations are never
- * tagged, so the marker cannot leak off-origin.
+ * signup is a signup wherever the user ends up.
+ *
+ * `next` is attacker-controlled — it arrives on the query string — so both the
+ * server redirect and the client navigation resolve it against the app's own
+ * origin and fall back to the dashboard when it points anywhere else.
  */
 
 export const SIGNUP_SUCCESS_PARAM = "signup";
@@ -52,25 +55,20 @@ export function resolveInternalDestination(
 }
 
 /**
- * Client-side counterpart: takes a relative path and returns it with the signup
- * marker applied, preserving any query string and hash already on it. External
- * or unparseable targets are returned untouched.
+ * Client-side counterpart: takes a `next` value and returns the path to
+ * navigate to, with the signup marker applied and any query string or hash
+ * preserved.
+ *
+ * Applies the same containment rule as the server. This matters more on the
+ * client than it looks: the result is handed to `router.push`, and a scheme
+ * like `javascript:` parses as a valid URL, so passing an unrecognised target
+ * through would hand attacker-controlled input to the router.
  */
 export function signupRedirectPath(
   target: string | null | undefined,
   isNewUser: boolean,
 ): string {
-  const destination = target || DEFAULT_DESTINATION;
-
-  let url: URL;
-  try {
-    url = new URL(destination, RELATIVE_BASE);
-  } catch {
-    return destination;
-  }
-
-  if (url.origin !== RELATIVE_BASE) return destination;
-
+  const url = resolveInternalDestination(target, RELATIVE_BASE);
   applySignupSuccess(url, isNewUser);
   return `${url.pathname}${url.search}${url.hash}`;
 }

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -409,7 +409,8 @@ export async function setPasswordAction(newPassword: string) {
  *   persisted to the `language` field for the user record.
  *
  * Returns:
- * - The up-to-date Prisma `user` record.
+ * - `user`: the up-to-date Prisma `user` record.
+ * - `isNewUser`: true only when this call created the record.
  *
  * Side effects:
  * - May sign the user out on integrity or identification errors.
@@ -458,14 +459,14 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
             },
           });
           console.log('[ensureUserInDatabase] SUCCESS: User updated successfully');
-          return updatedUser;
+          return { user: updatedUser, isNewUser: false };
         } catch (updateError) {
           console.error('[ensureUserInDatabase] ERROR: Failed to update user record:', updateError);
           throw new Error('Failed to update user');
         }
       }
       console.log('[ensureUserInDatabase] SUCCESS: Existing user found, no update needed');
-      return existingUserByAuthId;
+      return { user: existingUserByAuthId, isNewUser: false };
     }
 
     // If user doesn't exist by auth_user_id, check if email exists
@@ -517,7 +518,7 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
         // Don't throw here - user creation succeeded, layout can be created later
       }
       
-      return newUser;
+      return { user: newUser, isNewUser: true };
     } catch (createError) {
       if (createError instanceof Error &&
         createError.message.includes('Unique constraint failed')) {
@@ -580,8 +581,8 @@ export async function verifyOtp(email: string, token: string, type: 'email' | 's
     let isNewUser = false
     if (data.user && data.session) {
       const locale = email.includes('.fr') ? 'fr' : 'en';
-      const databaseUser = await ensureUserInDatabase(data.user, locale)
-      isNewUser = Date.now() - databaseUser.createdAt.getTime() < 60_000
+      const ensureResult = await ensureUserInDatabase(data.user, locale)
+      isNewUser = ensureResult.isNewUser
     }
 
     if (error) {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -577,16 +577,18 @@ export async function verifyOtp(email: string, token: string, type: 'email' | 's
       type
     })
 
+    let isNewUser = false
     if (data.user && data.session) {
       const locale = email.includes('.fr') ? 'fr' : 'en';
-      await ensureUserInDatabase(data.user, locale)
+      const databaseUser = await ensureUserInDatabase(data.user, locale)
+      isNewUser = Date.now() - databaseUser.createdAt.getTime() < 60_000
     }
 
     if (error) {
       throw new Error(error.message)
     }
 
-    return data
+    return { ...data, isNewUser }
   } catch (error: any) {
     handleAuthError(error)
   }

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -272,13 +272,15 @@ export async function signInWithPasswordAction(
         // Check if user is already signed in (session exists)
         if (signUpData.user && signUpData.session) {
           // User is automatically signed in (email confirmation disabled)
+          let isNewUser = false
           try {
-            await ensureUserInDatabase(signUpData.user, locale)
+            const ensureResult = await ensureUserInDatabase(signUpData.user, locale)
+            isNewUser = ensureResult.isNewUser
           } catch (e) {
             // Non-fatal; still proceed
             console.error('[signInWithPasswordAction] ensureUserInDatabase failed:', e)
           }
-          return { success: true, next }
+          return { success: true, next, isNewUser }
         }
         
         // If email confirmation is enabled, user needs to confirm email first
@@ -293,17 +295,19 @@ export async function signInWithPasswordAction(
         }
         
         // Continue with normal flow after successful sign-in
+        let isNewUser = false
         try {
           const { data: { user } } = await supabase.auth.getUser()
           if (user) {
-            await ensureUserInDatabase(user, locale)
+            const ensureResult = await ensureUserInDatabase(user, locale)
+            isNewUser = ensureResult.isNewUser
           }
         } catch (e) {
           // Non-fatal; still proceed
           console.error('[signInWithPasswordAction] ensureUserInDatabase failed:', e)
         }
-        
-        return { success: true, next }
+
+        return { success: true, next, isNewUser }
       }
       
       // For other errors, throw as-is
@@ -311,10 +315,12 @@ export async function signInWithPasswordAction(
     }
 
     // Sign-in succeeded normally
+    let isNewUser = false
     try {
       const { data: { user } } = await supabase.auth.getUser()
       if (user) {
-        await ensureUserInDatabase(user, locale)
+        const ensureResult = await ensureUserInDatabase(user, locale)
+        isNewUser = ensureResult.isNewUser
       }
     } catch (e) {
       // Non-fatal; still proceed
@@ -322,7 +328,7 @@ export async function signInWithPasswordAction(
     }
 
     // Optionally handle redirect on the client; return success and let client route
-    return { success: true, next }
+    return { success: true, next, isNewUser }
   } catch (error: any) {
     handleAuthError(error)
   }
@@ -355,16 +361,18 @@ export async function signUpWithPasswordAction(
     }
     
     // If email confirmation is disabled, user is automatically signed in
+    let isNewUser = false
     if (data.user && data.session) {
       try {
-        await ensureUserInDatabase(data.user, locale)
+        const ensureResult = await ensureUserInDatabase(data.user, locale)
+        isNewUser = ensureResult.isNewUser
       } catch (e) {
         // Non-fatal; still proceed
         console.error('[signUpWithPasswordAction] ensureUserInDatabase failed:', e)
       }
     }
-    
-    return { success: true, next }
+
+    return { success: true, next, isNewUser }
   } catch (error: any) {
     handleAuthError(error)
   }


### PR DESCRIPTION
## What

- Load the Google tag on `deltalytix.app` / `www.deltalytix.app` only after analytics or advertising consent.
- Configure GA4 `G-PYK62LTZRQ` and Google Ads `AW-16864609071`, and relay later consent changes without collecting additional personal data.
- Add `signup=success` only for genuinely new users across OAuth, OTP, and password registration flows while preserving locale-prefixed and internal `next` destinations.
- Reject external, protocol-relative, `javascript:`, and `data:` redirect targets before they reach server redirects or `router.push`.
- Carry the signup marker through Stripe checkout return URLs so checkout-bound registrations still reach an observable tagged page.
- Centralize Google consent and signup-redirect logic and add focused unit coverage.

## Why

Google Ads had no reliable completed-signup signal. The previous page-load conversion counted visits to the authentication page rather than successful registrations. This change gives new accounts a distinct `signup=success` landing URL while keeping ordinary sign-ins unmarked.

## Impact

Tracking-only and behavior-preserving for legitimate flows. The Google tag runs only on the production Deltalytix hosts and only after the user grants analytics or advertising consent. No email address, feedback content, raw prompt, payment detail, or other unnecessary personal data is sent to Google.

Existing users continue to follow their normal destination. Newly created users receive the marker on a safe internal destination; when signup leads directly to Stripe, the marker is forwarded to the success, cancellation, or already-subscribed return page.

## Validation

- ✅ GitHub Actions `Typecheck` passed on `0605648d`.
- ✅ Vercel preview deployment passed.
- ✅ Added focused tests for consent mapping, new-user redirect marking, hostile redirect rejection, and Stripe marker forwarding.
- ✅ Manual preview test: creating a new account landed on [`/en/dashboard?signup=success`](https://deltalytix-git-codex-google-ads-setup-deltalytix.vercel.app/en/dashboard?signup=success).
- ℹ️ The preview host intentionally does not load the Google tag; end-to-end Google Ads verification will be performed on production with Tag Assistant after promotion through `beta` to `main`.

This PR intentionally targets `beta`, never `main` directly.