### PR TITLE
Remove repetitive "No trades" text from calendar day cells

### DIFF
--- a/app/[locale]/(landing)/components/calendar-preview.tsx
+++ b/app/[locale]/(landing)/components/calendar-preview.tsx
@@ -217,16 +217,16 @@ function LandingCalendarPreview({
                         $0
                       </div>
                     )}
-                    <div
-                      className={cn(
-                        "text-[7px] sm:text-[9px] text-muted-foreground truncate text-center",
-                        !isCurrentMonth && "opacity-50",
-                      )}
-                    >
-                      {dayData
-                        ? `${dayData.tradeNumber} ${dayData.tradeNumber > 1 ? t("calendar.trades") : t("calendar.trade")}`
-                        : t("calendar.noTrades")}
-                    </div>
+                    {dayData && (
+                      <div
+                        className={cn(
+                          "text-[7px] sm:text-[9px] text-muted-foreground truncate text-center",
+                          !isCurrentMonth && "opacity-50",
+                        )}
+                      >
+                        {`${dayData.tradeNumber} ${dayData.tradeNumber > 1 ? t("calendar.trades") : t("calendar.trade")}`}
+                      </div>
+                    )}
                   </div>
                 </div>
                 {isLastDayOfWeek &&

--- a/app/[locale]/dashboard/components/calendar/responsive-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/responsive-calendar.tsx
@@ -672,21 +672,17 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
                               !isCurrentMonth && "opacity-50"
                             )}>$0</div>
                           )}
-                          <div className={cn(
-                            "text-[10px] sm:text-[9px] text-muted-foreground truncate text-center leading-tight",
-                            !isCurrentMonth && "opacity-50"
-                          )}>
-                            {dayData
-                              ? (
-                                <>
-                                  <span className="sm:hidden">{dayData.tradeNumber}</span>
-                                  <span className="hidden sm:inline">
-                                    {`${dayData.tradeNumber} ${dayData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`}
-                                  </span>
-                                </>
-                              )
-                              : <span className="hidden sm:inline">{t('calendar.noTrades')}</span>}
-                          </div>
+                          {dayData && (
+                            <div className={cn(
+                              "text-[10px] sm:text-[9px] text-muted-foreground truncate text-center leading-tight",
+                              !isCurrentMonth && "opacity-50"
+                            )}>
+                              <span className="sm:hidden">{dayData.tradeNumber}</span>
+                              <span className="hidden sm:inline">
+                                {`${dayData.tradeNumber} ${dayData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`}
+                              </span>
+                            </div>
+                          )}
                           {dayData && showMaxProfitAndDrawdown && (
                             <>
                               <div className={cn(

--- a/locales/en/landing-preview.ts
+++ b/locales/en/landing-preview.ts
@@ -9,7 +9,6 @@ export default {
   "calendar.weekdays.weekly": "Weekly",
   "calendar.trades": "trades",
   "calendar.trade": "trade",
-  "calendar.noTrades": "No trades",
   embed: {
     pnlPerContract: {
       title: "Avg Net P/L per Contract",

--- a/locales/fr/landing-preview.ts
+++ b/locales/fr/landing-preview.ts
@@ -9,7 +9,6 @@ export default {
   "calendar.weekdays.weekly": "Hebdo",
   "calendar.trades": "trades",
   "calendar.trade": "trade",
-  "calendar.noTrades": "Aucun trade",
   embed: {
     pnlPerContract: {
       title: "P/L net moyen par contrat",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the "No trades" / "Aucun trade" label from empty day cells in the dashboard calendar widget
- Remove the same label from the landing page calendar preview
- Clean up unused `calendar.noTrades` keys from landing-preview locales
- Days with trades still show the trade count as before

Empty calendar days are clearer without repeating the same empty-state string on every cell.

## Test plan
- [ ] Open the dashboard calendar and confirm empty days no longer show "No trades"
- [ ] Confirm days with trades still show the trade count
- [ ] Check the landing page calendar preview for the same behavior
- [ ] Spot-check FR locale (empty days should not show "Aucun trade")

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdea9-cac2-798d-a8c9-bbac72789c16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdea9-cac2-798d-a8c9-bbac72789c16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

