### PR TITLE
Add MFFU DxFeed sync provider

### DIFF
--- a/lib/dxfeed-propfirms.test.ts
+++ b/lib/dxfeed-propfirms.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  authPropfirmMatchesSelection,
+  buildHistoricalHostForPropFirm,
+  buildTradingHostForPropFirm,
+  getDxFeedPropFirm,
+  getDxFeedPropFirmByAuthName,
+  getEnabledDxFeedPropFirms,
+} from './dxfeed-propfirms'
+
+describe('dxfeed prop firms', () => {
+  it('enables My Funded Futures with its dxFeed endpoints', () => {
+    const firm = getDxFeedPropFirm('myfundedfutures')
+
+    expect(firm).toMatchObject({
+      name: 'My Funded Futures',
+      website: 'https://dxfeed.myfundedfutures.com',
+      enabled: true,
+    })
+    expect(buildHistoricalHostForPropFirm(firm!)).toBe(
+      'https://dxfeed.myfundedfutures.com',
+    )
+    expect(buildTradingHostForPropFirm(firm!)).toBe(
+      'https://dxfeed.myfundedfutures.com',
+    )
+  })
+
+  it('resolves My Funded Futures from normalized ids and auth names', () => {
+    expect(getDxFeedPropFirm('My Funded Futures')?.id).toBe('myfundedfutures')
+    expect(getDxFeedPropFirmByAuthName('MyFundedFutures')?.id).toBe(
+      'myfundedfutures',
+    )
+    expect(getDxFeedPropFirmByAuthName('MFFU')?.id).toBe('myfundedfutures')
+    expect(
+      authPropfirmMatchesSelection('MFFU', getDxFeedPropFirm('myfundedfutures')!),
+    ).toBe(true)
+    expect(getEnabledDxFeedPropFirms()).toContainEqual(
+      expect.objectContaining({ id: 'myfundedfutures' }),
+    )
+  })
+})

--- a/lib/dxfeed-propfirms.ts
+++ b/lib/dxfeed-propfirms.ts
@@ -13,6 +13,8 @@ export interface DxFeedPropFirmDefinition {
   id: string
   /** Display name in UI */
   name: string
+  /** Alternate names returned by auth or commonly used by the provider */
+  aliases?: string[]
   /** Optional marketing / login site */
   website?: string
   /** Root domain for host construction (e.g. miltraders.com) */
@@ -33,6 +35,16 @@ export const DXFEED_PROP_FIRMS: DxFeedPropFirmDefinition[] = [
     domain: 'miltraders.com',
     historicalSubdomain: 'volumetrica',
     tradingSubdomain: 'trading-volumetrica',
+    enabled: true,
+  },
+  {
+    id: 'myfundedfutures',
+    name: 'My Funded Futures',
+    aliases: ['MFFU'],
+    website: 'https://dxfeed.myfundedfutures.com',
+    domain: 'myfundedfutures.com',
+    historicalSubdomain: 'dxfeed',
+    tradingSubdomain: 'dxfeed',
     enabled: true,
   },
   {
@@ -95,7 +107,8 @@ export function getDxFeedPropFirmByAuthName(
     (f) =>
       normalizeDxFeedPropfirmKey(f.name) === key ||
       normalizeDxFeedPropfirmKey(f.id) === key ||
-      normalizeDxFeedPropfirmKey(f.domain.split('.')[0]) === key,
+      normalizeDxFeedPropfirmKey(f.domain.split('.')[0]) === key ||
+      f.aliases?.some((alias) => normalizeDxFeedPropfirmKey(alias) === key),
   )
 }
 
@@ -125,6 +138,7 @@ export function authPropfirmMatchesSelection(
     normalizeDxFeedPropfirmKey(selectedFirm.id),
     normalizeDxFeedPropfirmKey(selectedFirm.name),
     normalizeDxFeedPropfirmKey(selectedFirm.domain.split('.')[0]),
+    ...(selectedFirm.aliases ?? []).map(normalizeDxFeedPropfirmKey),
   ])
 
   return selectedKeys.has(authKey)


### PR DESCRIPTION
## What changed

- add My Funded Futures to the enabled DxFeed prop-firm registry
- configure `https://dxfeed.myfundedfutures.com` as its history and trading endpoint
- recognize `MFFU` as an alternate provider/authentication name
- add focused provider resolution, endpoint, and enablement tests

## Why

MFFU traders using DeepCharts authenticate through MFFU's DxFeed service, but MFFU was not available in Deltalytix's DxFeed connection provider list. This enables users to select MFFU and use the existing automatic DxFeed synchronization flow.

## Validation

- `bun test lib/dxfeed-propfirms.test.ts lib/dxfeed-auth.test.ts lib/dxfeed-token.test.ts` — 13 passed, 0 failed
- `git diff --check` — passed
- Full typecheck/build not run because dependencies are absent in this worktree. A pre-install `bun audit` reported 15 unresolved high-severity advisories in the locked dependency tree, so repository installation-safety policy prevented installing those packages.