### PR TITLE
Fix subscription email synchronization

### DIFF
--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -7,6 +7,7 @@ import { getSubscriptionDetails } from "@/server/subscription";
 import { getReferralBySlug } from "@/server/referral";
 import { capturePostHogEvent, hasAnalyticsConsent } from "@/lib/posthog-server";
 import { applySignupSuccess, hasSignupSuccess } from "@/lib/signup-redirect";
+import { resolveStripeCustomerForUser } from "@/server/stripe-customer";
 
 // This endpoint renders no page of ours — it redirects straight to Stripe — so
 // a signup marker arriving here would never reach the Google tag. Forward it to
@@ -54,35 +55,17 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
         );
     }
 
-    // First, try to find existing customer
-    const existingCustomers = await stripe.customers.list({
+    const customer = await resolveStripeCustomerForUser({
+        userId: user.id,
         email: user.email,
-        limit: 1,
+        createIfMissing: true,
+        synchronizeEmail: true,
     });
-
-    let customerId: string;
-    let isFirstOrder = false;
-
-    if (existingCustomers.data.length > 0) {
-        // Use existing customer
-        customerId = existingCustomers.data[0].id;
-        
-        // Check if customer has any previous subscriptions
-        const subscriptions = await stripe.subscriptions.list({
-            customer: customerId,
-            status: 'all', // Include all subscription statuses
-            limit: 1
-        });
-        
-        isFirstOrder = subscriptions.data.length === 0;
-    } else {
-        // Create new customer if none exists
-        const newCustomer = await stripe.customers.create({
-            email: user.email,
-        });
-        customerId = newCustomer.id;
-        isFirstOrder = true;
+    if (!customer) {
+        throw new Error('Unable to resolve Stripe customer');
     }
+
+    const customerId = customer.id;
 
     const prices = await stripe.prices.list({
         lookup_keys: [lookup_key],
@@ -119,6 +102,7 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
         customer: customerId,
         metadata: {
             plan: lookup_key,
+            user_id: user.id,
             ...(referral && { referral_code: referral }),
             ...(promo_code && { promo_code: promo_code }),
             ...(analyticsConsent && {
@@ -156,6 +140,11 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
         if (trialDays > 0) {
             sessionConfig.subscription_data = {
                 trial_period_days: trialDays,
+                metadata: { user_id: user.id },
+            };
+        } else {
+            sessionConfig.subscription_data = {
+                metadata: { user_id: user.id },
             };
         }
     }

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -58,6 +58,9 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
     const customer = await resolveStripeCustomerForUser({
         userId: user.id,
         email: user.email,
+        // Reaches the existing customer even when Stripe has not caught up with a
+        // recent email change, so checkout does not mint a duplicate.
+        previousEmail: subscriptionDetails?.billingEmail ?? undefined,
         createIfMissing: true,
         synchronizeEmail: true,
     });

--- a/app/api/stripe/webhooks/route.ts
+++ b/app/api/stripe/webhooks/route.ts
@@ -7,59 +7,7 @@ import { PrismaClient } from "@/prisma/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { sendSubscriptionErrorEmail } from "@/app/[locale]/(landing)/actions/send-support-email";
 import { capturePostHogEvent } from "@/lib/posthog-server";
-import { STRIPE_USER_ID_METADATA_KEY } from "@/lib/stripe-customer-identity";
-
-type LocalUser = { id: string; email: string };
-
-function readUserIdMetadata(
-  ...sources: (Stripe.Metadata | null | undefined)[]
-): string | null {
-  for (const metadata of sources) {
-    const userId = metadata?.[STRIPE_USER_ID_METADATA_KEY];
-    if (userId) return userId;
-  }
-
-  return null;
-}
-
-/**
- * Resolve the local user an event belongs to.
- *
- * Checkout stamps `user_id` metadata onto the session and the subscription, and
- * resolveStripeCustomerForUser stamps it onto the customer, so metadata is the
- * stable key. The customer email is only a fallback for events that predate that
- * metadata: once a user changes their address, the Stripe email and User.email
- * diverge and an email lookup silently misses.
- */
-async function resolveLocalUser(
-  prisma: PrismaClient,
-  { metadataUserId, email }: { metadataUserId?: string | null; email?: string | null },
-): Promise<LocalUser | null> {
-  const select = { id: true, email: true };
-
-  if (metadataUserId) {
-    // The metadata carries the Supabase auth id. It matches User.id for accounts
-    // created since the two ids were unified, and auth_user_id for the rest.
-    const byAuthId = await prisma.user.findUnique({
-      where: { auth_user_id: metadataUserId },
-      select,
-    });
-    if (byAuthId) return byAuthId;
-
-    const byId = await prisma.user.findUnique({
-      where: { id: metadataUserId },
-      select,
-    });
-    if (byId) return byId;
-  }
-
-  if (email) {
-    const byEmail = await prisma.user.findUnique({ where: { email }, select });
-    if (byEmail) return byEmail;
-  }
-
-  return null;
-}
+import { readUserIdMetadata, resolveLocalUser } from "@/server/stripe-webhook-identity";
 
 // Helper function to get current period end from subscription items
 function getCurrentPeriodEnd(subscription: Stripe.Subscription): number {

--- a/app/api/stripe/webhooks/route.ts
+++ b/app/api/stripe/webhooks/route.ts
@@ -7,6 +7,59 @@ import { PrismaClient } from "@/prisma/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { sendSubscriptionErrorEmail } from "@/app/[locale]/(landing)/actions/send-support-email";
 import { capturePostHogEvent } from "@/lib/posthog-server";
+import { STRIPE_USER_ID_METADATA_KEY } from "@/lib/stripe-customer-identity";
+
+type LocalUser = { id: string; email: string };
+
+function readUserIdMetadata(
+  ...sources: (Stripe.Metadata | null | undefined)[]
+): string | null {
+  for (const metadata of sources) {
+    const userId = metadata?.[STRIPE_USER_ID_METADATA_KEY];
+    if (userId) return userId;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the local user an event belongs to.
+ *
+ * Checkout stamps `user_id` metadata onto the session and the subscription, and
+ * resolveStripeCustomerForUser stamps it onto the customer, so metadata is the
+ * stable key. The customer email is only a fallback for events that predate that
+ * metadata: once a user changes their address, the Stripe email and User.email
+ * diverge and an email lookup silently misses.
+ */
+async function resolveLocalUser(
+  prisma: PrismaClient,
+  { metadataUserId, email }: { metadataUserId?: string | null; email?: string | null },
+): Promise<LocalUser | null> {
+  const select = { id: true, email: true };
+
+  if (metadataUserId) {
+    // The metadata carries the Supabase auth id. It matches User.id for accounts
+    // created since the two ids were unified, and auth_user_id for the rest.
+    const byAuthId = await prisma.user.findUnique({
+      where: { auth_user_id: metadataUserId },
+      select,
+    });
+    if (byAuthId) return byAuthId;
+
+    const byId = await prisma.user.findUnique({
+      where: { id: metadataUserId },
+      select,
+    });
+    if (byId) return byId;
+  }
+
+  if (email) {
+    const byEmail = await prisma.user.findUnique({ where: { email }, select });
+    if (byEmail) return byEmail;
+  }
+
+  return null;
+}
 
 // Helper function to get current period end from subscription items
 function getCurrentPeriodEnd(subscription: Stripe.Subscription): number {
@@ -104,9 +157,16 @@ export async function POST(req: Request) {
             // If interval_count is 3 then it is quarterly
             const interval = price.recurring?.interval_count === 3 ? 'quarter' : price.recurring?.interval || 'month';
 
-            const user = await prisma.user.findUnique({
-              where: { email: data.customer_details?.email as string },
+            const user = await resolveLocalUser(prisma, {
+              metadataUserId: readUserIdMetadata(data.metadata, subscription.metadata),
+              email: data.customer_details?.email,
             });
+
+            if (!user) {
+              // Throwing returns a 500 so Stripe retries: on a fresh signup the
+              // local user row can still be in flight when checkout completes.
+              throw new Error(`No local user for checkout session ${data.id}`);
+            }
 
             const currentPeriodEnd = getCurrentPeriodEnd(subscription);
 
@@ -115,7 +175,7 @@ export async function POST(req: Request) {
             // And multiple business subscriptions for the same user will be registered as different subscriptions in the database
             await prisma.subscription.upsert({
               where: {
-                email: data.customer_details?.email as string,
+                userId: user.id,
               },
               update: {
                 plan: subscriptionPlan,
@@ -125,9 +185,9 @@ export async function POST(req: Request) {
                 interval: interval,
               },
               create: {
-                email: data.customer_details?.email as string,
+                email: user.email,
                 plan: subscriptionPlan,
-                user: { connect: { id: user?.id } },
+                user: { connect: { id: user.id } },
                 endDate: new Date(currentPeriodEnd * 1000),
                 status: 'ACTIVE',
                 trialEndsAt: null,
@@ -195,9 +255,14 @@ export async function POST(req: Request) {
                 const productName = (price.product as Stripe.Product).name;
                 const subscriptionPlan = productName.toUpperCase() || 'LIFETIME';
 
-                const user = await prisma.user.findUnique({
-                  where: { email: data.customer_details?.email as string },
+                const user = await resolveLocalUser(prisma, {
+                  metadataUserId: readUserIdMetadata(data.metadata),
+                  email: data.customer_details?.email,
                 });
+
+                if (!user) {
+                  throw new Error(`No local user for checkout session ${data.id}`);
+                }
 
                 // For lifetime plans, set end date far in the future (100 years)
                 const lifetimeEndDate = new Date();
@@ -205,7 +270,7 @@ export async function POST(req: Request) {
 
                 await prisma.subscription.upsert({
                   where: {
-                    email: data.customer_details?.email as string,
+                    userId: user.id,
                   },
                   update: {
                     plan: subscriptionPlan,
@@ -215,9 +280,9 @@ export async function POST(req: Request) {
                     interval: 'lifetime',
                   },
                   create: {
-                    email: data.customer_details?.email as string,
+                    email: user.email,
                     plan: subscriptionPlan,
-                    user: { connect: { id: user?.id } },
+                    user: { connect: { id: user.id } },
                     endDate: lifetimeEndDate,
                     status: 'ACTIVE',
                     trialEndsAt: null,
@@ -276,15 +341,22 @@ export async function POST(req: Request) {
             data.customer as string
           ) as Stripe.Customer;
 
-          if (customerData.email) {
+          const deletedSubscriptionUser = await resolveLocalUser(prisma, {
+            metadataUserId: readUserIdMetadata(data.metadata, customerData.metadata),
+            email: customerData.email,
+          });
+
+          if (deletedSubscriptionUser) {
             await prisma.subscription.update({
-              where: { email: customerData.email },
+              where: { userId: deletedSubscriptionUser.id },
               data: {
                 plan: 'FREE',
                 status: "CANCELLED",
                 endDate: new Date(data.ended_at! * 1000)
               }
             });
+          } else {
+            console.warn(`No local user for deleted subscription ${data.id}`);
           }
           console.log(`Subscription deleted and updated in DB: ${data.id}`);
           // TODO: Schedule an email to ask feedback on the cancellation
@@ -296,7 +368,12 @@ export async function POST(req: Request) {
             data.customer as string
           ) as Stripe.Customer;
 
-          if (updatedCustomerData.email) {
+          const updatedSubscriptionUser = await resolveLocalUser(prisma, {
+            metadataUserId: readUserIdMetadata(data.metadata, updatedCustomerData.metadata),
+            email: updatedCustomerData.email,
+          });
+
+          if (updatedSubscriptionUser) {
             // Get the current price information
             const currentItems = await stripe.subscriptionItems.list({
               subscription: data.id,
@@ -338,7 +415,7 @@ export async function POST(req: Request) {
               const currentPeriodEnd = getCurrentPeriodEndFromEventData(data);
 
               await prisma.subscription.update({
-                where: { email: updatedCustomerData.email },
+                where: { userId: updatedSubscriptionUser.id },
                 data: {
                   status: "SCHEDULED_CANCELLATION",
                   endDate: new Date(currentPeriodEnd * 1000)
@@ -353,7 +430,7 @@ export async function POST(req: Request) {
                 cancellationDetails?.comment) {
                 await prisma.subscriptionFeedback.create({
                   data: {
-                    email: updatedCustomerData.email,
+                    email: updatedSubscriptionUser.email,
                     event: "SCHEDULED_CANCELLATION",
                     cancellationReason: cancellationDetails.feedback || null,
                     feedback: cancellationDetails.comment || null
@@ -366,7 +443,7 @@ export async function POST(req: Request) {
               const currentPeriodEnd = getCurrentPeriodEndFromEventData(data);
 
               await prisma.subscription.update({
-                where: { email: updatedCustomerData.email },
+                where: { userId: updatedSubscriptionUser.id },
                 data: {
                   status: subscriptionStatus,
                   plan: data.ended_at ? 'free' : updatedPlan,
@@ -378,6 +455,8 @@ export async function POST(req: Request) {
               });
               console.log(`Subscription updated with status ${subscriptionStatus}: ${data.id}`);
             }
+          } else {
+            console.warn(`No local user for updated subscription ${data.id}`);
           }
           break;
         case "customer.subscription.created":
@@ -387,9 +466,10 @@ export async function POST(req: Request) {
             data.customer as string
           ) as Stripe.Customer;
 
-          if (newCustomerData.email) {
-            const user = await prisma.user.findUnique({
-              where: { email: newCustomerData.email },
+          {
+            const user = await resolveLocalUser(prisma, {
+              metadataUserId: readUserIdMetadata(data.metadata, newCustomerData.metadata),
+              email: newCustomerData.email,
             });
 
             if (user) {
@@ -412,7 +492,7 @@ export async function POST(req: Request) {
               const currentPeriodEnd = getCurrentPeriodEndFromEventData(data);
 
               await prisma.subscription.upsert({
-                where: { email: newCustomerData.email },
+                where: { userId: user.id },
                 update: {
                   status: data.status === 'trialing' ? 'TRIAL' : 'ACTIVE',
                   plan: subscriptionPlan,
@@ -420,7 +500,7 @@ export async function POST(req: Request) {
                   trialEndsAt: data.trial_end ? new Date(data.trial_end * 1000) : null
                 },
                 create: {
-                  email: newCustomerData.email,
+                  email: user.email,
                   plan: subscriptionPlan,
                   user: { connect: { id: user.id } },
                   status: data.status === 'trialing' ? 'TRIAL' : 'ACTIVE',
@@ -429,21 +509,30 @@ export async function POST(req: Request) {
                 }
               });
               console.log(`New subscription created and saved: ${data.id}`);
+            } else {
+              console.warn(`No local user for created subscription ${data.id}`);
             }
           }
           break;
         case "invoice.payment_failed":
           console.log('invoice.payment_failed')
           data = event.data.object as Stripe.Invoice;
-          const customerEmail = (await stripe.customers.retrieve(data.customer as string) as Stripe.Customer).email;
+          const invoiceCustomer = await stripe.customers.retrieve(data.customer as string) as Stripe.Customer;
 
-          if (customerEmail) {
+          const paymentFailedUser = await resolveLocalUser(prisma, {
+            metadataUserId: readUserIdMetadata(invoiceCustomer.metadata),
+            email: invoiceCustomer.email,
+          });
+
+          if (paymentFailedUser) {
             await prisma.subscription.update({
-              where: { email: customerEmail },
+              where: { userId: paymentFailedUser.id },
               data: {
                 status: "PAYMENT_FAILED",
               }
             });
+          } else {
+            console.warn(`No local user for failed invoice ${data.id}`);
           }
           console.log(`Payment failed for invoice: ${data.id}`);
           break;

--- a/lib/stripe-customer-identity.test.ts
+++ b/lib/stripe-customer-identity.test.ts
@@ -55,20 +55,29 @@ describe("selectStripeCustomersForUser", () => {
 });
 
 describe("disambiguateStripeCustomersByBilling", () => {
-  it("picks the single candidate that carries billing history", () => {
+  it("picks the single candidate that carries a subscription", () => {
     expect(
       disambiguateStripeCustomersByBilling([
-        { customer: customer("empty"), subscriptionCount: 0 },
-        { customer: customer("billing"), subscriptionCount: 1 },
+        { customer: customer("empty"), subscriptionCount: 0, paymentCount: 0 },
+        { customer: customer("billing"), subscriptionCount: 1, paymentCount: 0 },
       ]),
     ).toEqual({ outcome: "resolved", customer: customer("billing") });
+  });
+
+  it("picks the lifetime customer, whose purchase leaves no subscription", () => {
+    expect(
+      disambiguateStripeCustomersByBilling([
+        { customer: customer("empty"), subscriptionCount: 0, paymentCount: 0 },
+        { customer: customer("lifetime"), subscriptionCount: 0, paymentCount: 1 },
+      ]),
+    ).toEqual({ outcome: "resolved", customer: customer("lifetime") });
   });
 
   it("reports every candidate as unclaimable when none has billing history", () => {
     expect(
       disambiguateStripeCustomersByBilling([
-        { customer: customer("empty-1"), subscriptionCount: 0 },
-        { customer: customer("empty-2"), subscriptionCount: 0 },
+        { customer: customer("empty-1"), subscriptionCount: 0, paymentCount: 0 },
+        { customer: customer("empty-2"), subscriptionCount: 0, paymentCount: 0 },
       ]),
     ).toEqual({ outcome: "unclaimable" });
   });
@@ -76,12 +85,24 @@ describe("disambiguateStripeCustomersByBilling", () => {
   it("stays ambiguous when several candidates carry billing history", () => {
     expect(
       disambiguateStripeCustomersByBilling([
-        { customer: customer("billing-1"), subscriptionCount: 2 },
-        { customer: customer("billing-2"), subscriptionCount: 1 },
+        { customer: customer("billing-1"), subscriptionCount: 2, paymentCount: 0 },
+        { customer: customer("billing-2"), subscriptionCount: 1, paymentCount: 0 },
       ]),
     ).toEqual({
       outcome: "ambiguous",
       customers: [customer("billing-1"), customer("billing-2")],
+    });
+  });
+
+  it("does not let a canceled subscription outrank a lifetime purchase", () => {
+    expect(
+      disambiguateStripeCustomersByBilling([
+        { customer: customer("canceled"), subscriptionCount: 1, paymentCount: 0 },
+        { customer: customer("lifetime"), subscriptionCount: 0, paymentCount: 1 },
+      ]),
+    ).toEqual({
+      outcome: "ambiguous",
+      customers: [customer("canceled"), customer("lifetime")],
     });
   });
 });

--- a/lib/stripe-customer-identity.test.ts
+++ b/lib/stripe-customer-identity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  selectStripeCustomersForUser,
+  type StripeCustomerIdentity,
+} from "./stripe-customer-identity";
+
+const customer = (id: string, userId?: string): StripeCustomerIdentity => ({
+  id,
+  metadata: userId ? { user_id: userId } : {},
+});
+
+describe("selectStripeCustomersForUser", () => {
+  it("selects only customers explicitly owned by the authenticated user", () => {
+    expect(
+      selectStripeCustomersForUser(
+        [customer("matching", "user-1"), customer("other", "user-2")],
+        "user-1",
+      ),
+    ).toEqual([customer("matching", "user-1")]);
+  });
+
+  it("allows one legacy customer to be claimed", () => {
+    expect(
+      selectStripeCustomersForUser([customer("legacy")], "user-1"),
+    ).toEqual([customer("legacy")]);
+  });
+
+  it("does not guess when multiple legacy customers share an email", () => {
+    expect(
+      selectStripeCustomersForUser(
+        [customer("legacy-1"), customer("legacy-2")],
+        "user-1",
+      ),
+    ).toEqual([]);
+  });
+
+  it("never claims a customer owned by another user", () => {
+    expect(
+      selectStripeCustomersForUser([customer("other", "user-2")], "user-1"),
+    ).toEqual([]);
+  });
+});

--- a/lib/stripe-customer-identity.test.ts
+++ b/lib/stripe-customer-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  disambiguateStripeCustomersByBilling,
   selectStripeCustomersForUser,
   type StripeCustomerIdentity,
 } from "./stripe-customer-identity";
@@ -17,27 +18,70 @@ describe("selectStripeCustomersForUser", () => {
         [customer("matching", "user-1"), customer("other", "user-2")],
         "user-1",
       ),
-    ).toEqual([customer("matching", "user-1")]);
+    ).toEqual({ outcome: "owned", customers: [customer("matching", "user-1")] });
   });
 
   it("allows one legacy customer to be claimed", () => {
-    expect(
-      selectStripeCustomersForUser([customer("legacy")], "user-1"),
-    ).toEqual([customer("legacy")]);
+    expect(selectStripeCustomersForUser([customer("legacy")], "user-1")).toEqual({
+      outcome: "unclaimed",
+      customers: [customer("legacy")],
+    });
   });
 
-  it("does not guess when multiple legacy customers share an email", () => {
+  it("reports ambiguity rather than emptiness when legacy customers share an email", () => {
     expect(
       selectStripeCustomersForUser(
         [customer("legacy-1"), customer("legacy-2")],
         "user-1",
       ),
-    ).toEqual([]);
+    ).toEqual({
+      outcome: "ambiguous",
+      customers: [customer("legacy-1"), customer("legacy-2")],
+    });
   });
 
   it("never claims a customer owned by another user", () => {
     expect(
       selectStripeCustomersForUser([customer("other", "user-2")], "user-1"),
-    ).toEqual([]);
+    ).toEqual({ outcome: "not_found", customers: [] });
+  });
+
+  it("reports not_found when there is no candidate at all", () => {
+    expect(selectStripeCustomersForUser([], "user-1")).toEqual({
+      outcome: "not_found",
+      customers: [],
+    });
+  });
+});
+
+describe("disambiguateStripeCustomersByBilling", () => {
+  it("picks the single candidate that carries billing history", () => {
+    expect(
+      disambiguateStripeCustomersByBilling([
+        { customer: customer("empty"), subscriptionCount: 0 },
+        { customer: customer("billing"), subscriptionCount: 1 },
+      ]),
+    ).toEqual({ outcome: "resolved", customer: customer("billing") });
+  });
+
+  it("reports every candidate as unclaimable when none has billing history", () => {
+    expect(
+      disambiguateStripeCustomersByBilling([
+        { customer: customer("empty-1"), subscriptionCount: 0 },
+        { customer: customer("empty-2"), subscriptionCount: 0 },
+      ]),
+    ).toEqual({ outcome: "unclaimable" });
+  });
+
+  it("stays ambiguous when several candidates carry billing history", () => {
+    expect(
+      disambiguateStripeCustomersByBilling([
+        { customer: customer("billing-1"), subscriptionCount: 2 },
+        { customer: customer("billing-2"), subscriptionCount: 1 },
+      ]),
+    ).toEqual({
+      outcome: "ambiguous",
+      customers: [customer("billing-1"), customer("billing-2")],
+    });
   });
 });

--- a/lib/stripe-customer-identity.ts
+++ b/lib/stripe-customer-identity.ts
@@ -1,0 +1,30 @@
+export type StripeCustomerIdentity = {
+  id: string;
+  metadata: Record<string, string>;
+};
+
+export const STRIPE_USER_ID_METADATA_KEY = "user_id";
+
+/**
+ * Select customers that can be safely associated with an authenticated user.
+ * Explicit user-id metadata always wins. A legacy customer without metadata is
+ * accepted only when there is exactly one unclaimed candidate.
+ */
+export function selectStripeCustomersForUser<T extends StripeCustomerIdentity>(
+  customers: T[],
+  userId: string,
+): T[] {
+  const ownedCustomers = customers.filter(
+    (customer) => customer.metadata[STRIPE_USER_ID_METADATA_KEY] === userId,
+  );
+
+  if (ownedCustomers.length > 0) {
+    return ownedCustomers;
+  }
+
+  const unclaimedCustomers = customers.filter(
+    (customer) => !customer.metadata[STRIPE_USER_ID_METADATA_KEY],
+  );
+
+  return unclaimedCustomers.length === 1 ? unclaimedCustomers : [];
+}

--- a/lib/stripe-customer-identity.ts
+++ b/lib/stripe-customer-identity.ts
@@ -5,26 +5,88 @@ export type StripeCustomerIdentity = {
 
 export const STRIPE_USER_ID_METADATA_KEY = "user_id";
 
+export type StripeCustomerSelection<T> =
+  /** At least one customer carries this user's id metadata. */
+  | { outcome: "owned"; customers: T[] }
+  /** Exactly one legacy customer has no owner and can be claimed safely. */
+  | { outcome: "unclaimed"; customers: T[] }
+  /** Several legacy customers have no owner, so ownership cannot be guessed. */
+  | { outcome: "ambiguous"; customers: T[] }
+  /** Nothing claimable: no candidates, or every candidate belongs elsewhere. */
+  | { outcome: "not_found"; customers: [] };
+
 /**
  * Select customers that can be safely associated with an authenticated user.
  * Explicit user-id metadata always wins. A legacy customer without metadata is
  * accepted only when there is exactly one unclaimed candidate.
+ *
+ * "No candidates" and "several ambiguous candidates" are reported separately:
+ * creating a replacement customer is correct for the first and destructive for
+ * the second, because an existing subscription may hang off one of the
+ * candidates.
  */
 export function selectStripeCustomersForUser<T extends StripeCustomerIdentity>(
   customers: T[],
   userId: string,
-): T[] {
+): StripeCustomerSelection<T> {
   const ownedCustomers = customers.filter(
     (customer) => customer.metadata[STRIPE_USER_ID_METADATA_KEY] === userId,
   );
 
   if (ownedCustomers.length > 0) {
-    return ownedCustomers;
+    return { outcome: "owned", customers: ownedCustomers };
   }
 
   const unclaimedCustomers = customers.filter(
     (customer) => !customer.metadata[STRIPE_USER_ID_METADATA_KEY],
   );
 
-  return unclaimedCustomers.length === 1 ? unclaimedCustomers : [];
+  if (unclaimedCustomers.length === 1) {
+    return { outcome: "unclaimed", customers: unclaimedCustomers };
+  }
+
+  if (unclaimedCustomers.length > 1) {
+    return { outcome: "ambiguous", customers: unclaimedCustomers };
+  }
+
+  return { outcome: "not_found", customers: [] };
+}
+
+export type StripeCustomerBillingActivity<T> = {
+  customer: T;
+  subscriptionCount: number;
+};
+
+export type StripeCustomerDisambiguation<T> =
+  /** Exactly one candidate holds billing history, so it is the real customer. */
+  | { outcome: "resolved"; customer: T }
+  /** No candidate holds billing history: none of them owns an entitlement. */
+  | { outcome: "unclaimable" }
+  /** Several candidates hold billing history and need a human to merge them. */
+  | { outcome: "ambiguous"; customers: T[] };
+
+/**
+ * Break a tie between unclaimed legacy customers using their billing history.
+ *
+ * Every customer created before user-id metadata existed is unclaimed, so an
+ * email shared by duplicates is common in production data. The subscription
+ * almost always lives on exactly one of them; picking that one recovers the
+ * entitlement instead of silently minting an empty replacement customer.
+ */
+export function disambiguateStripeCustomersByBilling<
+  T extends StripeCustomerIdentity,
+>(activity: StripeCustomerBillingActivity<T>[]): StripeCustomerDisambiguation<T> {
+  const billingCustomers = activity
+    .filter((candidate) => candidate.subscriptionCount > 0)
+    .map((candidate) => candidate.customer);
+
+  if (billingCustomers.length === 1) {
+    return { outcome: "resolved", customer: billingCustomers[0] };
+  }
+
+  if (billingCustomers.length === 0) {
+    return { outcome: "unclaimable" };
+  }
+
+  return { outcome: "ambiguous", customers: billingCustomers };
 }

--- a/lib/stripe-customer-identity.ts
+++ b/lib/stripe-customer-identity.ts
@@ -54,7 +54,15 @@ export function selectStripeCustomersForUser<T extends StripeCustomerIdentity>(
 
 export type StripeCustomerBillingActivity<T> = {
   customer: T;
+  /** Subscriptions in any status, including canceled ones. */
   subscriptionCount: number;
+  /**
+   * Successful one-time payments — succeeded charges and paid invoices.
+   * Lifetime plans check out in `mode: 'payment'` and never create a
+   * subscription, so counting subscriptions alone reads a paying lifetime
+   * customer as an empty shell.
+   */
+  paymentCount: number;
 };
 
 export type StripeCustomerDisambiguation<T> =
@@ -69,15 +77,22 @@ export type StripeCustomerDisambiguation<T> =
  * Break a tie between unclaimed legacy customers using their billing history.
  *
  * Every customer created before user-id metadata existed is unclaimed, so an
- * email shared by duplicates is common in production data. The subscription
- * almost always lives on exactly one of them; picking that one recovers the
- * entitlement instead of silently minting an empty replacement customer.
+ * email shared by duplicates is common in production data. The entitlement
+ * almost always lives on exactly one of them; picking that one recovers it
+ * instead of silently minting an empty replacement customer.
+ *
+ * Recurring and one-time activity count equally. Ranking them would claim the
+ * wrong customer when one duplicate holds a canceled subscription and the other
+ * holds the lifetime purchase, so that case stays ambiguous on purpose.
  */
 export function disambiguateStripeCustomersByBilling<
   T extends StripeCustomerIdentity,
 >(activity: StripeCustomerBillingActivity<T>[]): StripeCustomerDisambiguation<T> {
   const billingCustomers = activity
-    .filter((candidate) => candidate.subscriptionCount > 0)
+    .filter(
+      (candidate) =>
+        candidate.subscriptionCount > 0 || candidate.paymentCount > 0,
+    )
     .map((candidate) => candidate.customer);
 
   if (billingCustomers.length === 1) {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -451,21 +451,86 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
 
     // If user exists by auth_user_id, update fields if needed
     if (existingUserByAuthId) {
-      const shouldUpdateEmail = existingUserByAuthId.email !== user.email;
+      const normalizedAuthEmail = user.email?.trim().toLowerCase();
+      const shouldUpdateEmail = !!normalizedAuthEmail && existingUserByAuthId.email !== normalizedAuthEmail;
       const shouldUpdateLanguage = !!locale && locale !== existingUserByAuthId.language;
 
       if (shouldUpdateEmail || shouldUpdateLanguage) {
         console.log('[ensureUserInDatabase] Updating existing user record');
         try {
-          const updatedUser = await prisma.user.update({
-            where: {
-              auth_user_id: user.id // Always use auth_user_id as the unique identifier
-            },
-            data: {
-              email: shouldUpdateEmail ? (user.email || existingUserByAuthId.email) : existingUserByAuthId.email,
-              language: shouldUpdateLanguage ? (locale as string) : existingUserByAuthId.language
-            },
+          const subscription = shouldUpdateEmail
+            ? await prisma.subscription.findUnique({
+                where: { userId: existingUserByAuthId.id },
+                select: { email: true, userId: true },
+              })
+            : null;
+
+          if (shouldUpdateEmail) {
+            const [userWithNewEmail, subscriptionWithNewEmail] = await Promise.all([
+              prisma.user.findUnique({
+                where: { email: normalizedAuthEmail },
+                select: { id: true },
+              }),
+              prisma.subscription.findUnique({
+                where: { email: normalizedAuthEmail },
+                select: { userId: true },
+              }),
+            ]);
+
+            if (
+              (userWithNewEmail && userWithNewEmail.id !== existingUserByAuthId.id) ||
+              (subscriptionWithNewEmail && subscriptionWithNewEmail.userId !== existingUserByAuthId.id)
+            ) {
+              throw new Error('Account conflict: Email already associated with another user');
+            }
+          }
+
+          if (shouldUpdateEmail && subscription) {
+            try {
+              const { synchronizeStripeCustomerEmailForUser } = await import('@/server/stripe-customer');
+              const stripeCustomer = await synchronizeStripeCustomerEmailForUser({
+                userId: user.id,
+                previousEmail: subscription.email,
+                email: normalizedAuthEmail,
+              });
+
+              if (!stripeCustomer) {
+                console.warn('[ensureUserInDatabase] No unambiguous Stripe customer found for email synchronization', {
+                  userId: user.id,
+                });
+              }
+            } catch (stripeError) {
+              // Keep the previous local email so a later authenticated request can
+              // safely retry the Stripe lookup with the last known billing email.
+              console.error('[ensureUserInDatabase] Failed to synchronize Stripe customer email', {
+                userId: user.id,
+                error: stripeError instanceof Error ? stripeError.message : 'Unknown error',
+              });
+              return { user: existingUserByAuthId, isNewUser: false };
+            }
+          }
+
+          const updatedUser = await prisma.$transaction(async (transaction) => {
+            if (shouldUpdateEmail && subscription) {
+              // The subscription is selected and updated through the immutable user ID,
+              // never through the mutable previous email address.
+              await transaction.subscription.update({
+                where: { userId: existingUserByAuthId.id },
+                data: { email: normalizedAuthEmail },
+              });
+            }
+
+            return transaction.user.update({
+              where: {
+                auth_user_id: user.id // Always use auth_user_id as the unique identifier
+              },
+              data: {
+                email: shouldUpdateEmail ? normalizedAuthEmail : existingUserByAuthId.email,
+                language: shouldUpdateLanguage ? (locale as string) : existingUserByAuthId.language
+              },
+            });
           });
+
           console.log('[ensureUserInDatabase] SUCCESS: User updated successfully');
           return { user: updatedUser, isNewUser: false };
         } catch (updateError) {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -485,17 +485,35 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
             }
           }
 
-          if (shouldUpdateEmail && subscription) {
+          // Stripe is renamed before the local write so that a failure here leaves
+          // the previous billing email on record to retry with. The reverse order
+          // would strand Stripe on an address nothing points at any more; that is
+          // only recoverable because user-id metadata, not the email, is the key.
+          if (shouldUpdateEmail) {
             try {
               const { synchronizeStripeCustomerEmailForUser } = await import('@/server/stripe-customer');
-              const stripeCustomer = await synchronizeStripeCustomerEmailForUser({
+              // Accounts without a Subscription row still have a Stripe customer
+              // (getSubscriptionData creates one on read), so fall back to the
+              // local user email rather than skipping the rename entirely.
+              const syncResult = await synchronizeStripeCustomerEmailForUser({
                 userId: user.id,
-                previousEmail: subscription.email,
+                previousEmail: subscription?.email ?? existingUserByAuthId.email,
                 email: normalizedAuthEmail,
               });
 
-              if (!stripeCustomer) {
-                console.warn('[ensureUserInDatabase] No unambiguous Stripe customer found for email synchronization', {
+              if (syncResult.status === 'ambiguous') {
+                // The previous email is the only remaining pointer to the legacy
+                // customer holding the subscription. Keep it so a later request
+                // can retry once the duplicates are merged in Stripe.
+                console.error('[ensureUserInDatabase] Ambiguous Stripe customers, keeping previous billing email', {
+                  userId: user.id,
+                  customerIds: syncResult.customerIds,
+                });
+                return { user: existingUserByAuthId, isNewUser: false };
+              }
+
+              if (syncResult.status === 'not_found') {
+                console.warn('[ensureUserInDatabase] No Stripe customer found for email synchronization', {
                   userId: user.id,
                 });
               }
@@ -534,6 +552,12 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
           console.log('[ensureUserInDatabase] SUCCESS: User updated successfully');
           return { user: updatedUser, isNewUser: false };
         } catch (updateError) {
+          // The outer handler routes on the 'Account conflict' message. Rewrapping
+          // it would fall through to the catch-all branch and sign the user out
+          // with "Critical database error" instead of showing the conflict.
+          if (updateError instanceof Error && updateError.message.includes('Account conflict')) {
+            throw updateError;
+          }
           console.error('[ensureUserInDatabase] ERROR: Failed to update user record:', updateError);
           throw new Error('Failed to update user');
         }

--- a/server/billing.ts
+++ b/server/billing.ts
@@ -7,6 +7,7 @@ import { PrismaPg } from '@prisma/adapter-pg'
 import { stripe } from '@/server/stripe'
 import Stripe from 'stripe'
 import { isLocalDashboardAuthBypassEnabled } from '@/lib/local-dashboard-auth'
+import { resolveStripeCustomerForUser } from '@/server/stripe-customer'
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
@@ -76,36 +77,43 @@ export async function getSubscriptionData() {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user?.email) throw new Error('User not found')
 
+    const appUser = await prisma.user.findUnique({
+      where: { auth_user_id: user.id },
+      select: { id: true },
+    })
+    if (!appUser) throw new Error('User not found')
+
     // FIRST: Check local database for active lifetime subscription (highest priority)
     const localSubscription = await prisma.subscription.findUnique({
-      where: { email: user.email },
+      where: { userId: appUser.id },
     })
 
     if (localSubscription && localSubscription.status === 'ACTIVE' && localSubscription.interval === 'lifetime') {
 
       // Get customer and invoices for lifetime subscription
-      const customers = await stripe.customers.list({
+      const customer = await resolveStripeCustomerForUser({
+        userId: user.id,
         email: user.email,
-        limit: 1,
+        synchronizeEmail: true,
       })
 
       let invoices: { data: any[] } = { data: [] }
-      if (customers.data[0]) {
+      if (customer) {
         // First, get all invoices (for any subscription-based payments)
         const allInvoices = await stripe.invoices.list({
-          customer: customers.data[0].id,
+          customer: customer.id,
           limit: 10,
         })
 
         // Get payment intents (for one-time payments like lifetime purchases)
         const paymentIntents = await stripe.paymentIntents.list({
-          customer: customers.data[0].id,
+          customer: customer.id,
           limit: 10,
         })
 
         // Get charges (alternative method for one-time payments)
         const charges = await stripe.charges.list({
-          customer: customers.data[0].id,
+          customer: customer.id,
           limit: 10,
         })
 
@@ -187,21 +195,14 @@ export async function getSubscriptionData() {
     }
 
     // SECOND: Check for active Stripe subscription (recurring plans)
-    const customers = await stripe.customers.list({
+    const customer = await resolveStripeCustomerForUser({
+      userId: user.id,
       email: user.email,
-      limit: 1,
+      createIfMissing: true,
+      synchronizeEmail: true,
     })
-
-    const customer = customers.data[0]
     if (!customer) {
-      // Create a new customer if they don't exist
-      const newCustomer = await stripe.customers.create({
-        email: user.email,
-        metadata: {
-          user_id: user.id,
-        },
-      })
-      return null // New customer won't have a subscription yet
+      return null
     }
 
     // Get ONLY ACTIVE subscriptions (not canceled/expired ones)
@@ -439,13 +440,17 @@ export async function switchSubscriptionPlan(newLookupKey: string) {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user?.email) throw new Error('User not found')
 
-    // Get customer by email
-    const customers = await stripe.customers.list({
-      email: user.email,
-      limit: 1,
+    const appUser = await prisma.user.findUnique({
+      where: { auth_user_id: user.id },
+      select: { id: true },
     })
+    if (!appUser) throw new Error('User not found')
 
-    const customer = customers.data[0]
+    const customer = await resolveStripeCustomerForUser({
+      userId: user.id,
+      email: user.email,
+      synchronizeEmail: true,
+    })
     if (!customer) {
       throw new Error('Customer not found')
     }
@@ -482,7 +487,7 @@ export async function switchSubscriptionPlan(newLookupKey: string) {
         // Update local database
         await prisma.subscription.update({
           where: {
-            email: user.email,
+            userId: appUser.id,
           },
           data: {
             plan: 'FREE',
@@ -543,7 +548,7 @@ export async function switchSubscriptionPlan(newLookupKey: string) {
 
     await prisma.subscription.update({
       where: {
-        email: user.email,
+        userId: appUser.id,
       },
       data: {
         plan: subscriptionPlan,

--- a/server/billing.ts
+++ b/server/billing.ts
@@ -94,6 +94,7 @@ export async function getSubscriptionData() {
       const customer = await resolveStripeCustomerForUser({
         userId: user.id,
         email: user.email,
+        previousEmail: localSubscription.email,
         synchronizeEmail: true,
       })
 
@@ -195,9 +196,12 @@ export async function getSubscriptionData() {
     }
 
     // SECOND: Check for active Stripe subscription (recurring plans)
+    // The stored billing email is the last address Stripe was told about, so it
+    // still finds the customer while a rename is propagating through Search.
     const customer = await resolveStripeCustomerForUser({
       userId: user.id,
       email: user.email,
+      previousEmail: localSubscription?.email,
       createIfMissing: true,
       synchronizeEmail: true,
     })
@@ -446,9 +450,15 @@ export async function switchSubscriptionPlan(newLookupKey: string) {
     })
     if (!appUser) throw new Error('User not found')
 
+    const localSubscription = await prisma.subscription.findUnique({
+      where: { userId: appUser.id },
+      select: { email: true },
+    })
+
     const customer = await resolveStripeCustomerForUser({
       userId: user.id,
       email: user.email,
+      previousEmail: localSubscription?.email,
       synchronizeEmail: true,
     })
     if (!customer) {

--- a/server/stripe-customer.test.ts
+++ b/server/stripe-customer.test.ts
@@ -12,6 +12,12 @@ const stripeMock = vi.hoisted(() => ({
   subscriptions: {
     list: vi.fn(),
   },
+  charges: {
+    list: vi.fn(),
+  },
+  invoices: {
+    list: vi.fn(),
+  },
 }));
 
 vi.mock("@/server/stripe", () => ({ stripe: stripeMock }));
@@ -63,11 +69,28 @@ function givenSubscriptionCounts(counts: Record<string, number>) {
   );
 }
 
+/**
+ * Lifetime plans check out in `mode: 'payment'`, so their only trace is a
+ * succeeded charge — no subscription is ever created.
+ */
+function givenSucceededCharges(counts: Record<string, number>) {
+  stripeMock.charges.list.mockImplementation(({ customer }: { customer: string }) =>
+    Promise.resolve({
+      data: Array.from({ length: counts[customer] ?? 0 }, () => ({
+        status: "succeeded",
+        paid: true,
+      })),
+    }),
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   stripeMock.customers.search.mockResolvedValue({ data: [] });
   stripeMock.customers.list.mockResolvedValue({ data: [] });
   stripeMock.subscriptions.list.mockResolvedValue({ data: [] });
+  stripeMock.charges.list.mockResolvedValue({ data: [] });
+  stripeMock.invoices.list.mockResolvedValue({ data: [] });
   stripeMock.customers.create.mockImplementation(
     (params: Record<string, unknown>) =>
       Promise.resolve({ id: "cus_new", ...params }),
@@ -141,6 +164,66 @@ describe("resolveStripeCustomerForUser", () => {
 
     expect(customer?.id).toBe("cus_paying");
     expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("recovers the lifetime customer, which has a charge but no subscription", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_empty", "user@example.com"),
+      fakeCustomer("cus_lifetime", "user@example.com"),
+    ]);
+    givenSubscriptionCounts({});
+    givenSucceededCharges({ cus_lifetime: 1 });
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+      createIfMissing: true,
+    });
+
+    expect(customer?.id).toBe("cus_lifetime");
+    expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses to pick between a canceled subscription and a lifetime purchase", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_canceled", "user@example.com"),
+      fakeCustomer("cus_lifetime", "user@example.com"),
+    ]);
+    givenSubscriptionCounts({ cus_canceled: 1 });
+    givenSucceededCharges({ cus_lifetime: 1 });
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+      createIfMissing: true,
+    });
+
+    expect(customer).toBeNull();
+    expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("ignores failed charges when deciding a candidate is an empty shell", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_failed", "user@example.com"),
+      fakeCustomer("cus_paying", "user@example.com"),
+    ]);
+    givenSubscriptionCounts({ cus_paying: 1 });
+    stripeMock.charges.list.mockImplementation(({ customer }: { customer: string }) =>
+      Promise.resolve({
+        data:
+          customer === "cus_failed"
+            ? [{ status: "failed", paid: false }]
+            : [],
+      }),
+    );
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+      createIfMissing: true,
+    });
+
+    expect(customer?.id).toBe("cus_paying");
   });
 
   it("creates a customer when every ambiguous candidate is an empty shell", async () => {

--- a/server/stripe-customer.test.ts
+++ b/server/stripe-customer.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const stripeMock = vi.hoisted(() => ({
+  customers: {
+    search: vi.fn(),
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  subscriptions: {
+    list: vi.fn(),
+  },
+}));
+
+vi.mock("@/server/stripe", () => ({ stripe: stripeMock }));
+
+const {
+  resolveStripeCustomerForUser,
+  synchronizeStripeCustomerEmailForUser,
+} = await import("./stripe-customer");
+
+type FakeCustomer = {
+  id: string;
+  email: string;
+  metadata: Record<string, string>;
+};
+
+const fakeCustomer = (
+  id: string,
+  email: string,
+  userId?: string,
+): FakeCustomer => ({
+  id,
+  email,
+  metadata: userId ? { user_id: userId } : {},
+});
+
+/**
+ * Stripe Search only ever returns customers already carrying our metadata; the
+ * email list is what surfaces legacy customers. Model both so the ordering the
+ * resolver depends on is exercised.
+ */
+function givenStripeCustomers(customers: FakeCustomer[]) {
+  stripeMock.customers.search.mockImplementation(({ query }: { query: string }) => {
+    const userId = query.match(/'(.*)'$/)?.[1];
+    return Promise.resolve({
+      data: customers.filter((customer) => customer.metadata.user_id === userId),
+    });
+  });
+  stripeMock.customers.list.mockImplementation(({ email }: { email: string }) =>
+    Promise.resolve({
+      data: customers.filter((customer) => customer.email === email),
+    }),
+  );
+}
+
+function givenSubscriptionCounts(counts: Record<string, number>) {
+  stripeMock.subscriptions.list.mockImplementation(
+    ({ customer }: { customer: string }) =>
+      Promise.resolve({ data: Array.from({ length: counts[customer] ?? 0 }) }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stripeMock.customers.search.mockResolvedValue({ data: [] });
+  stripeMock.customers.list.mockResolvedValue({ data: [] });
+  stripeMock.subscriptions.list.mockResolvedValue({ data: [] });
+  stripeMock.customers.create.mockImplementation(
+    (params: Record<string, unknown>) =>
+      Promise.resolve({ id: "cus_new", ...params }),
+  );
+  stripeMock.customers.update.mockImplementation(
+    (id: string, params: Record<string, unknown>) =>
+      Promise.resolve({ id, ...params }),
+  );
+});
+
+describe("resolveStripeCustomerForUser", () => {
+  it("prefers the customer already claimed by this user over a legacy match", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_owned", "user@example.com", "user-1"),
+      fakeCustomer("cus_legacy", "user@example.com"),
+    ]);
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+    });
+
+    expect(customer?.id).toBe("cus_owned");
+    expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("claims a single legacy customer instead of creating a new one", async () => {
+    givenStripeCustomers([fakeCustomer("cus_legacy", "user@example.com")]);
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+      createIfMissing: true,
+    });
+
+    expect(customer?.id).toBe("cus_legacy");
+    expect(stripeMock.customers.update).toHaveBeenCalledWith("cus_legacy", {
+      metadata: { user_id: "user-1" },
+    });
+    expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a customer when nothing claimable exists", async () => {
+    givenStripeCustomers([fakeCustomer("cus_other", "user@example.com", "user-2")]);
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "User@Example.com",
+      createIfMissing: true,
+    });
+
+    expect(stripeMock.customers.create).toHaveBeenCalledWith({
+      email: "user@example.com",
+      metadata: { user_id: "user-1" },
+    });
+    expect(customer?.id).toBe("cus_new");
+  });
+
+  it("recovers the paying customer when ambiguous legacy customers share an email", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_empty", "user@example.com"),
+      fakeCustomer("cus_paying", "user@example.com"),
+    ]);
+    givenSubscriptionCounts({ cus_paying: 1 });
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+      createIfMissing: true,
+    });
+
+    expect(customer?.id).toBe("cus_paying");
+    expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a customer when every ambiguous candidate is an empty shell", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_empty_1", "user@example.com"),
+      fakeCustomer("cus_empty_2", "user@example.com"),
+    ]);
+    givenSubscriptionCounts({});
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+      createIfMissing: true,
+    });
+
+    expect(customer?.id).toBe("cus_new");
+  });
+
+  it("refuses to create when several ambiguous candidates hold subscriptions", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_paying_1", "user@example.com"),
+      fakeCustomer("cus_paying_2", "user@example.com"),
+    ]);
+    givenSubscriptionCounts({ cus_paying_1: 1, cus_paying_2: 1 });
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+      createIfMissing: true,
+    });
+
+    expect(customer).toBeNull();
+    expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("finds the customer through the previous email while Stripe still has the old one", async () => {
+    givenStripeCustomers([fakeCustomer("cus_legacy", "old@example.com")]);
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "new@example.com",
+      previousEmail: "old@example.com",
+      createIfMissing: true,
+      synchronizeEmail: true,
+    });
+
+    expect(customer?.id).toBe("cus_legacy");
+    expect(stripeMock.customers.update).toHaveBeenCalledWith("cus_legacy", {
+      email: "new@example.com",
+      metadata: { user_id: "user-1" },
+    });
+  });
+
+  it("returns null without creating when createIfMissing is off", async () => {
+    givenStripeCustomers([]);
+
+    await expect(
+      resolveStripeCustomerForUser({ userId: "user-1", email: "user@example.com" }),
+    ).resolves.toBeNull();
+    expect(stripeMock.customers.create).not.toHaveBeenCalled();
+  });
+
+  it("still resolves by email when Stripe Search is unavailable", async () => {
+    givenStripeCustomers([fakeCustomer("cus_owned", "user@example.com", "user-1")]);
+    stripeMock.customers.search.mockRejectedValue(new Error("search unavailable"));
+
+    const customer = await resolveStripeCustomerForUser({
+      userId: "user-1",
+      email: "user@example.com",
+    });
+
+    expect(customer?.id).toBe("cus_owned");
+  });
+});
+
+describe("synchronizeStripeCustomerEmailForUser", () => {
+  it("renames the customer found under the previous email", async () => {
+    givenStripeCustomers([fakeCustomer("cus_legacy", "old@example.com")]);
+
+    const result = await synchronizeStripeCustomerEmailForUser({
+      userId: "user-1",
+      previousEmail: "old@example.com",
+      email: "New@Example.com",
+    });
+
+    expect(result).toEqual({
+      status: "synchronized",
+      customer: {
+        id: "cus_legacy",
+        email: "new@example.com",
+        metadata: { user_id: "user-1" },
+      },
+    });
+  });
+
+  it("reports ambiguity instead of silently doing nothing", async () => {
+    givenStripeCustomers([
+      fakeCustomer("cus_paying_1", "old@example.com"),
+      fakeCustomer("cus_paying_2", "old@example.com"),
+    ]);
+    givenSubscriptionCounts({ cus_paying_1: 1, cus_paying_2: 3 });
+
+    const result = await synchronizeStripeCustomerEmailForUser({
+      userId: "user-1",
+      previousEmail: "old@example.com",
+      email: "new@example.com",
+    });
+
+    expect(result).toEqual({
+      status: "ambiguous",
+      customerIds: ["cus_paying_1", "cus_paying_2"],
+    });
+    expect(stripeMock.customers.update).not.toHaveBeenCalled();
+  });
+
+  it("reports not_found when the user has no Stripe customer", async () => {
+    givenStripeCustomers([]);
+
+    const result = await synchronizeStripeCustomerEmailForUser({
+      userId: "user-1",
+      previousEmail: "old@example.com",
+      email: "new@example.com",
+    });
+
+    expect(result).toEqual({ status: "not_found" });
+    expect(stripeMock.customers.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/stripe-customer.ts
+++ b/server/stripe-customer.ts
@@ -3,6 +3,7 @@ import "server-only";
 import type Stripe from "stripe";
 
 import {
+  disambiguateStripeCustomersByBilling,
   selectStripeCustomersForUser,
   STRIPE_USER_ID_METADATA_KEY,
 } from "@/lib/stripe-customer-identity";
@@ -15,6 +16,16 @@ type ResolveStripeCustomerOptions = {
   createIfMissing?: boolean;
   synchronizeEmail?: boolean;
 };
+
+type StripeCustomerMatch =
+  | { status: "found"; customers: Stripe.Customer[] }
+  | { status: "not_found" }
+  | { status: "ambiguous"; customerIds: string[] };
+
+export type StripeCustomerEmailSyncResult =
+  | { status: "synchronized"; customer: Stripe.Customer }
+  | { status: "not_found" }
+  | { status: "ambiguous"; customerIds: string[] };
 
 function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
@@ -55,6 +66,68 @@ async function listCustomerCandidates(userId: string, emails: string[]) {
   return [...customersById.values()];
 }
 
+async function countSubscriptions(customerId: string) {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 1,
+  });
+
+  return subscriptions.data.length;
+}
+
+async function findCustomersForUser({
+  userId,
+  email,
+  previousEmail,
+}: {
+  userId: string;
+  email: string;
+  previousEmail?: string;
+}): Promise<StripeCustomerMatch> {
+  const normalizedEmail = normalizeEmail(email);
+  const candidateEmails = [normalizedEmail];
+  if (previousEmail && normalizeEmail(previousEmail) !== normalizedEmail) {
+    candidateEmails.push(previousEmail);
+  }
+
+  const candidates = await listCustomerCandidates(userId, candidateEmails);
+  const selection = selectStripeCustomersForUser(candidates, userId);
+
+  if (selection.outcome === "owned" || selection.outcome === "unclaimed") {
+    return { status: "found", customers: selection.customers };
+  }
+
+  if (selection.outcome === "not_found") {
+    return { status: "not_found" };
+  }
+
+  // Several unclaimed legacy customers share this email. Ask Stripe which of
+  // them actually carries billing history before giving up on all of them.
+  const activity = await Promise.all(
+    selection.customers.map(async (customer) => ({
+      customer,
+      subscriptionCount: await countSubscriptions(customer.id),
+    })),
+  );
+  const disambiguation = disambiguateStripeCustomersByBilling(activity);
+
+  if (disambiguation.outcome === "resolved") {
+    return { status: "found", customers: [disambiguation.customer] };
+  }
+
+  if (disambiguation.outcome === "unclaimable") {
+    // Every candidate is an empty shell, so there is no entitlement to strand
+    // and the caller is free to start from a fresh, owned customer.
+    return { status: "not_found" };
+  }
+
+  return {
+    status: "ambiguous",
+    customerIds: disambiguation.customers.map((customer) => customer.id),
+  };
+}
+
 export async function resolveStripeCustomerForUser({
   userId,
   email,
@@ -63,15 +136,19 @@ export async function resolveStripeCustomerForUser({
   synchronizeEmail = false,
 }: ResolveStripeCustomerOptions): Promise<Stripe.Customer | null> {
   const normalizedEmail = normalizeEmail(email);
-  const candidateEmails = [normalizedEmail];
-  if (previousEmail && normalizeEmail(previousEmail) !== normalizedEmail) {
-    candidateEmails.push(previousEmail);
+  const match = await findCustomersForUser({ userId, email, previousEmail });
+
+  if (match.status === "ambiguous") {
+    // Creating a replacement here would read as "no subscription" while the
+    // active one keeps billing against a customer we can no longer reach.
+    console.error(
+      "[stripe-customer] Several legacy Stripe customers hold billing history for this user",
+      { userId, customerIds: match.customerIds },
+    );
+    return null;
   }
 
-  const candidates = await listCustomerCandidates(userId, candidateEmails);
-  const validatedCustomers = selectStripeCustomersForUser(candidates, userId);
-
-  if (validatedCustomers.length === 0) {
+  if (match.status === "not_found") {
     if (!createIfMissing) return null;
 
     return stripe.customers.create({
@@ -82,7 +159,7 @@ export async function resolveStripeCustomerForUser({
     });
   }
 
-  const [customer] = validatedCustomers;
+  const [customer] = match.customers;
   const shouldClaimCustomer =
     customer.metadata[STRIPE_USER_ID_METADATA_KEY] !== userId;
   const shouldUpdateEmail =
@@ -109,18 +186,24 @@ export async function synchronizeStripeCustomerEmailForUser({
   userId: string;
   previousEmail: string;
   email: string;
-}) {
+}): Promise<StripeCustomerEmailSyncResult> {
   const normalizedEmail = normalizeEmail(email);
-  const candidates = await listCustomerCandidates(userId, [
-    normalizedEmail,
+  const match = await findCustomersForUser({
+    userId,
+    email: normalizedEmail,
     previousEmail,
-  ]);
-  const validatedCustomers = selectStripeCustomersForUser(candidates, userId);
+  });
 
-  if (validatedCustomers.length === 0) return null;
+  if (match.status === "ambiguous") {
+    return { status: "ambiguous", customerIds: match.customerIds };
+  }
+
+  if (match.status === "not_found") {
+    return { status: "not_found" };
+  }
 
   const updatedCustomers = await Promise.all(
-    validatedCustomers.map((customer) =>
+    match.customers.map((customer) =>
       stripe.customers.update(customer.id, {
         email: normalizedEmail,
         metadata: {
@@ -130,5 +213,5 @@ export async function synchronizeStripeCustomerEmailForUser({
     ),
   );
 
-  return updatedCustomers[0];
+  return { status: "synchronized", customer: updatedCustomers[0] };
 }

--- a/server/stripe-customer.ts
+++ b/server/stripe-customer.ts
@@ -66,14 +66,35 @@ async function listCustomerCandidates(userId: string, emails: string[]) {
   return [...customersById.values()];
 }
 
-async function countSubscriptions(customerId: string) {
-  const subscriptions = await stripe.subscriptions.list({
-    customer: customerId,
-    status: "all",
-    limit: 1,
-  });
+/**
+ * Measure how much billing history a customer carries.
+ *
+ * Both halves matter: recurring plans leave subscriptions, and lifetime plans
+ * check out in `mode: 'payment'` and leave only a charge. Reading one signal
+ * would treat the other kind of paying customer as disposable. Charges and
+ * invoices are listed rather than counted precisely — all the caller needs to
+ * know is whether anything is there at all.
+ */
+async function readBillingActivity(customerId: string) {
+  const [subscriptions, charges, invoices] = await Promise.all([
+    stripe.subscriptions.list({ customer: customerId, status: "all", limit: 1 }),
+    stripe.charges.list({ customer: customerId, limit: 100 }),
+    stripe.invoices.list({ customer: customerId, limit: 100 }),
+  ]);
 
-  return subscriptions.data.length;
+  const paidCharges = charges.data.filter(
+    (charge) => charge.status === "succeeded" && charge.paid,
+  );
+  // A paid invoice normally has a charge, but it can be settled out of band or
+  // from credit balance, which leaves no charge behind.
+  const paidInvoices = invoices.data.filter(
+    (invoice) => invoice.status === "paid" || invoice.amount_paid > 0,
+  );
+
+  return {
+    subscriptionCount: subscriptions.data.length,
+    paymentCount: paidCharges.length + paidInvoices.length,
+  };
 }
 
 async function findCustomersForUser({
@@ -107,7 +128,7 @@ async function findCustomersForUser({
   const activity = await Promise.all(
     selection.customers.map(async (customer) => ({
       customer,
-      subscriptionCount: await countSubscriptions(customer.id),
+      ...(await readBillingActivity(customer.id)),
     })),
   );
   const disambiguation = disambiguateStripeCustomersByBilling(activity);

--- a/server/stripe-customer.ts
+++ b/server/stripe-customer.ts
@@ -1,0 +1,134 @@
+import "server-only";
+
+import type Stripe from "stripe";
+
+import {
+  selectStripeCustomersForUser,
+  STRIPE_USER_ID_METADATA_KEY,
+} from "@/lib/stripe-customer-identity";
+import { stripe } from "@/server/stripe";
+
+type ResolveStripeCustomerOptions = {
+  userId: string;
+  email: string;
+  previousEmail?: string;
+  createIfMissing?: boolean;
+  synchronizeEmail?: boolean;
+};
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+function escapeStripeSearchValue(value: string) {
+  return value.replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+}
+
+async function listCustomerCandidates(userId: string, emails: string[]) {
+  const customersById = new Map<string, Stripe.Customer>();
+
+  try {
+    const customers = await stripe.customers.search({
+      query: `metadata['${STRIPE_USER_ID_METADATA_KEY}']:'${escapeStripeSearchValue(userId)}'`,
+      limit: 100,
+    });
+    for (const customer of customers.data) {
+      customersById.set(customer.id, customer);
+    }
+  } catch (error) {
+    // Stripe Search can be temporarily unavailable or eventually consistent.
+    // The exact-email lookup below remains a safe fallback because ownership is
+    // checked before any customer is selected.
+    console.warn("[stripe-customer] Customer metadata search failed", {
+      userId,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+
+  for (const email of new Set(emails.map(normalizeEmail))) {
+    const customers = await stripe.customers.list({ email, limit: 100 });
+    for (const customer of customers.data) {
+      customersById.set(customer.id, customer);
+    }
+  }
+
+  return [...customersById.values()];
+}
+
+export async function resolveStripeCustomerForUser({
+  userId,
+  email,
+  previousEmail,
+  createIfMissing = false,
+  synchronizeEmail = false,
+}: ResolveStripeCustomerOptions): Promise<Stripe.Customer | null> {
+  const normalizedEmail = normalizeEmail(email);
+  const candidateEmails = [normalizedEmail];
+  if (previousEmail && normalizeEmail(previousEmail) !== normalizedEmail) {
+    candidateEmails.push(previousEmail);
+  }
+
+  const candidates = await listCustomerCandidates(userId, candidateEmails);
+  const validatedCustomers = selectStripeCustomersForUser(candidates, userId);
+
+  if (validatedCustomers.length === 0) {
+    if (!createIfMissing) return null;
+
+    return stripe.customers.create({
+      email: normalizedEmail,
+      metadata: {
+        [STRIPE_USER_ID_METADATA_KEY]: userId,
+      },
+    });
+  }
+
+  const [customer] = validatedCustomers;
+  const shouldClaimCustomer =
+    customer.metadata[STRIPE_USER_ID_METADATA_KEY] !== userId;
+  const shouldUpdateEmail =
+    synchronizeEmail &&
+    normalizeEmail(customer.email || "") !== normalizedEmail;
+
+  if (shouldClaimCustomer || shouldUpdateEmail) {
+    return stripe.customers.update(customer.id, {
+      ...(shouldUpdateEmail ? { email: normalizedEmail } : {}),
+      metadata: {
+        [STRIPE_USER_ID_METADATA_KEY]: userId,
+      },
+    });
+  }
+
+  return customer;
+}
+
+export async function synchronizeStripeCustomerEmailForUser({
+  userId,
+  previousEmail,
+  email,
+}: {
+  userId: string;
+  previousEmail: string;
+  email: string;
+}) {
+  const normalizedEmail = normalizeEmail(email);
+  const candidates = await listCustomerCandidates(userId, [
+    normalizedEmail,
+    previousEmail,
+  ]);
+  const validatedCustomers = selectStripeCustomersForUser(candidates, userId);
+
+  if (validatedCustomers.length === 0) return null;
+
+  const updatedCustomers = await Promise.all(
+    validatedCustomers.map((customer) =>
+      stripe.customers.update(customer.id, {
+        email: normalizedEmail,
+        metadata: {
+          [STRIPE_USER_ID_METADATA_KEY]: userId,
+        },
+      }),
+    ),
+  );
+
+  return updatedCustomers[0];
+}

--- a/server/stripe-webhook-identity.test.ts
+++ b/server/stripe-webhook-identity.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { PrismaClient } from "@/prisma/generated/prisma/client";
+
+import { readUserIdMetadata, resolveLocalUser } from "./stripe-webhook-identity";
+
+type UserRow = { id: string; email: string; auth_user_id: string };
+
+const findUnique = vi.fn();
+
+/**
+ * Stands in for prisma.user. The webhook only ever reads through the three
+ * unique keys, so matching on whichever one is present is enough.
+ */
+function givenUsers(users: UserRow[]) {
+  findUnique.mockImplementation(({ where }: { where: Partial<UserRow> }) => {
+    const match = users.find(
+      (user) =>
+        (where.auth_user_id !== undefined && user.auth_user_id === where.auth_user_id) ||
+        (where.id !== undefined && user.id === where.id) ||
+        (where.email !== undefined && user.email === where.email),
+    );
+
+    return Promise.resolve(match ? { id: match.id, email: match.email } : null);
+  });
+}
+
+const prisma = { user: { findUnique } } as unknown as PrismaClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("readUserIdMetadata", () => {
+  it("takes the first user_id across the sources in order", () => {
+    expect(
+      readUserIdMetadata({ user_id: "from-session" }, { user_id: "from-customer" }),
+    ).toBe("from-session");
+  });
+
+  it("falls through empty and absent metadata bags", () => {
+    expect(readUserIdMetadata(null, {}, { user_id: "from-customer" })).toBe(
+      "from-customer",
+    );
+  });
+
+  it("returns null when no source carries the key", () => {
+    expect(readUserIdMetadata(null, undefined, { plan: "plus" })).toBeNull();
+  });
+});
+
+describe("resolveLocalUser", () => {
+  it("resolves metadata against auth_user_id", async () => {
+    givenUsers([
+      { id: "prisma-id", email: "user@example.com", auth_user_id: "auth-id" },
+    ]);
+
+    await expect(
+      resolveLocalUser(prisma, { metadataUserId: "auth-id" }),
+    ).resolves.toEqual({ id: "prisma-id", email: "user@example.com" });
+  });
+
+  it("falls back to User.id for legacy rows where the ids diverge", async () => {
+    givenUsers([
+      { id: "shared-id", email: "user@example.com", auth_user_id: "other-auth-id" },
+    ]);
+
+    await expect(
+      resolveLocalUser(prisma, { metadataUserId: "shared-id" }),
+    ).resolves.toEqual({ id: "shared-id", email: "user@example.com" });
+  });
+
+  it("resolves by email when no metadata is present, for pre-metadata events", async () => {
+    givenUsers([
+      { id: "prisma-id", email: "legacy@example.com", auth_user_id: "auth-id" },
+    ]);
+
+    await expect(
+      resolveLocalUser(prisma, { email: "legacy@example.com" }),
+    ).resolves.toEqual({ id: "prisma-id", email: "legacy@example.com" });
+  });
+
+  it("does not fall back to email when metadata is present but unresolvable", async () => {
+    // The address was reused by another account after the original was deleted.
+    givenUsers([
+      { id: "new-owner", email: "reused@example.com", auth_user_id: "new-auth-id" },
+    ]);
+
+    await expect(
+      resolveLocalUser(prisma, {
+        metadataUserId: "deleted-account",
+        email: "reused@example.com",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("prefers metadata over an email that points at a different account", async () => {
+    givenUsers([
+      { id: "owner", email: "owner@example.com", auth_user_id: "owner-auth-id" },
+      { id: "other", email: "stale@example.com", auth_user_id: "other-auth-id" },
+    ]);
+
+    await expect(
+      resolveLocalUser(prisma, {
+        metadataUserId: "owner-auth-id",
+        email: "stale@example.com",
+      }),
+    ).resolves.toEqual({ id: "owner", email: "owner@example.com" });
+  });
+
+  it("returns null when neither metadata nor email is available", async () => {
+    givenUsers([]);
+
+    await expect(resolveLocalUser(prisma, {})).resolves.toBeNull();
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/server/stripe-webhook-identity.ts
+++ b/server/stripe-webhook-identity.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import type { Stripe } from "stripe";
+
+import type { PrismaClient } from "@/prisma/generated/prisma/client";
+import { STRIPE_USER_ID_METADATA_KEY } from "@/lib/stripe-customer-identity";
+
+export type LocalUser = { id: string; email: string };
+
+/**
+ * First `user_id` found across the metadata bags of an event, in the order they
+ * are passed: most specific object first.
+ */
+export function readUserIdMetadata(
+  ...sources: (Stripe.Metadata | null | undefined)[]
+): string | null {
+  for (const metadata of sources) {
+    const userId = metadata?.[STRIPE_USER_ID_METADATA_KEY];
+    if (userId) return userId;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the local user a Stripe event belongs to.
+ *
+ * Checkout stamps `user_id` metadata onto the session and the subscription, and
+ * resolveStripeCustomerForUser stamps it onto the customer, so metadata is the
+ * stable key. The customer email is only for events that predate that metadata:
+ * once a user changes their address, the Stripe email and User.email diverge and
+ * an email lookup silently misses.
+ *
+ * Metadata that is present but unresolvable returns null rather than falling
+ * through to email. A stale id means the account it named is gone, and the email
+ * on that old customer may since have been reused by somebody else — writing to
+ * them would hand one account's billing event to another.
+ */
+export async function resolveLocalUser(
+  prisma: PrismaClient,
+  { metadataUserId, email }: { metadataUserId?: string | null; email?: string | null },
+): Promise<LocalUser | null> {
+  const select = { id: true, email: true };
+
+  if (metadataUserId) {
+    // The metadata carries the Supabase auth id. It matches User.id for accounts
+    // created since the two ids were unified, and auth_user_id for the rest.
+    const byAuthId = await prisma.user.findUnique({
+      where: { auth_user_id: metadataUserId },
+      select,
+    });
+    if (byAuthId) return byAuthId;
+
+    const byId = await prisma.user.findUnique({
+      where: { id: metadataUserId },
+      select,
+    });
+    if (byId) return byId;
+
+    console.warn("[stripe-webhook] user_id metadata does not match any user", {
+      metadataUserId,
+    });
+    return null;
+  }
+
+  if (email) {
+    const byEmail = await prisma.user.findUnique({ where: { email }, select });
+    if (byEmail) return byEmail;
+  }
+
+  return null;
+}

--- a/server/subscription.ts
+++ b/server/subscription.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { prisma } from '@/lib/prisma'
-import { headers } from 'next/headers';
 import { createClient } from './auth';
 
 interface SubscriptionInfo {
@@ -12,32 +11,13 @@ interface SubscriptionInfo {
     trialEndsAt: Date | null;
 }
 
-// Validate email to prevent SQL injection and invalid queries
-function isValidEmail(email: string): boolean {
-    if (!email || typeof email !== 'string') return false
-    // Basic email validation regex
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
-}
-
 export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null> {
-    // Get user email using headers from our middleware
-    const headersList = await headers()
-    let email = headersList.get("x-user-email")
-    if (!email) {
-        // USE supabase to get user email
-        const supabase = await createClient()
-        const { data: { user } } = await supabase.auth.getUser()
-        if (!user) {
-            return null
-        }
-        email = user.email || null
-    }
-    // Input validation
-    if (!email || !isValidEmail(email)) {
-        console.error('[getSubscriptionDetails] Invalid email format:', email)
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user?.id) {
         return null
     }
-    const normalizedEmail = email.toLowerCase().trim()
+    const normalizedEmail = user.email?.toLowerCase().trim() || ''
 
     if (normalizedEmail.endsWith('@rithmic.com')) {
         return {
@@ -49,11 +29,17 @@ export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null>
         }
     }
 
-    console.log("[getSubscriptionDetails] Fetching details for", normalizedEmail)
+    console.log("[getSubscriptionDetails] Fetching details for authenticated user", user.id)
 
     try {
+        const appUser = await prisma.user.findUnique({
+            where: { auth_user_id: user.id },
+            select: { id: true },
+        })
+        if (!appUser) return null
+
         const subscription = await prisma.subscription.findUnique({
-            where: { email: normalizedEmail },
+            where: { userId: appUser.id },
             // Only select the fields we need
             select: {
                 status: true,
@@ -85,7 +71,7 @@ export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null>
 
     } catch (error) {
         console.error('[getSubscriptionDetails] Database error:', {
-            email: normalizedEmail,
+            userId: user.id,
             error: error instanceof Error ? error.message : 'Unknown error'
         })
         return null

--- a/server/subscription.ts
+++ b/server/subscription.ts
@@ -9,6 +9,8 @@ interface SubscriptionInfo {
     status: string;
     endDate: Date | null;
     trialEndsAt: Date | null;
+    /** Last address Stripe was told about; null when no local row exists. */
+    billingEmail: string | null;
 }
 
 export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null> {
@@ -25,7 +27,8 @@ export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null>
             plan: 'Plus',
             status: 'ACTIVE',
             endDate: null,
-            trialEndsAt: null
+            trialEndsAt: null,
+            billingEmail: null
         }
     }
 
@@ -45,7 +48,8 @@ export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null>
                 status: true,
                 plan: true,
                 endDate: true,
-                trialEndsAt: true
+                trialEndsAt: true,
+                email: true
             }
         })
 
@@ -66,7 +70,8 @@ export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null>
             plan: subscription.plan,
             status: subscription.status,
             endDate: subscription.endDate,
-            trialEndsAt: subscription.trialEndsAt
+            trialEndsAt: subscription.trialEndsAt,
+            billingEmail: subscription.email
         }
 
     } catch (error) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const projectRoot = fileURLToPath(new URL(".", import.meta.url)).replace(/\/$/, "");
+
+export default defineConfig({
+  resolve: {
+    // Mirror the "@/*" -> "./*" mapping from tsconfig.json. Without it any test
+    // that reaches a module importing "@/..." fails to load.
+    alias: [{ find: /^@\/(.*)$/, replacement: `${projectRoot}/$1` }],
+  },
+});


### PR DESCRIPTION
## What changed

- resolve local subscription entitlements through the authenticated Supabase user ID instead of mutable email headers
- synchronize `User.email` and `Subscription.email` using validated `auth_user_id` / `userId` selectors
- identify Stripe customers with Supabase user-ID metadata and safely claim only unambiguous legacy email matches
- rename validated Stripe customers when a confirmed Supabase email changes
- propagate the Supabase user ID into Stripe customer, Checkout Session, and subscription metadata
- update billing plan mutations through the validated local user ID
- add focused tests for Stripe customer ownership selection

## Root cause

Subscription ownership was linked correctly by `userId`, but entitlement and Stripe billing paths still looked up records by email. After a user changed email, the local subscription, Supabase Auth identity, and Stripe customer could disagree, causing an active PLUS plan to appear missing.

## User impact

Confirmed email changes now preserve local entitlements and synchronize the associated Stripe billing identity without allowing a matching email alone to override a conflicting Stripe user ID.

## Validation

- `vitest`: 10 focused tests passed
- changed helper/subscription files: ESLint passed
- `git diff --check`: passed
- full typecheck could not complete because `protobufjs@8.7.1`, present in beta's lockfile, is absent from the preinstalled main dependency tree
- a fresh `bun install` was intentionally not run because `bun audit --audit-level=high` reports 15 existing high-severity dependency advisories
- build reached Next.js after Prisma generation, then stopped because the temporary cross-worktree `node_modules` symlink is rejected by Turbopack