### PR TITLE
Refine localized welcome emails

### DIFF
--- a/app/[locale]/admin/actions/send-email.ts
+++ b/app/[locale]/admin/actions/send-email.ts
@@ -5,6 +5,7 @@ import { Resend } from "resend"
 import { prisma } from "@/lib/prisma"
 import { createClient, type User } from "@supabase/supabase-js"
 import { render } from "@react-email/render"
+import { renderWelcomeEmailText } from "@/components/emails/welcome"
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -350,6 +351,17 @@ export async function sendEmailsToUsers(
             subject: emailSubject,
             reply_to: "hugo.demenez@deltalytix.app",
             react: React.createElement(EmailComponent, mergedProps),
+            ...(template === "welcome"
+              ? {
+                  text: renderWelcomeEmailText({
+                    firstName: user.firstName,
+                    email: user.email,
+                    language: user.language,
+                    youtubeId:
+                      typeof customProps.youtubeId === "string" ? customProps.youtubeId : undefined,
+                  }),
+                }
+              : {}),
             headers: {
               "List-Unsubscribe": `<${unsubscribeUrl}>`,
               "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
@@ -419,5 +431,4 @@ function getDefaultSubject(template: EmailTemplate, language: string): string {
   const locale = language === "fr" ? "fr" : "en"
   return subjects[template][locale]
 }
-
 

--- a/app/[locale]/admin/actions/welcome.ts
+++ b/app/[locale]/admin/actions/welcome.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { render } from "@react-email/render"
-import WelcomeEmail from "@/components/emails/welcome"
+import WelcomeEmail, { renderWelcomeEmailText, WELCOME_VIDEO_IDS } from "@/components/emails/welcome"
 import { getLatestVideoFromPlaylist } from "./youtube"
 
 export async function renderWelcomeEmailPreview(params: {
@@ -10,8 +10,10 @@ export async function renderWelcomeEmailPreview(params: {
   language: string
 }) {
   try {
-    // Get the latest YouTube video ID
-    const youtubeId = await getLatestVideoFromPlaylist() || 'ugvyK1c3yPc' // Default video ID if null
+    const locale = params.language === "fr" ? "fr" : "en"
+    const youtubeId = locale === "fr"
+      ? await getLatestVideoFromPlaylist() || WELCOME_VIDEO_IDS.fr
+      : WELCOME_VIDEO_IDS.en
     
     const html = await render(
       WelcomeEmail({
@@ -24,6 +26,12 @@ export async function renderWelcomeEmailPreview(params: {
 
     return {
       success: true,
+      text: renderWelcomeEmailText({
+        firstName: params.firstName,
+        email: params.email,
+        language: params.language,
+        youtubeId
+      }),
       html: `<!DOCTYPE html>
         <html>
           <head>

--- a/app/api/email/welcome/route.ts
+++ b/app/api/email/welcome/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { PrismaClient } from "@/prisma/generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
 import { Resend } from 'resend'
-import WelcomeEmail from '@/components/emails/welcome'
+import WelcomeEmail, { renderWelcomeEmailText, WELCOME_VIDEO_IDS } from '@/components/emails/welcome'
 import { getLatestVideoFromPlaylist } from "@/app/[locale]/admin/actions/youtube"
 
 const adapter = new PrismaPg({
@@ -55,17 +55,18 @@ export async function POST(req: Request) {
       where: { email: record.email }
     })
     const userLanguage = user?.language || 'en'
-    let youtubeId = 'ZBrIZpCh_7Q'
-    if (userLanguage === 'fr') {
-      youtubeId = await getLatestVideoFromPlaylist() || '_-VtBaOGctY'
-    }
+    const locale = userLanguage === 'fr' ? 'fr' : 'en'
+    const youtubeId = locale === 'fr'
+      ? await getLatestVideoFromPlaylist() || WELCOME_VIDEO_IDS.fr
+      : WELCOME_VIDEO_IDS.en
 
     // Use react prop instead of rendering to HTML
     const { data, error } = await resend.emails.send({
       from: 'Deltalytix <welcome@eu.updates.deltalytix.app>',
       to: record.email,
       subject: userLanguage === 'fr' ? 'Bienvenue sur Deltalytix' : 'Welcome to Deltalytix',
-      react: WelcomeEmail({ firstName, email: record.email, language: userLanguage, youtubeId: youtubeId || 'ZBrIZpCh_7Q' }),
+      react: WelcomeEmail({ firstName, email: record.email, language: userLanguage, youtubeId }),
+      text: renderWelcomeEmailText({ firstName, email: record.email, language: userLanguage, youtubeId }),
       replyTo: 'hugo.demenez@deltalytix.app',
       headers: {
         'List-Unsubscribe': `<${unsubscribeUrl}>`,
@@ -95,4 +96,3 @@ export async function POST(req: Request) {
     )
   }
 }
-

--- a/components/emails/welcome.test.tsx
+++ b/components/emails/welcome.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@react-email/render";
+import { describe, expect, test } from "vitest";
+import WelcomeEmail, { renderWelcomeEmailText } from "./welcome";
+
+const videoId = "4AXxk8LId8Y";
+
+describe("WelcomeEmail", () => {
+  test.each([
+    ["en", "Hello", "/en/dashboard", "Watch the video"],
+    ["fr", "Bonjour", "/fr/dashboard", "Voir la dernière vidéo"],
+  ])("renders the %s locale with accessible, first-party media", async (language, greeting, route, videoCta) => {
+    const html = await render(
+      WelcomeEmail({
+        firstName: "Hugo",
+        email: "hugo@example.com",
+        language,
+        youtubeId: videoId,
+      })
+    );
+
+    expect(html).toContain(greeting);
+    expect(html).toContain("Hugo");
+    expect(html).toContain(route);
+    expect(html).toContain("utm_campaign=welcome");
+    expect(html).toContain(`/api/email/thumbnail/${videoId}/maxresdefault`);
+    expect(html).toContain('width="636"');
+    expect(html).toContain('height="358"');
+    expect(html).toContain(videoCta);
+    expect(html).toContain('name="color-scheme" content="light dark"');
+    expect(html).toContain("prefers-color-scheme: dark");
+    expect(html).toContain("[data-ogsc] .dm-bg");
+  });
+
+  test("renders a localized plain-text alternative", () => {
+    const text = renderWelcomeEmailText({
+      firstName: "Hugo",
+      email: "hugo@example.com",
+      language: "fr",
+      youtubeId: videoId,
+    });
+
+    expect(text).toContain("Bonjour Hugo,");
+    expect(text).toContain("Ouvrir mon dashboard: https://deltalytix.app/fr/dashboard");
+    expect(text).toContain(`Voir la dernière vidéo: https://youtu.be/${videoId}`);
+    expect(text).toContain("Se désabonner: https://deltalytix.app/api/email/unsubscribe");
+    expect(text).toContain("Politique de confidentialité: https://deltalytix.app/fr/privacy");
+  });
+});

--- a/components/emails/welcome.tsx
+++ b/components/emails/welcome.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
+import * as React from "react";
 import {
   Body,
   Button,
+  Column,
+  Container,
   Head,
   Heading,
   Hr,
@@ -9,170 +11,496 @@ import {
   Img,
   Link,
   Preview,
+  Row,
   Section,
-  Tailwind,
   Text,
-} from '@react-email/components';
+} from "@react-email/components";
 
-interface WelcomeEmailProps {
-  firstName: string;
+export interface WelcomeEmailProps {
+  firstName?: string;
   email?: string;
   language: string;
-  youtubeId: string;
+  youtubeId?: string;
 }
 
-export default function WelcomeEmail({ firstName = 'trader', email, language, youtubeId }: WelcomeEmailProps) {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || '';
-  const thumbnailUrl = `${baseUrl}/api/email/thumbnail/${youtubeId}/maxresdefault`;
-  const unsubscribeUrl = email 
-    ? `https://deltalytix.app/api/email/unsubscribe?email=${encodeURIComponent(email)}`
-    : '#';
+type WelcomeLocale = "en" | "fr";
 
-  if (language === 'fr') {
+export const WELCOME_VIDEO_IDS = {
+  en: "ZBrIZpCh_7Q",
+  fr: "_-VtBaOGctY",
+} as const;
+
+const copy = {
+  en: {
+    preview: "Welcome to Deltalytix — start building a clearer trading journal",
+    greeting: "Hello",
+    eyebrow: "WELCOME TO DELTALYTIX",
+    title: "Your trading journal starts here.",
+    intro:
+      "Deltalytix helps you track your trades, understand your performance, and make every review more useful.",
+    startTitle: "A simple place to begin",
+    startBody:
+      "Open your dashboard, import your first trades, and let your data reveal the habits behind your results.",
+    dashboardCta: "Open my dashboard",
+    videoLabel: "GET TO KNOW DELTALYTIX",
+    videoTitle: "See the platform in action",
+    videoBody:
+      "Watch the walkthrough for a quick look at the tools and workflows available to you.",
+    videoAlt: "Preview of the Deltalytix product walkthrough",
+    videoCta: "Watch the video",
+    help:
+      "Need a hand getting started? Reply to this email. I read every message and I’ll be happy to help.",
+    signoff: "Happy trading,",
+    signature: "Hugo",
+    role: "Founder of Deltalytix",
+    reason: "You’re receiving this email because you created a Deltalytix account.",
+    unsubscribe: "Unsubscribe",
+    privacy: "Privacy policy",
+  },
+  fr: {
+    preview: "Bienvenue sur Deltalytix — commencez un journal de trading plus clair",
+    greeting: "Bonjour",
+    eyebrow: "BIENVENUE SUR DELTALYTIX",
+    title: "Votre journal de trading commence ici.",
+    intro:
+      "Deltalytix vous aide à suivre vos trades, comprendre vos performances et tirer davantage de chaque revue.",
+    startTitle: "Un point de départ simple",
+    startBody:
+      "Ouvrez votre dashboard, importez vos premiers trades et laissez vos données révéler les habitudes derrière vos résultats.",
+    dashboardCta: "Ouvrir mon dashboard",
+    videoLabel: "LES DERNIÈRES NOUVEAUTÉS",
+    videoTitle: "Découvrez la dernière nouveauté",
+    videoBody:
+      "Regardez la dernière vidéo publiée pour découvrir les nouveautés et améliorations disponibles dans Deltalytix.",
+    videoAlt: "Aperçu de la dernière vidéo Deltalytix",
+    videoCta: "Voir la dernière vidéo",
+    help:
+      "Besoin d’un coup de main pour démarrer ? Répondez à cet email. Je lis chaque message et serai ravi de vous aider.",
+    signoff: "Bon trading,",
+    signature: "Hugo",
+    role: "Fondateur de Deltalytix",
+    reason: "Vous recevez cet email car vous avez créé un compte Deltalytix.",
+    unsubscribe: "Se désabonner",
+    privacy: "Politique de confidentialité",
+  },
+} as const;
+
+const emailCss = `
+  :root { color-scheme: light dark; supported-color-schemes: light dark; }
+  .hero-title { font-size: clamp(34px, 11vw, 42px) !important; }
+  .responsive-image { width: 100% !important; height: auto !important; }
+  @media only screen and (max-width: 600px) {
+    .email-body { padding: 8px !important; }
+    .email-content { padding-left: 12px !important; padding-right: 12px !important; }
+    .mobile-surface { padding-left: 18px !important; padding-right: 18px !important; }
+    .hero-title { line-height: 39px !important; }
+  }
+  @media (prefers-color-scheme: dark) {
+    .dm-bg { background-color: #111411 !important; }
+    .email-body > table, .email-body > table > tbody > tr > td { background-color: #111411 !important; }
+    .dm-heading { color: #f3f6f2 !important; }
+    .dm-text { color: #b8c1b8 !important; }
+    .dm-label { color: #8ab89a !important; }
+    .dm-surface-green { background-color: #19231b !important; }
+    .dm-surface-neutral { background-color: #1b1f1b !important; }
+    .dm-border { border-color: #343b34 !important; }
+    .dm-button { background-color: #edf2ec !important; }
+    .dm-button-link { color: #151915 !important; }
+    .dm-image { border-color: #394139 !important; }
+  }
+  [data-ogsc] .dm-bg { background-color: #111411 !important; }
+  [data-ogsc] .email-body > table, [data-ogsc] .email-body > table > tbody > tr > td { background-color: #111411 !important; }
+  [data-ogsc] .dm-heading { color: #f3f6f2 !important; }
+  [data-ogsc] .dm-text { color: #b8c1b8 !important; }
+  [data-ogsc] .dm-label { color: #8ab89a !important; }
+  [data-ogsc] .dm-surface-green { background-color: #19231b !important; }
+  [data-ogsc] .dm-surface-neutral { background-color: #1b1f1b !important; }
+  [data-ogsc] .dm-border { border-color: #343b34 !important; }
+  [data-ogsc] .dm-button { background-color: #edf2ec !important; }
+  [data-ogsc] .dm-button-link { color: #151915 !important; }
+  [data-ogsc] .dm-image { border-color: #394139 !important; }
+`;
+
+const styles: Record<string, React.CSSProperties> = {
+  body: {
+    margin: 0,
+    padding: "8px",
+    backgroundColor: "#ffffff",
+    color: "#1e231e",
+    fontFamily: "Arial, Helvetica, sans-serif",
+  },
+  container: {
+    width: "100%",
+    maxWidth: "680px",
+    margin: "0 auto",
+    backgroundColor: "#ffffff",
+  },
+  content: {
+    padding: "44px 12px 0",
+  },
+  greeting: {
+    margin: "0 0 18px",
+    color: "#1e231e",
+    fontSize: "15px",
+    fontWeight: 500,
+    lineHeight: "22px",
+  },
+  eyebrow: {
+    margin: "0 0 12px",
+    color: "#3e7550",
+    fontSize: "11px",
+    fontWeight: 700,
+    letterSpacing: "0.12em",
+    lineHeight: "16px",
+  },
+  title: {
+    margin: 0,
+    color: "#1e231e",
+    fontSize: "36px",
+    fontWeight: 400,
+    letterSpacing: "-0.04em",
+    lineHeight: "45px",
+  },
+  intro: {
+    margin: "12px 0 0",
+    color: "#5f665f",
+    fontSize: "17px",
+    lineHeight: "28px",
+  },
+  hero: {
+    padding: "0 0 30px",
+  },
+  startPanel: {
+    padding: "28px 24px",
+    backgroundColor: "#edf4ee",
+    borderRadius: "14px",
+  },
+  sectionHeading: {
+    margin: 0,
+    color: "#1e231e",
+    fontSize: "26px",
+    fontWeight: 500,
+    letterSpacing: "-0.025em",
+    lineHeight: "32px",
+  },
+  bodyText: {
+    margin: "10px 0 0",
+    color: "#5f665f",
+    fontSize: "15px",
+    lineHeight: "23px",
+  },
+  primaryButton: {
+    display: "inline-block",
+    marginTop: "20px",
+    padding: "13px 18px",
+    backgroundColor: "#222722",
+    borderRadius: "5px",
+    color: "#ffffff",
+    fontSize: "14px",
+    fontWeight: 600,
+    lineHeight: "20px",
+    textDecoration: "none",
+    whiteSpace: "nowrap",
+  },
+  divider: {
+    margin: "0",
+    borderColor: "#dfe3de",
+  },
+  videoIntro: {
+    padding: "32px 0 20px",
+  },
+  videoFrame: {
+    padding: "10px",
+    backgroundColor: "#f1f2ef",
+    border: "1px solid #dfe3de",
+    borderRadius: "12px",
+  },
+  videoImageLink: {
+    display: "block",
+    lineHeight: 0,
+    textDecoration: "none",
+  },
+  videoImage: {
+    display: "block",
+    width: "100%",
+    height: "auto",
+    borderTopLeftRadius: "6px",
+    borderTopRightRadius: "6px",
+  },
+  videoAction: {
+    boxSizing: "border-box",
+    width: "100%",
+    padding: "16px",
+    backgroundColor: "#222722",
+    borderBottomLeftRadius: "6px",
+    borderBottomRightRadius: "6px",
+  },
+  videoActionLink: {
+    color: "#ffffff",
+    fontSize: "14px",
+    fontWeight: 600,
+    lineHeight: "20px",
+    textDecoration: "none",
+  },
+  videoActionArrow: {
+    width: "24px",
+    color: "#ffffff",
+    fontSize: "16px",
+    lineHeight: "20px",
+    textAlign: "right",
+    textDecoration: "none",
+  },
+  support: {
+    padding: "30px 0 34px",
+  },
+  help: {
+    margin: 0,
+    color: "#5f665f",
+    fontSize: "15px",
+    lineHeight: "23px",
+  },
+  signature: {
+    margin: "24px 0 0",
+    color: "#1e231e",
+    fontSize: "15px",
+    lineHeight: "22px",
+  },
+  role: {
+    color: "#5f665f",
+    fontSize: "13px",
+    lineHeight: "20px",
+  },
+  footer: {
+    padding: "24px 36px 36px",
+    borderTop: "1px solid #dfe3de",
+  },
+  footerBrand: {
+    margin: 0,
+    color: "#1e231e",
+    fontSize: "13px",
+    fontWeight: 700,
+    lineHeight: "19px",
+  },
+  footerText: {
+    margin: "7px 0 0",
+    color: "#747b74",
+    fontSize: "12px",
+    lineHeight: "18px",
+  },
+  footerLinks: {
+    margin: "7px 0 0",
+    color: "#5f665f",
+    fontSize: "12px",
+    lineHeight: "18px",
+  },
+  footerLink: {
+    color: "#5f665f",
+    textDecoration: "underline",
+  },
+};
+
+function getWelcomeEmailData({
+  email,
+  language,
+  youtubeId,
+}: Pick<WelcomeEmailProps, "email" | "language" | "youtubeId">) {
+  const locale: WelcomeLocale = language === "fr" ? "fr" : "en";
+  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://deltalytix.app").replace(/\/$/, "");
+  const dashboardUrl = `${baseUrl}/${locale}/dashboard?utm_source=welcome_email&utm_medium=email&utm_campaign=welcome`;
+  const privacyUrl = `${baseUrl}/${locale}/privacy`;
+  const resolvedYoutubeId = youtubeId || WELCOME_VIDEO_IDS[locale];
+  const videoUrl = `https://youtu.be/${resolvedYoutubeId}`;
+  const thumbnailUrl = `${baseUrl}/api/email/thumbnail/${resolvedYoutubeId}/maxresdefault`;
+  const unsubscribeUrl = email
+    ? `${baseUrl}/api/email/unsubscribe?email=${encodeURIComponent(email)}`
+    : `${baseUrl}/${locale}/profile`;
+
+  return {
+    locale,
+    t: copy[locale],
+    dashboardUrl,
+    privacyUrl,
+    videoUrl,
+    thumbnailUrl,
+    unsubscribeUrl,
+  };
+}
+
+export function renderWelcomeEmailText({
+  firstName = "Trader",
+  email,
+  language,
+  youtubeId,
+}: WelcomeEmailProps) {
+  const { t, dashboardUrl, privacyUrl, videoUrl, unsubscribeUrl } = getWelcomeEmailData({
+    email,
+    language,
+    youtubeId,
+  });
+
+  return [
+    `${t.greeting} ${firstName},`,
+    "",
+    t.title,
+    t.intro,
+    "",
+    t.startTitle,
+    t.startBody,
+    `${t.dashboardCta}: ${dashboardUrl}`,
+    "",
+    t.videoTitle,
+    t.videoBody,
+    `${t.videoCta}: ${videoUrl}`,
+    "",
+    t.help,
+    "",
+    t.signoff,
+    t.signature,
+    t.role,
+    "",
+    t.reason,
+    `${t.unsubscribe}: ${unsubscribeUrl}`,
+    `${t.privacy}: ${privacyUrl}`,
+  ].join("\n");
+}
+
+export default function WelcomeEmail({
+  firstName = "Trader",
+  email,
+  language,
+  youtubeId,
+}: WelcomeEmailProps) {
+  const { locale, t, dashboardUrl, privacyUrl, videoUrl, thumbnailUrl, unsubscribeUrl } =
+    getWelcomeEmailData({ email, language, youtubeId });
+
   return (
-    <Html>
-      <Head />
-      <Preview>Bienvenue sur Deltalytix - Votre plateforme de suivi de trading</Preview>
-      <Tailwind>
-        <Body className="bg-gray-50 font-sans">
-          <Section className="bg-white max-w-[600px] mx-auto rounded-lg shadow-xs">
-            <Section className="px-6 py-8">
-              <Heading className="text-2xl font-bold text-gray-900 mb-6">
-                Bonjour {firstName},
+    <Html lang={locale}>
+      <Head>
+        <meta name="color-scheme" content="light dark" />
+        <meta name="supported-color-schemes" content="light dark" />
+        <style>{emailCss}</style>
+      </Head>
+      <Preview>{t.preview}</Preview>
+      <Body className="dm-bg email-body" style={styles.body}>
+        <Container className="dm-bg" style={styles.container}>
+          <Section className="dm-bg email-content" style={styles.content}>
+            <Section style={styles.hero}>
+              <Text className="dm-heading" style={styles.greeting}>
+                {t.greeting} {firstName},
+              </Text>
+              <Text className="dm-label" style={styles.eyebrow}>
+                {t.eyebrow}
+              </Text>
+              <Heading as="h1" className="dm-heading hero-title" style={styles.title}>
+                {t.title}
               </Heading>
-              
-              <Text className="text-gray-800 mb-4 leading-6">
-                Ravi de vous compter parmi les utilisateurs de Deltalytix !
+              <Text className="dm-text" style={styles.intro}>
+                {t.intro}
               </Text>
+            </Section>
 
-              <Text className="text-gray-800 mb-4 leading-6">
-                L&apos;objectif de la plateforme est de vous aider à suivre et analyser vos performances de trading de manière simple et efficace.
+            <Section className="dm-surface-green mobile-surface" style={styles.startPanel}>
+              <Heading as="h2" className="dm-heading" style={styles.sectionHeading}>
+                {t.startTitle}
+              </Heading>
+              <Text className="dm-text" style={styles.bodyText}>
+                {t.startBody}
               </Text>
+              <Button
+                href={dashboardUrl}
+                className="dm-button dm-button-link"
+                style={styles.primaryButton}
+              >
+                {t.dashboardCta} &rarr;
+              </Button>
+            </Section>
 
-              <Text className="text-gray-800 mb-6 leading-6">
-                J&apos;espère que vous avez déjà pu explorer un peu l&apos;interface.
+            <Section className="dm-border" style={styles.videoIntro}>
+              <Hr className="dm-border" style={styles.divider} />
+              <Text className="dm-label" style={{ ...styles.eyebrow, marginTop: "32px" }}>
+                {t.videoLabel}
               </Text>
+              <Heading as="h2" className="dm-heading" style={styles.sectionHeading}>
+                {t.videoTitle}
+              </Heading>
+              <Text className="dm-text" style={styles.bodyText}>
+                {t.videoBody}
+              </Text>
+            </Section>
 
-              <Section className="mb-8">
-                <Link href={`https://youtu.be/${youtubeId}`}>
-                  <Img
-                    src={thumbnailUrl}
-                    alt="Dernière vidéo Deltalytix"
-                    className="rounded-lg w-full mb-4 shadow-xs"
-                  />
-                </Link>
-                <Button
-                  className="bg-black text-white text-sm px-4 py-2 rounded-md font-medium box-border"
-                  href={`https://youtu.be/${youtubeId}`}
-                >
-                  ▶️ Voir la dernière vidéo
-                </Button>
+            <Section
+              className="dm-surface-neutral dm-image dm-border"
+              style={styles.videoFrame}
+            >
+              <Link href={videoUrl} style={styles.videoImageLink}>
+                <Img
+                  className="responsive-image"
+                  src={thumbnailUrl}
+                  width="636"
+                  height="358"
+                  alt={t.videoAlt}
+                  style={styles.videoImage}
+                />
+              </Link>
+              <Section style={styles.videoAction}>
+                <Row>
+                  <Column>
+                    <Link href={videoUrl} style={styles.videoActionLink}>
+                      &#9654;&nbsp;&nbsp;{t.videoCta}
+                    </Link>
+                  </Column>
+                  <Column align="right" style={{ width: "24px" }}>
+                    <Link href={videoUrl} style={styles.videoActionArrow}>
+                      &rarr;
+                    </Link>
+                  </Column>
+                </Row>
               </Section>
+            </Section>
 
-              <Text className="text-gray-800 mb-4 leading-6">
-                Si vous avez la moindre question ou besoin d&apos;un coup de main pour démarrer, n&apos;hésitez pas à me faire signe, je serai ravi de vous aider.
+            <Section className="dm-border" style={styles.support}>
+              <Hr className="dm-border" style={styles.divider} />
+              <Text className="dm-text" style={{ ...styles.help, marginTop: "30px" }}>
+                {t.help}
               </Text>
-
-              <Text className="text-gray-800 mb-6 leading-6">
-                Bon trading et à bientôt !
-              </Text>
-
-              <Section className="text-center">
-                <Button 
-                  className="bg-black text-white text-sm px-6 py-2.5 rounded-md font-medium box-border"
-                  href="https://deltalytix.app/dashboard"
-                >
-                  Accéder à mon tableau de bord →
-                </Button>
-              </Section>
-
-              <Hr className="border-gray-200 my-8" />
-
-              <Text className="text-gray-400 text-xs text-center">
-                Cet email vous a été envoyé par Deltalytix
-                {' • '}
-                <Link href={unsubscribeUrl} className="text-gray-400 underline">
-                  Se désabonner
-                </Link>
+              <Text className="dm-heading" style={styles.signature}>
+                {t.signoff}
+                <br />
+                <strong>{t.signature}</strong>
+                <br />
+                <span className="dm-text" style={styles.role}>
+                  {t.role}
+                </span>
               </Text>
             </Section>
           </Section>
-        </Body>
-      </Tailwind>
+
+          <Section className="dm-bg dm-border" style={styles.footer}>
+            <Text className="dm-heading" style={styles.footerBrand}>
+              Deltalytix
+            </Text>
+            <Text className="dm-text" style={styles.footerText}>
+              {t.reason}
+            </Text>
+            <Text className="dm-text" style={styles.footerLinks}>
+              <Link className="dm-text" href={unsubscribeUrl} style={styles.footerLink}>
+                {t.unsubscribe}
+              </Link>
+              {"  ·  "}
+              <Link className="dm-text" href={privacyUrl} style={styles.footerLink}>
+                {t.privacy}
+              </Link>
+            </Text>
+          </Section>
+        </Container>
+      </Body>
     </Html>
   );
-  } else {
-    return (
-      <Html>
-      <Head />
-      <Preview>Welcome to Deltalytix - Your trading tracking platform</Preview>
-      <Tailwind>
-        <Body className="bg-gray-50 font-sans">
-          <Section className="bg-white max-w-[600px] mx-auto rounded-lg shadow-xs">
-            <Section className="px-6 py-8">
-              <Heading className="text-2xl font-bold text-gray-900 mb-6">
-                Hello {firstName},
-              </Heading>
-              
-              <Text className="text-gray-800 mb-4 leading-6">
-                I&apos;m happy to count you among the users of Deltalytix!
-              </Text>
-
-              <Text className="text-gray-800 mb-4 leading-6">
-                The goal of the platform is to help you follow and analyze your trading performance in a simple and efficient way.
-              </Text>
-
-              <Text className="text-gray-800 mb-6 leading-6">
-                I hope you have had the chance to explore the interface.
-              </Text>
-
-              <Section className="mb-8">
-                <Link href={`https://youtu.be/${youtubeId}`}>
-                  <Img
-                    src={thumbnailUrl}
-                    alt="Latest Deltalytix video"
-                    className="rounded-lg w-full mb-4 shadow-xs"
-                  />
-                </Link>
-                <Button
-                  className="bg-black text-white text-sm px-4 py-2 rounded-md font-medium box-border"
-                  href={`https://youtu.be/${youtubeId}`}
-                >
-                  ▶️ Watch the latest video
-                </Button>
-              </Section>
-
-              <Text className="text-gray-800 mb-4 leading-6">
-                If you have any questions or need help getting started, please let me know, I&apos;d be happy to help.
-              </Text>
-
-              <Text className="text-gray-800 mb-6 leading-6">
-                Happy trading and see you soon!
-              </Text>
-
-              <Section className="text-center">
-                <Button 
-                  className="bg-black text-white text-sm px-6 py-2.5 rounded-md font-medium box-border"
-                  href="https://deltalytix.app/dashboard"
-                >
-                  Access my dashboard →
-                </Button>
-              </Section>
-
-              <Hr className="border-gray-200 my-8" />
-
-              <Text className="text-gray-400 text-xs text-center">
-                This email was sent by Deltalytix
-                {' • '}
-                <Link href={unsubscribeUrl} className="text-gray-400 underline">
-                  Unsubscribe
-                </Link>
-              </Text>
-            </Section>
-          </Section>
-        </Body>
-      </Tailwind>
-    </Html>
-    );
-  }
 }
+
+WelcomeEmail.PreviewProps = {
+  firstName: "Trader",
+  email: "trader@example.com",
+  language: "en",
+  youtubeId: WELCOME_VIDEO_IDS.en,
+};


### PR DESCRIPTION
## What changed

- rebuilt the localized welcome email to match the refined Paper design
- added responsive light and dark presentation with Outlook dark-mode fallbacks
- integrated the video CTA into the thumbnail and kept the English onboarding video separate from the latest French release
- routed thumbnails through the first-party image endpoint with explicit dimensions and accessible alt text
- added localized plain-text alternatives to automatic and admin sends
- added EN/FR regression tests for copy, links, media, dimensions, and dark-mode metadata

## Design

[Open the synchronized EN/FR light/dark artboards in Paper](https://app.paper.design/file/01KXXTH2CS8YB99RG2MANQ3EX9/01K4GP58P8JRM8PGBP0586VKYV)

## Validation

- `bun test components/emails/welcome.test.tsx` — 3 tests, 27 expectations
- `bun run typecheck`
- targeted ESLint on all five changed files
- `git diff --check`
- production Next.js build with non-production placeholder service keys
- visual QA: EN/FR × desktop/mobile × light/dark
- production thumbnail proxy returns `200 image/jpeg`

## Notes

Repository-wide `bun run lint` still reports the existing baseline of unrelated lint errors; all changed files pass ESLint. No email was sent as part of this PR.