### PR TITLE
Fix integration activation tracking

### DIFF
--- a/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/actions.ts
@@ -855,15 +855,17 @@ export async function storeDxFeedToken(
       },
     })
 
-    await capturePostHogEvent({
-      distinctId: user.id,
-      event: 'integration_connected',
-      properties: {
-        integration: 'dxfeed',
-        environment: DXFEED_ENVIRONMENT === 0 ? 'production' : 'demo',
-        is_first_connection: !existingConnection,
-      },
-    })
+    if (!existingConnection) {
+      await capturePostHogEvent({
+        distinctId: user.id,
+        event: 'integration_connected',
+        properties: {
+          integration: 'dxfeed',
+          environment: DXFEED_ENVIRONMENT === 0 ? 'production' : 'demo',
+          is_first_connection: true,
+        },
+      })
+    }
 
     return { success: true }
   } catch (error) {

--- a/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/actions.ts
@@ -100,14 +100,16 @@ export async function setRithmicSynchronization(
 
   await invalidateConnectionsPageCache(userId)
 
-  await capturePostHogEvent({
-    distinctId: userId,
-    event: 'integration_connected',
-    properties: {
-      integration: service,
-      is_first_connection: !existingConnection,
-    },
-  })
+  if (!existingConnection) {
+    await capturePostHogEvent({
+      distinctId: userId,
+      event: 'integration_connected',
+      properties: {
+        integration: service,
+        is_first_connection: true,
+      },
+    })
+  }
 
   return connection
 }

--- a/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
@@ -24,6 +24,7 @@ function formatDateForAPI(date: Date): string {
   return formatDateToTimestamp(date)
 }
 
+
 // Helper function to format duration in a readable format (e.g., "1min 34sec")
 function formatDuration(seconds: number): string {
   if (seconds < 60) {
@@ -1519,15 +1520,17 @@ export async function storeTradovateToken(
       }
     })
 
-    await capturePostHogEvent({
-      distinctId: user.id,
-      event: 'integration_connected',
-      properties: {
-        integration: 'tradovate',
-        environment,
-        is_first_connection: !existingConnection,
-      },
-    })
+    if (!existingConnection) {
+      await capturePostHogEvent({
+        distinctId: user.id,
+        event: 'integration_connected',
+        properties: {
+          integration: 'tradovate',
+          environment,
+          is_first_connection: true,
+        },
+      })
+    }
 
     return { success: true }
   } catch (error) {
@@ -2068,5 +2071,3 @@ export async function updateDailySyncTimeAction(
     return { success: false, error: 'Failed to update daily sync time' }
   }
 }
-
-


### PR DESCRIPTION
## What

- emit `integration_connected` only when a Rithmic, DxFeed, or Tradovate database connection is first created
- stop emitting the activation event when an existing token or synchronization is refreshed
- preserve the existing controlled properties and application behavior

## Why

PostHog recorded 131 `integration_connected` events from four people in the latest 24-hour window. Every event had `is_first_connection=false`; 119 occurred across three hours from repeated Rithmic synchronization updates. This makes the event unusable as a marketing activation signal.

Across the preceding seven aligned daily windows, only 5 of 115 events represented first connections. The event name should describe activation, not routine sync/token persistence.

## Tracking contract

- Event: `integration_connected`
- Trigger: immediately after successfully creating a previously nonexistent broker connection
- Event properties:
  - `integration`: controlled broker identifier (`rithmic`, `dxfeed`, or `tradovate` in these emitters)
  - `environment`: `production` or `demo` where already available
  - `is_first_connection`: boolean, always `true`
- Person properties: none added
- Privacy: no credentials, tokens, account identifiers, trade data, emails, or other personal data

Existing connection refreshes emit no activation event. A future sync-health event should be designed separately if operational sync analytics are needed.

## PostHog acceptance check

After deploying to beta:

1. Refresh or synchronize an existing Rithmic, DxFeed, and Tradovate connection; verify zero new `integration_connected` events.
2. Create a new test connection; verify exactly one event with `is_first_connection=true` and the expected `integration`/`environment` values.
3. Monitor a daily window and confirm `count(integration_connected WHERE is_first_connection=false) = 0`.

## Verification

- ✅ rebased on current `origin/beta`
- ✅ `bun install`
- ✅ `git diff --check`
- ✅ `bun run typecheck`
- ✅ `bunx prisma db push` against local `deltalytix_dev`
- ✅ `bun run seed:self-host`
- ✅ production build with documented local bypass and dummy service configuration
- ✅ `/dashboard` health check reports the authenticated local user
- ✅ `/authentication?next=dashboard` redirects to `/dashboard`
- ⚠️ targeted ESLint reports 14 pre-existing `no-explicit-any` errors and 4 warnings in the legacy Tradovate actions file; none are on changed lines. Rithmic and DxFeed pass targeted lint.

Targets `beta`, never `main`. Keep draft until the beta acceptance checks confirm existing syncs no longer inflate activation.