### PR TITLE
Remove outline borders from partner logos

### DIFF
--- a/app/[locale]/(landing)/components/partners.tsx
+++ b/app/[locale]/(landing)/components/partners.tsx
@@ -19,7 +19,7 @@ export default function Partners() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <span className="relative h-6 w-full max-w-[144px] opacity-65 outline outline-1 outline-black/5 transition-opacity duration-150 ease-out group-hover:opacity-100 dark:outline-white/5 md:h-5 md:max-w-[120px] md:opacity-55">
+          <span className="relative h-6 w-full max-w-[144px] opacity-65 transition-opacity duration-150 ease-out group-hover:opacity-100 md:h-5 md:max-w-[120px] md:opacity-55">
             <Image
               src="/logos/ninjatrader-ob.svg"
               alt="NinjaTrader"
@@ -31,7 +31,7 @@ export default function Partners() {
           </span>
         </a>
         <div className="flex min-h-20 items-center justify-center px-6">
-          <span className="relative h-6 w-full max-w-[402px] opacity-65 outline outline-1 outline-black/5 dark:outline-white/5 md:h-5 md:max-w-[335px] md:opacity-55">
+          <span className="relative h-6 w-full max-w-[402px] opacity-65 md:h-5 md:max-w-[335px] md:opacity-55">
             <Image
               src="/logos/rithmic-logo-black.png"
               alt="Rithmic"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the faint `outline` rings around the NinjaTrader and Rithmic logos in the landing partners section.

The selected logo wrapper had `outline outline-1 outline-black/5` (and the dark-mode counterpart), which showed as a thin gray border around each logo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-febd172d-a52e-4bca-8127-3624c6d39790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-febd172d-a52e-4bca-8127-3624c6d39790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

