### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,13 @@ Open PRs against **`beta`** (not `main`). `main` is production; feature work lan
 5. `OPENAI_API_KEY=dummy bun run build`
 6. Run dashboard health checks above
 
+## Cursor Cloud specific instructions
+
+- **Docker-in-Docker**: Cloud Agent VMs require `fuse-overlayfs` storage driver and `iptables-legacy` for Docker to work. Run `bash scripts/docker-bootstrap.sh` first; if it fails with overlay errors, install `fuse-overlayfs` (`sudo apt-get install -y fuse-overlayfs`) and set `/etc/docker/daemon.json` to `{"storage-driver": "fuse-overlayfs"}` before starting `dockerd`.
+- **Full local setup**: Run `bash scripts/self-host-quickstart.sh` then `bash scripts/dev.sh`. This handles Docker Postgres, `.env.local`, Bun install, Prisma, seeding, and dev server startup.
+- **Auth**: Uses `LOCAL_DASHBOARD_AUTH_BYPASS=true` — no external Supabase keys needed. The dashboard is accessible at `http://localhost:3000/dashboard` as `local-dashboard-user`.
+- **PRs target `beta`**, not `main`.
+
 <!-- BEGIN:nextjs-agent-rules -->
 # This is NOT the Next.js you know
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with Docker-in-Docker gotchas and quick-reference setup instructions for future Cloud Agents.

### What's included

- Docker-in-Docker `fuse-overlayfs` requirement for Cloud Agent VMs
- Reference to `self-host-quickstart.sh` for full local setup
- Auth bypass mode note (no external Supabase keys needed)
- PR target branch reminder (`beta`, not `main`)

### Environment validation

<a href="https://cursor.com/agents/bc-8c795bff-87b9-4d4e-8e49-36a7ad44150e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeltalytix-dashboard-auth-bypass-demo.mp4"><img src="https://cursor.com/artifacts/c/art-cf3022af-1a46-4c0c-ae9a-160cc3b77c43" alt="deltalytix-dashboard-auth-bypass-demo.mp4" /></a>

Dashboard running with auth bypass and 132 seeded trades.

| Check | Result |
|---|---|
| Bun install (beta branch) | Passed |
| `bunx prisma generate` (Prisma 7.8.0) | Passed |
| `bunx prisma db push` | Passed |
| `bun run seed:self-host` (132 trades, 60 days) | Passed |
| `bun run lint` (ESLint runs, pre-existing warnings) | Passed |
| `bun run typecheck` (clean pass) | Passed |
| `OPENAI_API_KEY=dummy bun run build` | Passed |
| `bash scripts/dev.sh` (Next.js 16.3.0-preview.6 on port 3000) | Passed |
| Dashboard health check (`x-auth-status: authenticated`) | Passed |
| Auth redirect health check (`307 -> /dashboard`) | Passed |
| Browser walkthrough (Widgets, Trade Table, Accounts) | Passed |

### Environment build

- **Successful build**: `bld-20260806-66542cb4-120a-493d-9ae5-581db1cc13e8` (Bun-based, beta branch)
- **Install script**: `bun install --cwd /workspace` (with Bun auto-install)
- **Start script**: *(empty)*

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c795bff-87b9-4d4e-8e49-36a7ad44150e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c795bff-87b9-4d4e-8e49-36a7ad44150e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

