### PR TITLE
Fix IG connect: reject email identifiers with a clear username hint

### DIFF
--- a/app/[locale]/dashboard/components/import/ig/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/ig/sync/actions.ts
@@ -20,6 +20,7 @@ import {
   switchIgAccount,
   type IgApiEnvironment,
 } from "@/lib/ig-api/client";
+import { isValidIgIdentifier } from "@/lib/ig-api/identifier";
 import { mapIgApiTransactions } from "@/lib/ig-api/transactions-to-trades";
 import type {
   IgActionResult,
@@ -64,6 +65,14 @@ function mapIgAuthError(
 
   if (code.includes("invalid-details")) {
     return { error: "IG_INVALID_CREDENTIALS" };
+  }
+  // Email logins work on ig.com; the REST API only accepts the username
+  // pattern [A-Za-z0-9_-]{1,30}. Surface that before a generic AUTH_FAILED.
+  if (
+    code.includes("authenticationrequest.identifier") ||
+    (code.includes("pattern.invalid") && code.includes("identifier"))
+  ) {
+    return { error: "IG_IDENTIFIER_INVALID" };
   }
   if (code.includes("api-key-disabled") || code.includes("api-key-revoked")) {
     return { error: "IG_API_KEY_DISABLED" };
@@ -172,6 +181,15 @@ export async function authenticateIg(
     if (!hasConnectionTokenEncryptionKey()) {
       logger.error("ENCRYPTION_KEY is not configured — refusing to connect IG");
       return { error: "ENCRYPTION_KEY_MISSING" };
+    }
+
+    // Same gate IG applies server-side. Catch emails (and other web-login forms)
+    // here so the trader gets a clear message instead of the raw pattern code.
+    if (!isValidIgIdentifier(trimmedIdentifier)) {
+      logger.warn(
+        `Rejecting identifier that does not match IG API pattern (length=${trimmedIdentifier.length})`,
+      );
+      return { error: "IG_IDENTIFIER_INVALID" };
     }
 
     logger.info(

--- a/app/[locale]/dashboard/components/import/ig/sync/ig-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/ig/sync/ig-credentials-manager.tsx
@@ -326,6 +326,9 @@ export function IgCredentialsManager() {
                 onChange={(e) => setIdentifier(e.target.value)}
                 className={fieldClassName}
               />
+              <p className="text-xs leading-relaxed text-black/45 dark:text-white/45">
+                {t("igSync.addAccount.usernameHint")}
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ig-mgr-password">

--- a/app/[locale]/dashboard/components/import/ig/sync/ig-faq.tsx
+++ b/app/[locale]/dashboard/components/import/ig/sync/ig-faq.tsx
@@ -23,6 +23,14 @@ export const IG_API_KEY_DOCS = {
     "https://www.ig.com/fr/plateformes-de-trading/api-de-trading/comment-utiliser-les-api-de-trading-ig",
   frHelp:
     "https://www.ig.com/fr/portail-d-aide/plateformes/questions-generales/comment-puis-je-acceder-a-l-api-ig-et-a-quoi-cela-sert-il",
+  /** Recover forgotten username via the email on the account. */
+  frLostDetails: "https://www.ig.com/fr/lost-details",
+  enLostDetails: "https://www.ig.com/uk/lost-details",
+  /** My IG → Configuration → Informations personnelles (username is editable there). */
+  frPersonalInfo:
+    "https://www.ig.com/fr/portail-d-aide/comptes-et-releves/mon-compte/comment-puis-je-mettre-a-jour-mes-informations-personnelles",
+  enPersonalInfo:
+    "https://www.ig.com/uk/help-and-support/account-and-trading/your-ig-account/how-do-i-update-my-personal-details",
 } as const;
 
 const linkClassName =
@@ -124,6 +132,17 @@ export function IgConnectIntro() {
  */
 export function IgFaq() {
   const t = useI18n();
+  const locale = useCurrentLocale();
+  const usernameDocs =
+    locale === "fr"
+      ? {
+          personalInfo: IG_API_KEY_DOCS.frPersonalInfo,
+          lostDetails: IG_API_KEY_DOCS.frLostDetails,
+        }
+      : {
+          personalInfo: IG_API_KEY_DOCS.enPersonalInfo,
+          lostDetails: IG_API_KEY_DOCS.enLostDetails,
+        };
 
   return (
     <div className="space-y-1">
@@ -152,6 +171,14 @@ export function IgFaq() {
           </AccordionTrigger>
           <AccordionContent className={contentClassName}>
             <p>{t("igSync.faq.usernameAnswer")}</p>
+            <div className="flex flex-col gap-1.5 pt-1 sm:flex-row sm:flex-wrap sm:gap-x-4">
+              <DocLink href={usernameDocs.personalInfo}>
+                {t("igSync.faq.usernameLinkPersonalInfo")}
+              </DocLink>
+              <DocLink href={usernameDocs.lostDetails}>
+                {t("igSync.faq.usernameLinkLostDetails")}
+              </DocLink>
+            </div>
           </AccordionContent>
         </AccordionItem>
 

--- a/app/[locale]/dashboard/components/import/ig/sync/ig-faq.tsx
+++ b/app/[locale]/dashboard/components/import/ig/sync/ig-faq.tsx
@@ -144,6 +144,18 @@ export function IgFaq() {
         </AccordionItem>
 
         <AccordionItem
+          value="username"
+          className="border-black/10 dark:border-white/10"
+        >
+          <AccordionTrigger className={triggerClassName}>
+            {t("igSync.faq.usernameQuestion")}
+          </AccordionTrigger>
+          <AccordionContent className={contentClassName}>
+            <p>{t("igSync.faq.usernameAnswer")}</p>
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem
           value="scope"
           className="border-black/10 dark:border-white/10"
         >

--- a/app/[locale]/dashboard/components/import/ig/sync/ig-sync.tsx
+++ b/app/[locale]/dashboard/components/import/ig/sync/ig-sync.tsx
@@ -159,6 +159,9 @@ function IgConnectView({
           required
           className={fieldClassName}
         />
+        <p className="text-xs leading-relaxed text-black/45 dark:text-white/45">
+          {t("igSync.addAccount.usernameHint")}
+        </p>
       </div>
 
       <div className="space-y-2">

--- a/lib/ig-api/identifier.test.ts
+++ b/lib/ig-api/identifier.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  IG_IDENTIFIER_PATTERN,
+  isValidIgIdentifier,
+} from "./identifier";
+
+describe("isValidIgIdentifier", () => {
+  it("accepts IG usernames that match the API pattern", () => {
+    expect(isValidIgIdentifier("Sebastien42")).toBe(true);
+    expect(isValidIgIdentifier("user_name-01")).toBe(true);
+    expect(isValidIgIdentifier("A")).toBe(true);
+    expect(isValidIgIdentifier("a".repeat(30))).toBe(true);
+  });
+
+  it("rejects email addresses that work on the IG website", () => {
+    expect(isValidIgIdentifier("sebastien@example.com")).toBe(false);
+    expect(isValidIgIdentifier("user.name@ig.com")).toBe(false);
+  });
+
+  it("rejects empty, too long, or punctuation outside the pattern", () => {
+    expect(isValidIgIdentifier("")).toBe(false);
+    expect(isValidIgIdentifier("a".repeat(31))).toBe(false);
+    expect(isValidIgIdentifier("user name")).toBe(false);
+    expect(isValidIgIdentifier("user.name")).toBe(false);
+    expect(isValidIgIdentifier("user+tag")).toBe(false);
+  });
+
+  it("keeps the exported regex aligned with the helper", () => {
+    expect(IG_IDENTIFIER_PATTERN.source).toBe("^[A-Za-z0-9_-]{1,30}$");
+  });
+});

--- a/lib/ig-api/identifier.ts
+++ b/lib/ig-api/identifier.ts
@@ -1,0 +1,13 @@
+/**
+ * IG session `identifier` constraint (v2 / v3):
+ * Pattern(regexp="[A-Za-z0-9\\-_]{1,30}")
+ *
+ * The web platform accepts email logins; the REST API does not. An address
+ * with `@` fails validation as `validation.pattern.invalid.authenticationRequest.identifier`
+ * before IG even checks the password.
+ */
+export const IG_IDENTIFIER_PATTERN = /^[A-Za-z0-9_-]{1,30}$/;
+
+export function isValidIgIdentifier(identifier: string): boolean {
+  return IG_IDENTIFIER_PATTERN.test(identifier);
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2445,6 +2445,8 @@ export default {
       AUTH_FAILED: "IG login failed: {reason}",
       IG_INVALID_CREDENTIALS:
         "IG rejected this username or password. Check them on ig.com and try again.",
+      IG_IDENTIFIER_INVALID:
+        "IG's API does not accept an email address as the login. Use your IG username (letters, numbers, hyphen, underscore — max 30 characters), not the email you use on the website. You can find it under My Account on ig.com.",
       IG_API_KEY_REJECTED:
         "IG rejected this API key. Make sure it was created for the {environment} environment — a key made for one environment never works on the other.",
       IG_API_KEY_DISABLED:
@@ -2475,11 +2477,13 @@ export default {
       description:
         "Sign in with your IG username and password, then paste a personal API key.",
       intro:
-        "IG's API needs two things: your IG login, which proves the account is yours, and a personal API key, which identifies Deltalytix to IG. You create the key yourself on IG — it's free and takes about a minute.",
+        "IG's API needs two things: your IG username (not your email), which proves the account is yours, and a personal API key, which identifies Deltalytix to IG. You create the key yourself on IG — it's free and takes about a minute.",
       environmentLabel: "Environment",
       environmentLive: "Live",
       environmentDemo: "Demo",
       usernameLabel: "Username",
+      usernameHint:
+        "Not your email. IG's API only accepts the username (letters, numbers, - and _), which you can find under My Account on ig.com.",
       passwordLabel: "Password",
       apiKeyLabel: "API key",
       createKeyToggle: "How do I create one?",
@@ -2500,6 +2504,9 @@ export default {
       whyBothQuestion: "Why do you need my login and an API key?",
       whyBothAnswer:
         "They do different jobs. Your username and password prove the account is yours — IG signs you in with them. The API key identifies Deltalytix as the app making the request, and IG rejects any API call that does not carry one. Neither works without the other.",
+      usernameQuestion: "I log into IG with my email — which username do I use?",
+      usernameAnswer:
+        "The website accepts your email; the API does not. Enter the IG username from My Account (letters, numbers, hyphen, or underscore only — no @). Using an email returns a pattern validation error from IG.",
       scopeQuestion: "What does Deltalytix do with the key?",
       scopeIntro:
         "IG API keys have no OAuth-style scopes or permission checkboxes. One key identifies your app, and access follows your IG login. Deltalytix only ever:",
@@ -2558,7 +2565,7 @@ export default {
   "import.type.igSync.description":
     "Direct account synchronization with IG",
   "import.type.igSync.details":
-    "Sign in with your IG username and password, plus a personal API key you create on IG. Deltalytix only reads closed Transaction History — it never places trades. Create the key under My Account → Settings → API keys.",
+    "Sign in with your IG username (not email) and password, plus a personal API key you create on IG. Deltalytix only reads closed Transaction History — it never places trades. Create the key under My Account → Settings → API keys.",
   "import.type.atas.name": "ATAS",
   "import.type.atas.description": "ATAS Excel file",
   "import.type.atas.details":

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2446,7 +2446,7 @@ export default {
       IG_INVALID_CREDENTIALS:
         "IG rejected this username or password. Check them on ig.com and try again.",
       IG_IDENTIFIER_INVALID:
-        "IG's API does not accept an email address as the login. Use your IG username (letters, numbers, hyphen, underscore — max 30 characters), not the email you use on the website. You can find it under My Account on ig.com.",
+        "IG's API does not accept an email address as the login. Use your IG username (letters, numbers, hyphen, underscore — max 30 characters), not the email you use on the website. Find it under My IG → Settings → Personal details, or recover it via IG’s lost-details page.",
       IG_API_KEY_REJECTED:
         "IG rejected this API key. Make sure it was created for the {environment} environment — a key made for one environment never works on the other.",
       IG_API_KEY_DISABLED:
@@ -2483,7 +2483,7 @@ export default {
       environmentDemo: "Demo",
       usernameLabel: "Username",
       usernameHint:
-        "Not your email. IG's API only accepts the username (letters, numbers, - and _), which you can find under My Account on ig.com.",
+        "Not your email. IG's API only accepts the username (letters, numbers, - and _), which you can find under My IG → Settings → Personal details.",
       passwordLabel: "Password",
       apiKeyLabel: "API key",
       createKeyToggle: "How do I create one?",
@@ -2506,7 +2506,9 @@ export default {
         "They do different jobs. Your username and password prove the account is yours — IG signs you in with them. The API key identifies Deltalytix as the app making the request, and IG rejects any API call that does not carry one. Neither works without the other.",
       usernameQuestion: "I log into IG with my email — which username do I use?",
       usernameAnswer:
-        "The website accepts your email; the API does not. Enter the IG username from My Account (letters, numbers, hyphen, or underscore only — no @). Using an email returns a pattern validation error from IG.",
+        "The website accepts your email; the API does not. Enter the IG username from My IG → Settings → Personal details (letters, numbers, hyphen, or underscore only — no @). If you only remember the email, use IG’s lost-details page to recover the username.",
+      usernameLinkPersonalInfo: "IG — update personal details (username)",
+      usernameLinkLostDetails: "IG — recover forgotten username",
       scopeQuestion: "What does Deltalytix do with the key?",
       scopeIntro:
         "IG API keys have no OAuth-style scopes or permission checkboxes. One key identifies your app, and access follows your IG login. Deltalytix only ever:",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2585,7 +2585,7 @@ export default {
       IG_INVALID_CREDENTIALS:
         "IG a refusé cet identifiant ou ce mot de passe. Vérifiez-les sur ig.com puis réessayez.",
       IG_IDENTIFIER_INVALID:
-        "L’API d’IG n’accepte pas une adresse e-mail comme identifiant. Utilisez votre nom d’utilisateur IG (lettres, chiffres, tiret, underscore — 30 caractères max), pas l’e-mail avec lequel vous vous connectez sur le site. Vous le trouverez dans Mon compte sur ig.com.",
+        "L’API d’IG n’accepte pas une adresse e-mail comme identifiant. Utilisez votre nom d’utilisateur IG (lettres, chiffres, tiret, underscore — 30 caractères max), pas l’e-mail avec lequel vous vous connectez sur le site. Vous le trouverez dans My IG → Configuration → Informations personnelles, ou via la page Identifiants perdus d’IG.",
       IG_API_KEY_REJECTED:
         "IG a refusé cette clé API. Vérifiez qu'elle a bien été créée pour l'environnement {environment} — une clé créée pour un environnement ne fonctionne jamais sur l'autre.",
       IG_API_KEY_DISABLED:
@@ -2626,7 +2626,7 @@ export default {
       environmentDemo: "Démo",
       usernameLabel: "Nom d'utilisateur",
       usernameHint:
-        "Pas votre e-mail. L’API n’accepte que le nom d’utilisateur IG (lettres, chiffres, - et _), visible dans Mon compte sur ig.com.",
+        "Pas votre e-mail. L’API n’accepte que le nom d’utilisateur IG (lettres, chiffres, - et _), visible dans My IG → Configuration → Informations personnelles.",
       passwordLabel: "Mot de passe",
       apiKeyLabel: "Clé API",
       createKeyToggle: "Comment en créer une ?",
@@ -2651,7 +2651,11 @@ export default {
       usernameQuestion:
         "Je me connecte à IG avec mon e-mail — quel nom d’utilisateur utiliser ?",
       usernameAnswer:
-        "Le site web accepte votre e-mail ; l’API, non. Saisissez le nom d’utilisateur IG indiqué dans Mon compte (lettres, chiffres, tiret ou underscore uniquement — pas de @). Un e-mail provoque une erreur de validation de format côté IG.",
+        "Le site web accepte votre e-mail ; l’API, non. Saisissez le nom d’utilisateur IG indiqué dans My IG → Configuration → Informations personnelles (lettres, chiffres, tiret ou underscore uniquement — pas de @). Si vous ne vous souvenez que de l’e-mail, utilisez la page IG « Identifiants perdus » pour le recevoir.",
+      usernameLinkPersonalInfo:
+        "IG France — modifier l’identifiant (infos personnelles)",
+      usernameLinkLostDetails:
+        "IG France — récupérer un identifiant oublié",
       scopeQuestion: "Que fait Deltalytix avec cette clé ?",
       scopeIntro:
         "Les clés API IG n’ont pas de scopes OAuth ni de cases à cocher de permissions. Une clé identifie votre application, et l’accès suit votre login IG. Deltalytix se contente de :",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2574,16 +2574,18 @@ export default {
     connected: "Compte IG connecté avec succès",
     error: {
       credentialsRequired:
-        "Saisissez l'identifiant, le mot de passe et la clé API",
+        "Saisissez le nom d'utilisateur, le mot de passe et la clé API",
       authFailed: "Impossible de se connecter à IG",
     },
     errors: {
       USER_NOT_AUTHENTICATED: "Vous devez être connecté pour lier IG.",
       CREDENTIALS_REQUIRED:
-        "Saisissez l'identifiant, le mot de passe et la clé API.",
+        "Saisissez le nom d'utilisateur, le mot de passe et la clé API.",
       AUTH_FAILED: "Échec de la connexion IG : {reason}",
       IG_INVALID_CREDENTIALS:
         "IG a refusé cet identifiant ou ce mot de passe. Vérifiez-les sur ig.com puis réessayez.",
+      IG_IDENTIFIER_INVALID:
+        "L’API d’IG n’accepte pas une adresse e-mail comme identifiant. Utilisez votre nom d’utilisateur IG (lettres, chiffres, tiret, underscore — 30 caractères max), pas l’e-mail avec lequel vous vous connectez sur le site. Vous le trouverez dans Mon compte sur ig.com.",
       IG_API_KEY_REJECTED:
         "IG a refusé cette clé API. Vérifiez qu'elle a bien été créée pour l'environnement {environment} — une clé créée pour un environnement ne fonctionne jamais sur l'autre.",
       IG_API_KEY_DISABLED:
@@ -2616,13 +2618,15 @@ export default {
     addAccount: {
       title: "Connecter IG",
       description:
-        "Connectez-vous avec votre identifiant et mot de passe IG, puis collez une clé API personnelle.",
+        "Connectez-vous avec votre nom d'utilisateur et mot de passe IG, puis collez une clé API personnelle.",
       intro:
-        "L’API d’IG demande deux choses : votre identifiant IG, qui prouve que le compte est le vôtre, et une clé API personnelle, qui identifie Deltalytix auprès d’IG. Vous créez la clé vous-même chez IG — c’est gratuit et cela prend une minute.",
+        "L’API d’IG demande deux choses : votre nom d’utilisateur IG (pas votre e-mail), qui prouve que le compte est le vôtre, et une clé API personnelle, qui identifie Deltalytix auprès d’IG. Vous créez la clé vous-même chez IG — c’est gratuit et cela prend une minute.",
       environmentLabel: "Environnement",
       environmentLive: "Réel",
       environmentDemo: "Démo",
-      usernameLabel: "Identifiant",
+      usernameLabel: "Nom d'utilisateur",
+      usernameHint:
+        "Pas votre e-mail. L’API n’accepte que le nom d’utilisateur IG (lettres, chiffres, - et _), visible dans Mon compte sur ig.com.",
       passwordLabel: "Mot de passe",
       apiKeyLabel: "Clé API",
       createKeyToggle: "Comment en créer une ?",
@@ -2644,6 +2648,10 @@ export default {
         "Pourquoi mon identifiant et une clé API sont-ils tous les deux nécessaires ?",
       whyBothAnswer:
         "Ils ne servent pas à la même chose. Votre identifiant et votre mot de passe prouvent que le compte est le vôtre : c’est avec eux qu’IG vous connecte. La clé API, elle, identifie Deltalytix comme l’application qui fait la requête, et IG refuse tout appel qui n’en contient pas. L’un ne fonctionne pas sans l’autre.",
+      usernameQuestion:
+        "Je me connecte à IG avec mon e-mail — quel nom d’utilisateur utiliser ?",
+      usernameAnswer:
+        "Le site web accepte votre e-mail ; l’API, non. Saisissez le nom d’utilisateur IG indiqué dans Mon compte (lettres, chiffres, tiret ou underscore uniquement — pas de @). Un e-mail provoque une erreur de validation de format côté IG.",
       scopeQuestion: "Que fait Deltalytix avec cette clé ?",
       scopeIntro:
         "Les clés API IG n’ont pas de scopes OAuth ni de cases à cocher de permissions. Une clé identifie votre application, et l’accès suit votre login IG. Deltalytix se contente de :",
@@ -2702,7 +2710,7 @@ export default {
   "import.type.igSync.description":
     "Synchronisation directe de compte avec IG",
   "import.type.igSync.details":
-    "Connectez-vous avec votre identifiant et mot de passe IG, plus une clé API personnelle que vous créez chez IG. Deltalytix lit uniquement l’historique des transactions clôturées — aucun ordre n’est passé. Créez la clé via Mon compte → Paramètres → Clés API.",
+    "Connectez-vous avec votre nom d’utilisateur IG (pas l’e-mail) et votre mot de passe, plus une clé API personnelle que vous créez chez IG. Deltalytix lit uniquement l’historique des transactions clôturées — aucun ordre n’est passé. Créez la clé via Mon compte → Paramètres → Clés API.",
   "import.type.atas.name": "ATAS",
   "import.type.atas.description": "Fichier Excel ATAS",
   "import.type.atas.details":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A user hit `validation.pattern.invalid.authenticationRequest.identifier` when connecting IG with their email (which works on the website).

IG’s session API only accepts:

```
identifier Pattern: [A-Za-z0-9\-_]{1,30}
```

Emails fail that pattern before credentials are checked.

## Changes

- Validate the identifier before calling IG and map the pattern error to `IG_IDENTIFIER_INVALID`
- Clarify EN/FR copy: username ≠ email, with a field hint and FAQ entry
- Link official help for finding / recovering the username (FR + EN)
- Add unit tests for the identifier pattern helper

## Ressources (FR)

- [Récupérer un identifiant oublié](https://www.ig.com/fr/lost-details)
- [Modifier l’identifiant — My IG → Configuration → Informations personnelles](https://www.ig.com/fr/portail-d-aide/comptes-et-releves/mon-compte/comment-puis-je-mettre-a-jour-mes-informations-personnelles)
- [Comment utiliser les API de trading IG](https://www.ig.com/fr/plateformes-de-trading/api-de-trading/comment-utiliser-les-api-de-trading-ig)
- [Accéder à l’API IG](https://www.ig.com/fr/portail-d-aide/plateformes/questions-generales/comment-puis-je-acceder-a-l-api-ig-et-a-quoi-cela-sert-il)
- Schema API (EN) : [`identifier` sur `/session`](https://labs.ig.com/reference/session.html)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29551322-acd0-4671-bb93-db1163efa438?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29551322-acd0-4671-bb93-db1163efa438&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

