### PR TITLE
Auth panel: reuse dashboard charts with live micro-interactions

### DIFF
--- a/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
+++ b/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import Image from "next/image"
 import Link from "next/link"
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
 import { UserAuthForm } from "../components/user-auth-form"
+import { AuthTerminalAnimation } from "../components/auth-terminal-animation"
 import { Logo } from "@/components/logo"
 import { useI18n } from '@/locales/client'
 
@@ -15,10 +13,8 @@ export default function AuthenticationPageClient() {
   return (
     <div>
       <div className="flex relative h-screen flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
-        <div className="relative hidden h-full flex-col bg-gray-900 p-10 text-white dark:border-r lg:flex">
-          <div className="absolute inset-0 overflow-hidden">
-          <Image src={"/auth-background.jpeg"} width={928} height={1232} className="opacity-35 w-full" alt="Auth abstract image background"></Image>
-          </div>
+        <div className="relative hidden h-full flex-col overflow-hidden bg-[oklch(0.17_0_0)] p-10 text-white dark:border-r lg:flex">
+          <AuthTerminalAnimation />
           <div className="relative z-20 flex items-center text-lg font-medium">
             <Link href="/" className="flex items-center gap-2">
               <Logo className="w-10 h-10 fill-white"/>
@@ -30,7 +26,7 @@ export default function AuthenticationPageClient() {
               <p className="text-lg">
                 {t('authentication.testimonial')}
               </p>
-              <footer className="text-sm">{t('authentication.testimonialAuthor')}</footer>
+              <footer className="text-sm text-white/70">{t('authentication.testimonialAuthor')}</footer>
             </blockquote>
           </div>
         </div>

--- a/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
+++ b/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
@@ -1,11 +1,22 @@
 "use client";
 
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
 
+import DailyPnLChartEmbed, {
+  type EmbedTrade,
+} from "@/app/[locale]/embed/components/pnl-bar-chart";
+import TradeDistributionChartEmbed from "@/app/[locale]/embed/components/trade-distribution";
+import { SparkAreaChart } from "@/components/SparkChart";
+import { Tracker } from "@/components/ui/tracker";
 import { cn } from "@/lib/utils";
+import {
+  LOADING_MOCK_DATE_PNL,
+  LOADING_MOCK_EQUITY,
+} from "@/app/[locale]/dashboard/components/charts/chart-loading-skeleton";
 
-const BAR_COUNT = 28;
-const TICK_MS = 1100;
+const TICK_MS = 1600;
+const VISIBLE_DAYS = 12;
+
 const TICKER_ITEMS = [
   { symbol: "ES", change: "+0.42%", up: true },
   { symbol: "NQ", change: "+0.61%", up: true },
@@ -13,58 +24,105 @@ const TICKER_ITEMS = [
   { symbol: "RTY", change: "+0.27%", up: true },
   { symbol: "CL", change: "−0.54%", up: false },
   { symbol: "GC", change: "+0.33%", up: true },
-  { symbol: "EUR", change: "+0.09%", up: true },
-  { symbol: "BTC", change: "−1.12%", up: false },
 ] as const;
 
-type Bar = {
-  id: number;
-  value: number;
-};
-
-function seededBar(seed: number): number {
-  const wave = Math.sin(seed * 0.55) * 0.35;
-  const pulse = Math.cos(seed * 1.3) * 0.2;
-  const noise = ((seed * 17) % 10) / 25 - 0.2;
-  return Math.max(-1, Math.min(1, wave + pulse + noise));
+function seededPnl(seed: number) {
+  const wave = Math.sin(seed * 0.7) * 280;
+  const pulse = Math.cos(seed * 1.15) * 120;
+  const noise = ((seed * 37) % 21) * 8 - 80;
+  return Math.round(wave + pulse + noise);
 }
 
-function createBars(startId: number): Bar[] {
-  return Array.from({ length: BAR_COUNT }, (_, index) => ({
-    id: startId + index,
-    value: seededBar(startId + index),
-  }));
+function dateFromOffset(offset: number) {
+  const date = new Date("2025-01-06T14:30:00.000Z");
+  date.setUTCDate(date.getUTCDate() + offset);
+  return date.toISOString();
 }
 
-function formatPnl(value: number) {
-  const scaled = Math.round(value * 1840);
-  const sign = scaled > 0 ? "+" : "";
-  return `${sign}${scaled.toLocaleString("en-US")}`;
+function buildSeedTrades(dayCount: number): EmbedTrade[] {
+  const trades: EmbedTrade[] = [];
+  for (let day = 0; day < dayCount; day += 1) {
+    const dayPnl = LOADING_MOCK_DATE_PNL[day % LOADING_MOCK_DATE_PNL.length]?.pnl
+      ?? seededPnl(day);
+    const split = day % 3 === 0 ? 3 : 2;
+    for (let i = 0; i < split; i += 1) {
+      const slice = Math.round(dayPnl / split);
+      trades.push({
+        pnl: i === 0 ? dayPnl - slice * (split - 1) : slice,
+        commission: 2.5,
+        entryDate: dateFromOffset(day),
+        side: (day + i) % 2 === 0 ? "long" : "short",
+      });
+    }
+  }
+  return trades;
+}
+
+function appendLiveDay(trades: EmbedTrade[], dayIndex: number): EmbedTrade[] {
+  const pnl = seededPnl(dayIndex + 20);
+  const nextTrades = [
+    ...trades,
+    {
+      pnl: Math.round(pnl * 0.55),
+      commission: 2.5,
+      entryDate: dateFromOffset(dayIndex),
+      side: dayIndex % 2 === 0 ? "long" : ("short" as const),
+    },
+    {
+      pnl: Math.round(pnl * 0.45),
+      commission: 2.5,
+      entryDate: dateFromOffset(dayIndex),
+      side: dayIndex % 2 === 0 ? "short" : ("long" as const),
+    },
+  ];
+
+  const byDate = new Map<string, EmbedTrade[]>();
+  for (const trade of nextTrades) {
+    const key =
+      typeof trade.entryDate === "string"
+        ? trade.entryDate.slice(0, 10)
+        : trade.entryDate?.toISOString().slice(0, 10);
+    if (!key) continue;
+    const bucket = byDate.get(key) ?? [];
+    bucket.push(trade);
+    byDate.set(key, bucket);
+  }
+
+  const keptDates = [...byDate.keys()].sort().slice(-VISIBLE_DAYS);
+  return keptDates.flatMap((date) => byDate.get(date) ?? []);
 }
 
 export function AuthTerminalAnimation({ className }: { className?: string }) {
-  const [bars, setBars] = useState<Bar[]>(() => createBars(0));
-  const [clock, setClock] = useState("09:31:04");
+  const [trades, setTrades] = useState<EmbedTrade[]>(() =>
+    buildSeedTrades(VISIBLE_DAYS),
+  );
+  const [dayIndex, setDayIndex] = useState(VISIBLE_DAYS);
+  const [equityPoints, setEquityPoints] = useState(() =>
+    LOADING_MOCK_EQUITY.map((point) => ({
+      date: point.date,
+      equity: point.equity,
+    })),
+  );
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [hoveredStat, setHoveredStat] = useState<string | null>(null);
 
   const advanceFeed = useEffectEvent(() => {
-    setBars((previous) => {
-      const incomingId = (previous[previous.length - 1]?.id ?? 0) + 1;
-      return [
-        ...previous.slice(1),
-        { id: incomingId, value: seededBar(incomingId) },
-      ];
+    setDayIndex((current) => {
+      const next = current + 1;
+      setTrades((previous) => appendLiveDay(previous, next));
+      setEquityPoints((previous) => {
+        const last = previous[previous.length - 1]?.equity ?? 50000;
+        const delta = seededPnl(next) * 0.35;
+        return [
+          ...previous.slice(1),
+          {
+            date: dateFromOffset(next).slice(0, 10),
+            equity: Math.round(last + delta),
+          },
+        ];
+      });
+      return next;
     });
-
-    const now = new Date();
-    setClock(
-      now.toLocaleTimeString("en-GB", {
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hour12: false,
-      }),
-    );
   });
 
   useEffect(() => {
@@ -77,40 +135,74 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
 
   useEffect(() => {
     if (prefersReducedMotion) return;
-
     const timer = window.setInterval(advanceFeed, TICK_MS);
     return () => window.clearInterval(timer);
   }, [prefersReducedMotion]);
 
-  const latest = bars[bars.length - 1]?.value ?? 0;
-  const latestId = bars[bars.length - 1]?.id ?? 0;
-  const sessionPnl = bars.reduce((sum, bar) => sum + bar.value, 0);
-  const winRate =
-    bars.filter((bar) => bar.value >= 0).length / Math.max(bars.length, 1);
+  const trackerData = useMemo(() => {
+    const byDate = new Map<string, number>();
+    for (const trade of trades) {
+      if (!trade.entryDate) continue;
+      const key =
+        typeof trade.entryDate === "string"
+          ? trade.entryDate.slice(0, 10)
+          : trade.entryDate.toISOString().slice(0, 10);
+      byDate.set(key, (byDate.get(key) ?? 0) + trade.pnl - (trade.commission ?? 0));
+    }
+    return [...byDate.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, pnl]) => ({
+        key: date,
+        color:
+          pnl >= 0
+            ? "bg-[hsl(var(--chart-win))]"
+            : "bg-[hsl(var(--chart-loss))]",
+        tooltip: `${date}: ${pnl >= 0 ? "+" : ""}${Math.round(pnl)}`,
+        hoverEffect: true,
+      }));
+  }, [trades]);
+
+  const sessionPnl = useMemo(
+    () =>
+      trades.reduce(
+        (sum, trade) => sum + trade.pnl - (trade.commission ?? 0),
+        0,
+      ),
+    [trades],
+  );
+
+  const winRate = useMemo(() => {
+    if (trades.length === 0) return 0;
+    const wins = trades.filter(
+      (trade) => trade.pnl - (trade.commission ?? 0) > 0,
+    ).length;
+    return Math.round((wins / trades.length) * 100);
+  }, [trades]);
+
+  const animate = !prefersReducedMotion;
 
   return (
     <div
-      aria-hidden
       className={cn(
-        "pointer-events-none absolute inset-0 overflow-hidden text-[oklch(0.93_0_0)]",
+        "dark pointer-events-auto absolute inset-0 overflow-hidden text-foreground",
         className,
       )}
     >
       <div className="absolute inset-0 bg-[oklch(0.17_0_0)]" />
       <div
-        className="absolute inset-0 opacity-[0.35]"
+        className="absolute inset-0 opacity-30"
         style={{
           backgroundImage:
-            "linear-gradient(to right, oklch(1 0 0 / 0.05) 1px, transparent 1px), linear-gradient(to bottom, oklch(1 0 0 / 0.05) 1px, transparent 1px)",
+            "linear-gradient(to right, oklch(1 0 0 / 0.04) 1px, transparent 1px), linear-gradient(to bottom, oklch(1 0 0 / 0.04) 1px, transparent 1px)",
           backgroundSize: "48px 48px",
         }}
       />
 
-      <div className="absolute inset-x-0 top-24 border-y border-white/[0.08] bg-[oklch(0.2_0_0)]/80">
+      <div className="absolute inset-x-0 top-24 border-y border-white/[0.08] bg-background/40 backdrop-blur-[2px]">
         <div
           className={cn(
-            "flex w-max gap-8 px-6 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-white/55",
-            !prefersReducedMotion && "auth-ticker-scroll",
+            "flex w-max gap-8 px-6 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground",
+            animate && "auth-ticker-scroll",
           )}
         >
           {[...TICKER_ITEMS, ...TICKER_ITEMS].map((item, index) => (
@@ -119,8 +211,8 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
               <span
                 className={
                   item.up
-                    ? "text-[oklch(0.78_0.12_155)]"
-                    : "text-[oklch(0.72_0.14_25)]"
+                    ? "text-[hsl(var(--chart-win))]"
+                    : "text-[hsl(var(--chart-loss))]"
                 }
               >
                 {item.change}
@@ -130,113 +222,122 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
         </div>
       </div>
 
-      <div className="absolute inset-x-8 top-40 bottom-36 flex flex-col gap-4 sm:inset-x-10">
-        <div className="flex items-end justify-between gap-4 border-b border-white/[0.08] pb-3">
+      <div className="absolute inset-x-6 top-36 bottom-32 flex min-h-0 flex-col gap-3 sm:inset-x-8">
+        <div className="flex items-center justify-between gap-3">
           <div>
-            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/45">
-              Session tape
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+              Live dashboard preview
             </p>
-            <p className="mt-1 text-2xl font-normal tracking-[-0.04em] text-[oklch(0.82_0.12_75)]">
-              DELT / LIVE
+            <p className="mt-1 text-xl tracking-[-0.04em] text-[oklch(0.82_0.12_75)]">
+              DELT / SESSION
             </p>
           </div>
-          <div className="text-right font-mono text-[10px] uppercase tracking-[0.12em] text-white/45">
-            <p>UTC {clock}</p>
-            <p
+          <div className="flex items-center gap-2 rounded-sm border border-white/10 bg-card/60 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-white/20 hover:text-foreground">
+            <span
               className={cn(
-                "mt-1 text-sm tracking-normal tabular-nums",
-                latest >= 0
-                  ? "text-[oklch(0.78_0.12_155)]"
-                  : "text-[oklch(0.72_0.14_25)]",
+                "size-1.5 rounded-full bg-[hsl(var(--chart-win))]",
+                animate && "auth-live-pulse",
               )}
-            >
-              {formatPnl(latest)}
-            </p>
+            />
+            Live
           </div>
         </div>
 
-        <div className="relative flex min-h-0 flex-1 flex-col rounded-sm border border-white/[0.08] bg-[oklch(0.19_0_0)]/70 p-4">
-          <div className="mb-3 flex shrink-0 items-center justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-white/40">
-            <span>Daily P&amp;L</span>
-            <span>28 bars</span>
-          </div>
+        <DailyPnLChartEmbed
+          trades={trades}
+          animated={animate}
+          showInfo={false}
+          className="auth-panel-enter min-h-0 flex-1 !h-auto rounded-sm border-white/10 bg-card/80 shadow-none backdrop-blur-[2px]"
+        />
 
-          <div className="relative min-h-0 flex-1">
-            <div className="absolute inset-0 flex flex-col justify-between pointer-events-none">
-              {[0, 1, 2, 3].map((line) => (
-                <div key={line} className="border-t border-white/[0.06]" />
+        <div className="grid min-h-[168px] grid-cols-5 gap-3">
+          <TradeDistributionChartEmbed
+            trades={trades}
+            animated={animate}
+            showInfo={false}
+            className="auth-panel-enter col-span-2 !h-full rounded-sm border-white/10 bg-card/80 shadow-none [animation-delay:80ms]"
+          />
+
+          <div className="auth-panel-enter col-span-3 flex h-full flex-col gap-3 [animation-delay:140ms]">
+            <div className="group flex min-h-0 flex-1 flex-col rounded-sm border border-white/10 bg-card/80 p-3 transition-[border-color,transform] duration-300 hover:-translate-y-0.5 hover:border-white/20">
+              <div className="mb-2 flex items-center justify-between">
+                <p className="text-sm font-medium">Equity</p>
+                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                  Spark
+                </p>
+              </div>
+              <div className="min-h-0 flex-1">
+                <SparkAreaChart
+                  data={equityPoints}
+                  index="date"
+                  categories={["equity"]}
+                  colors={{ equity: "hsl(var(--chart-win))" }}
+                  height={72}
+                  animated={animate}
+                  className="h-[72px]"
+                />
+              </div>
+              <Tracker
+                className="mt-3 h-6"
+                data={trackerData}
+                hoverEffect
+                defaultBackgroundColor="bg-muted"
+              />
+            </div>
+
+            <div className="grid grid-cols-3 gap-2">
+              {[
+                {
+                  id: "session",
+                  label: "Session",
+                  value: `${sessionPnl >= 0 ? "+" : ""}${Math.round(sessionPnl).toLocaleString("en-US")}`,
+                  tone: sessionPnl >= 0 ? "win" : "loss",
+                },
+                {
+                  id: "winrate",
+                  label: "Win rate",
+                  value: `${winRate}%`,
+                  tone: winRate >= 50 ? "win" : "loss",
+                },
+                {
+                  id: "trades",
+                  label: "Trades",
+                  value: String(trades.length),
+                  tone: "amber",
+                },
+              ].map((stat) => (
+                <button
+                  key={stat.id}
+                  type="button"
+                  onMouseEnter={() => setHoveredStat(stat.id)}
+                  onMouseLeave={() => setHoveredStat(null)}
+                  className={cn(
+                    "rounded-sm border border-white/10 bg-card/80 px-2.5 py-2 text-left transition-[border-color,transform,background-color] duration-200 hover:-translate-y-0.5 hover:border-white/20 active:scale-[0.98]",
+                    hoveredStat === stat.id && "bg-card",
+                  )}
+                >
+                  <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
+                    {stat.label}
+                  </p>
+                  <p
+                    className={cn(
+                      "mt-1 font-mono text-sm tabular-nums tracking-tight",
+                      stat.tone === "win" && "text-[hsl(var(--chart-win))]",
+                      stat.tone === "loss" && "text-[hsl(var(--chart-loss))]",
+                      stat.tone === "amber" && "text-[oklch(0.82_0.12_75)]",
+                    )}
+                  >
+                    {stat.value}
+                  </p>
+                </button>
               ))}
             </div>
-
-            <div className="absolute inset-0 flex items-stretch gap-[3px] px-1 pb-1 pt-2">
-              {bars.map((bar) => {
-                const magnitude = `${10 + Math.abs(bar.value) * 38}%`;
-                const positive = bar.value >= 0;
-                return (
-                  <div
-                    key={bar.id}
-                    className="relative flex min-h-0 min-w-0 flex-1 justify-center"
-                  >
-                    <div className="absolute inset-x-[10%] top-1/2 h-px bg-white/[0.12]" />
-                    <div
-                      className={cn(
-                        "absolute inset-x-[12%] max-w-[14px] rounded-[1px] transition-[height,background-color] duration-700 ease-out motion-reduce:transition-none",
-                        positive
-                          ? "bottom-1/2 origin-bottom bg-[oklch(0.78_0.12_155)]"
-                          : "top-1/2 origin-top bg-[oklch(0.72_0.14_25)]",
-                        !prefersReducedMotion && "auth-bar-enter",
-                      )}
-                      style={{ height: magnitude }}
-                    />
-                  </div>
-                );
-              })}
-            </div>
           </div>
-        </div>
-
-        <div className="grid grid-cols-3 gap-3">
-          {[
-            {
-              label: "Session",
-              value: formatPnl(sessionPnl / 4),
-              up: sessionPnl >= 0,
-            },
-            {
-              label: "Win rate",
-              value: `${Math.round(winRate * 100)}%`,
-              up: winRate >= 0.5,
-            },
-            {
-              label: "Trades",
-              value: String(84 + (latestId % 17)),
-              up: true,
-            },
-          ].map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-sm border border-white/[0.08] bg-[oklch(0.19_0_0)]/70 px-3 py-2.5"
-            >
-              <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-white/40">
-                {stat.label}
-              </p>
-              <p
-                className={cn(
-                  "mt-1 font-mono text-sm tabular-nums tracking-tight",
-                  stat.up
-                    ? "text-[oklch(0.82_0.12_75)]"
-                    : "text-[oklch(0.72_0.14_25)]",
-                )}
-              >
-                {stat.value}
-              </p>
-            </div>
-          ))}
         </div>
       </div>
 
-      <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/80 to-transparent" />
-      <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/85 to-transparent" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-36 bg-gradient-to-b from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/85 to-transparent" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-44 bg-gradient-to-t from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/90 to-transparent" />
 
       <style jsx global>{`
         @keyframes auth-ticker-scroll {
@@ -252,24 +353,41 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
           animation: auth-ticker-scroll 28s linear infinite;
         }
 
-        @keyframes auth-bar-enter {
-          from {
-            opacity: 0.35;
-            transform: scaleY(0.55);
-          }
-          to {
+        @keyframes auth-live-pulse {
+          0%,
+          100% {
             opacity: 1;
-            transform: scaleY(1);
+            transform: scale(1);
+          }
+          50% {
+            opacity: 0.45;
+            transform: scale(0.85);
           }
         }
 
-        .auth-bar-enter {
-          animation: auth-bar-enter 520ms cubic-bezier(0.23, 1, 0.32, 1) both;
+        .auth-live-pulse {
+          animation: auth-live-pulse 1.6s ease-in-out infinite;
+        }
+
+        @keyframes auth-panel-enter {
+          from {
+            opacity: 0;
+            transform: translateY(8px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+
+        .auth-panel-enter {
+          animation: auth-panel-enter 520ms cubic-bezier(0.23, 1, 0.32, 1) both;
         }
 
         @media (prefers-reduced-motion: reduce) {
           .auth-ticker-scroll,
-          .auth-bar-enter {
+          .auth-live-pulse,
+          .auth-panel-enter {
             animation: none;
           }
         }

--- a/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
+++ b/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useEffect, useEffectEvent, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+const BAR_COUNT = 28;
+const TICK_MS = 1100;
+const TICKER_ITEMS = [
+  { symbol: "ES", change: "+0.42%", up: true },
+  { symbol: "NQ", change: "+0.61%", up: true },
+  { symbol: "YM", change: "−0.18%", up: false },
+  { symbol: "RTY", change: "+0.27%", up: true },
+  { symbol: "CL", change: "−0.54%", up: false },
+  { symbol: "GC", change: "+0.33%", up: true },
+  { symbol: "EUR", change: "+0.09%", up: true },
+  { symbol: "BTC", change: "−1.12%", up: false },
+] as const;
+
+type Bar = {
+  id: number;
+  value: number;
+};
+
+function seededBar(seed: number): number {
+  const wave = Math.sin(seed * 0.55) * 0.35;
+  const pulse = Math.cos(seed * 1.3) * 0.2;
+  const noise = ((seed * 17) % 10) / 25 - 0.2;
+  return Math.max(-1, Math.min(1, wave + pulse + noise));
+}
+
+function createBars(startId: number): Bar[] {
+  return Array.from({ length: BAR_COUNT }, (_, index) => ({
+    id: startId + index,
+    value: seededBar(startId + index),
+  }));
+}
+
+function formatPnl(value: number) {
+  const scaled = Math.round(value * 1840);
+  const sign = scaled > 0 ? "+" : "";
+  return `${sign}${scaled.toLocaleString("en-US")}`;
+}
+
+export function AuthTerminalAnimation({ className }: { className?: string }) {
+  const [bars, setBars] = useState<Bar[]>(() => createBars(0));
+  const [clock, setClock] = useState("09:31:04");
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  const advanceFeed = useEffectEvent(() => {
+    setBars((previous) => {
+      const incomingId = (previous[previous.length - 1]?.id ?? 0) + 1;
+      return [
+        ...previous.slice(1),
+        { id: incomingId, value: seededBar(incomingId) },
+      ];
+    });
+
+    const now = new Date();
+    setClock(
+      now.toLocaleTimeString("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+      }),
+    );
+  });
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setPrefersReducedMotion(media.matches);
+    sync();
+    media.addEventListener("change", sync);
+    return () => media.removeEventListener("change", sync);
+  }, []);
+
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+
+    const timer = window.setInterval(advanceFeed, TICK_MS);
+    return () => window.clearInterval(timer);
+  }, [prefersReducedMotion]);
+
+  const latest = bars[bars.length - 1]?.value ?? 0;
+  const latestId = bars[bars.length - 1]?.id ?? 0;
+  const sessionPnl = bars.reduce((sum, bar) => sum + bar.value, 0);
+  const winRate =
+    bars.filter((bar) => bar.value >= 0).length / Math.max(bars.length, 1);
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute inset-0 overflow-hidden text-[oklch(0.93_0_0)]",
+        className,
+      )}
+    >
+      <div className="absolute inset-0 bg-[oklch(0.17_0_0)]" />
+      <div
+        className="absolute inset-0 opacity-[0.35]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, oklch(1 0 0 / 0.05) 1px, transparent 1px), linear-gradient(to bottom, oklch(1 0 0 / 0.05) 1px, transparent 1px)",
+          backgroundSize: "48px 48px",
+        }}
+      />
+
+      <div className="absolute inset-x-0 top-24 border-y border-white/[0.08] bg-[oklch(0.2_0_0)]/80">
+        <div
+          className={cn(
+            "flex w-max gap-8 px-6 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-white/55",
+            !prefersReducedMotion && "auth-ticker-scroll",
+          )}
+        >
+          {[...TICKER_ITEMS, ...TICKER_ITEMS].map((item, index) => (
+            <span key={`${item.symbol}-${index}`} className="flex items-center gap-2">
+              <span className="text-[oklch(0.82_0.12_75)]">{item.symbol}</span>
+              <span
+                className={
+                  item.up
+                    ? "text-[oklch(0.78_0.12_155)]"
+                    : "text-[oklch(0.72_0.14_25)]"
+                }
+              >
+                {item.change}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="absolute inset-x-8 top-40 bottom-36 flex flex-col gap-4 sm:inset-x-10">
+        <div className="flex items-end justify-between gap-4 border-b border-white/[0.08] pb-3">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/45">
+              Session tape
+            </p>
+            <p className="mt-1 text-2xl font-normal tracking-[-0.04em] text-[oklch(0.82_0.12_75)]">
+              DELT / LIVE
+            </p>
+          </div>
+          <div className="text-right font-mono text-[10px] uppercase tracking-[0.12em] text-white/45">
+            <p>UTC {clock}</p>
+            <p
+              className={cn(
+                "mt-1 text-sm tracking-normal tabular-nums",
+                latest >= 0
+                  ? "text-[oklch(0.78_0.12_155)]"
+                  : "text-[oklch(0.72_0.14_25)]",
+              )}
+            >
+              {formatPnl(latest)}
+            </p>
+          </div>
+        </div>
+
+        <div className="relative flex min-h-0 flex-1 flex-col rounded-sm border border-white/[0.08] bg-[oklch(0.19_0_0)]/70 p-4">
+          <div className="mb-3 flex shrink-0 items-center justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-white/40">
+            <span>Daily P&amp;L</span>
+            <span>28 bars</span>
+          </div>
+
+          <div className="relative min-h-0 flex-1">
+            <div className="absolute inset-0 flex flex-col justify-between pointer-events-none">
+              {[0, 1, 2, 3].map((line) => (
+                <div key={line} className="border-t border-white/[0.06]" />
+              ))}
+            </div>
+
+            <div className="absolute inset-0 flex items-stretch gap-[3px] px-1 pb-1 pt-2">
+              {bars.map((bar) => {
+                const height = `${12 + Math.abs(bar.value) * 82}%`;
+                const positive = bar.value >= 0;
+                return (
+                  <div
+                    key={bar.id}
+                    className="flex min-h-0 min-w-0 flex-1 items-end justify-center"
+                  >
+                    <div
+                      className={cn(
+                        "w-full max-w-[14px] origin-bottom rounded-[1px] transition-[height,background-color] duration-700 ease-out motion-reduce:transition-none",
+                        positive
+                          ? "bg-[oklch(0.78_0.12_155)]"
+                          : "bg-[oklch(0.72_0.14_25)]",
+                        !prefersReducedMotion && "auth-bar-enter",
+                      )}
+                      style={{ height }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          {[
+            {
+              label: "Session",
+              value: formatPnl(sessionPnl / 4),
+              up: sessionPnl >= 0,
+            },
+            {
+              label: "Win rate",
+              value: `${Math.round(winRate * 100)}%`,
+              up: winRate >= 0.5,
+            },
+            {
+              label: "Trades",
+              value: String(84 + (latestId % 17)),
+              up: true,
+            },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-sm border border-white/[0.08] bg-[oklch(0.19_0_0)]/70 px-3 py-2.5"
+            >
+              <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-white/40">
+                {stat.label}
+              </p>
+              <p
+                className={cn(
+                  "mt-1 font-mono text-sm tabular-nums tracking-tight",
+                  stat.up
+                    ? "text-[oklch(0.82_0.12_75)]"
+                    : "text-[oklch(0.72_0.14_25)]",
+                )}
+              >
+                {stat.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/80 to-transparent" />
+      <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/85 to-transparent" />
+
+      <style jsx global>{`
+        @keyframes auth-ticker-scroll {
+          from {
+            transform: translateX(0);
+          }
+          to {
+            transform: translateX(-50%);
+          }
+        }
+
+        .auth-ticker-scroll {
+          animation: auth-ticker-scroll 28s linear infinite;
+        }
+
+        @keyframes auth-bar-enter {
+          from {
+            opacity: 0.35;
+            transform: scaleY(0.72);
+          }
+          to {
+            opacity: 1;
+            transform: scaleY(1);
+          }
+        }
+
+        .auth-bar-enter {
+          transform-origin: bottom;
+          animation: auth-bar-enter 520ms cubic-bezier(0.23, 1, 0.32, 1) both;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .auth-ticker-scroll,
+          .auth-bar-enter {
+            animation: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
+++ b/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import DailyPnLChartEmbed, {
   type EmbedTrade,
@@ -9,135 +9,67 @@ import TradeDistributionChartEmbed from "@/app/[locale]/embed/components/trade-d
 import { SparkAreaChart } from "@/components/SparkChart";
 import { Tracker } from "@/components/ui/tracker";
 import { cn } from "@/lib/utils";
-import {
-  LOADING_MOCK_DATE_PNL,
-  LOADING_MOCK_EQUITY,
-} from "@/app/[locale]/dashboard/components/charts/chart-loading-skeleton";
 
-const TICK_MS = 1600;
 const VISIBLE_DAYS = 12;
 
-const TICKER_ITEMS = [
-  { symbol: "ES", change: "+0.42%", up: true },
-  { symbol: "NQ", change: "+0.61%", up: true },
-  { symbol: "YM", change: "−0.18%", up: false },
-  { symbol: "RTY", change: "+0.27%", up: true },
-  { symbol: "CL", change: "−0.54%", up: false },
-  { symbol: "GC", change: "+0.33%", up: true },
-] as const;
-
-function seededPnl(seed: number) {
-  const wave = Math.sin(seed * 0.7) * 280;
-  const pulse = Math.cos(seed * 1.15) * 120;
-  const noise = ((seed * 37) % 21) * 8 - 80;
-  return Math.round(wave + pulse + noise);
+function randomBetween(min: number, max: number) {
+  return min + Math.random() * (max - min);
 }
 
 function dateFromOffset(offset: number) {
-  const date = new Date("2025-01-06T14:30:00.000Z");
-  date.setUTCDate(date.getUTCDate() + offset);
+  const date = new Date();
+  date.setUTCHours(15, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() - (VISIBLE_DAYS - 1 - offset));
   return date.toISOString();
 }
 
-function buildSeedTrades(dayCount: number): EmbedTrade[] {
+function buildRandomTrades(dayCount: number): EmbedTrade[] {
   const trades: EmbedTrade[] = [];
+
   for (let day = 0; day < dayCount; day += 1) {
-    const dayPnl = LOADING_MOCK_DATE_PNL[day % LOADING_MOCK_DATE_PNL.length]?.pnl
-      ?? seededPnl(day);
-    const split = day % 3 === 0 ? 3 : 2;
+    const dayPnl = Math.round(randomBetween(-420, 640));
+    const split = Math.random() > 0.55 ? 3 : 2;
+
     for (let i = 0; i < split; i += 1) {
       const slice = Math.round(dayPnl / split);
       trades.push({
         pnl: i === 0 ? dayPnl - slice * (split - 1) : slice,
-        commission: 2.5,
+        commission: Number(randomBetween(1.5, 4.5).toFixed(2)),
         entryDate: dateFromOffset(day),
-        side: (day + i) % 2 === 0 ? "long" : "short",
+        side: Math.random() > 0.5 ? "long" : "short",
       });
     }
   }
+
   return trades;
 }
 
-function appendLiveDay(trades: EmbedTrade[], dayIndex: number): EmbedTrade[] {
-  const pnl = seededPnl(dayIndex + 20);
-  const nextTrades = [
-    ...trades,
-    {
-      pnl: Math.round(pnl * 0.55),
-      commission: 2.5,
-      entryDate: dateFromOffset(dayIndex),
-      side: dayIndex % 2 === 0 ? "long" : ("short" as const),
-    },
-    {
-      pnl: Math.round(pnl * 0.45),
-      commission: 2.5,
-      entryDate: dateFromOffset(dayIndex),
-      side: dayIndex % 2 === 0 ? "short" : ("long" as const),
-    },
-  ];
-
-  const byDate = new Map<string, EmbedTrade[]>();
-  for (const trade of nextTrades) {
+function buildRandomEquity(trades: EmbedTrade[]) {
+  const byDate = new Map<string, number>();
+  for (const trade of trades) {
+    if (!trade.entryDate) continue;
     const key =
       typeof trade.entryDate === "string"
         ? trade.entryDate.slice(0, 10)
-        : trade.entryDate?.toISOString().slice(0, 10);
-    if (!key) continue;
-    const bucket = byDate.get(key) ?? [];
-    bucket.push(trade);
-    byDate.set(key, bucket);
+        : trade.entryDate.toISOString().slice(0, 10);
+    byDate.set(
+      key,
+      (byDate.get(key) ?? 0) + trade.pnl - (trade.commission ?? 0),
+    );
   }
 
-  const keptDates = [...byDate.keys()].sort().slice(-VISIBLE_DAYS);
-  return keptDates.flatMap((date) => byDate.get(date) ?? []);
+  let equity = Math.round(randomBetween(48000, 56000));
+  return [...byDate.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, pnl]) => {
+      equity += pnl;
+      return { date, equity: Math.round(equity) };
+    });
 }
 
 export function AuthTerminalAnimation({ className }: { className?: string }) {
-  const [trades, setTrades] = useState<EmbedTrade[]>(() =>
-    buildSeedTrades(VISIBLE_DAYS),
-  );
-  const [dayIndex, setDayIndex] = useState(VISIBLE_DAYS);
-  const [equityPoints, setEquityPoints] = useState(() =>
-    LOADING_MOCK_EQUITY.map((point) => ({
-      date: point.date,
-      equity: point.equity,
-    })),
-  );
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [hoveredStat, setHoveredStat] = useState<string | null>(null);
-
-  const advanceFeed = useEffectEvent(() => {
-    setDayIndex((current) => {
-      const next = current + 1;
-      setTrades((previous) => appendLiveDay(previous, next));
-      setEquityPoints((previous) => {
-        const last = previous[previous.length - 1]?.equity ?? 50000;
-        const delta = seededPnl(next) * 0.35;
-        return [
-          ...previous.slice(1),
-          {
-            date: dateFromOffset(next).slice(0, 10),
-            equity: Math.round(last + delta),
-          },
-        ];
-      });
-      return next;
-    });
-  });
-
-  useEffect(() => {
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const sync = () => setPrefersReducedMotion(media.matches);
-    sync();
-    media.addEventListener("change", sync);
-    return () => media.removeEventListener("change", sync);
-  }, []);
-
-  useEffect(() => {
-    if (prefersReducedMotion) return;
-    const timer = window.setInterval(advanceFeed, TICK_MS);
-    return () => window.clearInterval(timer);
-  }, [prefersReducedMotion]);
+  const [trades] = useState(() => buildRandomTrades(VISIBLE_DAYS));
+  const equityPoints = useMemo(() => buildRandomEquity(trades), [trades]);
 
   const trackerData = useMemo(() => {
     const byDate = new Map<string, number>();
@@ -147,8 +79,12 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
         typeof trade.entryDate === "string"
           ? trade.entryDate.slice(0, 10)
           : trade.entryDate.toISOString().slice(0, 10);
-      byDate.set(key, (byDate.get(key) ?? 0) + trade.pnl - (trade.commission ?? 0));
+      byDate.set(
+        key,
+        (byDate.get(key) ?? 0) + trade.pnl - (trade.commission ?? 0),
+      );
     }
+
     return [...byDate.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([date, pnl]) => ({
@@ -158,7 +94,6 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
             ? "bg-[hsl(var(--chart-win))]"
             : "bg-[hsl(var(--chart-loss))]",
         tooltip: `${date}: ${pnl >= 0 ? "+" : ""}${Math.round(pnl)}`,
-        hoverEffect: true,
       }));
   }, [trades]);
 
@@ -179,12 +114,11 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
     return Math.round((wins / trades.length) * 100);
   }, [trades]);
 
-  const animate = !prefersReducedMotion;
-
   return (
     <div
+      aria-hidden
       className={cn(
-        "dark pointer-events-auto absolute inset-0 overflow-hidden text-foreground",
+        "dark pointer-events-none absolute inset-0 overflow-hidden text-foreground",
         className,
       )}
     >
@@ -198,68 +132,22 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
         }}
       />
 
-      <div className="absolute inset-x-0 top-24 border-y border-white/[0.08] bg-background/40 backdrop-blur-[2px]">
-        <div
-          className={cn(
-            "flex w-max gap-8 px-6 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground",
-            animate && "auth-ticker-scroll",
-          )}
-        >
-          {[...TICKER_ITEMS, ...TICKER_ITEMS].map((item, index) => (
-            <span key={`${item.symbol}-${index}`} className="flex items-center gap-2">
-              <span className="text-[oklch(0.82_0.12_75)]">{item.symbol}</span>
-              <span
-                className={
-                  item.up
-                    ? "text-[hsl(var(--chart-win))]"
-                    : "text-[hsl(var(--chart-loss))]"
-                }
-              >
-                {item.change}
-              </span>
-            </span>
-          ))}
-        </div>
-      </div>
-
-      <div className="absolute inset-x-6 top-36 bottom-32 flex min-h-0 flex-col gap-3 sm:inset-x-8">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-              Live dashboard preview
-            </p>
-            <p className="mt-1 text-xl tracking-[-0.04em] text-[oklch(0.82_0.12_75)]">
-              DELT / SESSION
-            </p>
-          </div>
-          <div className="flex items-center gap-2 rounded-sm border border-white/10 bg-card/60 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-white/20 hover:text-foreground">
-            <span
-              className={cn(
-                "size-1.5 rounded-full bg-[hsl(var(--chart-win))]",
-                animate && "auth-live-pulse",
-              )}
-            />
-            Live
-          </div>
-        </div>
-
+      <div className="absolute inset-x-6 top-28 bottom-32 flex min-h-0 flex-col gap-3 sm:inset-x-8 sm:top-32">
         <DailyPnLChartEmbed
           trades={trades}
-          animated={animate}
           showInfo={false}
-          className="auth-panel-enter min-h-0 flex-1 !h-auto rounded-sm border-white/10 bg-card/80 shadow-none backdrop-blur-[2px]"
+          className="min-h-0 flex-1 !h-auto rounded-sm border-white/10 bg-card/80 shadow-none"
         />
 
         <div className="grid min-h-[168px] grid-cols-5 gap-3">
           <TradeDistributionChartEmbed
             trades={trades}
-            animated={animate}
             showInfo={false}
-            className="auth-panel-enter col-span-2 !h-full rounded-sm border-white/10 bg-card/80 shadow-none [animation-delay:80ms]"
+            className="col-span-2 !h-full rounded-sm border-white/10 bg-card/80 shadow-none"
           />
 
-          <div className="auth-panel-enter col-span-3 flex h-full flex-col gap-3 [animation-delay:140ms]">
-            <div className="group flex min-h-0 flex-1 flex-col rounded-sm border border-white/10 bg-card/80 p-3 transition-[border-color,transform] duration-300 hover:-translate-y-0.5 hover:border-white/20">
+          <div className="col-span-3 flex h-full flex-col gap-3">
+            <div className="flex min-h-0 flex-1 flex-col rounded-sm border border-white/10 bg-card/80 p-3">
               <div className="mb-2 flex items-center justify-between">
                 <p className="text-sm font-medium">Equity</p>
                 <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
@@ -273,14 +161,12 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
                   categories={["equity"]}
                   colors={{ equity: "hsl(var(--chart-win))" }}
                   height={72}
-                  animated={animate}
                   className="h-[72px]"
                 />
               </div>
               <Tracker
                 className="mt-3 h-6"
                 data={trackerData}
-                hoverEffect
                 defaultBackgroundColor="bg-muted"
               />
             </div>
@@ -306,15 +192,9 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
                   tone: "amber",
                 },
               ].map((stat) => (
-                <button
+                <div
                   key={stat.id}
-                  type="button"
-                  onMouseEnter={() => setHoveredStat(stat.id)}
-                  onMouseLeave={() => setHoveredStat(null)}
-                  className={cn(
-                    "rounded-sm border border-white/10 bg-card/80 px-2.5 py-2 text-left transition-[border-color,transform,background-color] duration-200 hover:-translate-y-0.5 hover:border-white/20 active:scale-[0.98]",
-                    hoveredStat === stat.id && "bg-card",
-                  )}
+                  className="rounded-sm border border-white/10 bg-card/80 px-2.5 py-2"
                 >
                   <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
                     {stat.label}
@@ -329,69 +209,15 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
                   >
                     {stat.value}
                   </p>
-                </button>
+                </div>
               ))}
             </div>
           </div>
         </div>
       </div>
 
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-36 bg-gradient-to-b from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/85 to-transparent" />
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-44 bg-gradient-to-t from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/90 to-transparent" />
-
-      <style jsx global>{`
-        @keyframes auth-ticker-scroll {
-          from {
-            transform: translateX(0);
-          }
-          to {
-            transform: translateX(-50%);
-          }
-        }
-
-        .auth-ticker-scroll {
-          animation: auth-ticker-scroll 28s linear infinite;
-        }
-
-        @keyframes auth-live-pulse {
-          0%,
-          100% {
-            opacity: 1;
-            transform: scale(1);
-          }
-          50% {
-            opacity: 0.45;
-            transform: scale(0.85);
-          }
-        }
-
-        .auth-live-pulse {
-          animation: auth-live-pulse 1.6s ease-in-out infinite;
-        }
-
-        @keyframes auth-panel-enter {
-          from {
-            opacity: 0;
-            transform: translateY(8px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-
-        .auth-panel-enter {
-          animation: auth-panel-enter 520ms cubic-bezier(0.23, 1, 0.32, 1) both;
-        }
-
-        @media (prefers-reduced-motion: reduce) {
-          .auth-ticker-scroll,
-          .auth-live-pulse,
-          .auth-panel-enter {
-            animation: none;
-          }
-        }
-      `}</style>
+      <div className="absolute inset-x-0 top-0 h-36 bg-gradient-to-b from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/85 to-transparent" />
+      <div className="absolute inset-x-0 bottom-0 h-44 bg-gradient-to-t from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/90 to-transparent" />
     </div>
   );
 }

--- a/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
+++ b/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import DailyPnLChartEmbed, {
   type EmbedTrade,
@@ -11,6 +11,7 @@ import { Tracker } from "@/components/ui/tracker";
 import { cn } from "@/lib/utils";
 
 const VISIBLE_DAYS = 12;
+const STORAGE_KEY = "deltalytix.auth-terminal.demo-trades";
 
 function randomBetween(min: number, max: number) {
   return min + Math.random() * (max - min);
@@ -44,7 +45,27 @@ function buildRandomTrades(dayCount: number): EmbedTrade[] {
   return trades;
 }
 
-function buildRandomEquity(trades: EmbedTrade[]) {
+function readStoredTrades(): EmbedTrade[] | null {
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as EmbedTrade[];
+    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function storeTrades(trades: EmbedTrade[]) {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(trades));
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+}
+
+function buildEquity(trades: EmbedTrade[]) {
   const byDate = new Map<string, number>();
   for (const trade of trades) {
     if (!trade.entryDate) continue;
@@ -58,7 +79,7 @@ function buildRandomEquity(trades: EmbedTrade[]) {
     );
   }
 
-  let equity = Math.round(randomBetween(48000, 56000));
+  let equity = 52000;
   return [...byDate.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([date, pnl]) => {
@@ -68,10 +89,28 @@ function buildRandomEquity(trades: EmbedTrade[]) {
 }
 
 export function AuthTerminalAnimation({ className }: { className?: string }) {
-  const [trades] = useState(() => buildRandomTrades(VISIBLE_DAYS));
-  const equityPoints = useMemo(() => buildRandomEquity(trades), [trades]);
+  const [trades, setTrades] = useState<EmbedTrade[] | null>(null);
+
+  useEffect(() => {
+    const stored = readStoredTrades();
+    if (stored) {
+      setTrades(stored);
+      return;
+    }
+
+    const next = buildRandomTrades(VISIBLE_DAYS);
+    storeTrades(next);
+    setTrades(next);
+  }, []);
+
+  const equityPoints = useMemo(
+    () => (trades ? buildEquity(trades) : []),
+    [trades],
+  );
 
   const trackerData = useMemo(() => {
+    if (!trades) return [];
+
     const byDate = new Map<string, number>();
     for (const trade of trades) {
       if (!trade.entryDate) continue;
@@ -97,17 +136,16 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
       }));
   }, [trades]);
 
-  const sessionPnl = useMemo(
-    () =>
-      trades.reduce(
-        (sum, trade) => sum + trade.pnl - (trade.commission ?? 0),
-        0,
-      ),
-    [trades],
-  );
+  const sessionPnl = useMemo(() => {
+    if (!trades) return 0;
+    return trades.reduce(
+      (sum, trade) => sum + trade.pnl - (trade.commission ?? 0),
+      0,
+    );
+  }, [trades]);
 
   const winRate = useMemo(() => {
-    if (trades.length === 0) return 0;
+    if (!trades || trades.length === 0) return 0;
     const wins = trades.filter(
       (trade) => trade.pnl - (trade.commission ?? 0) > 0,
     ).length;
@@ -133,87 +171,102 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
       />
 
       <div className="absolute inset-x-6 top-28 bottom-32 flex min-h-0 flex-col gap-3 sm:inset-x-8 sm:top-32">
-        <DailyPnLChartEmbed
-          trades={trades}
-          showInfo={false}
-          className="min-h-0 flex-1 !h-auto rounded-sm border-white/10 bg-card/80 shadow-none"
-        />
+        {trades ? (
+          <>
+            <DailyPnLChartEmbed
+              trades={trades}
+              showInfo={false}
+              className="!h-0 min-h-0 flex-1 rounded-sm border-white/10 bg-card/80 shadow-none"
+            />
 
-        <div className="grid min-h-[168px] grid-cols-5 gap-3">
-          <TradeDistributionChartEmbed
-            trades={trades}
-            showInfo={false}
-            className="col-span-2 !h-full rounded-sm border-white/10 bg-card/80 shadow-none"
-          />
-
-          <div className="col-span-3 flex h-full flex-col gap-3">
-            <div className="flex min-h-0 flex-1 flex-col rounded-sm border border-white/10 bg-card/80 p-3">
-              <div className="mb-2 flex items-center justify-between">
-                <p className="text-sm font-medium">Equity</p>
-                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-                  Spark
-                </p>
-              </div>
-              <div className="min-h-0 flex-1">
-                <SparkAreaChart
-                  data={equityPoints}
-                  index="date"
-                  categories={["equity"]}
-                  colors={{ equity: "hsl(var(--chart-win))" }}
-                  height={72}
-                  className="h-[72px]"
-                />
-              </div>
-              <Tracker
-                className="mt-3 h-6"
-                data={trackerData}
-                defaultBackgroundColor="bg-muted"
+            <div className="grid h-[200px] shrink-0 grid-cols-5 gap-3">
+              <TradeDistributionChartEmbed
+                trades={trades}
+                showInfo={false}
+                className="col-span-2 !h-full rounded-sm border-white/10 bg-card/80 shadow-none"
               />
-            </div>
 
-            <div className="grid grid-cols-3 gap-2">
-              {[
-                {
-                  id: "session",
-                  label: "Session",
-                  value: `${sessionPnl >= 0 ? "+" : ""}${Math.round(sessionPnl).toLocaleString("en-US")}`,
-                  tone: sessionPnl >= 0 ? "win" : "loss",
-                },
-                {
-                  id: "winrate",
-                  label: "Win rate",
-                  value: `${winRate}%`,
-                  tone: winRate >= 50 ? "win" : "loss",
-                },
-                {
-                  id: "trades",
-                  label: "Trades",
-                  value: String(trades.length),
-                  tone: "amber",
-                },
-              ].map((stat) => (
-                <div
-                  key={stat.id}
-                  className="rounded-sm border border-white/10 bg-card/80 px-2.5 py-2"
-                >
-                  <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
-                    {stat.label}
-                  </p>
-                  <p
-                    className={cn(
-                      "mt-1 font-mono text-sm tabular-nums tracking-tight",
-                      stat.tone === "win" && "text-[hsl(var(--chart-win))]",
-                      stat.tone === "loss" && "text-[hsl(var(--chart-loss))]",
-                      stat.tone === "amber" && "text-[oklch(0.82_0.12_75)]",
-                    )}
-                  >
-                    {stat.value}
-                  </p>
+              <div className="col-span-3 flex h-full flex-col gap-3">
+                <div className="flex min-h-0 flex-1 flex-col rounded-sm border border-white/10 bg-card/80 p-3">
+                  <div className="mb-2 flex shrink-0 items-center justify-between">
+                    <p className="text-sm font-medium">Equity</p>
+                    <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                      Spark
+                    </p>
+                  </div>
+                  <div className="min-h-0 flex-1">
+                    <SparkAreaChart
+                      data={equityPoints}
+                      index="date"
+                      categories={["equity"]}
+                      colors={{ equity: "hsl(var(--chart-win))" }}
+                      height={72}
+                      className="h-full min-h-[56px]"
+                    />
+                  </div>
+                  <Tracker
+                    className="mt-3 h-6 shrink-0"
+                    data={trackerData}
+                    defaultBackgroundColor="bg-muted"
+                  />
                 </div>
-              ))}
+
+                <div className="grid shrink-0 grid-cols-3 gap-2">
+                  {[
+                    {
+                      id: "session",
+                      label: "Session",
+                      value: `${sessionPnl >= 0 ? "+" : ""}${Math.round(sessionPnl).toLocaleString("en-US")}`,
+                      tone: sessionPnl >= 0 ? "win" : "loss",
+                    },
+                    {
+                      id: "winrate",
+                      label: "Win rate",
+                      value: `${winRate}%`,
+                      tone: winRate >= 50 ? "win" : "loss",
+                    },
+                    {
+                      id: "trades",
+                      label: "Trades",
+                      value: String(trades.length),
+                      tone: "amber",
+                    },
+                  ].map((stat) => (
+                    <div
+                      key={stat.id}
+                      className="rounded-sm border border-white/10 bg-card/80 px-2.5 py-2"
+                    >
+                      <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
+                        {stat.label}
+                      </p>
+                      <p
+                        className={cn(
+                          "mt-1 font-mono text-sm tabular-nums tracking-tight",
+                          stat.tone === "win" &&
+                            "text-[hsl(var(--chart-win))]",
+                          stat.tone === "loss" &&
+                            "text-[hsl(var(--chart-loss))]",
+                          stat.tone === "amber" &&
+                            "text-[oklch(0.82_0.12_75)]",
+                        )}
+                      >
+                        {stat.value}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col gap-3">
+            <div className="min-h-0 flex-1 rounded-sm border border-white/10 bg-card/50" />
+            <div className="grid h-[200px] shrink-0 grid-cols-5 gap-3">
+              <div className="col-span-2 rounded-sm border border-white/10 bg-card/50" />
+              <div className="col-span-3 rounded-sm border border-white/10 bg-card/50" />
             </div>
           </div>
-        </div>
+        )}
       </div>
 
       <div className="absolute inset-x-0 top-0 h-36 bg-gradient-to-b from-[oklch(0.17_0_0)] via-[oklch(0.17_0_0)]/85 to-transparent" />

--- a/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
+++ b/app/[locale]/(authentication)/components/auth-terminal-animation.tsx
@@ -170,22 +170,23 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
 
             <div className="absolute inset-0 flex items-stretch gap-[3px] px-1 pb-1 pt-2">
               {bars.map((bar) => {
-                const height = `${12 + Math.abs(bar.value) * 82}%`;
+                const magnitude = `${10 + Math.abs(bar.value) * 38}%`;
                 const positive = bar.value >= 0;
                 return (
                   <div
                     key={bar.id}
-                    className="flex min-h-0 min-w-0 flex-1 items-end justify-center"
+                    className="relative flex min-h-0 min-w-0 flex-1 justify-center"
                   >
+                    <div className="absolute inset-x-[10%] top-1/2 h-px bg-white/[0.12]" />
                     <div
                       className={cn(
-                        "w-full max-w-[14px] origin-bottom rounded-[1px] transition-[height,background-color] duration-700 ease-out motion-reduce:transition-none",
+                        "absolute inset-x-[12%] max-w-[14px] rounded-[1px] transition-[height,background-color] duration-700 ease-out motion-reduce:transition-none",
                         positive
-                          ? "bg-[oklch(0.78_0.12_155)]"
-                          : "bg-[oklch(0.72_0.14_25)]",
+                          ? "bottom-1/2 origin-bottom bg-[oklch(0.78_0.12_155)]"
+                          : "top-1/2 origin-top bg-[oklch(0.72_0.14_25)]",
                         !prefersReducedMotion && "auth-bar-enter",
                       )}
-                      style={{ height }}
+                      style={{ height: magnitude }}
                     />
                   </div>
                 );
@@ -254,7 +255,7 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
         @keyframes auth-bar-enter {
           from {
             opacity: 0.35;
-            transform: scaleY(0.72);
+            transform: scaleY(0.55);
           }
           to {
             opacity: 1;
@@ -263,7 +264,6 @@ export function AuthTerminalAnimation({ className }: { className?: string }) {
         }
 
         .auth-bar-enter {
-          transform-origin: bottom;
           animation: auth-bar-enter 520ms cubic-bezier(0.23, 1, 0.32, 1) both;
         }
 

--- a/app/[locale]/embed/components/pnl-bar-chart.tsx
+++ b/app/[locale]/embed/components/pnl-bar-chart.tsx
@@ -145,12 +145,7 @@ export default function DailyPnLChartEmbed({
   };
 
   return (
-    <Card
-      className={cn(
-        "flex h-[500px] flex-col transition-[border-color,transform,box-shadow] duration-300 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:shadow-md",
-        className,
-      )}
-    >
+    <Card className={cn("flex h-[500px] flex-col", className)}>
       <CardHeader className="flex h-14 shrink-0 flex-row items-center justify-between space-y-0 border-b p-3 sm:p-4">
         <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-1.5">
@@ -205,7 +200,6 @@ export default function DailyPnLChartEmbed({
                 isAnimationActive={animated}
                 animationDuration={650}
                 animationEasing="ease-out"
-                className="transition-all duration-300 ease-in-out"
               >
                 {chartData.map((entry, idx) => (
                   <Cell
@@ -215,7 +209,6 @@ export default function DailyPnLChartEmbed({
                         ? "hsl(var(--chart-win))"
                         : "hsl(var(--chart-loss))"
                     }
-                    className="transition-opacity duration-200 hover:opacity-80"
                   />
                 ))}
               </Bar>

--- a/app/[locale]/embed/components/pnl-bar-chart.tsx
+++ b/app/[locale]/embed/components/pnl-bar-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { InfoBubble } from "@/components/ui/info-bubble"
 import { useI18n } from "@/locales/client";
+import { cn } from "@/lib/utils";
 
 export type EmbedTrade = {
   pnl: number;
@@ -33,8 +34,14 @@ function formatCurrency(value: number) {
 
 export default function DailyPnLChartEmbed({
   trades,
+  className,
+  animated = false,
+  showInfo = true,
 }: {
   trades: EmbedTrade[];
+  className?: string;
+  animated?: boolean;
+  showInfo?: boolean;
 }) {
   const t = useI18n();
 
@@ -138,21 +145,28 @@ export default function DailyPnLChartEmbed({
   };
 
   return (
-    <Card className="h-[500px] flex flex-col">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b shrink-0 p-3 sm:p-4 h-[56px]">
-        <div className="flex items-center justify-between w-full">
+    <Card
+      className={cn(
+        "flex h-[500px] flex-col transition-[border-color,transform,box-shadow] duration-300 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:shadow-md",
+        className,
+      )}
+    >
+      <CardHeader className="flex h-14 shrink-0 flex-row items-center justify-between space-y-0 border-b p-3 sm:p-4">
+        <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-1.5">
             <CardTitle className="line-clamp-1 text-base">
               {t("embed.pnl.title")}
             </CardTitle>
-            <InfoBubble side="top" iconClassName="size-4">
-              <p>{t("embed.pnl.description")}</p>
-            </InfoBubble>
+            {showInfo && (
+              <InfoBubble side="top" iconClassName="size-4">
+                <p>{t("embed.pnl.description")}</p>
+              </InfoBubble>
+            )}
           </div>
         </div>
       </CardHeader>
-      <CardContent className="flex-1 min-h-0 p-2 sm:p-4">
-        <div className="w-full h-full">
+      <CardContent className="min-h-0 flex-1 p-2 sm:p-4">
+        <div className="h-full w-full">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={chartData}
@@ -160,7 +174,7 @@ export default function DailyPnLChartEmbed({
             >
               <CartesianGrid
                 strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
+                className="text-border opacity-[0.2] dark:opacity-[0.12]"
               />
               <XAxis
                 dataKey="date"
@@ -188,6 +202,9 @@ export default function DailyPnLChartEmbed({
                 dataKey="pnl"
                 radius={[3, 3, 0, 0]}
                 maxBarSize={40}
+                isAnimationActive={animated}
+                animationDuration={650}
+                animationEasing="ease-out"
                 className="transition-all duration-300 ease-in-out"
               >
                 {chartData.map((entry, idx) => (
@@ -198,6 +215,7 @@ export default function DailyPnLChartEmbed({
                         ? "hsl(var(--chart-win))"
                         : "hsl(var(--chart-loss))"
                     }
+                    className="transition-opacity duration-200 hover:opacity-80"
                   />
                 ))}
               </Bar>

--- a/app/[locale]/embed/components/trade-distribution.tsx
+++ b/app/[locale]/embed/components/trade-distribution.tsx
@@ -15,6 +15,7 @@ import type { PolarViewBox } from "recharts/types/util/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { InfoBubble } from "@/components/ui/info-bubble"
 import { useI18n } from "@/locales/client";
+import { cn } from "@/lib/utils";
 import {
   BreakevenRange,
   DEFAULT_BREAKEVEN_RANGE,
@@ -23,9 +24,15 @@ import {
 export default function TradeDistributionChartEmbed({
   trades,
   breakevenRange = DEFAULT_BREAKEVEN_RANGE,
+  className,
+  animated = false,
+  showInfo = true,
 }: {
   trades: { pnl: number; commission?: number }[];
   breakevenRange?: BreakevenRange;
+  className?: string;
+  animated?: boolean;
+  showInfo?: boolean;
 }) {
   const t = useI18n();
 
@@ -124,21 +131,28 @@ export default function TradeDistributionChartEmbed({
   };
 
   return (
-    <Card className="h-[500px] flex flex-col">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b shrink-0 p-3 sm:p-4 h-14">
-        <div className="flex items-center justify-between w-full">
+    <Card
+      className={cn(
+        "flex h-[500px] flex-col transition-[border-color,transform,box-shadow] duration-300 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:shadow-md",
+        className,
+      )}
+    >
+      <CardHeader className="flex h-14 shrink-0 flex-row items-center justify-between space-y-0 border-b p-3 sm:p-4">
+        <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-1.5">
             <CardTitle className="line-clamp-1 text-base">
               {t("embed.tradeDistribution.title")}
             </CardTitle>
-            <InfoBubble side="top" iconClassName="size-4">
-              <p>{t("embed.tradeDistribution.description")}</p>
-            </InfoBubble>
+            {showInfo && (
+              <InfoBubble side="top" iconClassName="size-4">
+                <p>{t("embed.tradeDistribution.description")}</p>
+              </InfoBubble>
+            )}
           </div>
         </div>
       </CardHeader>
-      <CardContent className="flex-1 min-h-0 p-2 sm:p-4">
-        <div className="w-full h-full">
+      <CardContent className="min-h-0 flex-1 p-2 sm:p-4">
+        <div className="h-full w-full">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
@@ -153,6 +167,9 @@ export default function TradeDistributionChartEmbed({
                 endAngle={-270}
                 stroke="hsl(var(--background))"
                 strokeWidth={1}
+                isAnimationActive={animated}
+                animationDuration={650}
+                animationEasing="ease-out"
               >
                 {chartData.map((entry, idx) => (
                   <Cell

--- a/app/[locale]/embed/components/trade-distribution.tsx
+++ b/app/[locale]/embed/components/trade-distribution.tsx
@@ -131,12 +131,7 @@ export default function TradeDistributionChartEmbed({
   };
 
   return (
-    <Card
-      className={cn(
-        "flex h-[500px] flex-col transition-[border-color,transform,box-shadow] duration-300 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:shadow-md",
-        className,
-      )}
-    >
+    <Card className={cn("flex h-[500px] flex-col", className)}>
       <CardHeader className="flex h-14 shrink-0 flex-row items-center justify-between space-y-0 border-b p-3 sm:p-4">
         <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-1.5">

--- a/components/SparkChart.tsx
+++ b/components/SparkChart.tsx
@@ -23,6 +23,7 @@ type SparkChartProps<T extends Record<string, unknown>> = {
   colors?: Partial<Record<Extract<keyof T, string>, string>>
   className?: string
   height?: number
+  animated?: boolean
 }
 
 function useSparkConfig<K extends string>(
@@ -71,7 +72,7 @@ function SparkChartFrame<T extends Record<string, unknown>>({
 export function SparkAreaChart<T extends Record<string, unknown>>(
   props: SparkChartProps<T>
 ) {
-  const { data, index, categories, colors, className, height } = props
+  const { data, index, categories, colors, className, height, animated = false } = props
 
   return (
     <SparkChartFrame
@@ -95,7 +96,9 @@ export function SparkAreaChart<T extends Record<string, unknown>>(
             strokeWidth={1.5}
             fillOpacity={0.25}
             dot={false}
-            isAnimationActive={false}
+            isAnimationActive={animated}
+            animationDuration={650}
+            animationEasing="ease-out"
             baseValue={0}
           />
         ))}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the static auth background image with a dashboard-style preview built from real chart components.

### What’s on the panel
- **Daily PnL** and **Trade Distribution** embed charts
- **SparkAreaChart** equity spark + **Tracker** streak strip
- Random demo trades generated **client-side**, persisted in `sessionStorage` for the tab session
- Fixed flex heights so Recharts containers actually render
- Paper/terminal look: dark panel, hairline borders

![Auth terminal with dashboard charts](https://cursor.com/artifacts/c/art-1bb4c3d5-a95b-4e8f-81cd-a20e385118ee)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-febd172d-a52e-4bca-8127-3624c6d39790?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-febd172d-a52e-4bca-8127-3624c6d39790&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

