### PR TITLE
Improve support chat knowledge search and escalation UX

### DIFF
--- a/app/[locale]/(landing)/components/navbar.tsx
+++ b/app/[locale]/(landing)/components/navbar.tsx
@@ -326,6 +326,10 @@ export default function Component() {
       path: "/pricing",
     },
     {
+      title: t("landing.navbar.support"),
+      path: "/support",
+    },
+    {
       title: t("landing.navbar.updates"),
       children: [
         {
@@ -487,6 +491,19 @@ export default function Component() {
                     </ListItem>
                   </ul>
                 </NavigationMenuContent>
+              </NavigationMenuItem>
+              <NavigationMenuItem>
+                <NavigationMenuLink asChild>
+                  <Link
+                    href={localize("/support")}
+                    className={cn(
+                      navigationMenuTriggerStyle(),
+                      "bg-transparent",
+                    )}
+                  >
+                    {t("landing.navbar.support")}
+                  </Link>
+                </NavigationMenuLink>
               </NavigationMenuItem>
               <NavigationMenuItem
                 onMouseEnter={() => setHoveredItem("updates")}

--- a/app/[locale]/(landing)/support/components/support-form.tsx
+++ b/app/[locale]/(landing)/support/components/support-form.tsx
@@ -1,7 +1,17 @@
-import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { DialogDescription } from "@/components/ui/dialog";
-import { DialogContent } from "@/components/ui/dialog";
-import { Dialog } from "@/components/ui/dialog";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Drawer,
+    DrawerContent,
+    DrawerDescription,
+    DrawerHeader,
+    DrawerTitle,
+} from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -11,47 +21,61 @@ import { useI18n } from "@/locales/landing-client";
 import { useCallback, useEffect, useState } from "react";
 import { sendSupportEmail } from "../../actions/send-support-email";
 import { UIMessage } from "@ai-sdk/react";
-import { PromptInputMessage } from "@/components/ai-elements/prompt-input";
-import { useUserStore } from "@/store/user-store";
 import { createClient } from "@/lib/supabase";
+import { useMediaQuery } from "@/hooks/use-media-query";
 
-
-export default function SupportForm({ summary, locale, messages, setMessages, sendMessage }: {
+export default function SupportForm({
+    open,
+    onOpenChange,
+    summary,
+    locale,
+    messages,
+    setMessages,
+    onCancel,
+}: {
+    open: boolean,
+    onOpenChange: (open: boolean) => void,
+    /** Sent with the request but never shown — the assistant owns this text. */
     summary: string,
     locale: 'en' | 'fr',
     messages: UIMessage[],
     setMessages: (messages: UIMessage[]) => void,
-    sendMessage: (message: { text: string; files?: FileList; metadata?: unknown; messageId?: string } | { files: FileList; metadata?: unknown; messageId?: string }) => Promise<void>
+    onCancel?: () => void
 }) {
     const t = useI18n()
-    const [isContactFormOpen, setIsContactFormOpen] = useState(true)
+    const isDesktop = useMediaQuery("(min-width: 640px)")
     const [isSendingEmail, setIsSendingEmail] = useState(false)
-    const [name, setName] = useState('')
+    const [sessionName, setSessionName] = useState('')
+    const [sessionEmail, setSessionEmail] = useState('')
     const [email, setEmail] = useState('')
     const [additionalInfo, setAdditionalInfo] = useState('')
     const supabase = createClient()
 
     useEffect(() => {
+        // Prefill from the session when there is one — the support page is public.
         const fetchUser = async () => {
-            if (supabase) {
-                const { data, error } = await supabase.auth.getUser()
-                if (error) {
-                    console.error('Error getting user:', error)
-                    return
-                }
-                setName(data.user.user_metadata.full_name || '')
-                setEmail(data.user.email || '')
-            }
+            if (!supabase) return
+
+            const { data, error } = await supabase.auth.getUser()
+            if (error || !data.user) return
+
+            setSessionName(data.user.user_metadata?.full_name || '')
+            setSessionEmail(data.user.email || '')
         }
         fetchUser()
     }, [supabase])
+
+    // Only ask for an email when the session did not already give us one.
+    const hasSessionEmail = Boolean(sessionEmail)
+    const effectiveEmail = hasSessionEmail ? sessionEmail : email
 
     const handleSendEmail = useCallback(async () => {
         if (isSendingEmail) return
 
         setIsSendingEmail(true)
         try {
-            const contactInfo = { name, email, additionalInfo, locale }
+            const name = sessionName || effectiveEmail.split('@')[0] || ''
+            const contactInfo = { name, email: effectiveEmail, additionalInfo, locale }
             const result = await sendSupportEmail({
                 messages: messages.map(msg => ({
                     role: msg.role,
@@ -65,7 +89,6 @@ export default function SupportForm({ summary, locale, messages, setMessages, se
                     description: t('success'),
                     duration: 5000,
                 })
-                // Add confirmation message using sendMessage
                 setMessages([
                     ...messages,
                     {
@@ -77,7 +100,7 @@ export default function SupportForm({ summary, locale, messages, setMessages, se
                         }]
                     }
                 ])
-                setIsContactFormOpen(false)
+                onOpenChange(false)
             } else {
                 throw new Error(result.error)
             }
@@ -90,15 +113,71 @@ export default function SupportForm({ summary, locale, messages, setMessages, se
         } finally {
             setIsSendingEmail(false)
         }
-    }, [isSendingEmail, messages, setMessages, t, name, email, additionalInfo, locale, summary])
+    }, [isSendingEmail, messages, setMessages, t, sessionName, effectiveEmail, additionalInfo, locale, summary, onOpenChange])
 
     const handleFormSubmit = (e: React.FormEvent) => {
         e.preventDefault()
         handleSendEmail()
     }
 
+    const form = (
+        <form
+            onSubmit={handleFormSubmit}
+            className={isDesktop ? "space-y-4" : "space-y-4 px-4 pb-6"}
+        >
+            {!hasSessionEmail && (
+                <div>
+                    <Label htmlFor="email">{t('support.form.email')}</Label>
+                    <Input
+                        id="email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                    />
+                </div>
+            )}
+            <div>
+                <Label htmlFor="additionalInfo">{t('support.form.additionalInfo')}</Label>
+                <Textarea
+                    id="additionalInfo"
+                    value={additionalInfo}
+                    onChange={(e) => setAdditionalInfo(e.target.value)}
+                    placeholder={t('support.form.additionalInfoPlaceholder')}
+                />
+            </div>
+            <div className="flex justify-end space-x-2">
+                <Button type="button" variant="outline" onClick={() => {
+                    onOpenChange(false);
+                    onCancel?.();
+                }}>
+                    {t('support.form.cancel')}
+                </Button>
+                <Button type="submit" disabled={isSendingEmail}>
+                    {isSendingEmail ? t('support.form.sending') : t('support.form.submit')}
+                </Button>
+            </div>
+        </form>
+    )
+
+    if (!isDesktop) {
+        return (
+            <Drawer open={open} onOpenChange={onOpenChange}>
+                <DrawerContent>
+                    <DrawerHeader className="text-left">
+                        <DrawerTitle>{t('support.contactInformation')}</DrawerTitle>
+                        <DrawerDescription>
+                            {t('support.contactInformationDescription')}
+                        </DrawerDescription>
+                    </DrawerHeader>
+                    {form}
+                </DrawerContent>
+            </Drawer>
+        )
+    }
+
     return (
-        <Dialog open={isContactFormOpen} onOpenChange={setIsContactFormOpen}>
+        <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>{t('support.contactInformation')}</DialogTitle>
@@ -106,62 +185,8 @@ export default function SupportForm({ summary, locale, messages, setMessages, se
                         {t('support.contactInformationDescription')}
                     </DialogDescription>
                 </DialogHeader>
-                <form onSubmit={handleFormSubmit} className="space-y-4">
-                    <div>
-                        <Label htmlFor="summary">{t('support.form.summary')}</Label>
-                        <Textarea
-                            id="summary"
-                            value={summary}
-                            readOnly
-                            required
-                        />
-                    </div>
-                    <div>
-                        <Label htmlFor="name">{t('support.form.name')}</Label>
-                        <Input
-                            id="name"
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            required
-                        />
-                    </div>
-                    <div>
-                        <Label htmlFor="email">{t('support.form.email')}</Label>
-                        <Input
-                            id="email"
-                            type="email"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            required
-                        />
-                    </div>
-                    <div>
-                        <Label htmlFor="additionalInfo">{t('support.form.additionalInfo')}</Label>
-                        <Textarea
-                            id="additionalInfo"
-                            value={additionalInfo}
-                            onChange={(e) => setAdditionalInfo(e.target.value)}
-                            placeholder={t('support.form.additionalInfoPlaceholder')}
-                        />
-                    </div>
-                    <div className="flex justify-end space-x-2">
-                        <Button type="button" variant="outline" onClick={() => {
-                            setIsContactFormOpen(false);
-                            sendMessage(
-                                {
-                                    text: t('support.form.cancel'),
-                                },
-                            );
-                        }}>
-                            {t('support.form.cancel')}
-                        </Button>
-                        <Button type="submit" disabled={isSendingEmail}>
-                            {isSendingEmail ? t('support.form.sending') : t('support.form.submit')}
-                        </Button>
-                    </div>
-                </form>
+                {form}
             </DialogContent>
         </Dialog>
     )
-
 }

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -222,6 +222,9 @@ const ChatBotDemo = () => {
   const { messages, sendMessage, status, setMessages, stop } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/ai/support',
+      body: () => ({
+        locale,
+      }),
     }),
     onError: (error) => {
       console.error('Chat error:', error);

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -123,8 +123,8 @@ const ATTACHMENT_ONLY_PLACEHOLDER = 'Sent with attachments';
 const MAX_REASONING_LABEL_LENGTH = 60;
 
 /**
- * Reasoning summaries open with a short title ("**Exporting PDF instructions**").
- * Surfacing that beats "Thought for 1 seconds"; fall back when there is no title.
+ * Prefer a short first-line label from the reasoning summary when present;
+ * otherwise fall back to the localized thinking / thought-process copy.
  */
 const getReasoningLabel = (text: string): string | undefined => {
   const firstLine = text
@@ -175,9 +175,35 @@ function ReasoningBlock({
         </span>
         <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
       </ReasoningTrigger>
-      <ReasoningContent>{text}</ReasoningContent>
+      {text.trim() ? <ReasoningContent>{text}</ReasoningContent> : null}
     </Reasoning>
   );
+}
+
+/** Optimistic status row — same chrome as reasoning so the brain never vanishes mid-wait. */
+function PendingIndicator({ label }: { label: string }) {
+  return (
+    <div className="mb-4 flex w-full items-center gap-2 text-sm text-muted-foreground">
+      <BrainIcon className="size-4 shrink-0" />
+      <span className="min-w-0 truncate text-left shimmer">{label}</span>
+    </div>
+  );
+}
+
+function hasActiveReasoningRow(
+  message: ReturnType<typeof useChat>['messages'][number] | undefined,
+  status: ReturnType<typeof useChat>['status'],
+) {
+  if (!message || message.role !== 'assistant') return false;
+
+  return message.parts.some((part, index) => {
+    if (part.type !== 'reasoning') return false;
+
+    const isStreamingReasoning =
+      status === 'streaming' && index === message.parts.length - 1;
+
+    return Boolean(part.text?.trim()) || isStreamingReasoning;
+  });
 }
 
 function SupportPromptSubmit({
@@ -382,6 +408,8 @@ const ChatBotDemo = () => {
   const showStarterActions = messages.length <= 1 && !isBusy;
   // Once the conversation has started, the human escape hatch stays available.
   const showHumanHandoff = hasStarted && !isBusy;
+  const showPendingIndicator =
+    isBusy && !hasActiveReasoningRow(messages.at(-1), status);
 
   return (
     <MessageScrollerProvider autoScroll>
@@ -576,19 +604,21 @@ const ChatBotDemo = () => {
                             );
                           }
                           case 'reasoning': {
-                            if (!part.text?.trim()) {
+                            const isStreamingReasoning =
+                              status === 'streaming' &&
+                              i === message.parts.length - 1 &&
+                              message.id === messages.at(-1)?.id;
+
+                            // Keep the brain visible while reasoning tokens are still empty.
+                            if (!part.text?.trim() && !isStreamingReasoning) {
                               return null;
                             }
 
                             return (
                               <ReasoningBlock
                                 key={`${message.id}-${i}`}
-                                text={part.text}
-                                isStreaming={
-                                  status === 'streaming' &&
-                                  i === message.parts.length - 1 &&
-                                  message.id === messages.at(-1)?.id
-                                }
+                                text={part.text ?? ''}
+                                isStreaming={isStreamingReasoning}
                               />
                             );
                           }
@@ -675,12 +705,8 @@ const ChatBotDemo = () => {
                     </MessageScrollerItem>
                   ))}
 
-                  {status === 'submitted' && (
-                    <Marker>
-                      <MarkerContent className="shimmer">
-                        {t('support.generating')}
-                      </MarkerContent>
-                    </Marker>
+                  {showPendingIndicator && (
+                    <PendingIndicator label={t('support.generating')} />
                   )}
                 </MessageScrollerContent>
               </MessageScrollerViewport>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -282,17 +282,25 @@ const ChatBotDemo = () => {
   const startEditing = useCallback((messageId: string, text: string) => {
     setPendingEditMessageId(messageId);
     setInput(text);
-    requestAnimationFrame(() => {
-      const composer = composerRef.current;
-      composer?.focus();
-      composer?.setSelectionRange(composer.value.length, composer.value.length);
-    });
   }, []);
 
   const cancelEditing = useCallback(() => {
     setPendingEditMessageId(null);
     setInput('');
   }, []);
+
+  // Focus after React commits the edited text — rAF from the click handler races
+  // the controlled value update and often never lands on the textarea.
+  useEffect(() => {
+    if (!pendingEditMessageId) return;
+
+    const composer = composerRef.current;
+    if (!composer) return;
+
+    composer.focus();
+    const cursor = composer.value.length;
+    composer.setSelectionRange(cursor, cursor);
+  }, [pendingEditMessageId]);
 
   const pendingEditIndex = pendingEditMessageId
     ? messages.findIndex((message) => message.id === pendingEditMessageId)

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -20,11 +20,19 @@ import {
   Actions,
   Action,
 } from '@/components/ai-elements/actions';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { Response } from '@/components/ai-elements/response';
-import { HeadsetIcon, RefreshCcwIcon } from 'lucide-react';
-import { useI18n } from '@/locales/landing-client';
+import {
+  BrainIcon,
+  ChevronDownIcon,
+  HeadsetIcon,
+  PencilIcon,
+  RefreshCcwIcon,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { useCurrentLocale, useI18n } from '@/locales/landing-client';
 import {
   Source,
   Sources,
@@ -59,19 +67,9 @@ import { Marker, MarkerContent } from '@/components/ui/marker';
 import {
   Card,
   CardContent,
-  CardHeader,
-  CardTitle,
 } from '@/components/ui/card';
 
 const DISCORD_INVITE_URL = process.env.NEXT_PUBLIC_DISCORD_INVITATION;
-
-function DiscordIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z" />
-    </svg>
-  );
-}
 
 type askForEmailFormToolInput = {
   summary: string;
@@ -79,6 +77,7 @@ type askForEmailFormToolInput = {
 
 type askForEmailFormToolOutput = {
   summary: string;
+  locale: 'en' | 'fr';
 };
 
 type askForEmailFormToolUIPart = ToolUIPart<{
@@ -121,6 +120,66 @@ const preprocessContent = (content: string) => {
 
 const ATTACHMENT_ONLY_PLACEHOLDER = 'Sent with attachments';
 
+const MAX_REASONING_LABEL_LENGTH = 60;
+
+/**
+ * Reasoning summaries open with a short title ("**Exporting PDF instructions**").
+ * Surfacing that beats "Thought for 1 seconds"; fall back when there is no title.
+ */
+const getReasoningLabel = (text: string): string | undefined => {
+  const firstLine = text
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  if (!firstLine) return undefined;
+
+  const looksLikeHeading =
+    /^#{1,6}\s+/.test(firstLine) || /^\*\*.+\*\*$/.test(firstLine);
+
+  const cleaned = firstLine
+    .replace(/^#{1,6}\s+/, '')
+    .replace(/\*\*/g, '')
+    .replace(/[:.]+$/, '')
+    .trim();
+
+  if (!cleaned) return undefined;
+  if (!looksLikeHeading && cleaned.length > MAX_REASONING_LABEL_LENGTH) return undefined;
+
+  return cleaned;
+};
+
+function ReasoningBlock({
+  text,
+  isStreaming = false,
+  className,
+}: {
+  text: string;
+  isStreaming?: boolean;
+  className?: string;
+}) {
+  const t = useI18n();
+  const label = getReasoningLabel(text);
+
+  return (
+    <Reasoning
+      className={cn('w-full', className)}
+      defaultOpen={false}
+      disableAutoClose
+      isStreaming={isStreaming}
+    >
+      <ReasoningTrigger className="group">
+        <BrainIcon className="size-4 shrink-0" />
+        <span className={cn('min-w-0 truncate text-left', isStreaming && 'shimmer')}>
+          {label ?? (isStreaming ? t('support.thinking') : t('support.thoughtProcess'))}
+        </span>
+        <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+      </ReasoningTrigger>
+      <ReasoningContent>{text}</ReasoningContent>
+    </Reasoning>
+  );
+}
+
 function SupportPromptSubmit({
   input,
   status,
@@ -137,10 +196,30 @@ function SupportPromptSubmit({
   );
 }
 
+/** Falls back to the user's own words when the assistant has not summarised anything. */
+const buildConversationSummary = (messages: ReturnType<typeof useChat>['messages']) =>
+  messages
+    .filter((message) => message.role === 'user')
+    .flatMap((message) =>
+      message.parts
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text.trim()),
+    )
+    .filter((text) => text && text !== ATTACHMENT_ONLY_PLACEHOLDER)
+    .join('\n\n')
+    .slice(0, 2000);
+
 const ChatBotDemo = () => {
   const t = useI18n();
+  const locale = useCurrentLocale();
   const [input, setInput] = useState('');
-  const { messages, sendMessage, status, setMessages } = useChat({
+  const [contactForm, setContactForm] = useState({ open: false, summary: '' });
+  // Set while the composer holds an earlier message being rewritten.
+  const [pendingEditMessageId, setPendingEditMessageId] = useState<string | null>(null);
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+  // Tool-driven escalations should pop the dialog once, not on every re-render.
+  const autoOpenedEscalations = useRef(new Set<string>());
+  const { messages, sendMessage, status, setMessages, stop } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/ai/support',
     }),
@@ -162,12 +241,81 @@ const ChatBotDemo = () => {
     },
   });
 
+  const openContactForm = useCallback(
+    (summary?: string) => {
+      setContactForm((current) => ({
+        open: true,
+        summary: summary ?? current.summary,
+      }));
+    },
+    [],
+  );
+
+  const requestHumanSupport = useCallback(() => {
+    openContactForm(buildConversationSummary(messages));
+  }, [messages, openContactForm]);
+
+  /**
+   * Drop `messageId` and everything after it. `setMessages` writes through to the
+   * chat store synchronously, so a send issued right after already sees the
+   * truncated history.
+   */
+  const truncateFrom = useCallback(
+    (messageId: string) => {
+      if (status === 'submitted' || status === 'streaming') {
+        stop();
+      }
+
+      setMessages((current) => {
+        const index = current.findIndex((message) => message.id === messageId);
+        return index === -1 ? current : current.slice(0, index);
+      });
+    },
+    [status, stop, setMessages],
+  );
+
+  // Editing pulls the message back into the composer; the messages it would
+  // replace stay visible but dimmed until the user sends or cancels.
+  const startEditing = useCallback((messageId: string, text: string) => {
+    setPendingEditMessageId(messageId);
+    setInput(text);
+    requestAnimationFrame(() => {
+      const composer = composerRef.current;
+      composer?.focus();
+      composer?.setSelectionRange(composer.value.length, composer.value.length);
+    });
+  }, []);
+
+  const cancelEditing = useCallback(() => {
+    setPendingEditMessageId(null);
+    setInput('');
+  }, []);
+
+  const pendingEditIndex = pendingEditMessageId
+    ? messages.findIndex((message) => message.id === pendingEditMessageId)
+    : -1;
+
+  // The assistant can also escalate on its own — surface its summary in the form.
+  useEffect(() => {
+    for (const message of messages) {
+      for (const part of message.parts) {
+        if (part.type !== 'tool-askForEmailForm') continue;
+
+        const toolPart = part as askForEmailFormToolUIPart;
+        if (toolPart.state !== 'output-available' || !toolPart.toolCallId) continue;
+        if (autoOpenedEscalations.current.has(toolPart.toolCallId)) continue;
+
+        autoOpenedEscalations.current.add(toolPart.toolCallId);
+        setContactForm({ open: true, summary: toolPart.output?.summary ?? '' });
+      }
+    }
+  }, [messages]);
+
   const suggestions = useMemo(
     () => [
       t('support.suggestionImport'),
       t('support.suggestionBilling'),
       t('support.suggestionBug'),
-      t('support.suggestionHuman'),
     ],
     [t],
   );
@@ -197,6 +345,12 @@ const ChatBotDemo = () => {
       return;
     }
 
+    // Sending while editing replaces the original message and everything after it.
+    if (pendingEditMessageId) {
+      truncateFrom(pendingEditMessageId);
+      setPendingEditMessageId(null);
+    }
+
     if (hasText) {
       sendMessage({
         text: message.text!,
@@ -213,27 +367,70 @@ const ChatBotDemo = () => {
   };
 
   const isBusy = status === 'submitted' || status === 'streaming';
+  const hasStarted = messages.some((message) => message.role === 'user');
   const showStarterActions = messages.length <= 1 && !isBusy;
+  // Once the conversation has started, the human escape hatch stays available.
+  const showHumanHandoff = hasStarted && !isBusy;
 
   return (
     <MessageScrollerProvider autoScroll>
       <div className="mx-auto flex size-full h-[calc(100vh-64px)] max-w-4xl flex-col gap-4 p-4 sm:p-6">
+        {/* Page title lives outside the chat surface, like /updates. */}
+        <header className="space-y-1">
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            <HeadsetIcon className="size-6 text-primary" />
+            {t('support.pageTitle')}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {t('support.pageDescription')}
+            {DISCORD_INVITE_URL && (
+              <>
+                {' '}
+                {t('support.discordPrompt')}{' '}
+                <a
+                  href={DISCORD_INVITE_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+                >
+                  {t('support.joinDiscordInline')}
+                </a>
+                .
+              </>
+            )}
+          </p>
+        </header>
+
         <Card className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden py-0">
-          <CardHeader className="gap-1 border-b py-4">
-            <CardTitle className="flex items-center gap-2 text-lg">
-              <HeadsetIcon className="size-5 text-primary" />
-              {t('support.pageTitle')}
-            </CardTitle>
-          </CardHeader>
+          {/* Escalation appears only once the conversation has started. */}
+          {showHumanHandoff && (
+            <div className="flex justify-end border-b px-4 py-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={requestHumanSupport}
+              >
+                <HeadsetIcon className="size-4" />
+                {t('support.requestHumanSupport')}
+              </Button>
+            </div>
+          )}
 
           <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
             <MessageScroller className="min-h-0 flex-1">
               <MessageScrollerViewport>
                 <MessageScrollerContent aria-busy={isBusy} className="gap-4 p-4">
-                  {messages.map((message) => (
+                  {messages.map((message, messageIndex) => (
                     <MessageScrollerItem
                       key={message.id}
                       scrollAnchor={message.role === 'user'}
+                      // Dimmed = will be discarded when the edit is sent.
+                      className={
+                        pendingEditIndex !== -1 && messageIndex >= pendingEditIndex
+                          ? 'opacity-40 transition-opacity'
+                          : 'transition-opacity'
+                      }
                     >
                       {message.role === 'assistant' &&
                         message.parts.filter((part) => part.type === 'source-url').length > 0 && (
@@ -306,13 +503,10 @@ const ChatBotDemo = () => {
                             return (
                               <Fragment key={`${message.id}-${i}`}>
                                 {think.map((thought, index) => (
-                                  <Reasoning
+                                  <ReasoningBlock
                                     key={`${message.id}-${i}-think-${index}`}
-                                    className="w-full"
-                                  >
-                                    <ReasoningTrigger />
-                                    <ReasoningContent>{thought}</ReasoningContent>
-                                  </Reasoning>
+                                    text={thought}
+                                  />
                                 ))}
                                 <ChatMessage align={isUser ? 'end' : 'start'}>
                                   <MessageContent>
@@ -341,11 +535,23 @@ const ChatBotDemo = () => {
                                         </Actions>
                                       </MessageFooter>
                                     )}
-                                    {message.role === 'user' && (
+                                    {isUser && (
                                       <MessageFooter>
                                         <Actions className="justify-end">
+                                          {/* Editing re-sends without the attachment, so only offer it on plain text. */}
+                                          {!message.parts.some((p) => p.type === 'file') && (
+                                            <Action
+                                              onClick={() => startEditing(message.id, part.text)}
+                                              label={t('common.edit')}
+                                            >
+                                              <PencilIcon size={16} className="mr-2" />
+                                            </Action>
+                                          )}
                                           <Action
-                                            onClick={() => sendWithOptions(part.text)}
+                                            onClick={() => {
+                                              truncateFrom(message.id);
+                                              sendMessage({ text: part.text });
+                                            }}
                                             label={t('common.retry')}
                                           >
                                             <RefreshCcwIcon size={16} className="mr-2" />
@@ -364,32 +570,37 @@ const ChatBotDemo = () => {
                             }
 
                             return (
-                              <Reasoning
+                              <ReasoningBlock
                                 key={`${message.id}-${i}`}
-                                className="w-full"
-                                disableAutoClose
+                                text={part.text}
                                 isStreaming={
                                   status === 'streaming' &&
                                   i === message.parts.length - 1 &&
                                   message.id === messages.at(-1)?.id
                                 }
-                              >
-                                <ReasoningTrigger />
-                                <ReasoningContent>{part.text}</ReasoningContent>
-                              </Reasoning>
+                              />
                             );
                           }
-                          case 'tool-searchCodebase': {
+                          case 'tool-searchCodebase':
+                          case 'tool-listCodebaseFiles':
+                          case 'tool-grepCodebase':
+                          case 'tool-readCodebaseFile': {
                             switch (part.state) {
                               case 'input-available':
-                              case 'input-streaming':
+                              case 'input-streaming': {
+                                const label =
+                                  part.type === 'tool-readCodebaseFile'
+                                    ? t('support.tool.readingFile')
+                                    : part.type === 'tool-grepCodebase'
+                                      ? t('support.tool.grepping')
+                                      : t('support.tool.searchingDocs');
+
                                 return (
                                   <Marker key={`${message.id}-${i}`}>
-                                    <MarkerContent className="shimmer">
-                                      {t('support.tool.searchingDocs')}
-                                    </MarkerContent>
+                                    <MarkerContent className="shimmer">{label}</MarkerContent>
                                   </Marker>
                                 );
+                              }
                               default:
                                 return null;
                             }
@@ -404,26 +615,29 @@ const ChatBotDemo = () => {
                                     </MarkerContent>
                                   </Marker>
                                 );
-                              case 'output-available':
-                                if (
+                              case 'output-available': {
+                                const summary =
                                   part.output &&
                                   typeof part.output === 'object' &&
-                                  'summary' in part.output &&
-                                  'locale' in part.output
-                                ) {
-                                  return (
-                                    <div key={`${message.id}-${i}`}>
-                                      <SupportForm
-                                        locale={part.output.locale as 'en' | 'fr'}
-                                        messages={messages}
-                                        summary={part.output.summary as string}
-                                        setMessages={setMessages}
-                                        sendMessage={sendMessage}
-                                      />
-                                    </div>
-                                  );
-                                }
-                                return null;
+                                  'summary' in part.output
+                                    ? (part.output.summary as string)
+                                    : '';
+
+                                return (
+                                  <Marker key={`${message.id}-${i}`} variant="border">
+                                    <MarkerContent className="flex flex-wrap items-center justify-between gap-2">
+                                      {t('support.tool.requestReady')}
+                                      <Button
+                                        type="button"
+                                        size="sm"
+                                        onClick={() => openContactForm(summary)}
+                                      >
+                                        {t('support.openContactForm')}
+                                      </Button>
+                                    </MarkerContent>
+                                  </Marker>
+                                );
+                              }
                               case 'output-error':
                                 return (
                                   <Marker key={`${message.id}-${i}`} variant="border">
@@ -450,29 +664,6 @@ const ChatBotDemo = () => {
                     </MessageScrollerItem>
                   ))}
 
-                  {showStarterActions && DISCORD_INVITE_URL && (
-                    <MessageScrollerItem>
-                      <ChatMessage align="start">
-                        <MessageContent>
-                          <div className="flex max-w-sm flex-col gap-2">
-                            <a
-                              href={DISCORD_INVITE_URL}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="inline-flex w-fit items-center gap-2.5 rounded-xl bg-[#5865F2] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#4752C4] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60 focus-visible:ring-offset-2"
-                            >
-                              <DiscordIcon className="size-5 shrink-0" />
-                              {t('support.joinDiscord')}
-                            </a>
-                            <p className="text-xs text-muted-foreground">
-                              {t('support.discordDescription')}
-                            </p>
-                          </div>
-                        </MessageContent>
-                      </ChatMessage>
-                    </MessageScrollerItem>
-                  )}
-
                   {status === 'submitted' && (
                     <Marker>
                       <MarkerContent className="shimmer">
@@ -495,35 +686,76 @@ const ChatBotDemo = () => {
                       onClick={sendWithOptions}
                     />
                   ))}
+                  {/* Goes straight to the form — routing it through the model is the loop we are fixing. */}
+                  <Suggestion
+                    suggestion={t('support.suggestionHuman')}
+                    onClick={requestHumanSupport}
+                  />
                 </Suggestions>
               </div>
             )}
+
+            {/* Input is docked inside the chat panel so it reads as one conversation surface. */}
+            <div
+              className="border-t p-3 sm:p-4"
+              // Escape bubbles up from the textarea, which owns its own onKeyDown.
+              onKeyDown={(event) => {
+                if (event.key === 'Escape' && pendingEditMessageId) {
+                  cancelEditing();
+                }
+              }}
+            >
+              {pendingEditMessageId && (
+                <Marker className="mb-2">
+                  <MarkerContent className="flex flex-wrap items-center justify-between gap-2">
+                    {t('support.editingNotice')}
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={cancelEditing}
+                    >
+                      {t('common.cancel')}
+                    </Button>
+                  </MarkerContent>
+                </Marker>
+              )}
+              <PromptInput accept="image/*" onSubmit={handleSubmit} globalDrop multiple>
+                <PromptInputBody>
+                  <PromptInputAttachments>
+                    {(attachment) => <PromptInputAttachment data={attachment} />}
+                  </PromptInputAttachments>
+                  <PromptInputTextarea
+                    ref={composerRef}
+                    onChange={(e) => setInput(e.target.value)}
+                    value={input}
+                    placeholder={t('support.inputPlaceholder')}
+                  />
+                </PromptInputBody>
+                <PromptInputToolbar>
+                  <PromptInputTools>
+                    <PromptInputActionMenu>
+                      <PromptInputActionMenuTrigger />
+                      <PromptInputActionMenuContent>
+                        <PromptInputActionAddAttachments />
+                      </PromptInputActionMenuContent>
+                    </PromptInputActionMenu>
+                  </PromptInputTools>
+                  <SupportPromptSubmit input={input} status={status} />
+                </PromptInputToolbar>
+              </PromptInput>
+            </div>
           </CardContent>
         </Card>
 
-        <PromptInput accept="image/*" onSubmit={handleSubmit} globalDrop multiple>
-          <PromptInputBody>
-            <PromptInputAttachments>
-              {(attachment) => <PromptInputAttachment data={attachment} />}
-            </PromptInputAttachments>
-            <PromptInputTextarea
-              onChange={(e) => setInput(e.target.value)}
-              value={input}
-              placeholder={t('support.inputPlaceholder')}
-            />
-          </PromptInputBody>
-          <PromptInputToolbar>
-            <PromptInputTools>
-              <PromptInputActionMenu>
-                <PromptInputActionMenuTrigger />
-                <PromptInputActionMenuContent>
-                  <PromptInputActionAddAttachments />
-                </PromptInputActionMenuContent>
-              </PromptInputActionMenu>
-            </PromptInputTools>
-            <SupportPromptSubmit input={input} status={status} />
-          </PromptInputToolbar>
-        </PromptInput>
+        <SupportForm
+          open={contactForm.open}
+          onOpenChange={(open) => setContactForm((current) => ({ ...current, open }))}
+          summary={contactForm.summary}
+          locale={locale}
+          messages={messages}
+          setMessages={setMessages}
+        />
       </div>
     </MessageScrollerProvider>
   );

--- a/app/api/ai/support/README.md
+++ b/app/api/ai/support/README.md
@@ -38,12 +38,16 @@ Vercel AI Gateway; override with `SUPPORT_AGENT_MODEL`). The system prompt requi
 search before answering, search at least twice before concluding something does not exist, and
 escalate rather than ask a second round of clarifying questions.
 
+The support page sends the current UI `locale` (`en` | `fr`) with every request. `prepareCall`
+injects a UI-locale block so reasoning titles and answers follow `/en` or `/fr` instead of
+guessing from the first message.
+
 ## Request flow
 
 `route.ts` validates the request (`schema.ts`), strips the initial greeting, rejects unsupported
-file URLs, then streams `supportAgent` via `createAgentUIStreamResponse`. Errors map to typed
-JSON (`rate_limit_exceeded`, `service_unavailable`, `internal_error`) that the client turns into
-localized messages.
+file URLs, then streams `supportAgent` via `createAgentUIStreamResponse` with
+`options: { locale }`. Errors map to typed JSON (`rate_limit_exceeded`, `service_unavailable`,
+`internal_error`) that the client turns into localized messages.
 
 ## Environment
 

--- a/app/api/ai/support/README.md
+++ b/app/api/ai/support/README.md
@@ -34,13 +34,12 @@ bundle via `SUPPORT_SEARCH_TRACE_INCLUDES`.
 ## Agent
 
 `lib/ai/support-agent.ts` — a `ToolLoopAgent`. Model defaults to `openai/gpt-5-mini` (via the
-Vercel AI Gateway; override with `SUPPORT_AGENT_MODEL`). The system prompt requires the model to
-search before answering, search at least twice before concluding something does not exist, and
-escalate rather than ask a second round of clarifying questions.
+Vercel AI Gateway; override with `SUPPORT_AGENT_MODEL`). Instructions stay short: use tools,
+search before answering, escalate when stuck, and do not re-introduce or title replies (the UI
+already greets the user).
 
 The support page sends the current UI `locale` (`en` | `fr`) with every request. `prepareCall`
-injects a UI-locale block so reasoning titles and answers follow `/en` or `/fr` instead of
-guessing from the first message.
+appends a one-line locale hint so replies follow `/en` or `/fr`.
 
 ## Request flow
 

--- a/app/api/ai/support/README.md
+++ b/app/api/ai/support/README.md
@@ -1,85 +1,53 @@
-# Deltalytix Support Assistant - Refined System
+# Deltalytix Support Assistant
 
-## Overview
-The support assistant has been refined to provide immediate, helpful responses while gathering comprehensive context with minimal questions. The system now focuses on efficiency and problem-solving rather than endless clarification.
+The support assistant answers product questions from the real repository and, crucially, never leaves a user stuck: a human hand-off is always one click away.
 
-## Key Improvements
+## Two escape hatches, always available
 
-### 1. Smart Context Gathering
-- **gatherUserContext**: Captures comprehensive user information in one tool call
-- Gathers issue category, urgency, platform details, error messages, reproduction steps, and more
-- Eliminates the need for multiple back-and-forth questions
+The UI (`app/[locale]/(landing)/support/page.tsx`) owns escalation, not the model:
 
-### 2. Intelligent Issue Analysis
-- **analyzeIssueComplexity**: Automatically determines issue type and complexity
-- Suggests appropriate resolution paths (self-service, documentation, human support, etc.)
-- Prioritizes issues based on urgency and impact
+- A **Request Human Support** button in the header, plus a **Talk to a human** starter chip, open the contact form directly — no model round-trip.
+- After the user's first message, an inline **human hand-off** prompt appears under the conversation so a stuck user is never more than one click from a person.
+- The model can _also_ escalate by calling `askForEmailForm`; when it does, the UI opens the same contact form pre-filled with the model's summary.
 
-### 3. Proactive Response System
-- **provideInitialResponse**: Provides immediate solutions when possible
-- Offers partial solutions with clear next steps
-- Includes relevant resources and documentation links
+This is deliberate: routing "I want a human" through the model is exactly the loop we removed.
 
-### 4. Efficient Escalation
-- Only escalates when truly necessary
-- Provides clear escalation reasons
-- Maintains context throughout the support process
+## Knowledge: real search over the repo
 
-## Tool Usage Flow
+The agent reads the actual codebase through `lib/ai/search-codebase.ts`, backed by an
+in-memory index built in `lib/ai/codebase-index.ts` (`CORPUS_ROOTS` defines the scope:
+`content/**`, root markdown, `locales/**`, and application source under `app`, `components`,
+`lib`, `server`, `hooks`, `store`, `context`, plus `prisma/schema.prisma`).
 
-1. **gatherUserContext** - Capture all available information from user's initial message
-2. **analyzeIssueComplexity** - Determine the best resolution approach
-3. **provideInitialResponse** - Provide helpful initial response with solutions/resources
-4. **askForEmailForm** - When ready for email support (if needed)
-5. **askForHumanHelp** - When human intervention is required
+Tools exposed to the model (`tools/search-codebase.ts`):
 
-## Example Scenarios
+- **searchCodebase** — ranked keyword search (TF-IDF-ish scoring, doc/locale weighted above
+  source, locale-aware) returning the strongest files with surrounding context lines.
+- **grepCodebase** — regex grep with an optional glob filter, for exact strings (UI labels,
+  error messages, env vars, route names).
+- **readCodebaseFile** — read a file or line range a search returned.
+- **listCodebaseFiles** — enumerate files matching a glob (e.g. every release note).
 
-### Scenario 1: Simple Question
-**User**: "How do I import my trading data?"
-**Assistant**: 
-- Uses gatherUserContext to capture platform and data type
-- Uses analyzeIssueComplexity to identify as simple configuration help
-- Uses provideInitialResponse to give step-by-step instructions with documentation links
-- No additional questions needed
+The corpus is read from disk at runtime, so `next.config.ts` traces it into the serverless
+bundle via `SUPPORT_SEARCH_TRACE_INCLUDES`.
 
-### Scenario 2: Technical Issue
-**User**: "I'm getting an error when uploading my CSV file"
-**Assistant**:
-- Uses gatherUserContext to capture error details, file type, browser info
-- Uses analyzeIssueComplexity to identify as technical bug
-- Uses provideInitialResponse to provide troubleshooting steps and workarounds
-- May escalate to human support if complex
+## Agent
 
-### Scenario 3: Account Issue
-**User**: "I can't access my dashboard"
-**Assistant**:
-- Uses gatherUserContext to capture account details and error messages
-- Uses analyzeIssueComplexity to identify as account issue requiring human help
-- Uses askForHumanHelp to escalate with comprehensive context
-- Provides immediate workarounds if available
+`lib/ai/support-agent.ts` — a `ToolLoopAgent`. Model defaults to `openai/gpt-5-mini` (via the
+Vercel AI Gateway; override with `SUPPORT_AGENT_MODEL`). The system prompt requires the model to
+search before answering, search at least twice before concluding something does not exist, and
+escalate rather than ask a second round of clarifying questions.
 
-## Benefits
+## Request flow
 
-1. **Reduced Support Load**: Fewer back-and-forth messages
-2. **Faster Resolution**: Immediate solutions for common issues
-3. **Better Context**: Comprehensive information gathering
-4. **Improved User Experience**: Less frustration, more solutions
-5. **Efficient Escalation**: Clear escalation paths with full context
+`route.ts` validates the request (`schema.ts`), strips the initial greeting, rejects unsupported
+file URLs, then streams `supportAgent` via `createAgentUIStreamResponse`. Errors map to typed
+JSON (`rate_limit_exceeded`, `service_unavailable`, `internal_error`) that the client turns into
+localized messages.
 
-## Configuration
+## Environment
 
-The system uses GPT-4o-mini with a temperature of 0.3 for consistent, focused responses. The system prompt emphasizes:
-- Efficiency over extensive questioning
-- Proactive problem solving
-- Immediate value provision
-- Smart context gathering
-- Clear escalation paths
-
-## Monitoring
-
-The system tracks:
-- Response types and success rates
-- Escalation patterns
-- User satisfaction with initial responses
-- Resolution time improvements
+- `AI_GATEWAY_API_KEY` — required for the agent to run (Vercel AI Gateway).
+- `SUPPORT_AGENT_MODEL` — optional model override.
+- `RESEND_API_KEY`, `SUPPORT_EMAIL` / `SUPPORT_TEAM_EMAIL` — support email delivery.
+- `SUPPORT_SEARCH_DEBUG=0` — silence search debug logging in development.

--- a/app/api/ai/support/route.ts
+++ b/app/api/ai/support/route.ts
@@ -27,6 +27,7 @@ export async function POST(req: Request) {
       );
     }
 
+    const { locale } = parsed.data;
     const messages = stripInitialAssistantGreeting(parsed.data.messages);
 
     if (!hasUserMessage(messages)) {
@@ -56,6 +57,7 @@ export async function POST(req: Request) {
     return createAgentUIStreamResponse({
       agent: supportAgent,
       uiMessages: messages as UIMessage[],
+      options: { locale },
       sendReasoning: true,
       onStepFinish: (step) => {
         console.log(
@@ -64,6 +66,7 @@ export async function POST(req: Request) {
             {
               finishReason: step.finishReason,
               toolCalls: step.toolCalls?.map((toolCall) => toolCall.toolName),
+              locale,
             },
             null,
             2,

--- a/app/api/ai/support/schema.test.ts
+++ b/app/api/ai/support/schema.test.ts
@@ -25,6 +25,30 @@ describe("supportChatRequestSchema", () => {
     });
 
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.locale).toBe("en");
+    }
+  });
+
+  it("accepts an explicit UI locale", () => {
+    const result = supportChatRequestSchema.safeParse({
+      messages: [userMessage],
+      locale: "fr",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.locale).toBe("fr");
+    }
+  });
+
+  it("rejects unsupported locales", () => {
+    const result = supportChatRequestSchema.safeParse({
+      messages: [userMessage],
+      locale: "de",
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it("rejects client-supplied system messages", () => {

--- a/app/api/ai/support/schema.ts
+++ b/app/api/ai/support/schema.ts
@@ -6,6 +6,9 @@ const MAX_MESSAGE_PARTS = 50;
 const MAX_PART_TYPE_LENGTH = 80;
 const MAX_TEXT_PART_LENGTH = 8_000;
 
+export const supportAgentLocaleSchema = z.enum(["en", "fr"]);
+export type SupportAgentLocale = z.infer<typeof supportAgentLocaleSchema>;
+
 const uiMessagePartSchema = z
   .object({
     type: z.string().min(1).max(MAX_PART_TYPE_LENGTH),
@@ -41,6 +44,7 @@ export const supportChatRequestSchema = z.object({
     .array(supportChatMessageSchema)
     .min(1, "At least one message is required")
     .max(MAX_SUPPORT_MESSAGES, "Too many messages"),
+  locale: supportAgentLocaleSchema.default("en"),
 });
 
 export type SupportChatRequest = z.infer<typeof supportChatRequestSchema>;

--- a/app/api/ai/support/tools/search-codebase.ts
+++ b/app/api/ai/support/tools/search-codebase.ts
@@ -1,42 +1,35 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { searchCodebase } from "@/lib/ai/search-codebase";
-
-const shouldLogSupportSearchDebug =
-  process.env.NODE_ENV !== "production" && process.env.SUPPORT_SEARCH_DEBUG !== "0";
+import {
+  grepCodebase,
+  listCodebaseFiles,
+  readCodebaseFile,
+  searchCodebase,
+} from "@/lib/ai/search-codebase";
 
 export const searchCodebaseTool = tool({
   description:
-    "Search Deltalytix product documentation, release notes, locale strings, and self-hosting guides in the repository. Use this before answering questions about features, imports, billing, dashboard behavior, or setup.",
+    "Ranked keyword search across Deltalytix product docs (content/**), release notes, locale strings (every UI label lives there), and application source (app, components, lib, server, store, hooks, prisma schema). Start here for any question about features, imports, integrations, billing, dashboard behaviour, or self-hosting. Returns the strongest files with surrounding context lines.",
   inputSchema: z.object({
     query: z
       .string()
       .describe(
-        "Keywords or a short phrase describing what to look up, e.g. 'import CSV trades' or 'Tradovate sync'",
+        "Keywords describing what to look up, e.g. 'Tradovate CSV import timezone' or 'subscription cancel billing portal'",
       ),
     locale: z
       .enum(["en", "fr"])
       .optional()
-      .describe("Prefer documentation in this language when available"),
+      .describe("Prefer documentation and locale strings in this language"),
   }),
   execute: async ({ query, locale }) => {
     const result = await searchCodebase(query, { locale });
-
-    if (shouldLogSupportSearchDebug) {
-      console.log("[searchCodebase]", {
-        query,
-        locale,
-        matchCount: result.matchCount,
-        sampleFiles: result.matches.slice(0, 3).map((match) => match.file),
-      });
-    }
 
     if (result.matchCount === 0) {
       return {
         found: false,
         query: result.query,
         message:
-          "No matching documentation was found. Ask a clarifying question or escalate to email support.",
+          "No matches. Try fewer or different keywords, or use grepCodebase with a specific identifier, UI label, or error string.",
         matches: [],
       };
     }
@@ -48,4 +41,80 @@ export const searchCodebaseTool = tool({
       matches: result.matches,
     };
   },
+});
+
+export const grepCodebaseTool = tool({
+  description:
+    "Regex grep over the Deltalytix repository (docs, locales, and source). Use this when you know an exact string to look for — a UI label, an error message, an env var, a function or route name — or to narrow a search to specific files with a glob. Prefer searchCodebase for open-ended questions.",
+  inputSchema: z.object({
+    pattern: z
+      .string()
+      .describe(
+        "JavaScript regular expression, e.g. 'RESEND_API_KEY' or 'stripe.*checkout'. Case-insensitive by default.",
+      ),
+    glob: z
+      .string()
+      .optional()
+      .describe(
+        "Optional path filter, comma-separated. Examples: 'content/updates/en/**/*.mdx', 'locales/**/*.ts', 'app/api/**/*.ts'",
+      ),
+    caseSensitive: z.boolean().optional().describe("Match case exactly (default false)"),
+    contextLines: z
+      .number()
+      .int()
+      .min(0)
+      .max(6)
+      .optional()
+      .describe("Lines of context around each match (default 2)"),
+  }),
+  execute: async ({ pattern, glob, caseSensitive, contextLines }) => {
+    const result = await grepCodebase(pattern, { glob, caseSensitive, contextLines });
+
+    if (result.error) {
+      return { found: false, pattern: result.pattern, error: result.error, matches: [] };
+    }
+
+    if (result.matchCount === 0) {
+      return {
+        found: false,
+        pattern: result.pattern,
+        message:
+          "No matches. Loosen the pattern, drop the glob, or fall back to searchCodebase.",
+        matches: [],
+      };
+    }
+
+    return {
+      found: true,
+      pattern: result.pattern,
+      matchCount: result.matchCount,
+      truncated: result.truncated,
+      matches: result.matches,
+    };
+  },
+});
+
+export const readCodebaseFileTool = tool({
+  description:
+    "Read a file (or a line range) that searchCodebase or grepCodebase returned. Use it when a snippet is not enough to answer confidently — for example to read a whole release note or a full locale section.",
+  inputSchema: z.object({
+    file: z
+      .string()
+      .describe("Repository-relative path exactly as returned by a previous search"),
+    startLine: z.number().int().min(1).optional().describe("First line to read (1-indexed)"),
+    endLine: z.number().int().min(1).optional().describe("Last line to read (inclusive)"),
+  }),
+  execute: async ({ file, startLine, endLine }) => readCodebaseFile(file, { startLine, endLine }),
+});
+
+export const listCodebaseFilesTool = tool({
+  description:
+    "List searchable files matching a glob. Useful to discover what documentation exists, e.g. 'content/updates/en/**/*.mdx' to see every release note.",
+  inputSchema: z.object({
+    glob: z
+      .string()
+      .optional()
+      .describe("Glob pattern, e.g. 'content/**/*.mdx' or 'locales/en/*.ts'"),
+  }),
+  execute: async ({ glob }) => listCodebaseFiles(glob),
 });

--- a/lib/ai/codebase-index.ts
+++ b/lib/ai/codebase-index.ts
@@ -1,0 +1,246 @@
+import type { Dirent } from "node:fs";
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+export type CorpusKind = "doc" | "locale" | "source" | "schema";
+
+type CorpusRoot = {
+  /** Repo-relative directory or file. */
+  path: string;
+  kind: CorpusKind;
+  /** Extensions accepted when walking a directory. */
+  extensions: readonly string[];
+};
+
+const DOC_EXTENSIONS = [".md", ".mdx"] as const;
+const SOURCE_EXTENSIONS = [".ts", ".tsx"] as const;
+
+/**
+ * Everything the support agent is allowed to search or read. Product docs and
+ * locale strings answer most questions, but the agent also needs the real
+ * source to explain behaviour that was never written down.
+ */
+export const CORPUS_ROOTS: readonly CorpusRoot[] = [
+  { path: "content", kind: "doc", extensions: DOC_EXTENSIONS },
+  { path: "README.md", kind: "doc", extensions: DOC_EXTENSIONS },
+  { path: "SELF_HOSTING.md", kind: "doc", extensions: DOC_EXTENSIONS },
+  { path: "SECURITY.md", kind: "doc", extensions: DOC_EXTENSIONS },
+  { path: "AGENTS.md", kind: "doc", extensions: DOC_EXTENSIONS },
+  { path: "locales", kind: "locale", extensions: SOURCE_EXTENSIONS },
+  { path: "app", kind: "source", extensions: [...SOURCE_EXTENSIONS, ...DOC_EXTENSIONS] },
+  { path: "components", kind: "source", extensions: SOURCE_EXTENSIONS },
+  { path: "lib", kind: "source", extensions: SOURCE_EXTENSIONS },
+  { path: "server", kind: "source", extensions: SOURCE_EXTENSIONS },
+  { path: "hooks", kind: "source", extensions: SOURCE_EXTENSIONS },
+  { path: "store", kind: "source", extensions: SOURCE_EXTENSIONS },
+  { path: "context", kind: "source", extensions: SOURCE_EXTENSIONS },
+  { path: "prisma/schema.prisma", kind: "schema", extensions: [".prisma"] },
+];
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  "node_modules",
+  ".git",
+  ".next",
+  "generated",
+  "__snapshots__",
+]);
+
+const IGNORED_FILE_PATTERN = /(\.d\.ts|\.test\.tsx?|\.spec\.tsx?)$/i;
+
+/** Skip anything too large to be useful as a support answer. */
+const MAX_FILE_BYTES = 400_000;
+
+const CACHE_TTL_MS = process.env.NODE_ENV === "production" ? Number.POSITIVE_INFINITY : 15_000;
+
+export type IndexedFile = {
+  path: string;
+  kind: CorpusKind;
+  /** Frontmatter or first heading title, when the file has one. */
+  title?: string;
+  content: string;
+  lowerContent: string;
+  lines: string[];
+  /** Path lowercased with separators turned into spaces, for path matching. */
+  searchablePath: string;
+};
+
+function repoPath(...segments: string[]): string {
+  return path.join(/*turbopackIgnore: true*/ process.cwd(), ...segments);
+}
+
+export function shouldLogSearchDebug(): boolean {
+  return process.env.NODE_ENV !== "production" && process.env.SUPPORT_SEARCH_DEBUG !== "0";
+}
+
+/**
+ * Glob patterns for `outputFileTracingIncludes` — the corpus is read from disk
+ * at runtime, so it has to survive into the serverless bundle.
+ */
+export const SUPPORT_SEARCH_TRACE_INCLUDES: readonly string[] = CORPUS_ROOTS.flatMap(
+  (root) =>
+    path.extname(root.path)
+      ? [`./${root.path}`]
+      : root.extensions.map((extension) => `./${root.path}/**/*${extension}`),
+);
+
+function extractTitle(relativePath: string, content: string): string | undefined {
+  const frontmatterTitle = /^---\r?\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m.exec(content);
+  if (frontmatterTitle) return frontmatterTitle[1].trim();
+
+  const heading = /^#\s+(.+)$/m.exec(content);
+  if (heading) return heading[1].trim();
+
+  return undefined;
+}
+
+function toSearchablePath(relativePath: string): string {
+  return relativePath.toLowerCase().replace(/[\\/_.-]+/g, " ");
+}
+
+async function loadFile(
+  relativePath: string,
+  kind: CorpusKind,
+): Promise<IndexedFile | null> {
+  let content: string;
+  try {
+    const fileStat = await stat(repoPath(relativePath));
+    if (!fileStat.isFile() || fileStat.size > MAX_FILE_BYTES) return null;
+    content = await readFile(repoPath(relativePath), "utf8");
+  } catch {
+    return null;
+  }
+
+  return {
+    path: relativePath,
+    kind,
+    title: extractTitle(relativePath, content),
+    content,
+    lowerContent: content.toLowerCase(),
+    lines: content.split("\n"),
+    searchablePath: toSearchablePath(relativePath),
+  };
+}
+
+async function walkRoot(root: CorpusRoot, collected: IndexedFile[]): Promise<void> {
+  async function walk(relativeDir: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(repoPath(relativeDir), { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const nested: Promise<void>[] = [];
+    const files: Promise<IndexedFile | null>[] = [];
+
+    for (const entry of entries) {
+      const relativePath = path.join(relativeDir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRECTORY_NAMES.has(entry.name)) continue;
+        nested.push(walk(relativePath));
+        continue;
+      }
+
+      if (!root.extensions.some((extension) => entry.name.endsWith(extension))) continue;
+      if (IGNORED_FILE_PATTERN.test(entry.name)) continue;
+
+      files.push(loadFile(relativePath, root.kind));
+    }
+
+    for (const file of await Promise.all(files)) {
+      if (file) collected.push(file);
+    }
+
+    await Promise.all(nested);
+  }
+
+  if (path.extname(root.path)) {
+    const file = await loadFile(root.path, root.kind);
+    if (file) collected.push(file);
+    return;
+  }
+
+  await walk(root.path);
+}
+
+let cachedCorpus: { loadedAt: number; files: IndexedFile[] } | null = null;
+let inflightLoad: Promise<IndexedFile[]> | null = null;
+
+async function buildCorpus(): Promise<IndexedFile[]> {
+  const started = Date.now();
+  const files: IndexedFile[] = [];
+
+  await Promise.all(CORPUS_ROOTS.map((root) => walkRoot(root, files)));
+  files.sort((left, right) => left.path.localeCompare(right.path));
+
+  if (shouldLogSearchDebug()) {
+    console.log("[codebaseIndex] Corpus built", {
+      files: files.length,
+      ms: Date.now() - started,
+      cwd: repoPath(),
+    });
+  }
+
+  if (files.length === 0) {
+    console.warn("[codebaseIndex] Corpus is empty — is the working directory the repo root?", {
+      cwd: repoPath(),
+    });
+  }
+
+  return files;
+}
+
+export async function getCorpus(): Promise<IndexedFile[]> {
+  if (cachedCorpus && Date.now() - cachedCorpus.loadedAt < CACHE_TTL_MS) {
+    return cachedCorpus.files;
+  }
+
+  inflightLoad ??= buildCorpus()
+    .then((files) => {
+      cachedCorpus = { loadedAt: Date.now(), files };
+      return files;
+    })
+    .finally(() => {
+      inflightLoad = null;
+    });
+
+  return inflightLoad;
+}
+
+export function clearCorpusCache(): void {
+  cachedCorpus = null;
+}
+
+/** Translate a `*` / `**` / `?` glob (or comma-separated list) into a matcher. */
+export function createGlobMatcher(glob?: string): (relativePath: string) => boolean {
+  if (!glob?.trim()) return () => true;
+
+  const patterns = glob
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => part.replace(/^\.\//, ""));
+
+  if (patterns.length === 0) return () => true;
+
+  const regexes = patterns.map((pattern) => {
+    const source = pattern
+      .split(/(\*\*\/|\*\*|\*|\?)/)
+      .map((segment) => {
+        if (segment === "**/") return "(?:.*/)?";
+        if (segment === "**") return ".*";
+        if (segment === "*") return "[^/]*";
+        if (segment === "?") return "[^/]";
+        return segment.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+      })
+      .join("");
+
+    return new RegExp(`^${source}$`, "i");
+  });
+
+  return (relativePath) => {
+    const normalized = relativePath.split(path.sep).join("/");
+    return regexes.some((regex) => regex.test(normalized));
+  };
+}

--- a/lib/ai/search-codebase.ts
+++ b/lib/ai/search-codebase.ts
@@ -1,89 +1,59 @@
-import type { Dirent } from "node:fs";
-import { access, readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
+import {
+  type CorpusKind,
+  type IndexedFile,
+  createGlobMatcher,
+  getCorpus,
+  shouldLogSearchDebug,
+} from "./codebase-index";
 
-/** Product documentation and user-facing copy only — not full locale aggregates. */
-const CONTENT_ROOT = "content" as const;
+export { SUPPORT_SEARCH_TRACE_INCLUDES } from "./codebase-index";
+export type { CorpusKind } from "./codebase-index";
 
-export const SUPPORT_SEARCH_TRACE_INCLUDES = [
-  "./content/**/*",
-  "./locales/en/support.ts",
-  "./locales/fr/support.ts",
-  "./locales/en/faq.ts",
-  "./locales/fr/faq.ts",
-  "./locales/en/chat.ts",
-  "./locales/fr/chat.ts",
-  "./locales/en/landing.ts",
-  "./locales/fr/landing.ts",
-  "./README.md",
-  "./SELF_HOSTING.md",
-  "./AGENTS.md",
-] as const;
+const MAX_FILES = 6;
+const MAX_BLOCKS_PER_FILE = 3;
+const CONTEXT_RADIUS = 3;
+const MAX_BLOCK_CHARS = 900;
+const MAX_LINE_CHARS = 240;
+const MAX_TERM_OCCURRENCES = 8;
 
-const LOCALE_DOC_FILES = [
-  "locales/en/support.ts",
-  "locales/fr/support.ts",
-  "locales/en/faq.ts",
-  "locales/fr/faq.ts",
-  "locales/en/chat.ts",
-  "locales/fr/chat.ts",
-  "locales/en/landing.ts",
-  "locales/fr/landing.ts",
-] as const;
+const MAX_GREP_MATCHES = 25;
+const MAX_GREP_PATTERN_LENGTH = 200;
+const GREP_TIME_BUDGET_MS = 2_500;
 
-const ROOT_MARKDOWN_FILES = ["README.md", "SELF_HOSTING.md", "AGENTS.md"] as const;
+const MAX_READ_LINES = 400;
 
-const MAX_RESULTS = 12;
-const MAX_SNIPPET_CHARS = 600;
-
-const SEARCHABLE_FILE_PATTERN = /\.(md|mdx|ts)$/i;
-
-function shouldLogSearchDebug(): boolean {
-  return process.env.NODE_ENV !== "production" && process.env.SUPPORT_SEARCH_DEBUG !== "0";
-}
-
+/** Words that carry no signal in a support question. */
 const SEARCH_STOP_WORDS = new Set([
-  "a",
-  "an",
-  "the",
-  "and",
-  "or",
-  "for",
-  "to",
-  "how",
-  "what",
-  "when",
-  "where",
-  "why",
-  "is",
-  "are",
-  "was",
-  "were",
-  "do",
-  "does",
-  "did",
-  "can",
-  "could",
-  "should",
-  "would",
-  "about",
-  "with",
-  "from",
-  "into",
-  "documentation",
-  "docs",
-  "guide",
-  "help",
-  "setup",
-  "instructions",
-  "information",
-  "details",
+  "a", "an", "the", "and", "or", "but", "for", "to", "of", "in", "on", "at", "by",
+  "how", "what", "when", "where", "why", "which", "who",
+  "is", "are", "was", "were", "be", "been", "am",
+  "do", "does", "did", "done", "can", "could", "should", "would", "will", "shall",
+  "my", "me", "i", "we", "you", "your", "our", "it", "its", "this", "that",
+  "about", "with", "from", "into", "please", "help", "need", "want",
+  "documentation", "docs", "doc", "guide", "setup", "instructions", "information",
+  "details", "deltalytix", "app", "platform",
+  // French equivalents — the assistant answers in both languages.
+  "le", "la", "les", "un", "une", "des", "de", "du", "et", "ou", "pour", "dans",
+  "sur", "avec", "comment", "pourquoi", "quand", "est", "sont", "je", "tu", "il",
+  "nous", "vous", "mon", "ma", "mes", "aide", "besoin", "faire",
 ]);
+
+/** Weight by how likely a file is to hold a user-facing answer. */
+const KIND_WEIGHT: Record<CorpusKind, number> = {
+  doc: 1.7,
+  locale: 1.3,
+  schema: 1.1,
+  source: 1,
+};
 
 export type CodebaseSearchMatch = {
   file: string;
   line: number;
   snippet: string;
+  title?: string;
+  kind?: CorpusKind;
+  score?: number;
 };
 
 export type CodebaseSearchResult = {
@@ -92,258 +62,411 @@ export type CodebaseSearchResult = {
   matches: CodebaseSearchMatch[];
 };
 
-function normalizeSnippet(text: string): string {
-  return text.replace(/\s+/g, " ").trim().slice(0, MAX_SNIPPET_CHARS);
+export type CodebaseGrepResult = {
+  pattern: string;
+  matchCount: number;
+  matches: CodebaseSearchMatch[];
+  truncated: boolean;
+  error?: string;
+};
+
+export type CodebaseReadResult = {
+  file: string;
+  startLine: number;
+  endLine: number;
+  totalLines: number;
+  content: string;
+  truncated: boolean;
+  error?: string;
+};
+
+function truncateLine(line: string): string {
+  const normalized = line.replace(/\s+$/, "");
+  return normalized.length > MAX_LINE_CHARS
+    ? `${normalized.slice(0, MAX_LINE_CHARS)}…`
+    : normalized;
 }
 
-function repoPath(...segments: string[]): string {
-  return path.join(/*turbopackIgnore: true*/ process.cwd(), ...segments);
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function localeContentPath(locale?: string): string | undefined {
-  if (locale === "en" || locale === "fr") {
-    return path.join(CONTENT_ROOT, "updates", locale);
-  }
-
-  return undefined;
+/**
+ * Terms plus cheap singular/plural variants — "imports" should still find
+ * "import", and vice versa.
+ */
+function termVariants(term: string): string[] {
+  const variants = new Set([term]);
+  if (term.endsWith("ies") && term.length > 4) variants.add(`${term.slice(0, -3)}y`);
+  if (term.endsWith("es") && term.length > 3) variants.add(term.slice(0, -2));
+  if (term.endsWith("s") && term.length > 3) variants.add(term.slice(0, -1));
+  else variants.add(`${term}s`);
+  return [...variants];
 }
 
-function isSearchableFile(relativePath: string): boolean {
-  return SEARCHABLE_FILE_PATTERN.test(relativePath);
-}
+type SearchTerm = {
+  term: string;
+  variants: string[];
+  /** Inverse document frequency, filled in once the corpus is scanned. */
+  idf: number;
+};
 
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    await access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function buildFallbackSearchPaths(): string[] {
-  return [CONTENT_ROOT, ...LOCALE_DOC_FILES, ...ROOT_MARKDOWN_FILES];
-}
-
-function parseSearchTerms(query: string): string[] {
-  const rawTerms = query
-    .trim()
-    .split(/\s+/)
-    .map((term) => term.replace(/[^\p{L}\p{N}_-]/gu, ""))
-    .filter((term) => term.length >= 2);
-
-  const terms = [
-    ...new Set(rawTerms.filter((term) => !SEARCH_STOP_WORDS.has(term.toLowerCase()))),
-  ];
-
-  return terms.length > 0 ? terms : rawTerms.slice(0, 1);
-}
-
-function fileContainsAllTerms(content: string, terms: string[]): boolean {
-  const lowerContent = content.toLowerCase();
-  return terms.every((term) => lowerContent.includes(term.toLowerCase()));
-}
-
-function fileNameContainsAllTerms(relativePath: string, terms: string[]): boolean {
-  const slug = path
-    .basename(relativePath, path.extname(relativePath))
+function buildSearchTerms(query: string): SearchTerm[] {
+  const raw = query
     .toLowerCase()
-    .replace(/-/g, " ");
-  return terms.every((term) => slug.includes(term.toLowerCase()));
+    .split(/[^\p{L}\p{N}_]+/u)
+    .filter((token) => token.length >= 2);
+
+  const unique = [...new Set(raw)];
+  const meaningful = unique.filter((token) => !SEARCH_STOP_WORDS.has(token));
+  const chosen = meaningful.length > 0 ? meaningful : unique;
+
+  return chosen.slice(0, 12).map((term) => ({
+    term,
+    variants: termVariants(term),
+    idf: 1,
+  }));
 }
 
-function fileMatchesTerms(relativePath: string, content: string, terms: string[]): boolean {
-  return (
-    fileContainsAllTerms(content, terms) || fileNameContainsAllTerms(relativePath, terms)
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1 && count < MAX_TERM_OCCURRENCES) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+function fileContainsTerm(file: IndexedFile, term: SearchTerm): boolean {
+  return term.variants.some(
+    (variant) =>
+      file.lowerContent.includes(variant) || file.searchablePath.includes(variant),
   );
 }
 
-const GENERIC_SEARCH_TERMS = new Set([
-  "firm",
-  "sync",
-  "account",
-  "import",
-  "trade",
-  "trades",
-  "selection",
-  "support",
-  "connection",
-  "dashboard",
-]);
+function localeMultiplier(file: IndexedFile, locale?: "en" | "fr"): number {
+  if (!locale) return 1;
 
-function pickPrimarySearchTerm(terms: string[]): string {
-  const distinctiveTerms = terms.filter(
-    (term) => !GENERIC_SEARCH_TERMS.has(term.toLowerCase()),
-  );
-  return distinctiveTerms[0] ?? terms[0];
+  const other = locale === "en" ? "fr" : "en";
+  const normalized = file.path.split(path.sep).join("/");
+
+  if (normalized.includes(`/${locale}/`) || normalized.endsWith(`/${locale}.ts`)) return 1.25;
+  if (normalized.includes(`/${other}/`) || normalized.endsWith(`/${other}.ts`)) return 0.5;
+  return 1;
 }
 
-function lineMatchedTermCount(line: string, terms: string[]): number {
+type ScoredFile = { file: IndexedFile; score: number };
+
+function scoreFiles(
+  files: IndexedFile[],
+  terms: SearchTerm[],
+  phrase: string,
+  locale?: "en" | "fr",
+): ScoredFile[] {
+  if (terms.length === 0) return [];
+
+  // Document frequency drives idf, so a term like "rithmic" outranks "trade".
+  for (const term of terms) {
+    let documentFrequency = 0;
+    for (const file of files) {
+      if (fileContainsTerm(file, term)) documentFrequency += 1;
+    }
+    term.idf = Math.log((files.length + 1) / (documentFrequency + 1)) + 0.4;
+  }
+
+  const scored: ScoredFile[] = [];
+
+  for (const file of files) {
+    let score = 0;
+    let matchedTerms = 0;
+
+    for (const term of terms) {
+      const contentHits = term.variants.reduce(
+        (total, variant) => total + countOccurrences(file.lowerContent, variant),
+        0,
+      );
+      const pathHit = term.variants.some((variant) => file.searchablePath.includes(variant));
+
+      if (contentHits === 0 && !pathHit) continue;
+
+      matchedTerms += 1;
+      if (contentHits > 0) score += term.idf * (1 + Math.log(Math.min(contentHits, MAX_TERM_OCCURRENCES)));
+      if (pathHit) score += term.idf * 2.5;
+    }
+
+    if (matchedTerms === 0) continue;
+
+    // Covering every term is a much stronger signal than covering one.
+    score *= 1 + (matchedTerms / terms.length) * 0.8;
+    if (phrase.length > 4 && file.lowerContent.includes(phrase)) score *= 2;
+
+    score *= KIND_WEIGHT[file.kind];
+    score *= localeMultiplier(file, locale);
+
+    scored.push({ file, score });
+  }
+
+  scored.sort((left, right) => right.score - left.score);
+  return scored;
+}
+
+function lineScore(line: string, terms: SearchTerm[]): number {
   const lowerLine = line.toLowerCase();
-  return terms.filter((term) => lowerLine.includes(term.toLowerCase())).length;
+  let score = 0;
+  for (const term of terms) {
+    if (term.variants.some((variant) => lowerLine.includes(variant))) score += term.idf;
+  }
+  return score;
 }
 
-async function searchFile(
-  relativePath: string,
-  terms: string[],
-  matches: CodebaseSearchMatch[],
-): Promise<void> {
-  if (matches.length >= MAX_RESULTS || terms.length === 0) return;
+/** Pull the strongest regions of a file, with surrounding lines for context. */
+function extractBlocks(file: IndexedFile, terms: SearchTerm[]): CodebaseSearchMatch[] {
+  const hits: Array<{ index: number; score: number }> = [];
 
-  const absolutePath = repoPath(relativePath);
-
-  let content: string;
-  try {
-    content = await readFile(absolutePath, "utf8");
-  } catch {
-    return;
+  for (let index = 0; index < file.lines.length; index += 1) {
+    const score = lineScore(file.lines[index], terms);
+    if (score > 0) hits.push({ index, score });
   }
 
-  if (!fileMatchesTerms(relativePath, content, terms)) {
-    return;
+  if (hits.length === 0) {
+    return [
+      {
+        file: file.path,
+        line: 1,
+        snippet: file.lines.slice(0, CONTEXT_RADIUS * 2 + 1).map(truncateLine).join("\n"),
+        title: file.title,
+        kind: file.kind,
+      },
+    ];
   }
 
-  const lines = content.split("\n");
-  const lineMatches: Array<{ index: number; score: number }> = [];
+  hits.sort((left, right) => right.score - left.score || left.index - right.index);
 
-  for (let index = 0; index < lines.length; index += 1) {
-    const score = lineMatchedTermCount(lines[index], terms);
-    if (score === 0) continue;
-    lineMatches.push({ index, score });
-  }
+  const ranges: Array<{ start: number; end: number }> = [];
+  for (const hit of hits) {
+    if (ranges.length >= MAX_BLOCKS_PER_FILE) break;
 
-  lineMatches.sort((left, right) => right.score - left.score);
+    const start = Math.max(0, hit.index - CONTEXT_RADIUS);
+    const end = Math.min(file.lines.length - 1, hit.index + CONTEXT_RADIUS);
 
-  for (const { index } of lineMatches) {
-    matches.push({
-      file: relativePath,
-      line: index + 1,
-      snippet: normalizeSnippet(lines[index]),
-    });
-
-    if (matches.length >= MAX_RESULTS) break;
-  }
-}
-
-async function searchFiles(
-  terms: string[],
-  searchPaths: string[],
-): Promise<CodebaseSearchMatch[]> {
-  const matches: CodebaseSearchMatch[] = [];
-
-  async function walk(dir: string): Promise<void> {
-    if (matches.length >= MAX_RESULTS) return;
-
-    const absoluteDir = repoPath(dir);
-    if (!(await fileExists(absoluteDir))) return;
-
-    let entries: Dirent[];
-    try {
-      entries = await readdir(absoluteDir, { withFileTypes: true });
-    } catch (error) {
-      if (shouldLogSearchDebug()) {
-        console.warn("[searchCodebase] Skipping unreadable directory", {
-          dir,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-      return;
-    }
-
-    for (const entry of entries) {
-      if (matches.length >= MAX_RESULTS) break;
-
-      const relativePath = path.join(dir, entry.name);
-
-      if (entry.isDirectory()) {
-        if (entry.name === "node_modules" || entry.name === ".git") continue;
-        await walk(relativePath);
-        continue;
-      }
-
-      if (!isSearchableFile(relativePath)) continue;
-
-      await searchFile(relativePath, terms, matches);
-    }
-  }
-
-  for (const searchPath of searchPaths) {
-    if (matches.length >= MAX_RESULTS) break;
-
-    const absolutePath = repoPath(searchPath);
-
-    try {
-      const fileStat = await stat(absolutePath);
-      if (fileStat.isFile()) {
-        if (isSearchableFile(searchPath)) {
-          await searchFile(searchPath, terms, matches);
-        }
-        continue;
-      }
-    } catch {
+    const overlapping = ranges.find((range) => start <= range.end + 1 && end >= range.start - 1);
+    if (overlapping) {
+      overlapping.start = Math.min(overlapping.start, start);
+      overlapping.end = Math.max(overlapping.end, end);
       continue;
     }
 
-    await walk(searchPath);
+    ranges.push({ start, end });
   }
 
-  return matches;
-}
+  ranges.sort((left, right) => left.start - right.start);
 
-async function runSearch(
-  query: string,
-  searchPaths: string[],
-): Promise<CodebaseSearchMatch[]> {
-  const existingPaths: string[] = [];
-  for (const searchPath of searchPaths) {
-    if (await fileExists(repoPath(searchPath))) {
-      existingPaths.push(searchPath);
-    }
-  }
-
-  if (existingPaths.length === 0) {
-    console.warn("[searchCodebase] No searchable paths found", {
-      cwd: repoPath(),
-      requestedPaths: searchPaths,
-    });
-    return [];
-  }
-
-  const terms = parseSearchTerms(query);
-  let matches = await searchFiles(terms, existingPaths);
-
-  if (matches.length === 0 && terms.length > 1) {
-    matches = await searchFiles([pickPrimarySearchTerm(terms)], existingPaths);
-  }
-
-  return matches;
+  return ranges.map((range) => ({
+    file: file.path,
+    line: range.start + 1,
+    snippet: file.lines
+      .slice(range.start, range.end + 1)
+      .map(truncateLine)
+      .join("\n")
+      .slice(0, MAX_BLOCK_CHARS),
+    title: file.title,
+    kind: file.kind,
+  }));
 }
 
 export async function searchCodebase(
   query: string,
-  options?: { locale?: "en" | "fr" },
+  options?: { locale?: "en" | "fr"; limit?: number },
 ): Promise<CodebaseSearchResult> {
   const trimmedQuery = query.trim();
   if (!trimmedQuery) {
     return { query: trimmedQuery, matchCount: 0, matches: [] };
   }
 
-  const localePath = localeContentPath(options?.locale);
-  const fallbackPaths = buildFallbackSearchPaths();
+  const files = await getCorpus();
+  const terms = buildSearchTerms(trimmedQuery);
+  const scored = scoreFiles(files, terms, trimmedQuery.toLowerCase(), options?.locale);
 
-  let matches: CodebaseSearchMatch[] = [];
+  const fileLimit = Math.max(1, Math.min(options?.limit ?? MAX_FILES, 10));
+  const matches: CodebaseSearchMatch[] = [];
 
-  if (localePath) {
-    matches = await runSearch(trimmedQuery, [localePath]);
+  for (const { file, score } of scored.slice(0, fileLimit)) {
+    for (const block of extractBlocks(file, terms)) {
+      matches.push({ ...block, score: Number(score.toFixed(2)) });
+    }
   }
 
-  if (matches.length === 0) {
-    matches = await runSearch(trimmedQuery, fallbackPaths);
+  if (shouldLogSearchDebug()) {
+    console.log("[searchCodebase]", {
+      query: trimmedQuery,
+      locale: options?.locale,
+      terms: terms.map((term) => term.term),
+      corpusFiles: files.length,
+      topFiles: scored.slice(0, fileLimit).map(({ file, score }) => `${file.path} (${score.toFixed(1)})`),
+    });
   }
+
+  return { query: trimmedQuery, matchCount: matches.length, matches };
+}
+
+export async function grepCodebase(
+  pattern: string,
+  options?: {
+    glob?: string;
+    caseSensitive?: boolean;
+    isRegex?: boolean;
+    contextLines?: number;
+    maxResults?: number;
+  },
+): Promise<CodebaseGrepResult> {
+  const trimmedPattern = pattern.trim();
+  if (!trimmedPattern) {
+    return { pattern: trimmedPattern, matchCount: 0, matches: [], truncated: false };
+  }
+
+  if (trimmedPattern.length > MAX_GREP_PATTERN_LENGTH) {
+    return {
+      pattern: trimmedPattern,
+      matchCount: 0,
+      matches: [],
+      truncated: false,
+      error: `Pattern is too long (max ${MAX_GREP_PATTERN_LENGTH} characters).`,
+    };
+  }
+
+  let regex: RegExp;
+  try {
+    const source = options?.isRegex === false ? escapeRegExp(trimmedPattern) : trimmedPattern;
+    regex = new RegExp(source, options?.caseSensitive ? "" : "i");
+  } catch (error) {
+    return {
+      pattern: trimmedPattern,
+      matchCount: 0,
+      matches: [],
+      truncated: false,
+      error: `Invalid regular expression: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const files = await getCorpus();
+  const matchesGlob = createGlobMatcher(options?.glob);
+  const contextRadius = Math.max(0, Math.min(options?.contextLines ?? 2, 6));
+  const maxResults = Math.max(1, Math.min(options?.maxResults ?? MAX_GREP_MATCHES, MAX_GREP_MATCHES));
+
+  const matches: CodebaseSearchMatch[] = [];
+  const deadline = Date.now() + GREP_TIME_BUDGET_MS;
+  let truncated = false;
+
+  for (const file of files) {
+    if (matches.length >= maxResults) {
+      truncated = true;
+      break;
+    }
+    if (Date.now() > deadline) {
+      truncated = true;
+      break;
+    }
+    if (!matchesGlob(file.path)) continue;
+    if (!regex.test(file.content)) continue;
+
+    for (let index = 0; index < file.lines.length; index += 1) {
+      if (matches.length >= maxResults) {
+        truncated = true;
+        break;
+      }
+      if (!regex.test(file.lines[index])) continue;
+
+      const start = Math.max(0, index - contextRadius);
+      const end = Math.min(file.lines.length - 1, index + contextRadius);
+
+      matches.push({
+        file: file.path,
+        line: index + 1,
+        snippet: file.lines
+          .slice(start, end + 1)
+          .map(truncateLine)
+          .join("\n")
+          .slice(0, MAX_BLOCK_CHARS),
+        title: file.title,
+        kind: file.kind,
+      });
+    }
+  }
+
+  if (shouldLogSearchDebug()) {
+    console.log("[grepCodebase]", {
+      pattern: trimmedPattern,
+      glob: options?.glob,
+      matchCount: matches.length,
+      truncated,
+    });
+  }
+
+  return { pattern: trimmedPattern, matchCount: matches.length, matches, truncated };
+}
+
+export async function readCodebaseFile(
+  filePath: string,
+  options?: { startLine?: number; endLine?: number },
+): Promise<CodebaseReadResult> {
+  const normalized = filePath.trim().replace(/^\.\//, "").split(path.sep).join("/");
+  const files = await getCorpus();
+  const file = files.find(
+    (candidate) => candidate.path.split(path.sep).join("/") === normalized,
+  );
+
+  if (!file) {
+    return {
+      file: normalized,
+      startLine: 0,
+      endLine: 0,
+      totalLines: 0,
+      content: "",
+      truncated: false,
+      error:
+        "File is not part of the searchable corpus. Use searchCodebase or grepCodebase to find a valid path first.",
+    };
+  }
+
+  const totalLines = file.lines.length;
+  const requestedStart = Math.max(1, options?.startLine ?? 1);
+  const requestedEnd = Math.min(totalLines, options?.endLine ?? totalLines);
+  const startLine = Math.min(requestedStart, totalLines);
+  const cappedEnd = Math.min(
+    Math.max(requestedEnd, startLine),
+    startLine + MAX_READ_LINES - 1,
+  );
+
+  const content = file.lines
+    .slice(startLine - 1, cappedEnd)
+    .map((line, offset) => `${startLine + offset}: ${truncateLine(line)}`)
+    .join("\n");
 
   return {
-    query: trimmedQuery,
-    matchCount: matches.length,
-    matches,
+    file: file.path,
+    startLine,
+    endLine: cappedEnd,
+    totalLines,
+    content,
+    truncated: cappedEnd < requestedEnd || cappedEnd < totalLines,
+  };
+}
+
+export async function listCodebaseFiles(
+  glob?: string,
+  limit = 40,
+): Promise<{ glob: string; fileCount: number; files: string[]; truncated: boolean }> {
+  const files = await getCorpus();
+  const matchesGlob = createGlobMatcher(glob);
+  const matched = files.filter((file) => matchesGlob(file.path)).map((file) => file.path);
+
+  return {
+    glob: glob?.trim() ?? "**/*",
+    fileCount: matched.length,
+    files: matched.slice(0, limit),
+    truncated: matched.length > limit,
   };
 }

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -26,43 +26,16 @@ export const supportAgentCallOptionsSchema = z.object({
 
 export type SupportAgentCallOptions = z.infer<typeof supportAgentCallOptionsSchema>;
 
-const SUPPORT_AGENT_INSTRUCTIONS = `You are the Deltalytix support assistant — a trading journaling platform. You help users with product questions and troubleshooting, and you hand off to human support the moment that is the faster path.
+const SUPPORT_AGENT_INSTRUCTIONS = `You are Deltalytix support. Use tools to answer product questions; do not invent features or UI labels.
 
-## RESEARCH BEFORE YOU ANSWER
-You can read the actual Deltalytix repository: product docs and release notes (content/**), every UI label (locales/**), and the application source (app, components, lib, server, store, hooks, prisma/schema.prisma).
+Tools: searchCodebase (default), grepCodebase (exact strings), readCodebaseFile, listCodebaseFiles, askForEmailForm. Search before answering; try a second query if the first is empty.
 
-- **searchCodebase**: your default first move for any product question. Ranked keyword search with context.
-- **grepCodebase**: when you know an exact string — a UI label the user quoted, an error message, an env var, a route, a broker or integration name. Narrow with a glob when you know where to look.
-- **readCodebaseFile**: open a file a search returned when the snippet is not enough to answer confidently.
-- **listCodebaseFiles**: discover what documentation exists, e.g. every release note under content/updates/en.
-
-Search at least twice with different wording before concluding something does not exist. A single empty search proves nothing — reword it, drop qualifiers, or grep for the literal term the user used. Ground every product claim in something you actually read, and name the feature exactly as the UI labels it.
-
-## ESCALATION — NEVER LEAVE A USER STUCK
-Call **askForEmailForm** immediately, without further questions, when:
-- The user asks for a human, an agent, an email, or says the answer did not help.
-- The request concerns billing, subscriptions, refunds, or their specific account data.
-- You have given one substantive answer and the user is still blocked.
-- Your research did not produce a confident answer.
-
-Never ask a second round of clarifying questions before escalating. At most one clarifying question per conversation — after that, escalate. Pass a summary written in the UI locale that states the problem, what was already tried, and what the user needs.
-
-The interface also shows the user a permanent "Talk to a human" button, so never tell them there is no way to reach a person.
-
-## COMMUNICATION STYLE
-- Be concise, friendly, and actionable; Markdown for steps and lists.
-- Say you are an AI assistant when the conversation starts.
-- Open each reasoning summary with a short title line describing what you are doing (e.g. "**Exporting PDF instructions**" / "**Instructions d'export PDF**"). The interface shows that title while you work.
-- Never invent feature names, UI labels, settings, or steps you did not find. If you are unsure, say so and escalate.`;
+Call askForEmailForm when the user asks for a human, for billing/account issues, or when you cannot answer confidently. One clarifying question max, then escalate. The UI already greets the user and offers human support — do not re-introduce yourself or add reply titles.`;
 
 function getLocaleInstructions(locale: SupportAgentLocale): string {
   const language = locale === "fr" ? "French" : "English";
 
-  return `## UI LOCALE
-The support page is currently in \`${locale}\` (${language}).
-- Write every reasoning summary title and body in ${language}. Never mix languages in reasoning.
-- Prefer ${language} for answers unless the user clearly writes in the other supported language.
-- When calling askForEmailForm or searchCodebase, pass locale: "${locale}".`;
+  return `Reply in ${language} (UI locale ${locale}). Pass locale "${locale}" to askForEmailForm and searchCodebase. Keep reasoning short and in ${language}.`;
 }
 
 export function buildSupportAgentInstructions(locale: SupportAgentLocale): string {

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -1,4 +1,5 @@
 import { ToolLoopAgent, stepCountIs } from "ai";
+import { z } from "zod";
 import { askForEmailForm } from "@/app/api/ai/support/tools/ask-for-email-form";
 import {
   grepCodebaseTool,
@@ -6,12 +7,24 @@ import {
   readCodebaseFileTool,
   searchCodebaseTool,
 } from "@/app/api/ai/support/tools/search-codebase";
+import {
+  supportAgentLocaleSchema,
+  type SupportAgentLocale,
+} from "@/app/api/ai/support/schema";
 
 /**
  * Tool-loop search needs a model that reliably chains calls; nano tends to
  * answer from memory instead of searching. Override per environment if needed.
  */
 const SUPPORT_AGENT_MODEL = process.env.SUPPORT_AGENT_MODEL ?? "openai/gpt-5-mini";
+
+export type { SupportAgentLocale };
+
+export const supportAgentCallOptionsSchema = z.object({
+  locale: supportAgentLocaleSchema,
+});
+
+export type SupportAgentCallOptions = z.infer<typeof supportAgentCallOptionsSchema>;
 
 const SUPPORT_AGENT_INSTRUCTIONS = `You are the Deltalytix support assistant — a trading journaling platform. You help users with product questions and troubleshooting, and you hand off to human support the moment that is the faster path.
 
@@ -32,20 +45,40 @@ Call **askForEmailForm** immediately, without further questions, when:
 - You have given one substantive answer and the user is still blocked.
 - Your research did not produce a confident answer.
 
-Never ask a second round of clarifying questions before escalating. At most one clarifying question per conversation — after that, escalate. Pass a summary written in the user's language that states the problem, what was already tried, and what the user needs.
+Never ask a second round of clarifying questions before escalating. At most one clarifying question per conversation — after that, escalate. Pass a summary written in the UI locale that states the problem, what was already tried, and what the user needs.
 
 The interface also shows the user a permanent "Talk to a human" button, so never tell them there is no way to reach a person.
 
 ## COMMUNICATION STYLE
 - Be concise, friendly, and actionable; Markdown for steps and lists.
 - Say you are an AI assistant when the conversation starts.
-- Match the user's language (English or French) — in your reasoning summaries as well as your answers. A French user must never see English reasoning.
-- Open each reasoning summary with a short title line describing what you are doing (e.g. "**Exporting PDF instructions**"), written in the user's language. The interface shows that title while you work.
+- Open each reasoning summary with a short title line describing what you are doing (e.g. "**Exporting PDF instructions**" / "**Instructions d'export PDF**"). The interface shows that title while you work.
 - Never invent feature names, UI labels, settings, or steps you did not find. If you are unsure, say so and escalate.`;
 
-export const supportAgent = new ToolLoopAgent({
+function getLocaleInstructions(locale: SupportAgentLocale): string {
+  const language = locale === "fr" ? "French" : "English";
+
+  return `## UI LOCALE
+The support page is currently in \`${locale}\` (${language}).
+- Write every reasoning summary title and body in ${language}. Never mix languages in reasoning.
+- Prefer ${language} for answers unless the user clearly writes in the other supported language.
+- When calling askForEmailForm or searchCodebase, pass locale: "${locale}".`;
+}
+
+export function buildSupportAgentInstructions(locale: SupportAgentLocale): string {
+  return `${SUPPORT_AGENT_INSTRUCTIONS}
+
+${getLocaleInstructions(locale)}`;
+}
+
+export const supportAgent = new ToolLoopAgent<SupportAgentCallOptions>({
   model: SUPPORT_AGENT_MODEL,
   instructions: SUPPORT_AGENT_INSTRUCTIONS,
+  callOptionsSchema: supportAgentCallOptionsSchema,
+  prepareCall: ({ options, ...settings }) => ({
+    ...settings,
+    instructions: buildSupportAgentInstructions(options.locale),
+  }),
   stopWhen: stepCountIs(12),
   providerOptions: {
     openai: {

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -1,40 +1,52 @@
 import { ToolLoopAgent, stepCountIs } from "ai";
 import { askForEmailForm } from "@/app/api/ai/support/tools/ask-for-email-form";
-import { searchCodebaseTool } from "@/app/api/ai/support/tools/search-codebase";
+import {
+  grepCodebaseTool,
+  listCodebaseFilesTool,
+  readCodebaseFileTool,
+  searchCodebaseTool,
+} from "@/app/api/ai/support/tools/search-codebase";
 
-const SUPPORT_AGENT_MODEL = "openai/gpt-5-nano";
+/**
+ * Tool-loop search needs a model that reliably chains calls; nano tends to
+ * answer from memory instead of searching. Override per environment if needed.
+ */
+const SUPPORT_AGENT_MODEL = process.env.SUPPORT_AGENT_MODEL ?? "openai/gpt-5-mini";
 
-const SUPPORT_AGENT_INSTRUCTIONS = `You are the Deltalytix support assistant — a trading journaling platform. Your role is to help users with product questions, troubleshooting, and routing complex issues to human support.
+const SUPPORT_AGENT_INSTRUCTIONS = `You are the Deltalytix support assistant — a trading journaling platform. You help users with product questions and troubleshooting, and you hand off to human support the moment that is the faster path.
 
-## TOOL USAGE
-- **searchCodebase**: Use this FIRST when users ask about Deltalytix features, imports, dashboard behavior, integrations, self-hosting, or how-to questions. Search with focused keywords, then answer only from what you find.
-- **askForEmailForm**: Use when the issue needs human follow-up (billing, account-specific data, bugs you cannot resolve, or when documentation search returns nothing useful). Provide a clear summary in the user's language.
+## RESEARCH BEFORE YOU ANSWER
+You can read the actual Deltalytix repository: product docs and release notes (content/**), every UI label (locales/**), and the application source (app, components, lib, server, store, hooks, prisma/schema.prisma).
 
-## RESPONSE STRATEGY
-1. For product/how-to questions: search the codebase docs, then give a concise, accurate answer grounded in the search results.
-2. For general technical issues (browser, login): help with basic troubleshooting when possible.
-3. When uncertain or search finds nothing relevant: say so honestly, ask one clarifying question, or escalate with askForEmailForm.
-4. Never invent feature details, UI labels, or steps that are not supported by search results or well-known general troubleshooting.
+- **searchCodebase**: your default first move for any product question. Ranked keyword search with context.
+- **grepCodebase**: when you know an exact string — a UI label the user quoted, an error message, an env var, a route, a broker or integration name. Narrow with a glob when you know where to look.
+- **readCodebaseFile**: open a file a search returned when the snippet is not enough to answer confidently.
+- **listCodebaseFiles**: discover what documentation exists, e.g. every release note under content/updates/en.
+
+Search at least twice with different wording before concluding something does not exist. A single empty search proves nothing — reword it, drop qualifiers, or grep for the literal term the user used. Ground every product claim in something you actually read, and name the feature exactly as the UI labels it.
+
+## ESCALATION — NEVER LEAVE A USER STUCK
+Call **askForEmailForm** immediately, without further questions, when:
+- The user asks for a human, an agent, an email, or says the answer did not help.
+- The request concerns billing, subscriptions, refunds, or their specific account data.
+- You have given one substantive answer and the user is still blocked.
+- Your research did not produce a confident answer.
+
+Never ask a second round of clarifying questions before escalating. At most one clarifying question per conversation — after that, escalate. Pass a summary written in the user's language that states the problem, what was already tried, and what the user needs.
+
+The interface also shows the user a permanent "Talk to a human" button, so never tell them there is no way to reach a person.
 
 ## COMMUNICATION STYLE
-- Identify yourself as an AI assistant at the start of new conversations.
-- Be concise, friendly, and actionable.
-- Use Markdown for steps and lists when helpful.
-- Match the user's language (English or French).
-
-## ESCALATION
-Use askForEmailForm when:
-- Billing or subscription questions
-- Account-specific data or settings
-- Persistent bugs after troubleshooting
-- Questions you cannot answer after searching documentation
-
-Remember: search before you guess. Escalate when human support is the right path.`;
+- Be concise, friendly, and actionable; Markdown for steps and lists.
+- Say you are an AI assistant when the conversation starts.
+- Match the user's language (English or French) — in your reasoning summaries as well as your answers. A French user must never see English reasoning.
+- Open each reasoning summary with a short title line describing what you are doing (e.g. "**Exporting PDF instructions**"), written in the user's language. The interface shows that title while you work.
+- Never invent feature names, UI labels, settings, or steps you did not find. If you are unsure, say so and escalate.`;
 
 export const supportAgent = new ToolLoopAgent({
   model: SUPPORT_AGENT_MODEL,
   instructions: SUPPORT_AGENT_INSTRUCTIONS,
-  stopWhen: stepCountIs(8),
+  stopWhen: stepCountIs(12),
   providerOptions: {
     openai: {
       reasoningEffort: "low",
@@ -43,6 +55,9 @@ export const supportAgent = new ToolLoopAgent({
   },
   tools: {
     searchCodebase: searchCodebaseTool,
+    grepCodebase: grepCodebaseTool,
+    readCodebaseFile: readCodebaseFileTool,
+    listCodebaseFiles: listCodebaseFilesTool,
     askForEmailForm,
   },
 });

--- a/locales/en/landing-bundle.ts
+++ b/locales/en/landing-bundle.ts
@@ -41,5 +41,8 @@ export default {
   common: {
     copy: "Copy",
     retry: "Retry",
+    edit: "Edit",
+    cancel: "Cancel",
+    send: "Send",
   },
 } as const;

--- a/locales/en/landing.ts
+++ b/locales/en/landing.ts
@@ -239,6 +239,7 @@ export default {
       joinCommunity: "Join the community",
       api: "API",
       pricing: "Pricing",
+      support: "Support",
       updates: "Updates",
       logo: {
         title: "Navigation",

--- a/locales/en/support.ts
+++ b/locales/en/support.ts
@@ -19,25 +19,28 @@ export default {
     emailConfirmation:
       "Thank you, {name}. I've gathered your information and sent your support request to our team. They will review your case and reach out to you at {email} as soon as possible. Is there anything else I can assist you with?",
     form: {
-      name: "Name",
       email: "Email",
       additionalInfo: "Additional Information",
       additionalInfoPlaceholder:
         "Add any extra details that might help our support team understand your issue...",
       submit: "Submit",
       cancel: "Cancel",
-      summary: "Summary",
       sending: "Sending...",
     },
+    openContactForm: "Open contact form",
+    editingNotice: "Editing — replies after this message will be removed.",
+    thinking: "Thinking…",
+    thoughtProcess: "Thought process",
     evaluatingSupport:
       "Reviewing your message to determine the best way to help...",
     evaluationError: "There was an error while evaluating your support needs.",
     preparingEmail: "Preparing your support request for our team...",
     emailPreparationError: "There was an error preparing your support request.",
-    joinDiscord: "Join Discord Community",
-    discordDescription:
-      "Get instant help from our community of traders and developers.",
+    joinDiscordInline: "join our Discord community",
     pageTitle: "Support Assistant",
+    pageDescription:
+      "Get quick answers from our AI assistant, built on our open knowledge base.",
+    discordPrompt: "Can't find what you need?",
     generating: "Generating response…",
     suggestionImport: "Help with importing trades",
     suggestionBilling: "Billing or subscription question",
@@ -45,7 +48,10 @@ export default {
     suggestionHuman: "Talk to a human",
     tool: {
       searchingDocs: "Searching product documentation...",
+      grepping: "Searching the codebase...",
+      readingFile: "Reading documentation...",
       preparingRequest: "Preparing your support request for our team...",
+      requestReady: "Your support request is ready to send to our team.",
       requestError: "There was an error while preparing your support request.",
       requestErrorDetails: "Error details: {error}",
     },

--- a/locales/fr/landing-bundle.ts
+++ b/locales/fr/landing-bundle.ts
@@ -42,5 +42,8 @@ export default {
   common: {
     copy: "Copier",
     retry: "Réessayer",
+    edit: "Modifier",
+    cancel: "Annuler",
+    send: "Envoyer",
   },
 } as const;

--- a/locales/fr/landing.ts
+++ b/locales/fr/landing.ts
@@ -243,6 +243,7 @@ export default {
       joinCommunity: "Rejoindre la communauté",
       api: "API",
       pricing: "Tarifs",
+      support: "Support",
       updates: "Mises à jour",
       logo: {
         title: "Navigation",

--- a/locales/fr/support.ts
+++ b/locales/fr/support.ts
@@ -19,16 +19,19 @@ export default {
     emailConfirmation:
       "Merci, {name}. J'ai rassemblé vos informations et envoyé votre demande de support à notre équipe. Ils examineront votre cas et vous recontacteront à l'adresse {email} dès que possible. Y a-t-il autre chose avec quoi je peux vous aider ?",
     form: {
-      name: "Nom",
       email: "Email",
       additionalInfo: "Informations supplémentaires",
       additionalInfoPlaceholder:
         "Ajoutez des détails supplémentaires qui pourraient aider notre équipe de support à comprendre votre problème...",
       submit: "Envoyer",
       cancel: "Annuler",
-      summary: "Résumé",
       sending: "Envoi en cours...",
     },
+    openContactForm: "Ouvrir le formulaire de contact",
+    editingNotice:
+      "Modification en cours — les réponses suivantes seront supprimées.",
+    thinking: "Réflexion…",
+    thoughtProcess: "Raisonnement",
     evaluatingSupport:
       "Examen de votre message pour déterminer la meilleure façon de vous aider...",
     evaluationError:
@@ -37,10 +40,11 @@ export default {
       "Préparation de votre demande de support pour notre équipe...",
     emailPreparationError:
       "Il y a eu une erreur lors de la préparation de votre demande de support.",
-    joinDiscord: "Rejoindre la Communauté Discord",
-    discordDescription:
-      "Obtenez une aide instantanée de notre communauté de traders et développeurs.",
+    joinDiscordInline: "rejoignez notre communauté Discord",
     pageTitle: "Assistant Support",
+    pageDescription:
+      "Obtenez des réponses rapides de notre assistant IA, basé sur notre base de connaissances ouverte.",
+    discordPrompt: "Vous ne trouvez pas ce qu'il vous faut ?",
     generating: "Génération de la réponse…",
     suggestionImport: "Aide pour importer des trades",
     suggestionBilling: "Question sur la facturation ou l'abonnement",
@@ -49,8 +53,12 @@ export default {
     tool: {
       searchingDocs:
         "Recherche dans la documentation produit...",
+      grepping: "Recherche dans le code source...",
+      readingFile: "Lecture de la documentation...",
       preparingRequest:
         "Préparation de votre demande de support pour notre équipe...",
+      requestReady:
+        "Votre demande de support est prête à être envoyée à notre équipe.",
       requestError:
         "Il y a eu une erreur lors de la préparation de votre demande de support.",
       requestErrorDetails: "Détails de l'erreur : {error}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Expands the support AI agent’s knowledge tools with a corpus index plus search/grep/read/list over docs, locales, and source.
- Polishes the support chat UI: brain-led pending/reasoning indicators that stay visible while waiting, message edit/truncate with composer focus, conversation-aware human escalation, and a responsive contact form.
- Adds a Support link to the landing navbar (desktop + mobile).
- Keeps agent instructions short and tool-first; passes UI locale (`en` | `fr`) via `prepareCall`.

## Test plan
- [ ] Open `/en/support` and `/fr/support` and send a product question
- [ ] Confirm brain + “Generating response” appears immediately and stays until reasoning (or completion)
- [ ] Confirm empty/streaming reasoning still shows the brain row
- [ ] Edit a prior user message — composer should focus
- [ ] Confirm Support appears in landing navbar (desktop + mobile) and routes to `/support`
- [ ] Use “Talk to a human” / escalation tool on desktop and mobile
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe206-c01f-70b8-8a5a-fe4bf19bbfb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe206-c01f-70b8-8a5a-fe4bf19bbfb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

