### PR TITLE
Rebuild the auth page: live candlestick chart + landing design language

### DIFF
--- a/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
+++ b/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
@@ -1,40 +1,43 @@
 'use client'
 
-import Image from "next/image"
 import Link from "next/link"
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
 import { UserAuthForm } from "../components/user-auth-form"
 import { Logo } from "@/components/logo"
+import { TradingCandlestickIcon } from "@/components/trading-candlestick-icon"
 import { useI18n } from '@/locales/client'
 
 export default function AuthenticationPageClient() {
   const t = useI18n()
 
   return (
-    <div>
+    <div className="bg-[oklch(0.97_0_0)] text-[oklch(0.17_0_0)] [--background:0_0%_96.1%] [--card:0_0%_100%] [--foreground:0_0%_9%] dark:bg-[oklch(0.17_0_0)] dark:text-[oklch(0.93_0_0)] dark:[--background:0_0%_6.7%] dark:[--card:0_0%_0%] dark:[--foreground:0_0%_93%]">
       <div className="flex relative h-screen flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
-        <div className="relative hidden h-full flex-col bg-gray-900 p-10 text-white dark:border-r lg:flex">
-          <div className="absolute inset-0 overflow-hidden">
-          <Image src={"/auth-background.jpeg"} width={928} height={1232} className="opacity-35 w-full" alt="Auth abstract image background"></Image>
-          </div>
+        <div className="relative hidden h-full flex-col border-r border-border bg-background p-10 text-foreground lg:flex">
           <div className="relative z-20 flex items-center text-lg font-medium">
             <Link href="/" className="flex items-center gap-2">
-              <Logo className="w-10 h-10 fill-white"/>
+              <Logo className="h-10 w-10 fill-foreground"/>
               Deltalytix
             </Link>
           </div>
+          <div className="relative z-20 flex flex-1 items-center">
+            <TradingCandlestickIcon
+              width={560}
+              height={220}
+              visibleCandles={18}
+              className="h-[220px] w-full max-w-none text-foreground/50"
+            />
+          </div>
           <div className="relative z-20 mt-auto">
             <blockquote className="space-y-2">
-              <p className="text-lg">
+              <p className="text-lg text-foreground/90">
                 {t('authentication.testimonial')}
               </p>
-              <footer className="text-sm">{t('authentication.testimonialAuthor')}</footer>
+              <footer className="text-sm text-muted-foreground">{t('authentication.testimonialAuthor')}</footer>
             </blockquote>
           </div>
         </div>
-        <div className="p-4 lg:p-8">
+        <div className="flex h-full items-center justify-center bg-card p-4 lg:p-8">
           <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
             <div className="flex flex-col space-y-2 text-center">
               <h1 className="text-2xl font-semibold tracking-tight">

--- a/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
+++ b/app/[locale]/(authentication)/authentication/authentication-page-client.tsx
@@ -30,36 +30,36 @@ export default function AuthenticationPageClient() {
           </div>
           <div className="relative z-20 mt-auto">
             <blockquote className="space-y-2">
-              <p className="text-lg text-foreground/90">
+              <p className="text-pretty text-lg leading-relaxed text-black/60 dark:text-white/60">
                 {t('authentication.testimonial')}
               </p>
-              <footer className="text-sm text-muted-foreground">{t('authentication.testimonialAuthor')}</footer>
+              <footer className="text-sm text-black/45 dark:text-white/45">{t('authentication.testimonialAuthor')}</footer>
             </blockquote>
           </div>
         </div>
         <div className="flex h-full items-center justify-center bg-card p-4 lg:p-8">
-          <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
-            <div className="flex flex-col space-y-2 text-center">
-              <h1 className="text-2xl font-semibold tracking-tight">
+          <div className="mx-auto flex w-full flex-col justify-center gap-8 sm:w-[380px]">
+            <div className="flex flex-col gap-3">
+              <h1 className="text-balance text-3xl font-normal tracking-[-0.04em] md:text-4xl">
                 {t('authentication.title')}
               </h1>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-pretty leading-relaxed text-black/55 dark:text-white/55">
                 {t('authentication.description')}
               </p>
             </div>
             <UserAuthForm />
-            <p className="px-8 text-center text-sm text-muted-foreground">
+            <p className="text-pretty text-sm leading-relaxed text-black/45 dark:text-white/45">
               {t('authentication.termsAndPrivacy.prefix')}{" "}
               <Link
                 href="/terms"
-                className="underline underline-offset-4 hover:text-primary"
+                className="underline underline-offset-4 transition-colors duration-150 hover:text-black dark:hover:text-white"
               >
                 {t('authentication.termsAndPrivacy.terms')}
               </Link>{" "}
               {t('authentication.termsAndPrivacy.and')}{" "}
               <Link
                 href="/privacy"
-                className="underline underline-offset-4 hover:text-primary"
+                className="underline underline-offset-4 transition-colors duration-150 hover:text-black dark:hover:text-white"
               >
                 {t('authentication.termsAndPrivacy.privacy')}
               </Link>

--- a/app/[locale]/(authentication)/components/user-auth-form.tsx
+++ b/app/[locale]/(authentication)/components/user-auth-form.tsx
@@ -3,6 +3,7 @@
 import { signInWithDiscord, signInWithEmail, verifyOtp, signInWithGoogle, signInWithPasswordAction } from "@/server/auth"
 
 import * as React from "react"
+import { ArrowLeft } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
@@ -28,12 +29,25 @@ import {
     InputOTPSlot,
     InputOTPSeparator
 } from "@/components/ui/input-otp"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Badge } from "@/components/ui/badge"
 // Link removed; unauthenticated users can't reach settings
 import { useAuthPreferenceStore } from "@/store/auth-preference-store"
 import { openMailbox } from "@/lib/open-mailbox"
 import { signupRedirectPath } from "@/lib/signup-redirect"
+
+/* Landing-page control language: rounded-sm, hairline borders, no shadows, a
+   filled oklch primary and hover washes instead of accent fills. Mirrors the
+   hero CTAs in app/[locale]/(landing)/components/hero.tsx. */
+const PRIMARY_ACTION =
+    "h-11 w-full rounded-sm bg-[oklch(0.22_0.01_95)] text-sm font-medium text-white shadow-none transition-[opacity,transform] duration-150 hover:bg-[oklch(0.22_0.01_95)] hover:opacity-85 active:scale-[0.96] disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)] dark:hover:bg-[oklch(0.94_0.01_95)]"
+
+const SECONDARY_ACTION =
+    "h-11 w-full rounded-sm border border-black/20 bg-transparent text-sm font-medium shadow-none transition-[colors,transform] duration-150 hover:bg-black/5 active:scale-[0.96] disabled:opacity-40 dark:border-white/20 dark:hover:bg-white/5"
+
+const OTP_SLOT =
+    "h-11 w-11 rounded-sm border-black/10 text-base shadow-none first:rounded-l-sm last:rounded-r-sm dark:border-white/10"
+
+const FIELD =
+    "h-11 rounded-sm border-black/10 bg-transparent shadow-none placeholder:text-black/40 focus-visible:ring-1 focus-visible:ring-black/25 focus-visible:ring-offset-0 dark:border-white/10 dark:placeholder:text-white/40 dark:focus-visible:ring-white/25"
 
 const formSchema = z.object({
     email: z.string().email(),
@@ -41,10 +55,6 @@ const formSchema = z.object({
         z.string().min(6, 'Password must be at least 6 characters'),
         z.literal('')
     ]).optional(),
-})
-
-const otpFormSchema = z.object({
-    otp: z.string().length(6, "Verification code must be 6 digits"),
 })
 
 interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {}
@@ -64,7 +74,11 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
     const [nextUrl, setNextUrl] = React.useState<string | null>(null)
     const router = useRouter()
     const { lastAuthPreference, setLastAuthPreference } = useAuthPreferenceStore()
-    const [tab, setTab] = React.useState<'magic' | 'password'>(lastAuthPreference)
+    const [usePassword, setUsePassword] = React.useState<boolean>(lastAuthPreference === 'password')
+    const [otp, setOtp] = React.useState<string>("")
+    /* Ref rather than state: the auto-verify guard has to be correct within a
+       single change event, before a state update could land. */
+    const isVerifyingRef = React.useRef(false)
     const t = useI18n()
     const locale = useCurrentLocale()
 
@@ -112,12 +126,22 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
         },
     })
 
-    const otpForm = useForm<z.infer<typeof otpFormSchema>>({
-        resolver: zodResolver(otpFormSchema),
-        defaultValues: {
-            otp: "",
-        },
-    })
+    /* Sending the link locks the email field, so there has to be a way back out —
+       to fix a typo, or to switch to password sign-in instead. */
+    function resetEmailFlow() {
+        setIsEmailSent(false)
+        setShowOtpInput(false)
+        setOtp("")
+        setCountdown(0)
+        setAuthMethod(null)
+    }
+
+    function toggleUsePassword() {
+        const next = !usePassword
+        setUsePassword(next)
+        setLastAuthPreference(next ? 'password' : 'magic')
+        if (!next) form.setValue('password', '')
+    }
 
     async function onSubmitEmail(values: z.infer<typeof formSchema>) {
         if (countdown > 0) return
@@ -229,6 +253,15 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
     }
 
     async function onSubmitPassword(values: z.infer<typeof formSchema>) {
+        /* The schema keeps password optional because the email flow shares it, so
+           the empty case has to be caught here rather than at the server. */
+        if (!values.password) {
+            form.setError('password', {
+                type: 'manual',
+                message: t('auth.passwordMinLength'),
+            })
+            return
+        }
         setIsLoading(true)
         setAuthMethod('email')
         try {
@@ -268,11 +301,13 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
 
     // Signup handled via magic link; no password signup flow here
 
-    async function onSubmitOtp(values: z.infer<typeof otpFormSchema>) {
+    async function verifyCode(code: string) {
+        if (isVerifyingRef.current) return
+        isVerifyingRef.current = true
         setIsLoading(true)
         try {
             const email = form.getValues('email')
-            const result = await verifyOtp(email, values.otp)
+            const result = await verifyOtp(email, code)
             toast.success("Successfully verified. Redirecting...", {
                 description: "Successfully verified. Redirecting...",
             })
@@ -283,9 +318,18 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
             toast.error("Error", {
                 description: error instanceof Error ? error.message : "Failed to verify code",
             })
+            /* Clear so the next keystroke can re-trigger auto-verify. */
+            setOtp("")
         } finally {
+            isVerifyingRef.current = false
             setIsLoading(false)
         }
+    }
+
+    /* No submit button: the code is fixed-length, so verify as soon as it's complete. */
+    function onOtpChange(value: string) {
+        setOtp(value)
+        if (value.length === 6) verifyCode(value)
     }
 
     async function onSubmitDiscord(event: React.SyntheticEvent) {
@@ -337,231 +381,200 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
 
     return (
         <div className={cn("grid gap-6", className)} {...props}>
-            <Tabs value={tab} onValueChange={(v) => { setTab(v as 'magic' | 'password'); setLastAuthPreference(v as 'magic' | 'password'); }}>
-                <TabsList className="flex w-full overflow-x-auto gap-1 sm:grid sm:grid-cols-2 sm:gap-0">
-                    <TabsTrigger value="magic" className="flex-1 min-w-0 text-xs sm:text-sm px-2 py-1">
-                        <span className="truncate">{t('auth.tabs.magic')}</span>
-                    </TabsTrigger>
-                    <TabsTrigger value="password" className="relative flex-1 min-w-0 text-xs sm:text-sm px-2 py-1">
-                        <span className="truncate">{t('auth.tabs.password')}</span>
-                        <Badge
-                            variant="secondary"
-                            className="hidden sm:inline-flex absolute -top-1 -right-1 text-[9px] leading-3 px-1 py-0.5"
-                        >
-                            {t('auth.new')}
-                        </Badge>
-                    </TabsTrigger>
-                    {/* Signup tab removed: handled by Magic Link */}
-                </TabsList>
-
-                <TabsContent value="magic">
-                <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmitEmail)} className="grid gap-2">
+            <Form {...form}>
+                <form
+                    onSubmit={form.handleSubmit(usePassword && !isEmailSent ? onSubmitPassword : onSubmitEmail)}
+                    className="grid gap-3"
+                >
                     <FormField
                         control={form.control}
                         name="email"
                         render={({ field }) => (
                             <FormItem>
                                 <FormLabel className="sr-only">Email</FormLabel>
-                                <FormControl>
-                                    <Input
-                                        id="email"
-                                        placeholder={t('auth.emailPlaceholder')}
-                                        type="email"
-                                        autoCapitalize="none"
-                                        autoComplete="email"
-                                        autoCorrect="off"
-                                        disabled={isLoading || (isEmailSent || authMethod === 'discord' || authMethod === 'google')}
-                                        {...field}
-                                    />
-                                </FormControl>
+                                <div className="relative">
+                                    <FormControl>
+                                        <Input
+                                            id="email"
+                                            className={cn(FIELD, isEmailSent && "pr-11")}
+                                            placeholder={t('auth.emailPlaceholder')}
+                                            type="email"
+                                            autoCapitalize="none"
+                                            autoComplete="email"
+                                            autoCorrect="off"
+                                            disabled={isLoading || isEmailSent || authMethod === 'discord' || authMethod === 'google'}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    {isEmailSent && (
+                                        <button
+                                            type="button"
+                                            onClick={resetEmailFlow}
+                                            aria-label={t('auth.changeEmail')}
+                                            title={t('auth.changeEmail')}
+                                            className="absolute right-1 top-1 flex h-9 w-9 items-center justify-center rounded-sm text-black/45 transition-colors duration-150 hover:bg-black/5 hover:text-black dark:text-white/45 dark:hover:bg-white/5 dark:hover:text-white"
+                                        >
+                                            <ArrowLeft className="h-4 w-4" aria-hidden />
+                                        </button>
+                                    )}
+                                </div>
                                 <FormMessage />
                             </FormItem>
                         )}
                     />
+
+                    {/* Progressive disclosure instead of tabs. A 0fr->1fr grid row is
+                        animatable where height:auto is not, so the reveal doesn't snap. */}
+                    <div
+                        aria-hidden={!usePassword}
+                        className={cn(
+                            "grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
+                            usePassword ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+                        )}
+                    >
+                        <div className="overflow-hidden">
+                            <FormField
+                                control={form.control}
+                                name="password"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className="sr-only">{t('auth.password')}</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                id="password_login"
+                                                className={FIELD}
+                                                placeholder={t('auth.passwordPlaceholder')}
+                                                type="password"
+                                                autoComplete="current-password"
+                                                disabled={isLoading || !usePassword}
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                    </div>
+
                     {!isEmailSent ? (
-                            <Button 
+                        <>
+                            <Button
+                                className={PRIMARY_ACTION}
                                 disabled={isLoading || countdown > 0 || authMethod === 'discord' || authMethod === 'google'}
                                 type="submit"
                             >
                                 {isLoading && authMethod === 'email' && (
                                     <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
                                 )}
-                                {t('auth.signInWithEmail')}
+                                {usePassword ? t('auth.signInWithPassword') : t('auth.signInWithEmail')}
                             </Button>
-                        ) : (
-                            <div className="space-y-2">
-                                <Button 
-                                    type="button" 
-                                    variant="outline" 
-                                    className="w-full"
-                                    onClick={openMailClient}
-                                    disabled={authMethod === 'discord' || authMethod === 'google'}
-                                >
-                                    <Icons.envelope className="mr-2 h-4 w-4" />
-                                    {t('auth.openMailbox')}
-                                </Button>
-                                <Button
-                                    type="submit"
-                                    variant="ghost"
-                                    className="w-full"
-                                    disabled={countdown > 0 || authMethod === 'discord' || authMethod === 'google'}
-                                >
-                                    {countdown > 0 ? (
-                                        `${t('auth.resendIn')} ${countdown}s`
-                                    ) : (
-                                        t('auth.resendEmail')
-                                    )}
-                                </Button>
-                            </div>
-                        )}
+                            <button
+                                type="button"
+                                onClick={toggleUsePassword}
+                                className="justify-self-center rounded-sm text-sm text-black/55 underline underline-offset-4 transition-colors duration-150 hover:text-black dark:text-white/55 dark:hover:text-white"
+                            >
+                                {usePassword ? t('auth.useMagicLink') : t('auth.usePassword')}
+                            </button>
+                        </>
+                    ) : (
+                        <div className="grid grid-cols-2 gap-3">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                className={SECONDARY_ACTION}
+                                onClick={openMailClient}
+                                disabled={authMethod === 'discord' || authMethod === 'google'}
+                            >
+                                <Icons.envelope className="mr-2 h-4 w-4" />
+                                {t('auth.openMailbox')}
+                            </Button>
+                            <Button
+                                type="submit"
+                                variant="outline"
+                                className={SECONDARY_ACTION}
+                                disabled={countdown > 0 || authMethod === 'discord' || authMethod === 'google'}
+                            >
+                                {countdown > 0
+                                    ? `${t('auth.resendIn')} ${countdown}s`
+                                    : t('auth.resendEmail')}
+                            </Button>
+                        </div>
+                    )}
                 </form>
             </Form>
+
             {showOtpInput && (
-                <Form {...otpForm}>
-                    <form onSubmit={otpForm.handleSubmit(onSubmitOtp)} className="space-y-4">
-                        <FormField
-                            control={otpForm.control}
-                            name="otp"
-                            render={({ field }) => (
-                                <FormItem className="space-y-2">
-                                    <FormLabel className="text-center block">{t('auth.verificationCode')}</FormLabel>
-                                    <FormControl>
-                                        <div className="flex justify-center">
-                                            <InputOTP
-                                                maxLength={6}
-                                                value={field.value}
-                                                onChange={field.onChange}
-                                                className="gap-2"
-                                            >
-                                                <InputOTPGroup>
-                                                    <InputOTPSlot index={0} />
-                                                    <InputOTPSlot index={1} />
-                                                    <InputOTPSlot index={2} />
-                                                </InputOTPGroup>
-                                                <InputOTPSeparator />
-                                                <InputOTPGroup>
-                                                    <InputOTPSlot index={3} />
-                                                    <InputOTPSlot index={4} />
-                                                    <InputOTPSlot index={5} />
-                                                </InputOTPGroup>
-                                            </InputOTP>
-                                        </div>
-                                    </FormControl>
-                                    <FormMessage className="text-center" />
-                                </FormItem>
-                            )}
-                        />
-                        <Button 
-                            type="submit" 
-                            className="w-full"
+                <div className="grid gap-3">
+                    <p className="text-center text-sm text-black/55 dark:text-white/55">
+                        {t('auth.verificationCode')}
+                    </p>
+                    <div className="flex justify-center">
+                        <InputOTP
+                            maxLength={6}
+                            value={otp}
+                            onChange={onOtpChange}
                             disabled={isLoading}
+                            className="gap-2"
                         >
-                            {isLoading ? (
-                                <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-                            ) : null}
-                            {t('auth.verifyCode')}
-                        </Button>
-                    </form>
-                </Form>
+                            <InputOTPGroup>
+                                <InputOTPSlot index={0} className={OTP_SLOT} />
+                                <InputOTPSlot index={1} className={OTP_SLOT} />
+                                <InputOTPSlot index={2} className={OTP_SLOT} />
+                            </InputOTPGroup>
+                            <InputOTPSeparator />
+                            <InputOTPGroup>
+                                <InputOTPSlot index={3} className={OTP_SLOT} />
+                                <InputOTPSlot index={4} className={OTP_SLOT} />
+                                <InputOTPSlot index={5} className={OTP_SLOT} />
+                            </InputOTPGroup>
+                        </InputOTP>
+                    </div>
+                </div>
             )}
-            {/* Hint removed: settings not accessible unauthenticated */}
-                </TabsContent>
-
-                <TabsContent value="password">
-                <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmitPassword)} className="grid gap-2">
-                    <FormField
-                        control={form.control}
-                        name="email"
-                        render={({ field }) => (
-                            <FormItem>
-                                <FormLabel className="sr-only">Email</FormLabel>
-                                <FormControl>
-                                    <Input
-                                        id="email_password"
-                                        placeholder={t('auth.emailPlaceholder')}
-                                        type="email"
-                                        autoCapitalize="none"
-                                        autoComplete="email"
-                                        autoCorrect="off"
-                                        disabled={isLoading}
-                                        {...field}
-                                    />
-                                </FormControl>
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-                    <FormField
-                        control={form.control}
-                        name="password"
-                        render={({ field }) => (
-                            <FormItem>
-                                <FormLabel className="sr-only">Password</FormLabel>
-                                <FormControl>
-                                    <Input
-                                        id="password_login"
-                                        placeholder={t('auth.passwordPlaceholder')}
-                                        type="password"
-                                        autoComplete="current-password"
-                                        disabled={isLoading}
-                                        {...field}
-                                    />
-                                </FormControl>
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-                    <Button disabled={isLoading} type="submit">
-                        {isLoading && authMethod === 'email' && (
-                            <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-                        )}
-                        {t('auth.signInWithPassword')}
-                    </Button>
-                </form>
-                </Form>
-                </TabsContent>
-
-                {/* Signup content removed */}
-            </Tabs>
 
             <div className="relative">
                 <div className="absolute inset-0 flex items-center">
-                    <span className="w-full border-t" />
+                    <span className="w-full border-t border-black/10 dark:border-white/10" />
                 </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                    <span className="bg-background px-2 text-muted-foreground">
+                <div className="relative flex justify-center text-xs uppercase tracking-wide">
+                    {/* bg matches the panel, not --background, or the label sits on a grey chip. */}
+                    <span className="bg-card px-3 text-black/45 dark:text-white/45">
                         {t('auth.continueWith')}
                     </span>
                 </div>
             </div>
-            <Button 
-                variant="outline" 
-                type="button" 
-                disabled={isLoading || authMethod === 'email'} 
-                onClick={onSubmitDiscord}
-            >
-                {isLoading && authMethod === 'discord' ? (
-                    <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                    <Icons.discord className="mr-2 h-4 w-4" />
-                )}{" "}
-                {t('auth.signInWithDiscord')}
-            </Button>
-            <Button 
-                variant="outline" 
-                type="button" 
-                disabled={isLoading || authMethod === 'email'} 
-                onClick={onSubmitGoogle}
-            >
-                {isLoading && authMethod === 'google' ? (
-                    <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                    <Icons.google className="mr-2 h-4 w-4" />
-                )}{" "}
-                {t('auth.signInWithGoogle')}
-            </Button>
+
+            <div className="grid gap-3">
+                <Button
+                    variant="outline"
+                    type="button"
+                    className={SECONDARY_ACTION}
+                    disabled={isLoading || authMethod === 'email'}
+                    onClick={onSubmitDiscord}
+                >
+                    {isLoading && authMethod === 'discord' ? (
+                        <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                        <Icons.discord className="mr-2 h-4 w-4" />
+                    )}{" "}
+                    {t('auth.signInWithDiscord')}
+                </Button>
+                <Button
+                    variant="outline"
+                    type="button"
+                    className={SECONDARY_ACTION}
+                    disabled={isLoading || authMethod === 'email'}
+                    onClick={onSubmitGoogle}
+                >
+                    {isLoading && authMethod === 'google' ? (
+                        <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                        <Icons.google className="mr-2 h-4 w-4" />
+                    )}{" "}
+                    {t('auth.signInWithGoogle')}
+                </Button>
+            </div>
         </div>
     )
 }

--- a/components/trading-candlestick-icon.tsx
+++ b/components/trading-candlestick-icon.tsx
@@ -1,0 +1,400 @@
+'use client';
+
+import { useEffect, useId, useMemo, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Lifetime of one bar before the next one opens. */
+const BAR_MS = 2200;
+/** Price prints inside one bar. Discrete on purpose — a live feed ticks, it doesn't ease. */
+const TICKS_PER_BAR = 26;
+/** Horizontal distance between bar centres, in view units. */
+const PITCH = 10;
+/** Standard candlestick proportions: body ~60% of pitch, wick ~1/6 of the body. */
+const BODY_WIDTH = PITCH * 0.6;
+const WICK_WIDTH = BODY_WIDTH / 6;
+/** How fast the y-axis catches up when the visible range changes. */
+const SCALE_TAU_MS = 650;
+/** Guards against the series jumping minutes ahead after the tab was backgrounded. */
+const MAX_FRAME_MS = 100;
+
+const DEFAULT_VISIBLE_BARS = 3;
+const UP_COLOR = "hsl(var(--chart-win))";
+const DOWN_COLOR = "hsl(var(--chart-loss))";
+
+/* ------------------------------------------------------------------ series */
+
+/** Deterministic PRNG so the chart is identical on every mount. */
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Bar = {
+  open: number;
+  close: number;
+  /** Price at each print. `ticks[0]` is the open, `ticks[TICKS_PER_BAR]` the close. */
+  ticks: number[];
+  /** Running high/low up to each print — the wick extremes as they were known then. */
+  runHigh: number[];
+  runLow: number[];
+};
+
+/**
+ * Random walk with volatility clustering and mean reversion, sampled at tick
+ * resolution. The wick extremes fall out of the walk rather than being drawn
+ * first and animated into, which is what makes the print read as real data.
+ */
+function createSeries(seed: number) {
+  const rand = mulberry32(seed);
+  /** Approximately normal, cheap. */
+  const shock = () => rand() + rand() + rand() - 1.5;
+
+  let price = 0;
+  let vol = 1;
+  let trend = 0;
+
+  return function nextBar(): Bar {
+    vol = Math.min(1.9, Math.max(0.55, vol * (0.86 + rand() * 0.32)));
+    trend = trend * 0.72 + shock() * 0.55 - price * 0.05;
+
+    const open = price;
+    const drift = trend / TICKS_PER_BAR;
+    const ticks = [open];
+    const runHigh = [open];
+    const runLow = [open];
+
+    for (let i = 1; i <= TICKS_PER_BAR; i += 1) {
+      price += drift + shock() * 0.22 * vol;
+      ticks.push(price);
+      runHigh.push(Math.max(runHigh[i - 1], price));
+      runLow.push(Math.min(runLow[i - 1], price));
+    }
+
+    return { open, close: price, ticks, runHigh, runLow };
+  };
+}
+
+/* ------------------------------------------------------------------- props */
+
+type TradingCandlestickIconProps = {
+  className?: string;
+  width?: number;
+  height?: number;
+  size?: number;
+  /** Bars filling the viewport. */
+  visibleCandles?: number;
+  /** Horizontal dashed line tracking the live price, like a chart's last-price marker. */
+  showPriceLine?: boolean;
+  seed?: number;
+};
+
+export function TradingCandlestickIcon({
+  className,
+  width,
+  height,
+  size = 14,
+  visibleCandles = DEFAULT_VISIBLE_BARS,
+  showPriceLine = true,
+  seed = 20240816,
+}: TradingCandlestickIconProps) {
+  const reactId = useId().replace(/:/g, "");
+  const maskId = `tc-${reactId}-fade`;
+  const gradientId = `tc-${reactId}-fade-grad`;
+
+  const visible = Math.max(1, Math.round(visibleCandles));
+  /** One spare off-screen left, one entering right. */
+  const slots = visible + 2;
+
+  const renderedWidth = width ?? size;
+  const renderedHeight = height ?? size;
+
+  /* Bar density is fixed by count; the height follows the element's real aspect
+     ratio so nothing is ever stretched — bodies stay rectangular and wicks stay
+     hairlines. The props only seed the first paint; a ResizeObserver keeps the
+     viewBox matched to the box CSS actually gives us. */
+  const viewWidth = visible * PITCH;
+  const initialViewHeight = (viewWidth * renderedHeight) / renderedWidth;
+
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const viewHeightRef = useRef(initialViewHeight);
+  const bodyRefs = useRef<(SVGRectElement | null)[]>([]);
+  const wickRefs = useRef<(SVGLineElement | null)[]>([]);
+  const priceLineRef = useRef<SVGLineElement | null>(null);
+
+  const slotIndexes = useMemo(
+    () => Array.from({ length: slots }, (_, i) => i),
+    [slots],
+  );
+
+  useEffect(() => {
+    const nextBar = createSeries(seed);
+    /** `bars[0]` is bar number `firstIndex`; bars are generated on demand. */
+    const bars: Bar[] = [];
+    let firstIndex = 0;
+
+    const barAt = (index: number) => {
+      while (firstIndex + bars.length <= index) bars.push(nextBar());
+      return bars[index - firstIndex];
+    };
+
+    /** Drop history that has scrolled off, never past the leftmost drawn bar. */
+    const trimBefore = (index: number) => {
+      while (firstIndex < index && bars.length > slots + 1) {
+        bars.shift();
+        firstIndex += 1;
+      }
+    };
+
+    /* The strip opens mid-session, so the timeline starts a full window in. */
+    const startCursor = slots - 1;
+
+    let domainLow = Number.NaN;
+    let domainHigh = Number.NaN;
+
+    const draw = (elapsedMs: number, frameMs: number) => {
+      const cursor = startCursor + elapsedMs / BAR_MS;
+      const liveIndex = Math.floor(cursor);
+      const barProgress = cursor - liveIndex;
+
+      const first = liveIndex - slots + 1;
+      trimBefore(first);
+
+      const state: {
+        x: number;
+        open: number;
+        price: number;
+        high: number;
+        low: number;
+      }[] = [];
+
+      let targetLow = Infinity;
+      let targetHigh = -Infinity;
+
+      for (let s = 0; s < slots; s += 1) {
+        const index = first + s;
+        const bar = barAt(index);
+        const live = index === liveIndex;
+        /* Discrete prints: the price jumps between ticks the way a feed does. */
+        const tick = live
+          ? Math.min(TICKS_PER_BAR, Math.floor(barProgress * TICKS_PER_BAR))
+          : TICKS_PER_BAR;
+
+        const entry = {
+          x: viewWidth - PITCH / 2 - (cursor - index) * PITCH,
+          open: bar.open,
+          price: bar.ticks[tick],
+          high: bar.runHigh[tick],
+          low: bar.runLow[tick],
+        };
+        state.push(entry);
+
+        /* Scale to what is currently known, never to the bar's future extremes. */
+        if (entry.x > -PITCH && entry.x < viewWidth + PITCH) {
+          if (entry.low < targetLow) targetLow = entry.low;
+          if (entry.high > targetHigh) targetHigh = entry.high;
+        }
+      }
+
+      if (targetHigh - targetLow < 0.5) {
+        const mid = (targetHigh + targetLow) / 2;
+        targetLow = mid - 0.25;
+        targetHigh = mid + 0.25;
+      }
+
+      /* Ease the axis toward the new range — a chart rescales, it doesn't snap. */
+      if (Number.isNaN(domainLow)) {
+        domainLow = targetLow;
+        domainHigh = targetHigh;
+      } else {
+        const k = 1 - Math.exp(-frameMs / SCALE_TAU_MS);
+        domainLow += (targetLow - domainLow) * k;
+        domainHigh += (targetHigh - domainHigh) * k;
+      }
+
+      const viewHeight = viewHeightRef.current;
+      const padY = viewHeight * 0.12;
+      const span = domainHigh - domainLow || 1;
+      const plot = viewHeight - padY * 2;
+      const y = (price: number) => padY + ((domainHigh - price) / span) * plot;
+
+      for (let s = 0; s < slots; s += 1) {
+        const { x, open, price, high, low } = state[s];
+        const body = bodyRefs.current[s];
+        const wick = wickRefs.current[s];
+        if (!body || !wick) continue;
+
+        const up = price >= open;
+        const color = up ? UP_COLOR : DOWN_COLOR;
+        const top = y(Math.max(open, price));
+        const bottom = y(Math.min(open, price));
+        /* A doji still has to render as a line, not vanish. */
+        const bodyHeight = Math.max(bottom - top, WICK_WIDTH);
+
+        wick.setAttribute("x1", `${x}`);
+        wick.setAttribute("x2", `${x}`);
+        wick.setAttribute("y1", `${y(high)}`);
+        wick.setAttribute("y2", `${y(low)}`);
+        if (wick.dataset.color !== color) {
+          wick.setAttribute("stroke", color);
+          wick.dataset.color = color;
+        }
+
+        body.setAttribute("x", `${x - BODY_WIDTH / 2}`);
+        body.setAttribute("y", `${top}`);
+        body.setAttribute("height", `${bodyHeight}`);
+        if (body.dataset.color !== color) {
+          body.setAttribute("fill", color);
+          body.dataset.color = color;
+        }
+      }
+
+      const priceLine = priceLineRef.current;
+      if (priceLine) {
+        const live = state[slots - 1];
+        const lineY = `${y(live.price)}`;
+        priceLine.setAttribute("y1", lineY);
+        priceLine.setAttribute("y2", lineY);
+      }
+    };
+
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    let frame = 0;
+    let previous = 0;
+    let elapsed = 0;
+
+    const tick = (now: number) => {
+      const frameMs = previous ? Math.min(now - previous, MAX_FRAME_MS) : 16;
+      previous = now;
+      elapsed += frameMs;
+      draw(elapsed, frameMs);
+      frame = requestAnimationFrame(tick);
+    };
+
+    /* A frame long enough to snap the axis straight to its target, so the chart
+       never opens mid-rescale. */
+    const settle = () => draw(elapsed, SCALE_TAU_MS * 20);
+
+    const start = () => {
+      /* Paint one correct frame synchronously. rAF never fires while the tab is
+         backgrounded, so without this the chart can mount and stay blank. */
+      settle();
+      if (reduceMotion.matches) return;
+      previous = 0;
+      frame = requestAnimationFrame(tick);
+    };
+
+    const restart = () => {
+      cancelAnimationFrame(frame);
+      frame = 0;
+      start();
+    };
+
+    const svg = svgRef.current;
+    const observer = new ResizeObserver(() => {
+      /* Read from the element rather than the entry — `contentRect` on SVG roots
+         is less consistent across engines than getBoundingClientRect. */
+      const box = svg?.getBoundingClientRect();
+      if (!svg || !box || box.width === 0 || box.height === 0) return;
+      viewHeightRef.current = (viewWidth * box.height) / box.width;
+      svg.setAttribute("viewBox", `0 0 ${viewWidth} ${viewHeightRef.current}`);
+      /* Re-map to the new height now; the rAF loop would only catch up next frame. */
+      settle();
+    });
+    if (svg) observer.observe(svg);
+
+    start();
+    reduceMotion.addEventListener("change", restart);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      reduceMotion.removeEventListener("change", restart);
+    };
+  }, [seed, slots, viewWidth]);
+
+  return (
+    <svg
+      ref={svgRef}
+      aria-hidden="true"
+      className={cn("inline-block shrink-0", className)}
+      width={renderedWidth}
+      height={renderedHeight}
+      viewBox={`0 0 ${viewWidth} ${initialViewHeight}`}
+      fill="none"
+    >
+      <defs>
+        <linearGradient
+          id={gradientId}
+          gradientUnits="userSpaceOnUse"
+          x1="0"
+          x2={viewWidth}
+        >
+          <stop offset="0" stopColor="#fff" stopOpacity="0" />
+          <stop offset="0.14" stopColor="#fff" stopOpacity="0.55" />
+          <stop offset="0.34" stopColor="#fff" stopOpacity="1" />
+        </linearGradient>
+        {/* Tall enough to cover any viewBox height the ResizeObserver lands on. */}
+        <mask id={maskId} maskUnits="userSpaceOnUse">
+          <rect
+            x="0"
+            y="-2000"
+            width={viewWidth}
+            height="4000"
+            fill={`url(#${gradientId})`}
+          />
+        </mask>
+      </defs>
+
+      <g mask={`url(#${maskId})`}>
+        {showPriceLine && (
+          <line
+            ref={priceLineRef}
+            x1="0"
+            x2={viewWidth}
+            y1={initialViewHeight / 2}
+            y2={initialViewHeight / 2}
+            stroke="currentColor"
+            strokeOpacity="0.25"
+            strokeWidth={WICK_WIDTH * 0.8}
+            strokeDasharray={`${PITCH * 0.2} ${PITCH * 0.25}`}
+          />
+        )}
+
+        {slotIndexes.map((s) => (
+          <g key={s}>
+            {/* One high→low line with the body drawn over it — how charts render a bar. */}
+            <line
+              ref={(node) => {
+                wickRefs.current[s] = node;
+              }}
+              x1="0"
+              x2="0"
+              y1={initialViewHeight / 2}
+              y2={initialViewHeight / 2}
+              stroke={UP_COLOR}
+              strokeWidth={WICK_WIDTH}
+            />
+            <rect
+              ref={(node) => {
+                bodyRefs.current[s] = node;
+              }}
+              x="0"
+              y={initialViewHeight / 2}
+              width={BODY_WIDTH}
+              height={WICK_WIDTH}
+              rx={WICK_WIDTH * 0.5}
+              fill={UP_COLOR}
+            />
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/locales/en/auth.ts
+++ b/locales/en/auth.ts
@@ -34,6 +34,7 @@ export default {
         openMailboxManualCheck: 'Check your inbox for the sign-in email from Deltalytix.',
         resendIn: 'Resend in',
         resendEmail: 'Resend Email',
+        changeEmail: 'Use a different email',
         verificationCode: 'Verification Code',
         verifyCode: 'Verify Code',
         // Identity linking

--- a/locales/fr/auth.ts
+++ b/locales/fr/auth.ts
@@ -34,6 +34,7 @@ export default {
         openMailboxManualCheck: 'Consultez votre boîte de réception pour l\'e-mail de connexion Deltalytix.',
         resendIn: 'Renvoyer dans',
         resendEmail: 'Renvoyer l\'Email',
+        changeEmail: 'Utiliser une autre adresse',
         verificationCode: 'Code de Vérification',
         verifyCode: 'Vérifier le Code',
         // Identity linking


### PR DESCRIPTION
Two commits against the authentication page.

## 1. Replace the hero image with a live candlestick chart

The left panel used a static `/auth-background.jpeg`. It's now a streaming candlestick chart that prints bars in real time.

- **One rAF loop, no React re-renders.** SVG attributes are written through refs each frame.
- **Bars are real data, not a keyframe motif.** A seeded random walk with volatility clustering and mean reversion, sampled at tick resolution. The body spans open→current print; the wick is that same walk's running high/low, so extremes only ever extend and never retract.
- **Discrete price, continuous scroll.** Price steps between ticks the way a live feed does, while the strip scrolls smoothly and the y-axis rescales with exponential smoothing.
- **No distortion at any size.** The viewBox is derived from the element's measured box via `ResizeObserver`.
- **Colors** use the existing `--chart-win` / `--chart-loss` tokens.

Edge cases: one frame paints synchronously on mount (`requestAnimationFrame` never fires if the page loads backgrounded, which would leave the chart blank); `prefers-reduced-motion` renders a single settled chart; frame deltas are clamped so returning from a background tab doesn't jump the series forward by minutes.

## 2. Restyle the form to the landing page design language

Previously default shadcn chrome — filled tab pills, shadowed controls, `lg` radii, a centred semibold heading.

- `rounded-sm`, hairline borders, no shadows, the filled oklch primary CTA and hover washes lifted from the hero, and the `/55` `/45` text hierarchy.
- **Tabs → progressive disclosure.** An email field plus a "Use password instead" toggle that reveals the password field. Two peer tabs reflowed everything below them on switch; a user-triggered disclosure is simpler and is expected to change height. The reveal animates a `0fr`→`1fr` grid row, which is animatable where `height: auto` is not.
- **Auto-verify the OTP.** The code is fixed-length, so "Verify Code" was never a decision. A ref guards double submits; a failed attempt clears the field so the next keystroke retries.
- **"Open Mailbox" and "Resend Email" share a row**, and a return control now sits inside the email field once the link is sent — that state locks the field, so there was previously no way to fix a typo or switch to password sign-in without reloading.
- OTP slots sized to the same 44px as every other control.

Also fixes the separator label, which sat on a grey chip because it used `bg-background` on a `bg-card` panel, and gives the form column `h-full` so `bg-card` covers the whole panel instead of shrink-wrapping to the form.

New locale key `auth.changeEmail` in `en` and `fr`. `auth.usePassword` / `auth.useMagicLink` already existed.

## Verification

Typechecks clean; ESLint reports the same 4 pre-existing problems before and after. Chart print behaviour verified frame by frame by driving the draw function across a full bar: the strip advances exactly one pitch per bar, the upper wick only rises and the lower only falls, the body tracks the price between them. Form verified at desktop, tablet and mobile, including the email-sent state (forced locally rather than sending mail) — every control measures 44px.

## Known follow-up (not in this PR)

At tablet widths (768–1023px) the form column has grey gutters: the container turns on `md:grid` but only defines columns at `lg:grid-cols-2`, so the single implicit track is auto-sized and centered. `md:grid-cols-1` would make it full-bleed; left out pending a call on whether the centered column is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)