### PR TITLE
Remove sensitive feedback properties from PostHog

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -83,22 +83,20 @@ export async function POST(request: Request) {
     page,
   }
 
-  // Two independent delivery channels. PostHog is the analytics/correlation
-  // layer; the support inbox is the durable one, since PostHog event retention
-  // is plan-limited.
+  // PostHog records only non-sensitive submission metadata. The support inbox
+  // is the sole durable channel for the message and the user's email address.
   //
   // consentGranted: the user typed this and pressed send, so it is a submission
   // fulfilling their own request rather than passive analytics. Same reasoning
   // as the Stripe webhook events.
-  const [capturedByPostHog, emailedToSupport] = await Promise.all([
+  const [, emailedToSupport] = await Promise.all([
     capturePostHogEvent({
       consentGranted: true,
       distinctId: user.id,
       event: 'feedback_submitted',
       properties: {
         feedback_type: type,
-        feedback_message: message,
-        email: user.email ?? null,
+        message_length: message.length,
         locale,
         page,
       },
@@ -106,9 +104,9 @@ export async function POST(request: Request) {
     sendFeedbackNotificationEmail(emailInput),
   ])
 
-  // Only a total failure loses the message. Surface that instead of reporting
-  // success; either channel landing means the team has the feedback.
-  if (!capturedByPostHog && !emailedToSupport) {
+  // Analytics no longer contains the message, so a support-email failure must
+  // be surfaced instead of reporting a successful submission.
+  if (!emailedToSupport) {
     return NextResponse.json(
       { error: 'Failed to deliver feedback' },
       { status: 502 },


### PR DESCRIPTION
## What

- stop sending feedback message contents and email addresses to PostHog
- retain aggregate-only `feedback_submitted` telemetry: `feedback_type`, `message_length`, `locale`, and safe `page`
- require the support/Resend inbox delivery to succeed, because PostHog is no longer a fallback store for the message

## Why

The live PostHog schema still exposes `feedback_message` and `email`. Full feedback and sender details belong only in the support inbox; PostHog should retain enough metadata for volume and segmentation statistics without duplicating sensitive content.

This replaces the closed, unmerged #376 on current `beta`.

## Tracking contract

- Event: `feedback_submitted`
- Trigger: after an authenticated, validated feedback submission
- Event properties:
  - `feedback_type`: controlled feedback category
  - `message_length`: integer character count
  - `locale`: normalized locale
  - `page`: origin plus pathname only; query and hash removed
- Person properties: none added
- Excluded: message contents, email address, credentials, payment data, raw prompts, or other unnecessary personal data

## PostHog acceptance check

After the beta preview receives a test submission, query `feedback_submitted` and confirm:

1. `message_length` is numeric and greater than zero.
2. `feedback_type`, `locale`, and `page` are populated as expected.
3. New events do not contain `feedback_message` or `email`.
4. The support inbox receives the full message and authenticated sender details.

Historical PostHog properties remain in the schema until retention removes them; validation should inspect newly ingested events.

## Verification

- ✅ rebased on current `origin/beta`
- ✅ `bun install`
- ✅ `git diff --check`
- ✅ `bunx eslint app/api/feedback/route.ts`
- ✅ `bun run typecheck`
- ✅ `bunx prisma db push` against local `deltalytix_dev`
- ✅ `bun run seed:self-host`
- ✅ production build with documented local bypass and dummy service configuration
- ✅ `/dashboard` health check reports authenticated local user
- ✅ `/authentication?next=dashboard` redirects to `/dashboard`

Targets `beta`, never `main`. Draft pending a beta feedback submission and inbox/PostHog acceptance check.