### PR TITLE
Derive user identity from the Supabase session, not request headers

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -51,13 +51,12 @@ export async function GET(request: Request) {
           return NextResponse.redirect(redirectUrl)
         }
 
-        // Ensure DB user exists and persist locale before redirecting
+        // Ensure DB user exists and persist locale before redirecting.
+        // ensureUserInDatabase resolves the identity from the verified session
+        // itself, so there is no user to fetch or pass in here.
         try {
-          const { data: { user } } = await supabase.auth.getUser()
-          if (user) {
-            const ensureResult = await ensureUserInDatabase(user, locale)
-            isNewUser = ensureResult.isNewUser
-          }
+          const ensureResult = await ensureUserInDatabase(locale)
+          isNewUser = ensureResult.isNewUser
         } catch (e) {
           console.error('Auth callback ensureUserInDatabase error:', e)
           // Non-fatal: continue redirect

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -4,7 +4,6 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
 import { headers } from "next/headers"
-import { User } from '@supabase/supabase-js'
 import {
   buildLocalDashboardBypassUser,
   getLocalDashboardUserEmail,
@@ -274,7 +273,7 @@ export async function signInWithPasswordAction(
           // User is automatically signed in (email confirmation disabled)
           let isNewUser = false
           try {
-            const ensureResult = await ensureUserInDatabase(signUpData.user, locale)
+            const ensureResult = await ensureUserRecord(signUpData.user, locale)
             isNewUser = ensureResult.isNewUser
           } catch (e) {
             // Non-fatal; still proceed
@@ -294,12 +293,13 @@ export async function signInWithPasswordAction(
           throw new Error(signInError.message)
         }
         
-        // Continue with normal flow after successful sign-in
+        // Continue with normal flow after successful sign-in. signInWithPassword
+        // just returned this user from the Auth server, so it is already verified —
+        // no need to re-fetch it.
         let isNewUser = false
         try {
-          const { data: { user } } = await supabase.auth.getUser()
-          if (user) {
-            const ensureResult = await ensureUserInDatabase(user, locale)
+          if (signInData.user) {
+            const ensureResult = await ensureUserRecord(signInData.user, locale)
             isNewUser = ensureResult.isNewUser
           }
         } catch (e) {
@@ -314,12 +314,12 @@ export async function signInWithPasswordAction(
       throw new Error(error.message)
     }
 
-    // Sign-in succeeded normally
+    // Sign-in succeeded normally. `data.user` comes straight from the
+    // signInWithPassword response, so it is already Auth-server verified.
     let isNewUser = false
     try {
-      const { data: { user } } = await supabase.auth.getUser()
-      if (user) {
-        const ensureResult = await ensureUserInDatabase(user, locale)
+      if (data.user) {
+        const ensureResult = await ensureUserRecord(data.user, locale)
         isNewUser = ensureResult.isNewUser
       }
     } catch (e) {
@@ -364,7 +364,7 @@ export async function signUpWithPasswordAction(
     let isNewUser = false
     if (data.user && data.session) {
       try {
-        const ensureResult = await ensureUserInDatabase(data.user, locale)
+        const ensureResult = await ensureUserRecord(data.user, locale)
         isNewUser = ensureResult.isNewUser
       } catch (e) {
         // Non-fatal; still proceed
@@ -411,8 +411,10 @@ export async function setPasswordAction(newPassword: string) {
  *   email set from the Supabase profile, and language set to `locale` (default 'en'). Also
  *   attempts to create a default dashboard layout for first-time users.
  *
+ * Identity is resolved from the verified Supabase session inside this function and is
+ * never accepted as an argument — see `ensureUserRecord` for why.
+ *
  * Parameters:
- * - user: Supabase `User` object (required). Must contain a valid `id`.
  * - locale: Optional locale string from the client (e.g. 'en', 'fr'). When provided, it is
  *   persisted to the `language` field for the user record.
  *
@@ -425,10 +427,27 @@ export async function setPasswordAction(newPassword: string) {
  * - May create a default dashboard layout for new users.
  *
  * Errors:
- * - Throws on missing user or id, account conflicts, Prisma integrity/validation issues, or
- *   unexpected errors. NEXT_REDIRECT errors are re-thrown to allow Next.js redirects.
+ * - Throws when there is no authenticated session, and on account conflicts, Prisma
+ *   integrity/validation issues, or unexpected errors. NEXT_REDIRECT errors are re-thrown
+ *   to allow Next.js redirects.
  */
-export async function ensureUserInDatabase(user: User, locale?: string) {
+export async function ensureUserInDatabase(locale?: string) {
+  const user = await getAuthenticatedUser();
+
+  return ensureUserRecord(user, locale);
+}
+
+/**
+ * Internal counterpart of `ensureUserInDatabase`.
+ *
+ * Deliberately NOT exported: this module is `'use server'`, so every export is a
+ * callable Server Action whose arguments are supplied by the client. Keeping this
+ * unexported is what makes the `user` argument trustworthy — it can only be reached
+ * from a caller inside this module that already holds an identity verified by the
+ * Auth server (a sign-in/sign-up/verify-OTP response, or `getAuthenticatedUser()`).
+ * Exporting it would let a forged `User` object create or rewrite arbitrary rows.
+ */
+async function ensureUserRecord(user: AuthenticatedIdentity, locale?: string) {
   console.log('[ensureUserInDatabase] Starting with user:', { id: user?.id, email: user?.email });
   
   if (!user) {
@@ -442,17 +461,6 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
     await signOut();
     throw new Error('User ID is required');
   }
-
-  // This module is 'use server', so every export is a callable Server Action and
-  // `user` is caller-supplied. Bind it to the verified session before it reaches
-  // Prisma, otherwise a forged User object can create or rewrite arbitrary rows.
-  const sessionSupabase = await createClient();
-  const { data: { user: sessionUser } } = await sessionSupabase.auth.getUser();
-  if (!sessionUser?.id || sessionUser.id !== user.id) {
-    console.log('[ensureUserInDatabase] ERROR: Session does not match provided user');
-    throw new Error('Unauthorized');
-  }
-  user = sessionUser;
 
   try {
     // First try to find user by auth_user_id
@@ -600,7 +608,7 @@ export async function verifyOtp(email: string, token: string, type: 'email' | 's
     let isNewUser = false
     if (data.user && data.session) {
       const locale = email.includes('.fr') ? 'fr' : 'en';
-      const ensureResult = await ensureUserInDatabase(data.user, locale)
+      const ensureResult = await ensureUserRecord(data.user, locale)
       isNewUser = ensureResult.isNewUser
     }
 
@@ -614,15 +622,50 @@ export async function verifyOtp(email: string, token: string, type: 'email' | 's
   }
 }
 
+/**
+ * The subset of the Supabase user the database sync actually reads. A full
+ * `User` is assignable to it, so callers holding one can pass it straight
+ * through, while a verified JWT claim set satisfies it without being faked
+ * into a `User` shape.
+ */
+type AuthenticatedIdentity = {
+  id: string
+  email?: string | null
+  app_metadata?: { provider?: string; [key: string]: any }
+}
+
 // The proxy publishes the resolved identity as *response* headers (x-user-id,
 // x-user-email) for observability. It never rewrites the inbound request —
 // NextResponse.next({ request: { headers } }) forwards the caller's own headers
 // untouched — and it does not run for /api/* at all. Reading those names back
 // off the incoming request therefore only ever returns a value the caller
 // supplied, so identity is always resolved from the verified Supabase session.
-async function getAuthenticatedUser(): Promise<User> {
+async function getAuthenticatedUser(): Promise<AuthenticatedIdentity> {
   try {
     const supabase = await createClient()
+
+    // getClaims() *verifies* the access token rather than merely decoding it:
+    // with asymmetric signing keys it checks the signature locally via WebCrypto
+    // against the cached JWKS, and with a symmetric secret it falls back to
+    // asking the Auth server exactly like getUser(). Either way the identity is
+    // authenticated, so this is not the unverified getSession() shortcut — it
+    // just skips a network round trip on the common path. Same approach the
+    // proxy already takes in updateSession().
+    if (typeof supabase.auth.getClaims === "function") {
+      const { data, error } = await supabase.auth.getClaims()
+      const claims = data?.claims
+
+      if (!error && claims?.sub) {
+        return {
+          id: claims.sub,
+          email: claims.email ?? null,
+          app_metadata: claims.app_metadata,
+        }
+      }
+    }
+
+    // No getClaims (the local-dashboard bypass stub) or it could not verify —
+    // fall back to the Auth server.
     const {
       data: { user },
       error,

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -443,6 +443,17 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
     throw new Error('User ID is required');
   }
 
+  // This module is 'use server', so every export is a callable Server Action and
+  // `user` is caller-supplied. Bind it to the verified session before it reaches
+  // Prisma, otherwise a forged User object can create or rewrite arbitrary rows.
+  const sessionSupabase = await createClient();
+  const { data: { user: sessionUser } } = await sessionSupabase.auth.getUser();
+  if (!sessionUser?.id || sessionUser.id !== user.id) {
+    console.log('[ensureUserInDatabase] ERROR: Session does not match provided user');
+    throw new Error('Unauthorized');
+  }
+  user = sessionUser;
+
   try {
     // First try to find user by auth_user_id
     const existingUserByAuthId = await prisma.user.findUnique({
@@ -603,25 +614,14 @@ export async function verifyOtp(email: string, token: string, type: 'email' | 's
   }
 }
 
-// Optimized function that uses middleware data when available
-export async function getUserId(): Promise<string> {
-  if (isLocalDashboardAuthBypassEnabled()) {
-    await ensureLocalDashboardUserInDatabase()
-    return getLocalDashboardUserId()
-  }
-
-  // First try to get user ID from middleware headers
-  const headersList = await headers()
-  const userIdFromMiddleware = headersList.get("x-user-id")
-
-  if (userIdFromMiddleware) {
-    console.log("[Auth] Using user ID from middleware")
-    return userIdFromMiddleware
-  }
-
-  // Fallback to Supabase call (for API routes or edge cases)
+// The proxy publishes the resolved identity as *response* headers (x-user-id,
+// x-user-email) for observability. It never rewrites the inbound request —
+// NextResponse.next({ request: { headers } }) forwards the caller's own headers
+// untouched — and it does not run for /api/* at all. Reading those names back
+// off the incoming request therefore only ever returns a value the caller
+// supplied, so identity is always resolved from the verified Supabase session.
+async function getAuthenticatedUser(): Promise<User> {
   try {
-    console.log("[Auth] Fallback to Supabase call")
     const supabase = await createClient()
     const {
       data: { user },
@@ -632,10 +632,21 @@ export async function getUserId(): Promise<string> {
       throw new Error("User not authenticated")
     }
 
-    return user.id
+    return user
   } catch (error: any) {
     handleAuthError(error)
   }
+}
+
+export async function getUserId(): Promise<string> {
+  if (isLocalDashboardAuthBypassEnabled()) {
+    await ensureLocalDashboardUserInDatabase()
+    return getLocalDashboardUserId()
+  }
+
+  const user = await getAuthenticatedUser()
+
+  return user.id
 }
 
 export async function getUserEmail(): Promise<string> {
@@ -643,10 +654,9 @@ export async function getUserEmail(): Promise<string> {
     return getLocalDashboardUserEmail()
   }
 
-  const headersList = await headers()
-  const userEmail = headersList.get("x-user-email")
-  console.log("[Auth] getUserEmail FROM HEADERS", userEmail)
-  return userEmail || ""
+  const user = await getAuthenticatedUser()
+
+  return user.email || ""
 }
 
 // Lightweight updater for user language without full ensure logic

--- a/server/subscription.ts
+++ b/server/subscription.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { prisma } from '@/lib/prisma'
-import { headers } from 'next/headers';
 import { createClient } from './auth';
 
 interface SubscriptionInfo {
@@ -20,18 +19,15 @@ function isValidEmail(email: string): boolean {
 }
 
 export async function getSubscriptionDetails(): Promise<SubscriptionInfo | null> {
-    // Get user email using headers from our middleware
-    const headersList = await headers()
-    let email = headersList.get("x-user-email")
-    if (!email) {
-        // USE supabase to get user email
-        const supabase = await createClient()
-        const { data: { user } } = await supabase.auth.getUser()
-        if (!user) {
-            return null
-        }
-        email = user.email || null
+    // Entitlements are keyed on the email, so it must come from the verified
+    // session — never from a request header, which the caller controls.
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+        return null
     }
+    const email = user.email || null
+
     // Input validation
     if (!email || !isValidEmail(email)) {
         console.error('[getSubscriptionDetails] Invalid email format:', email)


### PR DESCRIPTION
First slice of #407, split out so the critical fix can ship and be rolled back on its own. Targets `beta`.

## The problem

`getUserId()` read `x-user-id` off the **incoming request** and returned it as the caller's identity:

```ts
const headersList = await headers()
const userIdFromMiddleware = headersList.get("x-user-id")
if (userIdFromMiddleware) {
  return userIdFromMiddleware   // caller-supplied
}
```

The comment called this "middleware data", but the proxy only ever sets those names on the **response**:

```ts
// proxy.ts
const response = NextResponse.next({ request: { headers: request.headers } })  // forwards caller's headers untouched
response.headers.set("x-user-id", user.id)                                      // response only
```

`NextResponse.next({ request: { headers } })` passes the caller's own headers through — it does not inject anything — and the proxy is skipped for `/api/*` entirely. So `headers().get("x-user-id")` inside a Server Action returns whatever the client sent.

**Impact:** any request carrying `x-user-id: VICTIM_UUID` was treated as that user by every Server Action and route that resolves identity through `getUserId()` — reads and writes alike. No session or token required. `getSubscriptionDetails()` had the same problem through `x-user-email`, which keys entitlements.

## The fix

- `getUserId()` / `getUserEmail()` resolve through a shared `getAuthenticatedUser()` backed by `supabase.auth.getUser()`. The header path is gone, along with the comment that made it look intentional.
- `getSubscriptionDetails()` reads the email from the verified session.
- `ensureUserInDatabase` is an export of a `'use server'` module, so its `User` argument is caller-supplied and reached Prisma unverified — a forged object could create or rewrite rows. It is now bound to the session user before any write.

`supabase.auth.getUser()` was already the fallback on every one of these paths, so the behaviour for legitimate traffic is unchanged; only the bypass is removed.

## Scope

Deliberately limited to identity resolution. The rest of #407 is filed as #411–#425 so each piece lands as its own reviewable MR.

Two things I left alone on purpose:

- The proxy still sets `x-user-id` / `x-user-email` as response headers. They have no consumer and put the user's email in every response, but removing them is a separate change — filed as #425.
- `getUserEmail()` has no callers anywhere in the repo. Fixed rather than deleted, to keep this diff to the vulnerability.

## Test plan

- [x] `bun run typecheck` clean
- [ ] Preview: sign in, confirm dashboard/trades load and subscription state resolves
- [ ] Preview: fresh signup through `/api/auth/callback` still creates the DB user (exercises the `ensureUserInDatabase` session binding)
- [ ] Preview: `curl -H "x-user-id: OTHER_USER_UUID"` against a dashboard route returns the *caller's* data, not the victim's

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aMFhtzMid7vohuXCYPaa1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-critical auth and entitlement resolution changes; incorrect session binding could break login or DB sync, but the fix removes impersonation via headers and forged server-action arguments.
> 
> **Overview**
> **Closes a critical identity spoofing path** where `getUserId()`, `getUserEmail()`, and subscription lookups could trust caller-controlled `x-user-id` / `x-user-email` request headers (the proxy only sets those on responses, so inbound headers were client-supplied).
> 
> Identity now flows through a shared **`getAuthenticatedUser()`** that verifies the session via `supabase.auth.getClaims()` when available, otherwise **`getUser()`**. **`getSubscriptionDetails()`** uses the session email only for entitlements.
> 
> **`ensureUserInDatabase`** no longer accepts a Supabase `User` from the client (a `'use server'` export made that argument forgeable). It binds to the verified session internally; password/OAuth/OTP paths call an unexported **`ensureUserRecord`** only with users returned from the Auth server. The OAuth callback calls **`ensureUserInDatabase(locale)`** after `exchangeCodeForSession` without a separate `getUser()` fetch.
> 
> Legitimate authenticated traffic should behave the same; the header and forged-user bypasses are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5703f206dfb04030a5e1880a54a8a5d6e9f1c18b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->