### PR TITLE
Keep every text field at 16px on mobile so iOS does not zoom

### DIFF
--- a/app/[locale]/dashboard/billing/components/billing-management.tsx
+++ b/app/[locale]/dashboard/billing/components/billing-management.tsx
@@ -386,7 +386,7 @@ export default function BillingManagement() {
                             </label>
                             <select
                               id="cancellationReason"
-                              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
+                              className="w-full rounded-md border border-input bg-background px-3 py-2 text-base sm:text-sm ring-offset-background"
                               value={cancellationReason}
                               onChange={(e) => setCancellationReason(e.target.value)}
                             >
@@ -404,7 +404,7 @@ export default function BillingManagement() {
                             </label>
                             <textarea
                               id="feedback"
-                              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
+                              className="w-full rounded-md border border-input bg-background px-3 py-2 text-base sm:text-sm ring-offset-background"
                               rows={3}
                               value={feedback}
                               onChange={(e) => setFeedback(e.target.value)}

--- a/app/[locale]/dashboard/components/accounts/suggestion-input.tsx
+++ b/app/[locale]/dashboard/components/accounts/suggestion-input.tsx
@@ -244,7 +244,7 @@ export default function EnhancedInput({
           aria-invalid={isValid === false}
           aria-describedby={isValid === false ? "validation-message" : undefined}
           className={cn(
-            "w-full rounded-md border-0 bg-transparent px-3 py-2 text-sm outline-hidden ring-0 focus:ring-0 pr-14",
+            "w-full rounded-md border-0 bg-transparent px-3 py-2 text-base sm:text-sm outline-hidden ring-0 focus:ring-0 pr-14",
             "text-foreground",
             "placeholder:text-muted-foreground",
             isValid === false ? "text-destructive" : "",

--- a/app/[locale]/dashboard/components/filters/filter-command-menu-pnl-section.tsx
+++ b/app/[locale]/dashboard/components/filters/filter-command-menu-pnl-section.tsx
@@ -84,14 +84,14 @@ export function PnlSection({ searchValue }: PnlSectionProps) {
               placeholder={t('filters.min')}
               value={customMin}
               onChange={(e) => setCustomMin(e.target.value)}
-              className="h-8 text-sm"
+              className="h-8 text-base sm:text-sm"
             />
             <Input
               type="number"
               placeholder={t('filters.max')}
               value={customMax}
               onChange={(e) => setCustomMax(e.target.value)}
-              className="h-8 text-sm"
+              className="h-8 text-base sm:text-sm"
             />
           </div>
           <Button

--- a/app/[locale]/dashboard/components/filters/filter-command-menu-tag-section.tsx
+++ b/app/[locale]/dashboard/components/filters/filter-command-menu-tag-section.tsx
@@ -220,7 +220,7 @@ export function TagSection({ searchValue }: TagSectionProps) {
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   placeholder={t('widgets.tags.namePlaceholder')}
                   disabled={isLoading}
-                  className="h-8 text-sm"
+                  className="h-8 text-base sm:text-sm"
                   autoFocus
                 />
               </div>
@@ -232,7 +232,7 @@ export function TagSection({ searchValue }: TagSectionProps) {
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   placeholder={t('widgets.tags.descriptionPlaceholder')}
                   disabled={isLoading}
-                  className="resize-none h-16 text-sm"
+                  className="resize-none h-16 text-base sm:text-sm"
                 />
               </div>
               <div className="space-y-2">

--- a/app/[locale]/dashboard/components/filters/pnl-filter-simple.tsx
+++ b/app/[locale]/dashboard/components/filters/pnl-filter-simple.tsx
@@ -75,14 +75,14 @@ export function PnlFilterSimple({ className }: PnlFilterSimpleProps) {
                 placeholder={t('filters.min')}
                 value={customMin}
                 onChange={(e) => setCustomMin(e.target.value)}
-                className="h-8 text-xs"
+                className="h-8 text-base sm:text-xs"
               />
               <Input
                 type="number"
                 placeholder={t('filters.max')}
                 value={customMax}
                 onChange={(e) => setCustomMax(e.target.value)}
-                className="h-8 text-xs"
+                className="h-8 text-base sm:text-xs"
               />
             </div>
             <Button 

--- a/app/[locale]/dashboard/components/filters/tag-widget.tsx
+++ b/app/[locale]/dashboard/components/filters/tag-widget.tsx
@@ -430,7 +430,7 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className={cn(
                   "flex-1 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
-                  size === 'small' ? "h-7 text-xs" : "h-8 text-sm"
+                  size === 'small' ? "h-7 text-base sm:text-xs" : "h-8 text-base sm:text-sm"
                 )}
               />
             </div>

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-sync.tsx
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-sync.tsx
@@ -37,7 +37,7 @@ const DEFAULT_PROP_FIRM_ID = DXFEED_PROP_FIRM_OPTIONS[0]?.id ?? ''
 const PROP_FIRM_SEARCH_THRESHOLD = 5
 
 const fieldClassName =
-  'h-11 rounded-sm border-black/10 bg-transparent text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+  'h-11 rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
 
 const configSelectClassName =
   'inline-flex h-8 max-w-full items-center gap-1 rounded-sm border border-black/10 bg-transparent px-2 text-xs font-normal shadow-none transition-colors duration-150 hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5'

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
@@ -26,7 +26,7 @@ import { RithmicProtocolCredentialsManager } from './rithmic-protocol-credential
 import { useRithmicProtocolConnectOptions } from './use-rithmic-protocol-connect-options'
 
 const fieldClassName =
-  'h-11 rounded-sm border-black/10 bg-transparent text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+  'h-11 rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
 
 const configSelectClassName =
   'h-8 w-auto min-w-0 max-w-full gap-1 rounded-sm border-black/10 bg-transparent px-2 text-xs shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10 [&>span]:truncate'

--- a/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-credentials-manager.tsx
@@ -47,7 +47,7 @@ import { useRithmicSyncContext } from "@/context/rithmic-sync-context";
 import { cn } from "@/lib/utils";
 
 const fieldClassName =
-  "h-9 rounded-sm border-black/10 bg-transparent text-sm shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10";
+  "h-9 rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10";
 const primaryButtonClassName =
   "h-9 rounded-sm bg-[oklch(0.22_0.01_95)] px-4 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]";
 const secondaryButtonClassName =

--- a/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-sync-connection.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic/sync/rithmic-sync-connection.tsx
@@ -22,7 +22,7 @@ import { captureConnectionCreated } from '@/lib/connection-analytics'
 import { cn } from '@/lib/utils'
 
 const fieldClassName =
-  'h-11 rounded-sm border-black/10 bg-transparent text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+  'h-11 rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
 
 const configSelectClassName =
   'h-8 w-auto min-w-0 max-w-full gap-1 rounded-sm border-black/10 bg-transparent px-2 text-xs shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10 [&>span]:truncate'

--- a/app/[locale]/dashboard/components/import/thor/thor-sync.tsx
+++ b/app/[locale]/dashboard/components/import/thor/thor-sync.tsx
@@ -24,7 +24,7 @@ import { captureConnectionCreated } from "@/lib/connection-analytics"
 import { useUserStore } from "../../../../../../store/user-store"
 
 const fieldClassName =
-  'h-11 flex-1 rounded-sm border-black/10 bg-transparent font-mono text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+  'h-11 flex-1 rounded-sm border-black/10 bg-transparent font-mono text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
 
 const iconButtonClassName =
   'inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-sm border border-black/20 bg-transparent text-black/55 shadow-none transition-[opacity,transform,background-color,color] duration-150 hover:bg-black/5 hover:text-black active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:border-white/20 dark:text-white/55 dark:hover:bg-white/5 dark:hover:text-white'

--- a/app/[locale]/dashboard/components/share-button.tsx
+++ b/app/[locale]/dashboard/components/share-button.tsx
@@ -526,7 +526,7 @@ export const ShareButton = forwardRef<HTMLButtonElement, ShareButtonProps>(
                           <Input
                             readOnly
                             value={shareUrl}
-                            className="pr-24 font-mono text-sm bg-muted text-center"
+                            className="pr-24 font-mono text-base sm:text-sm bg-muted text-center"
                           />
                           <div className="absolute right-0 top-0 h-full flex items-center gap-1 pr-2">
                             <Button

--- a/app/[locale]/dashboard/components/tables/bulk-edit-panel.tsx
+++ b/app/[locale]/dashboard/components/tables/bulk-edit-panel.tsx
@@ -268,7 +268,7 @@ export function BulkEditPanel({
                 placeholder={t('trade-table.bulkEdit.newInstrumentName')}
                 value={instrumentValue}
                 onChange={(e) => setInstrumentValue(e.target.value)}
-                className="h-8 text-xs"
+                className="h-8 text-base sm:text-xs"
               />
             )}
 
@@ -330,7 +330,7 @@ export function BulkEditPanel({
                 placeholder={instrumentAction === 'prefix' ? t('trade-table.bulkEdit.textToPrepend') : t('trade-table.bulkEdit.textToAppend')}
                 value={instrumentValue}
                 onChange={(e) => setInstrumentValue(e.target.value)}
-                className="h-8 text-xs"
+                className="h-8 text-base sm:text-xs"
               />
             )}
 

--- a/app/[locale]/dashboard/components/tables/editable-instrument-cell.tsx
+++ b/app/[locale]/dashboard/components/tables/editable-instrument-cell.tsx
@@ -90,7 +90,7 @@ export function EditableInstrumentCell({
           onKeyDown={handleKeyDown}
           onBlur={handleSave}
           placeholder="Instrument"
-          className="h-7 text-xs font-medium border-blue-500 focus-visible:ring-1"
+          className="h-7 text-base sm:text-xs font-medium border-blue-500 focus-visible:ring-1"
           disabled={isSaving}
         />
         <Button

--- a/app/[locale]/dashboard/components/tables/editable-time-cell.tsx
+++ b/app/[locale]/dashboard/components/tables/editable-time-cell.tsx
@@ -116,7 +116,7 @@ export function EditableTimeCell({
           onChange={(e) => setTempValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="HH:mm:ss"
-          className="h-7 text-xs font-mono border-blue-500 focus-visible:ring-1"
+          className="h-7 text-base sm:text-xs font-mono border-blue-500 focus-visible:ring-1"
           disabled={isSaving}
         />
         <Button

--- a/app/[locale]/dashboard/components/tables/trade-comment.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-comment.tsx
@@ -113,7 +113,7 @@ export function TradeComment({ tradeIds, comment: initialComment, onCommentChang
                   value={localComment}
                   onChange={(e) => setLocalComment(e.target.value)}
                   className={cn(
-                    "w-full px-3 py-2 text-sm bg-transparent border rounded min-h-[100px]",
+                    "w-full px-3 py-2 text-base sm:text-sm bg-transparent border rounded min-h-[100px]",
                     "focus:outline-hidden focus:ring-2 focus:ring-primary resize-none transition-all duration-200",
                     showSuccess && "border-green-500 ring-2 ring-green-500/20",
                     isUpdating && "border-primary/50"

--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -174,7 +174,7 @@ function TagsColumnHeader() {
                   placeholder={t("widgets.tags.searchPlaceholder")}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="flex-1 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 h-8 text-sm"
+                  className="flex-1 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 h-8 text-base sm:text-sm"
                 />
               </div>
 

--- a/components/ai-elements/web-preview.tsx
+++ b/components/ai-elements/web-preview.tsx
@@ -144,7 +144,7 @@ export const WebPreviewUrl = ({
 
   return (
     <Input
-      className="h-8 flex-1 text-sm"
+      className="h-8 flex-1 text-base sm:text-sm"
       onChange={onChange}
       onKeyDown={handleKeyDown}
       placeholder="Enter URL..."

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base sm:text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/lib/mobile-input-zoom.test.ts
+++ b/lib/mobile-input-zoom.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * iOS Safari zooms the whole page when a focused text field renders below 16px,
+ * and it does not zoom back out on blur. Every field the user can type into
+ * therefore needs at least `text-base` at mobile widths, typically written as
+ * `text-base sm:text-sm` so desktop keeps the denser size.
+ *
+ * This guard exists because the rule is invisible on a desktop browser: the
+ * offending class looks correct until someone opens the page on a phone. It
+ * scans source rather than rendered output, which is coarse, but it catches the
+ * one mistake that actually recurs — a `text-sm` typed onto a new input.
+ */
+
+const ROOTS = ['app', 'components']
+
+/** Elements whose focused font-size drives iOS zoom. Radix `<Select>` renders a
+ *  button and native `<select>` is included; both are covered by the regex. */
+const FIELD_PATTERN = /<(Input|Textarea|CommandInput|input|textarea|select)\b/
+const SMALL_TEXT = /\btext-(xs|sm)\b/
+const MOBILE_GUARD = /\btext-(base|lg|xl)\b/
+
+/**
+ * Fields that cannot receive typed text, so they never trigger the zoom.
+ * Keyed by `path:line` of the opening tag.
+ */
+const ALLOWED: ReadonlyArray<{ file: string; reason: string }> = [
+  {
+    file: 'app/[locale]/admin/components/newsletter/newsletter-audio-splitter.tsx',
+    reason: 'type="file" — the class styles the picker button, not typed text',
+  },
+  {
+    file: 'app/[locale]/admin/components/newsletter/newsletter-audio-extractor.tsx',
+    reason: 'type="file" — the class styles the picker button, not typed text',
+  },
+]
+
+function collectTsxFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.next')) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      collectTsxFiles(full, found)
+    } else if (full.endsWith('.tsx')) {
+      found.push(full)
+    }
+  }
+  return found
+}
+
+/** The opening tag of the element starting on `lines[index]`. */
+function readOpeningTag(lines: string[], index: number): string {
+  const window = lines.slice(index, index + 14).join('\n')
+  const selfClosing = window.indexOf('/>')
+  const plain = window.indexOf('>')
+  const end = selfClosing !== -1 ? selfClosing : plain
+  return end === -1 ? window : window.slice(0, end + 2)
+}
+
+function findUnguardedFields(): string[] {
+  const offenders: string[] = []
+  const allowedFiles = new Set(ALLOWED.map((entry) => entry.file))
+
+  for (const root of ROOTS) {
+    for (const file of collectTsxFiles(root)) {
+      if (allowedFiles.has(file)) continue
+
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, index) => {
+        if (!FIELD_PATTERN.test(line)) return
+        const tag = readOpeningTag(lines, index)
+        if (SMALL_TEXT.test(tag) && !MOBILE_GUARD.test(tag)) {
+          offenders.push(`${file}:${index + 1}`)
+        }
+      })
+    }
+  }
+
+  return offenders
+}
+
+describe('mobile input zoom', () => {
+  it('has no text field sized below 16px at mobile widths', () => {
+    // A failure here lists the exact tags to fix: add `text-base` and move the
+    // small size behind `sm:` (e.g. `text-sm` becomes `text-base sm:text-sm`).
+    expect(findUnguardedFields()).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

iOS Safari zooms the whole page when a focused text field renders below 16px, and it does not zoom back out on blur — the user is left on a magnified, horizontally scrolling page in the middle of a form.

`Input` already guarded against this with `text-lg sm:text-sm`, but the guard was never applied anywhere else. **20 fields across the app zoom on focus today.**

## The worst of it: every broker connect form

All five connect forms share the same `fieldClassName` constant with a flat `text-sm`. Because it is passed as a `className`, it overrides the base `Input` guard — so **every credential entry in the app zooms on a phone**:

| File | Fields |
| --- | --- |
| `dxfeed-sync.tsx:40` | email, password |
| `rithmic-sync-connection.tsx:25` | credentials |
| `rithmic-credentials-manager.tsx:50` | credentials |
| `rithmic-protocol-sync.tsx:29` | credentials |
| `thor-sync.tsx:27` | token |

## Everything else

- **`components/ui/textarea.tsx`** — the base component had a flat `text-sm`, unlike `Input`. Nine call sites inherit it.
- **Raw `<textarea>`** bypassing the base component: trade comments, billing cancellation feedback
- **The native `<select>`** in billing — zooms for exactly the same reason, and it is the only native select in the codebase
- **Dashboard fields overriding the base `Input` guard**: share link, bulk edit (min/max), editable time and instrument cells, trade review, P&L filters, tag filters, account suggestion input, web preview URL

## The fix

Each becomes `text-base sm:text-<original>` — 16px at mobile widths, the previous denser size from `sm` up.

`text-base` rather than matching `Input`'s `text-lg`: 16px is the actual iOS threshold, and 18px would visibly inflate dense controls like the `h-7` editable table cells. The existing `text-lg` instances in `Input` and `prompt-input` are left alone.

## Regression guard

Added `lib/mobile-input-zoom.test.ts`, which scans source for text fields carrying `text-xs`/`text-sm` with no mobile guard.

This rule is invisible in a desktop browser — the offending class looks correct until someone opens the page on a phone — so without a check it comes back the next time an input is styled. I verified the guard is not vacuous: reintroducing the `Textarea` regression fails it with the exact file and line, and reverting passes it again.

The two allowlisted entries are `type="file"` pickers, which take no typed input.

## Deliberately not changed

- **Radix `<Select>`** renders a `<button>`, not a native select, so it does not zoom (5 call sites matched my initial scan as false positives)
- **The OTP field** — `InputOTPSlot` is a `<div>`, and we set no font-size on the underlying input
- **Admin file pickers** — the class styles the picker button, not typed text
- **The viewport meta** is already correct (`width=device-width, initialScale=1`). Adding `maximum-scale=1` is the other common "fix" for this; it breaks pinch-zoom in every non-Safari browser and fails WCAG.

## Testing

- `bun run typecheck` — clean
- `bunx vitest run` — 152 pass (151 + the new guard); the 2 failing test *files* fail identically on clean `beta`, where vitest has no `@/` alias configured
- `bunx eslint` on the changed files reports **60 problems both with and without this branch** — verified by stashing, so nothing new was introduced. The new test file is clean.

## Related

The IBKR connect form has the same bug; it is fixed inside #382 so that PR's own field works independently of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gt7Jzqyu6JkpbHfk4GBC6

---
_Generated by [Claude Code](https://claude.ai/code/session_012Gt7Jzqyu6JkpbHfk4GBC6)_