### PR TITLE
Smooth-scroll hero Features CTA to #features

### DIFF
--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCurrentLocale, useI18n } from "@/locales/landing-client";
-import { localizeLandingHref } from "@/lib/landing-nav-paths";
+import { localizeLandingHref, scrollToLandingHash } from "@/lib/landing-nav-paths";
 import Link, { useLinkStatus } from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
@@ -117,6 +117,13 @@ export default function Hero() {
             </Link>
             <Link
               href="#features"
+              onClick={(event) => {
+                event.preventDefault();
+                scrollToLandingHash("features");
+                if (window.location.hash !== "#features") {
+                  window.history.pushState(null, "", "#features");
+                }
+              }}
               className="inline-flex h-12 items-center justify-center rounded-sm border border-black/20 px-6 text-sm font-medium transition-[colors,transform] hover:bg-black/5 active:scale-[0.96] dark:border-white/20 dark:hover:bg-white/5"
             >
               {t("landing.features.heading")} <span className="ml-3">↓</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Makes the hero **Features ↓** button smooth-scroll to `#features` instead of jumping.

Uses the existing `scrollToLandingHash` helper (same as landing navbar hash links), prevents the default instant hash jump, and updates the URL hash via `history.pushState`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-febd172d-a52e-4bca-8127-3624c6d39790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-febd172d-a52e-4bca-8127-3624c6d39790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

