### PR TITLE
Speed up landing page chart carousels by 2x

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -548,7 +548,7 @@
   }
 
   .landing-carousel-progress {
-    animation: landing-carousel-progress 6s linear forwards;
+    animation: landing-carousel-progress 3s linear forwards;
   }
 
   .performance-carousel[data-autoplay-paused='true'] .landing-carousel-progress {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Halves the homepage performance chart carousel autoplay interval so slides advance twice as fast.

Both landing chart carousels (Performance Visualization and Track Your Performance) share the `.landing-carousel-progress` CSS animation. That duration was `6s`; it is now `3s`.

## Test plan
- [ ] Open the landing page and scroll to the performance chart sections
- [ ] Confirm autoplay advances about every 3 seconds (was ~6s)
- [ ] Confirm pause / play and manual dot selection still work
- [ ] Confirm reduced-motion preference still disables the progress animation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fde96-b0d9-78ea-8f87-45a4c65cc74d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fde96-b0d9-78ea-8f87-45a4c65cc74d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

