### PR TITLE
Make landing chat demo text-only with tighter spacing

### DIFF
--- a/app/[locale]/(landing)/components/chat-feature.tsx
+++ b/app/[locale]/(landing)/components/chat-feature.tsx
@@ -76,7 +76,7 @@ function ConversationItem({
     item.stage === "response" || item.stage === "insight";
 
   return (
-    <div className="space-y-2" data-demo-turn={item.id}>
+    <div className="space-y-1.5" data-demo-turn={item.id}>
       {showQuestion && (
         <div
           className={cn(
@@ -95,25 +95,21 @@ function ConversationItem({
             isActive && "coach-message-enter",
           )}
         >
-          <div
-            className={cn(
-              "t-skel overflow-hidden rounded-xl bg-muted text-foreground",
-              responseRevealed && "is-revealed",
-            )}
-          >
-            <div className="t-skel-skeleton is-pulsing flex flex-col justify-center gap-2 px-3 py-3">
-              <span className="h-2 w-[88%] rounded-full bg-foreground/10" />
-              <span className="h-2 w-[68%] rounded-full bg-foreground/[0.08]" />
+          {!responseRevealed ? (
+            <div className="flex flex-col justify-center gap-2 rounded-xl bg-muted px-3 py-3">
+              <span className="h-2 w-[88%] animate-pulse rounded-full bg-foreground/10" />
+              <span className="h-2 w-[68%] animate-pulse rounded-full bg-foreground/[0.08]" />
               <span className="mt-0.5 text-[9px] text-muted-foreground sm:text-[10px]">
                 {t("landing.features.chat-feature.analyzing")}
               </span>
             </div>
-            <div className="t-skel-content box-border flex items-start p-3">
+          ) : (
+            <div className="rounded-xl bg-muted px-3 py-2 text-foreground">
               <p className="text-[10px] leading-relaxed sm:text-[11px]">
                 {responseText}
               </p>
             </div>
-          </div>
+          )}
         </div>
       )}
     </div>
@@ -333,7 +329,7 @@ export default function TradingChatAssistant({
             data-demo-stage={activeTurn.stage}
             className="min-h-0 flex-1 overflow-hidden overscroll-none"
           >
-            <div className="flex min-h-full flex-col justify-end gap-2 px-3.5 py-3 sm:px-5 sm:py-4">
+            <div className="flex min-h-full flex-col justify-end gap-1.5 px-3.5 py-3 sm:px-5 sm:py-4">
               <div className="flex items-center gap-2 text-[9px] text-muted-foreground sm:text-[10px]">
                 <Database className="size-3 shrink-0" />
                 <span className="truncate">
@@ -400,51 +396,6 @@ export default function TradingChatAssistant({
           animation: coach-caret 900ms ease-in-out infinite;
         }
 
-        .t-skel {
-          position: relative;
-        }
-
-        .t-skel-skeleton {
-          position: absolute;
-          inset: 0;
-        }
-
-        .t-skel-content {
-          position: relative;
-        }
-
-        .t-skel-skeleton {
-          z-index: 1;
-          opacity: 1;
-          filter: blur(0);
-          transition:
-            opacity 140ms cubic-bezier(0.23, 1, 0.32, 1),
-            filter 140ms cubic-bezier(0.23, 1, 0.32, 1);
-        }
-
-        .t-skel-content {
-          z-index: 2;
-          opacity: 0;
-          filter: blur(2px);
-          transition:
-            opacity 180ms cubic-bezier(0.23, 1, 0.32, 1) 120ms,
-            filter 180ms cubic-bezier(0.23, 1, 0.32, 1) 120ms;
-        }
-
-        .t-skel.is-revealed .t-skel-skeleton {
-          opacity: 0;
-          filter: blur(2px);
-        }
-
-        .t-skel.is-revealed .t-skel-content {
-          opacity: 1;
-          filter: blur(0);
-        }
-
-        .t-skel-skeleton.is-pulsing > * {
-          animation: t-skel-pulse 1000ms ease-in-out 1;
-        }
-
         @keyframes coach-enter {
           from {
             opacity: 0;
@@ -468,26 +419,10 @@ export default function TradingChatAssistant({
           }
         }
 
-        @keyframes t-skel-pulse {
-          0%,
-          100% {
-            opacity: 1;
-          }
-          50% {
-            opacity: 0.5;
-          }
-        }
-
         @media (prefers-reduced-motion: reduce) {
           .coach-message-enter,
-          .coach-caret,
-          .t-skel-skeleton.is-pulsing > * {
+          .coach-caret {
             animation: none;
-          }
-
-          .t-skel-skeleton,
-          .t-skel-content {
-            transition: none;
           }
         }
       `}</style>

--- a/app/[locale]/(landing)/components/chat-feature.tsx
+++ b/app/[locale]/(landing)/components/chat-feature.tsx
@@ -76,7 +76,7 @@ function ConversationItem({
     item.stage === "response" || item.stage === "insight";
 
   return (
-    <div className="space-y-2.5 sm:space-y-3" data-demo-turn={item.id}>
+    <div className="space-y-2" data-demo-turn={item.id}>
       {showQuestion && (
         <div
           className={cn(
@@ -108,7 +108,7 @@ function ConversationItem({
                 {t("landing.features.chat-feature.analyzing")}
               </span>
             </div>
-            <div className="t-skel-content box-border flex min-h-[96px] items-start p-3">
+            <div className="t-skel-content box-border flex items-start p-3">
               <p className="text-[10px] leading-relaxed sm:text-[11px]">
                 {responseText}
               </p>
@@ -333,7 +333,7 @@ export default function TradingChatAssistant({
             data-demo-stage={activeTurn.stage}
             className="min-h-0 flex-1 overflow-hidden overscroll-none"
           >
-            <div className="flex min-h-full flex-col justify-end gap-4 px-3.5 py-3 sm:px-5 sm:py-4">
+            <div className="flex min-h-full flex-col justify-end gap-2 px-3.5 py-3 sm:px-5 sm:py-4">
               <div className="flex items-center gap-2 text-[9px] text-muted-foreground sm:text-[10px]">
                 <Database className="size-3 shrink-0" />
                 <span className="truncate">

--- a/app/[locale]/(landing)/components/chat-feature.tsx
+++ b/app/[locale]/(landing)/components/chat-feature.tsx
@@ -8,8 +8,6 @@ import {
   useState,
 } from "react";
 import {
-  BarChart3,
-  Check,
   Database,
   Plus,
   RotateCcw,
@@ -33,10 +31,6 @@ type DemoStage =
 type ConversationTurn = {
   question: string;
   response: string;
-  metric: string;
-  value: string;
-  insight: string;
-  trend: "positive" | "negative";
 };
 
 type DemoTurn = {
@@ -60,48 +54,6 @@ const STAGE_TIMINGS: Record<DemoStage, number> = {
   insight: 3400,
 };
 
-function AnalysisCard({
-  turn,
-  t,
-}: {
-  turn: ConversationTurn;
-  t: ReturnType<typeof useI18n>;
-}) {
-  const isPositive = turn.trend === "positive";
-
-  return (
-    <div className="coach-insight overflow-hidden rounded-xl border border-border bg-background">
-      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2 text-[10px] font-medium text-muted-foreground sm:text-[11px]">
-          <BarChart3 className="size-3.5 shrink-0" />
-          <span className="truncate">{turn.metric}</span>
-        </div>
-        <span
-          className={cn(
-            "flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] sm:text-[9px]",
-            isPositive
-              ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-              : "bg-amber-500/10 text-amber-800 dark:text-amber-300",
-          )}
-        >
-          <Check className="size-2.5" />
-          {isPositive
-            ? t("landing.features.chat-feature.analysis.trends.positive")
-            : t("landing.features.chat-feature.analysis.trends.negative")}
-        </span>
-      </div>
-      <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3 px-3 py-2.5">
-        <span className="whitespace-nowrap text-lg font-medium tracking-[-0.03em] sm:text-xl">
-          {turn.value}
-        </span>
-        <p className="min-w-0 text-[9px] leading-relaxed text-muted-foreground sm:text-[10px]">
-          {turn.insight}
-        </p>
-      </div>
-    </div>
-  );
-}
-
 function ConversationItem({
   item,
   turn,
@@ -122,7 +74,6 @@ function ConversationItem({
     item.stage === "insight";
   const responseRevealed =
     item.stage === "response" || item.stage === "insight";
-  const insightRevealed = item.stage === "insight";
 
   return (
     <div className="space-y-2.5 sm:space-y-3" data-demo-turn={item.id}>
@@ -165,8 +116,6 @@ function ConversationItem({
           </div>
         </div>
       )}
-
-      {insightRevealed && <AnalysisCard turn={turn} t={t} />}
     </div>
   );
 }
@@ -179,28 +128,14 @@ export default function TradingChatAssistant({
     {
       question: t("landing.features.chat-feature.conversation.patterns"),
       response: t("landing.features.chat-feature.responses.patterns"),
-      metric: t("landing.features.chat-feature.analysis.revengeTrading.metric"),
-      value: t("landing.features.chat-feature.analysis.revengeTrading.value"),
-      insight: t(
-        "landing.features.chat-feature.analysis.revengeTrading.insight",
-      ),
-      trend: "negative",
     },
     {
       question: t("landing.features.chat-feature.conversation.analyze"),
       response: t("landing.features.chat-feature.responses.analyze"),
-      metric: t("landing.features.chat-feature.analysis.winRate.metric"),
-      value: t("landing.features.chat-feature.analysis.winRate.value"),
-      insight: t("landing.features.chat-feature.analysis.winRate.insight"),
-      trend: "positive",
     },
     {
       question: t("landing.features.chat-feature.conversation.riskManagement"),
       response: t("landing.features.chat-feature.responses.riskManagement"),
-      metric: t("landing.features.chat-feature.analysis.riskReward.metric"),
-      value: t("landing.features.chat-feature.analysis.riskReward.value"),
-      insight: t("landing.features.chat-feature.analysis.riskReward.insight"),
-      trend: "positive",
     },
   ];
 
@@ -456,14 +391,9 @@ export default function TradingChatAssistant({
       </div>
 
       <style jsx global>{`
-        .coach-message-enter,
-        .coach-insight {
+        .coach-message-enter {
           animation: coach-enter 240ms cubic-bezier(0.23, 1, 0.32, 1) both;
           will-change: transform, opacity;
-        }
-
-        .coach-insight {
-          animation-delay: 30ms;
         }
 
         .coach-caret {
@@ -550,7 +480,6 @@ export default function TradingChatAssistant({
 
         @media (prefers-reduced-motion: reduce) {
           .coach-message-enter,
-          .coach-insight,
           .coach-caret,
           .t-skel-skeleton.is-pulsing > * {
             animation: none;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the landing AI chat demo to feel like a real conversation:

- Removes the metric/analysis card (not a real chat element)
- Fixes oversized assistant bubbles: the faded thinking skeleton was still in document flow and roughly doubled bubble height, which looked like a huge gap between messages
- Thinking state is now a compact skeleton; replies size to text
- Tightens message spacing to `gap-1.5` / `space-y-1.5`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-febd172d-a52e-4bca-8127-3624c6d39790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-febd172d-a52e-4bca-8127-3624c6d39790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

