### PR TITLE
Support agent: source-first codebase grep and investigation

### DIFF
--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -24,7 +24,6 @@ import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { Response } from '@/components/ai-elements/response';
 import {
-  BrainIcon,
   ChevronDownIcon,
   PencilIcon,
   RefreshCcwIcon,
@@ -121,7 +120,7 @@ const ATTACHMENT_ONLY_PLACEHOLDER = 'Sent with attachments';
  * Lock the title once the first line is complete so streaming does not flicker
  * between a growing title, a dropped label, and a static i18n string.
  */
-function useStableReasoningLabel(text: string, isStreaming: boolean, lockKey: string): string {
+function useStableReasoningLabel(text: string, isStreaming: boolean, lockKey: string) {
   const lockedRef = useRef<string | null>(null);
   const lockKeyRef = useRef(lockKey);
 
@@ -137,39 +136,157 @@ function useStableReasoningLabel(text: string, isStreaming: boolean, lockKey: st
   });
   lockedRef.current = resolved.locked;
 
-  return resolved.label;
+  return {
+    liveLabel: resolved.label,
+    lockedSource: resolved.locked,
+  };
+}
+
+/**
+ * For non-English locales, translate the locked first-line title once it
+ * stabilizes. Keep a shimmer skeleton until the translation is ready so we
+ * never flash English into a French UI.
+ */
+function useLocalizedReasoningLabel(args: {
+  text: string;
+  isStreaming: boolean;
+  lockKey: string;
+  locale: 'en' | 'fr';
+}): { label: string; showSkeleton: boolean } {
+  const { liveLabel, lockedSource } = useStableReasoningLabel(
+    args.text,
+    args.isStreaming,
+    args.lockKey,
+  );
+  const [translated, setTranslated] = useState<string | null>(null);
+  const [isTranslating, setIsTranslating] = useState(false);
+  const requestKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setTranslated(null);
+    setIsTranslating(false);
+    requestKeyRef.current = null;
+  }, [args.lockKey]);
+
+  useEffect(() => {
+    if (args.locale === 'en' || !lockedSource) return;
+
+    const requestKey = `${args.lockKey}:${lockedSource}`;
+    if (requestKeyRef.current === requestKey) return;
+    requestKeyRef.current = requestKey;
+
+    let cancelled = false;
+    setIsTranslating(true);
+
+    void (async () => {
+      try {
+        const response = await fetch('/api/ai/support/translate-label', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: lockedSource, locale: args.locale }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`translate-label failed: ${response.status}`);
+        }
+
+        const data = (await response.json()) as { label?: string };
+        if (cancelled) return;
+        setTranslated((data.label?.trim() || lockedSource));
+      } catch {
+        if (cancelled) return;
+        // Fail soft — better a stable English title than an empty row forever.
+        setTranslated(lockedSource);
+      } finally {
+        if (!cancelled) setIsTranslating(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [args.locale, args.lockKey, lockedSource]);
+
+  if (args.locale === 'en') {
+    return {
+      label: liveLabel,
+      showSkeleton: !liveLabel,
+    };
+  }
+
+  return {
+    label: translated ?? '',
+    showSkeleton: !translated || isTranslating,
+  };
+}
+
+function ReasoningLabelSkeleton({ label }: { label: string }) {
+  // `shimmer` is a text utility (background-clip: text) — needs real characters.
+  return (
+    <span className="shimmer min-w-0 truncate text-left text-muted-foreground">
+      {label}
+    </span>
+  );
 }
 
 function ReasoningBlock({
   text,
   isStreaming = false,
   lockKey,
+  locale,
+  skeletonLabel,
   className,
 }: {
   text: string;
   isStreaming?: boolean;
   /** Stable id for this reasoning step — changing it clears the locked title. */
   lockKey: string;
+  locale: 'en' | 'fr';
+  /** Localized shimmer copy shown before a title is ready. */
+  skeletonLabel?: string;
   className?: string;
 }) {
-  const label = useStableReasoningLabel(text, isStreaming, lockKey);
+  const t = useI18n();
+  const { label, showSkeleton } = useLocalizedReasoningLabel({
+    text,
+    isStreaming,
+    lockKey,
+    locale,
+  });
+  const canExpand = Boolean(text.trim());
+  const pendingLabel =
+    skeletonLabel ??
+    (isStreaming ? t('support.thinking') : t('support.thoughtProcess'));
 
   return (
     <Reasoning
       className={cn('w-full', className)}
       defaultOpen={false}
       disableAutoClose
-      isStreaming={isStreaming}
+      isStreaming={isStreaming || showSkeleton}
     >
-      <ReasoningTrigger className="group">
-        <BrainIcon className="size-4 shrink-0" />
-        <span className={cn('min-w-0 truncate text-left', isStreaming && 'shimmer')}>
-          {/* Keep height stable while waiting for the first model tokens. */}
-          {label || '\u00A0'}
-        </span>
-        <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+      <ReasoningTrigger
+        className="group"
+        disabled={!canExpand}
+        aria-label={showSkeleton ? pendingLabel : label}
+      >
+        {showSkeleton ? (
+          <ReasoningLabelSkeleton label={pendingLabel} />
+        ) : (
+          <span
+            className={cn(
+              'min-w-0 truncate text-left',
+              isStreaming && 'shimmer',
+            )}
+          >
+            {label}
+          </span>
+        )}
+        {canExpand ? (
+          <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+        ) : null}
       </ReasoningTrigger>
-      {text.trim() ? <ReasoningContent>{text}</ReasoningContent> : null}
+      {canExpand ? <ReasoningContent>{text}</ReasoningContent> : null}
     </Reasoning>
   );
 }
@@ -514,6 +631,7 @@ const ChatBotDemo = () => {
                                     key={`${message.id}-${i}-think-${index}`}
                                     lockKey={`${message.id}-${i}-think-${index}`}
                                     text={thought}
+                                    locale={locale}
                                   />
                                 ))}
                                 <ChatMessage align={isUser ? 'end' : 'start'}>
@@ -609,7 +727,7 @@ const ChatBotDemo = () => {
                               i === lastReasoningIndex &&
                               message.id === messages.at(-1)?.id;
 
-                            // Keep the brain visible while reasoning tokens are still empty.
+                            // Keep a shimmer skeleton while reasoning tokens are still empty.
                             if (!part.text?.trim() && !isStreamingReasoning) {
                               return null;
                             }
@@ -620,6 +738,7 @@ const ChatBotDemo = () => {
                                 lockKey={`${message.id}-reasoning-${i}`}
                                 text={part.text ?? ''}
                                 isStreaming={isStreamingReasoning}
+                                locale={locale}
                               />
                             );
                           }
@@ -711,6 +830,8 @@ const ChatBotDemo = () => {
                       lockKey={`pending-${messages.at(-1)?.id ?? 'new'}`}
                       text=""
                       isStreaming
+                      locale={locale}
+                      skeletonLabel={t('support.generating')}
                     />
                   )}
                 </MessageScrollerContent>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -125,9 +125,6 @@ const MAX_REASONING_LABEL_LENGTH = 60;
 /**
  * Prefer a short first-line label from the reasoning summary when present;
  * otherwise fall back to the localized thinking / thought-process copy.
- *
- * Only used for English UI — OpenAI reasoning summaries stay English even when
- * the reply is French, so non-EN UIs never surface that text as a title.
  */
 const getReasoningLabel = (text: string): string | undefined => {
   const firstLine = text
@@ -162,27 +159,7 @@ function ReasoningBlock({
   className?: string;
 }) {
   const t = useI18n();
-  const locale = useCurrentLocale();
-  const localizedLabel = isStreaming ? t('support.thinking') : t('support.thoughtProcess');
-  // Provider reasoning summaries ignore the UI locale; keep FR/other chats local.
-  const showModelReasoning = locale === 'en';
-  const label = showModelReasoning ? (getReasoningLabel(text) ?? localizedLabel) : localizedLabel;
-
-  if (!showModelReasoning) {
-    return (
-      <div
-        className={cn(
-          'mb-4 flex w-full items-center gap-2 text-sm text-muted-foreground',
-          className,
-        )}
-      >
-        <BrainIcon className="size-4 shrink-0" />
-        <span className={cn('min-w-0 truncate text-left', isStreaming && 'shimmer')}>
-          {label}
-        </span>
-      </div>
-    );
-  }
+  const label = getReasoningLabel(text);
 
   return (
     <Reasoning
@@ -194,7 +171,7 @@ function ReasoningBlock({
       <ReasoningTrigger className="group">
         <BrainIcon className="size-4 shrink-0" />
         <span className={cn('min-w-0 truncate text-left', isStreaming && 'shimmer')}>
-          {label}
+          {label ?? (isStreaming ? t('support.thinking') : t('support.thoughtProcess'))}
         </span>
         <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
       </ReasoningTrigger>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -48,6 +48,9 @@ import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion';
 import { DefaultChatTransport, ToolUIPart } from 'ai';
 import { ClipboardCheckIcon } from '@/components/animated-icons/clipboard-check';
 import SupportForm from './components/support-form';
+import {
+  resolveStableReasoningLabel,
+} from './reasoning-label';
 import { toast } from 'sonner';
 import {
   MessageScroller,
@@ -120,46 +123,42 @@ const preprocessContent = (content: string) => {
 
 const ATTACHMENT_ONLY_PLACEHOLDER = 'Sent with attachments';
 
-const MAX_REASONING_LABEL_LENGTH = 60;
-
 /**
- * Prefer a short first-line label from the reasoning summary when present;
- * otherwise fall back to the localized thinking / thought-process copy.
+ * Lock the title once the first line is complete so streaming does not flicker
+ * between a growing title, a dropped label, and a static i18n string.
  */
-const getReasoningLabel = (text: string): string | undefined => {
-  const firstLine = text
-    .split('\n')
-    .map((line) => line.trim())
-    .find(Boolean);
+function useStableReasoningLabel(text: string, isStreaming: boolean, lockKey: string): string {
+  const lockedRef = useRef<string | null>(null);
+  const lockKeyRef = useRef(lockKey);
 
-  if (!firstLine) return undefined;
+  if (lockKeyRef.current !== lockKey) {
+    lockKeyRef.current = lockKey;
+    lockedRef.current = null;
+  }
 
-  const looksLikeHeading =
-    /^#{1,6}\s+/.test(firstLine) || /^\*\*.+\*\*$/.test(firstLine);
+  const resolved = resolveStableReasoningLabel({
+    text,
+    isStreaming,
+    locked: lockedRef.current,
+  });
+  lockedRef.current = resolved.locked;
 
-  const cleaned = firstLine
-    .replace(/^#{1,6}\s+/, '')
-    .replace(/\*\*/g, '')
-    .replace(/[:.]+$/, '')
-    .trim();
-
-  if (!cleaned) return undefined;
-  if (!looksLikeHeading && cleaned.length > MAX_REASONING_LABEL_LENGTH) return undefined;
-
-  return cleaned;
-};
+  return resolved.label;
+}
 
 function ReasoningBlock({
   text,
   isStreaming = false,
+  lockKey,
   className,
 }: {
   text: string;
   isStreaming?: boolean;
+  /** Stable id for this reasoning step — changing it clears the locked title. */
+  lockKey: string;
   className?: string;
 }) {
-  const t = useI18n();
-  const label = getReasoningLabel(text);
+  const label = useStableReasoningLabel(text, isStreaming, lockKey);
 
   return (
     <Reasoning
@@ -171,22 +170,13 @@ function ReasoningBlock({
       <ReasoningTrigger className="group">
         <BrainIcon className="size-4 shrink-0" />
         <span className={cn('min-w-0 truncate text-left', isStreaming && 'shimmer')}>
-          {label ?? (isStreaming ? t('support.thinking') : t('support.thoughtProcess'))}
+          {/* Keep height stable while waiting for the first model tokens. */}
+          {label || '\u00A0'}
         </span>
         <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
       </ReasoningTrigger>
       {text.trim() ? <ReasoningContent>{text}</ReasoningContent> : null}
     </Reasoning>
-  );
-}
-
-/** Optimistic status row — same chrome as reasoning so the brain never vanishes mid-wait. */
-function PendingIndicator({ label }: { label: string }) {
-  return (
-    <div className="mb-4 flex w-full items-center gap-2 text-sm text-muted-foreground">
-      <BrainIcon className="size-4 shrink-0" />
-      <span className="min-w-0 truncate text-left shimmer">{label}</span>
-    </div>
   );
 }
 
@@ -196,14 +186,17 @@ function hasActiveReasoningRow(
 ) {
   if (!message || message.role !== 'assistant') return false;
 
-  return message.parts.some((part, index) => {
-    if (part.type !== 'reasoning') return false;
+  const lastReasoningIndex = message.parts.reduce(
+    (last, part, index) => (part.type === 'reasoning' ? index : last),
+    -1,
+  );
+  if (lastReasoningIndex === -1) return false;
 
-    const isStreamingReasoning =
-      status === 'streaming' && index === message.parts.length - 1;
+  const part = message.parts[lastReasoningIndex];
+  if (part?.type !== 'reasoning') return false;
 
-    return Boolean(part.text?.trim()) || isStreamingReasoning;
-  });
+  const isStreamingReasoning = status === 'streaming';
+  return Boolean(part.text?.trim()) || isStreamingReasoning;
 }
 
 function SupportPromptSubmit({
@@ -544,6 +537,7 @@ const ChatBotDemo = () => {
                                 {think.map((thought, index) => (
                                   <ReasoningBlock
                                     key={`${message.id}-${i}-think-${index}`}
+                                    lockKey={`${message.id}-${i}-think-${index}`}
                                     text={thought}
                                   />
                                 ))}
@@ -604,9 +598,14 @@ const ChatBotDemo = () => {
                             );
                           }
                           case 'reasoning': {
+                            const lastReasoningIndex = message.parts.reduce(
+                              (last, candidate, index) =>
+                                candidate.type === 'reasoning' ? index : last,
+                              -1,
+                            );
                             const isStreamingReasoning =
                               status === 'streaming' &&
-                              i === message.parts.length - 1 &&
+                              i === lastReasoningIndex &&
                               message.id === messages.at(-1)?.id;
 
                             // Keep the brain visible while reasoning tokens are still empty.
@@ -616,7 +615,8 @@ const ChatBotDemo = () => {
 
                             return (
                               <ReasoningBlock
-                                key={`${message.id}-${i}`}
+                                key={`${message.id}-reasoning-${i}`}
+                                lockKey={`${message.id}-reasoning-${i}`}
                                 text={part.text ?? ''}
                                 isStreaming={isStreamingReasoning}
                               />
@@ -706,7 +706,11 @@ const ChatBotDemo = () => {
                   ))}
 
                   {showPendingIndicator && (
-                    <PendingIndicator label={t('support.generating')} />
+                    <ReasoningBlock
+                      lockKey={`pending-${messages.at(-1)?.id ?? 'new'}`}
+                      text=""
+                      isStreaming
+                    />
                   )}
                 </MessageScrollerContent>
               </MessageScrollerViewport>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -386,9 +386,6 @@ const ChatBotDemo = () => {
       <main className="min-h-screen">
         <header className="border-b border-black/10 dark:border-white/10">
           <div className="mx-auto w-full max-w-[1440px] px-5 py-16 sm:px-8 sm:py-24 lg:px-12 lg:py-32">
-            <p className="mb-7 text-sm text-black/55 dark:text-white/55">
-              Deltalytix
-            </p>
             <div className="flex flex-col gap-7 lg:flex-row lg:items-end lg:justify-between">
               <div>
                 <h1 className="max-w-[960px] text-[clamp(3rem,7.2vw,7.25rem)] font-normal leading-[0.92] tracking-[-0.06em]">

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -553,41 +553,63 @@ const ChatBotDemo = () => {
                                     </Bubble>
                                     {message.role === 'assistant' && (
                                       <MessageFooter>
-                                        <Actions>
-                                          <Action
-                                            onClick={() => {
-                                              navigator.clipboard.writeText(contentWithoutThink);
-                                              toast.success(t('support.copied'), {
-                                                position: 'top-right',
-                                              });
-                                            }}
-                                            label={t('common.copy')}
-                                          >
-                                            <ClipboardCheckIcon size={16} className="mr-2" />
-                                          </Action>
+                                        <Actions
+                                          className={cn(
+                                            message.id.startsWith('error-') &&
+                                              'opacity-0 pointer-events-none transition-opacity group-hover/message:opacity-100 group-hover/message:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto',
+                                          )}
+                                        >
+                                          {!message.id.startsWith('error-') && (
+                                            <Action
+                                              onClick={() => {
+                                                navigator.clipboard.writeText(contentWithoutThink);
+                                                toast.success(t('support.copied'), {
+                                                  position: 'top-right',
+                                                });
+                                              }}
+                                              label={t('common.copy')}
+                                            >
+                                              <ClipboardCheckIcon size={16} className="mr-2" />
+                                            </Action>
+                                          )}
+                                          {message.id.startsWith('error-') && (
+                                            <Action
+                                              onClick={() => {
+                                                const previousUserText = [...messages]
+                                                  .slice(
+                                                    0,
+                                                    messages.findIndex(
+                                                      (candidate) => candidate.id === message.id,
+                                                    ),
+                                                  )
+                                                  .reverse()
+                                                  .find((candidate) => candidate.role === 'user')
+                                                  ?.parts.filter((candidate) => candidate.type === 'text')
+                                                  .map((candidate) => candidate.text.trim())
+                                                  .find(Boolean);
+
+                                                if (!previousUserText) return;
+
+                                                truncateFrom(message.id);
+                                                sendMessage({ text: previousUserText });
+                                              }}
+                                              label={t('common.retry')}
+                                            >
+                                              <RefreshCcwIcon size={16} className="mr-2" />
+                                            </Action>
+                                          )}
                                         </Actions>
                                       </MessageFooter>
                                     )}
-                                    {isUser && (
+                                    {isUser &&
+                                      !message.parts.some((candidate) => candidate.type === 'file') && (
                                       <MessageFooter>
-                                        <Actions className="justify-end">
-                                          {/* Editing re-sends without the attachment, so only offer it on plain text. */}
-                                          {!message.parts.some((p) => p.type === 'file') && (
-                                            <Action
-                                              onClick={() => startEditing(message.id, part.text)}
-                                              label={t('common.edit')}
-                                            >
-                                              <PencilIcon size={16} className="mr-2" />
-                                            </Action>
-                                          )}
+                                        <Actions className="justify-end opacity-0 pointer-events-none transition-opacity group-hover/message:opacity-100 group-hover/message:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto">
                                           <Action
-                                            onClick={() => {
-                                              truncateFrom(message.id);
-                                              sendMessage({ text: part.text });
-                                            }}
-                                            label={t('common.retry')}
+                                            onClick={() => startEditing(message.id, part.text)}
+                                            label={t('common.edit')}
                                           >
-                                            <RefreshCcwIcon size={16} className="mr-2" />
+                                            <PencilIcon size={16} className="mr-2" />
                                           </Action>
                                         </Actions>
                                       </MessageFooter>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -542,7 +542,7 @@ const ChatBotDemo = () => {
                                   />
                                 ))}
                                 <ChatMessage align={isUser ? 'end' : 'start'}>
-                                  <MessageContent>
+                                  <MessageContent className="relative pb-0">
                                     <Bubble
                                       variant={isUser ? 'default' : 'muted'}
                                       align={isUser ? 'end' : 'start'}
@@ -552,15 +552,15 @@ const ChatBotDemo = () => {
                                       </BubbleContent>
                                     </Bubble>
                                     {message.role === 'assistant' && (
-                                      <MessageFooter>
+                                      <MessageFooter className="absolute top-full z-10 mt-0.5 px-0">
                                         <Actions
                                           className={cn(
-                                            message.id.startsWith('error-') &&
-                                              'opacity-0 pointer-events-none transition-opacity group-hover/message:opacity-100 group-hover/message:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto',
+                                            'opacity-0 pointer-events-none transition-opacity group-hover/message:opacity-100 group-hover/message:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto',
                                           )}
                                         >
                                           {!message.id.startsWith('error-') && (
                                             <Action
+                                              className="size-7"
                                               onClick={() => {
                                                 navigator.clipboard.writeText(contentWithoutThink);
                                                 toast.success(t('support.copied'), {
@@ -569,11 +569,12 @@ const ChatBotDemo = () => {
                                               }}
                                               label={t('common.copy')}
                                             >
-                                              <ClipboardCheckIcon size={16} className="mr-2" />
+                                              <ClipboardCheckIcon size={14} className="mr-2" />
                                             </Action>
                                           )}
                                           {message.id.startsWith('error-') && (
                                             <Action
+                                              className="size-7"
                                               onClick={() => {
                                                 const errorIndex = messages.findIndex(
                                                   (candidate) => candidate.id === message.id,
@@ -597,7 +598,7 @@ const ChatBotDemo = () => {
                                               }}
                                               label={t('common.retry')}
                                             >
-                                              <RefreshCcwIcon size={16} className="mr-2" />
+                                              <RefreshCcwIcon size={14} />
                                             </Action>
                                           )}
                                         </Actions>
@@ -605,13 +606,14 @@ const ChatBotDemo = () => {
                                     )}
                                     {isUser &&
                                       !message.parts.some((candidate) => candidate.type === 'file') && (
-                                      <MessageFooter>
+                                      <MessageFooter className="absolute top-full right-0 z-10 mt-0.5 px-0">
                                         <Actions className="justify-end opacity-0 pointer-events-none transition-opacity group-hover/message:opacity-100 group-hover/message:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto">
                                           <Action
+                                            className="size-7"
                                             onClick={() => startEditing(message.id, part.text)}
                                             label={t('common.edit')}
                                           >
-                                            <PencilIcon size={16} className="mr-2" />
+                                            <PencilIcon size={14} />
                                           </Action>
                                         </Actions>
                                       </MessageFooter>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -21,6 +21,7 @@ import {
   Action,
 } from '@/components/ai-elements/actions';
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useChat } from '@ai-sdk/react';
 import { Response } from '@/components/ai-elements/response';
 import {
@@ -229,6 +230,60 @@ function ReasoningLabelSkeleton({ label }: { label: string }) {
   );
 }
 
+function ReasoningLabelSwap({
+  showSkeleton,
+  skeletonLabel,
+  label,
+  isStreaming,
+}: {
+  showSkeleton: boolean;
+  skeletonLabel: string;
+  label: string;
+  isStreaming: boolean;
+}) {
+  const reduceMotion = useReducedMotion();
+  const transition = reduceMotion
+    ? { duration: 0 }
+    : { duration: 0.28, ease: 'easeInOut' as const };
+
+  return (
+    <span className="relative min-h-5 min-w-0 flex-1 overflow-hidden text-left">
+      {/* Invisible sizer keeps the trigger height stable during the crossfade. */}
+      <span className="invisible block truncate" aria-hidden>
+        {showSkeleton ? skeletonLabel : label || skeletonLabel}
+      </span>
+      <AnimatePresence initial={false} mode="sync">
+        {showSkeleton ? (
+          <motion.span
+            key="skeleton"
+            className="absolute inset-y-0 left-0 right-0 flex items-center"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={transition}
+          >
+            <ReasoningLabelSkeleton label={skeletonLabel} />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="label"
+            className={cn(
+              'absolute inset-y-0 left-0 right-0 truncate',
+              isStreaming && 'shimmer',
+            )}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={transition}
+          >
+            {label}
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </span>
+  );
+}
+
 function ReasoningBlock({
   text,
   isStreaming = false,
@@ -270,18 +325,12 @@ function ReasoningBlock({
         disabled={!canExpand}
         aria-label={showSkeleton ? pendingLabel : label}
       >
-        {showSkeleton ? (
-          <ReasoningLabelSkeleton label={pendingLabel} />
-        ) : (
-          <span
-            className={cn(
-              'min-w-0 truncate text-left',
-              isStreaming && 'shimmer',
-            )}
-          >
-            {label}
-          </span>
-        )}
+        <ReasoningLabelSwap
+          showSkeleton={showSkeleton}
+          skeletonLabel={pendingLabel}
+          label={label}
+          isStreaming={isStreaming}
+        />
         {canExpand ? (
           <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
         ) : null}

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -125,6 +125,9 @@ const MAX_REASONING_LABEL_LENGTH = 60;
 /**
  * Prefer a short first-line label from the reasoning summary when present;
  * otherwise fall back to the localized thinking / thought-process copy.
+ *
+ * Only used for English UI — OpenAI reasoning summaries stay English even when
+ * the reply is French, so non-EN UIs never surface that text as a title.
  */
 const getReasoningLabel = (text: string): string | undefined => {
   const firstLine = text
@@ -159,7 +162,27 @@ function ReasoningBlock({
   className?: string;
 }) {
   const t = useI18n();
-  const label = getReasoningLabel(text);
+  const locale = useCurrentLocale();
+  const localizedLabel = isStreaming ? t('support.thinking') : t('support.thoughtProcess');
+  // Provider reasoning summaries ignore the UI locale; keep FR/other chats local.
+  const showModelReasoning = locale === 'en';
+  const label = showModelReasoning ? (getReasoningLabel(text) ?? localizedLabel) : localizedLabel;
+
+  if (!showModelReasoning) {
+    return (
+      <div
+        className={cn(
+          'mb-4 flex w-full items-center gap-2 text-sm text-muted-foreground',
+          className,
+        )}
+      >
+        <BrainIcon className="size-4 shrink-0" />
+        <span className={cn('min-w-0 truncate text-left', isStreaming && 'shimmer')}>
+          {label}
+        </span>
+      </div>
+    );
+  }
 
   return (
     <Reasoning
@@ -171,7 +194,7 @@ function ReasoningBlock({
       <ReasoningTrigger className="group">
         <BrainIcon className="size-4 shrink-0" />
         <span className={cn('min-w-0 truncate text-left', isStreaming && 'shimmer')}>
-          {label ?? (isStreaming ? t('support.thinking') : t('support.thoughtProcess'))}
+          {label}
         </span>
         <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
       </ReasoningTrigger>

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -20,13 +20,12 @@ import {
   Actions,
   Action,
 } from '@/components/ai-elements/actions';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { Response } from '@/components/ai-elements/response';
 import {
   BrainIcon,
   ChevronDownIcon,
-  HeadsetIcon,
   PencilIcon,
   RefreshCcwIcon,
 } from 'lucide-react';
@@ -44,7 +43,6 @@ import {
   ReasoningContent,
   ReasoningTrigger,
 } from '@/components/ai-elements/reasoning';
-import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion';
 import { DefaultChatTransport, ToolUIPart } from 'ai';
 import { ClipboardCheckIcon } from '@/components/animated-icons/clipboard-check';
 import SupportForm from './components/support-form';
@@ -67,10 +65,6 @@ import {
 } from '@/components/ui/message';
 import { Bubble, BubbleContent } from '@/components/ui/bubble';
 import { Marker, MarkerContent } from '@/components/ui/marker';
-import {
-  Card,
-  CardContent,
-} from '@/components/ui/card';
 
 const DISCORD_INVITE_URL = process.env.NEXT_PUBLIC_DISCORD_INVITATION;
 
@@ -341,15 +335,6 @@ const ChatBotDemo = () => {
     }
   }, [messages]);
 
-  const suggestions = useMemo(
-    () => [
-      t('support.suggestionImport'),
-      t('support.suggestionBilling'),
-      t('support.suggestionBug'),
-    ],
-    [t],
-  );
-
   useEffect(() => {
     if (messages.length === 0) {
       setMessages([
@@ -392,64 +377,57 @@ const ChatBotDemo = () => {
     setInput('');
   };
 
-  const sendWithOptions = (text: string) => {
-    sendMessage({ text });
-  };
-
   const isBusy = status === 'submitted' || status === 'streaming';
-  const hasStarted = messages.some((message) => message.role === 'user');
-  const showStarterActions = messages.length <= 1 && !isBusy;
-  // Once the conversation has started, the human escape hatch stays available.
-  const showHumanHandoff = hasStarted && !isBusy;
   const showPendingIndicator =
     isBusy && !hasActiveReasoningRow(messages.at(-1), status);
 
   return (
     <MessageScrollerProvider autoScroll>
-      <div className="mx-auto flex size-full h-[calc(100vh-64px)] max-w-4xl flex-col gap-4 p-4 sm:p-6">
-        {/* Page title lives outside the chat surface, like /updates. */}
-        <header className="space-y-1">
-          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
-            <HeadsetIcon className="size-6 text-primary" />
-            {t('support.pageTitle')}
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            {t('support.pageDescription')}
-            {DISCORD_INVITE_URL && (
-              <>
-                {' '}
-                {t('support.discordPrompt')}{' '}
-                <a
-                  href={DISCORD_INVITE_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
-                >
-                  {t('support.joinDiscordInline')}
-                </a>
-                .
-              </>
-            )}
-          </p>
-        </header>
-
-        <Card className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden py-0">
-          {/* Escalation appears only once the conversation has started. */}
-          {showHumanHandoff && (
-            <div className="flex justify-end border-b px-4 py-2">
+      <main className="min-h-screen">
+        <header className="border-b border-black/10 dark:border-white/10">
+          <div className="mx-auto w-full max-w-[1440px] px-5 py-16 sm:px-8 sm:py-24 lg:px-12 lg:py-32">
+            <p className="mb-7 text-sm text-black/55 dark:text-white/55">
+              Deltalytix
+            </p>
+            <div className="flex flex-col gap-7 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <h1 className="max-w-[960px] text-[clamp(3rem,7.2vw,7.25rem)] font-normal leading-[0.92] tracking-[-0.06em]">
+                  {t('support.pageTitle')}
+                </h1>
+                <p className="mt-7 max-w-[680px] text-lg leading-relaxed text-black/60 dark:text-white/60 md:text-xl">
+                  {t('support.pageDescription')}
+                  {DISCORD_INVITE_URL && (
+                    <>
+                      {' '}
+                      {t('support.discordPrompt')}{' '}
+                      <a
+                        href={DISCORD_INVITE_URL}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-black underline underline-offset-4 hover:text-black/80 dark:text-white dark:hover:text-white/80"
+                      >
+                        {t('support.joinDiscordInline')}
+                      </a>
+                      .
+                    </>
+                  )}
+                </p>
+              </div>
               <Button
                 type="button"
-                size="sm"
                 variant="outline"
+                className="shrink-0 border-black/15 bg-transparent text-black hover:bg-black/5 dark:border-white/15 dark:text-white dark:hover:bg-white/5"
                 onClick={requestHumanSupport}
               >
-                <HeadsetIcon className="size-4" />
-                {t('support.requestHumanSupport')}
+                {t('support.fillSupportRequest')}
               </Button>
             </div>
-          )}
+          </div>
+        </header>
 
-          <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
+        <section>
+          <div className="mx-auto flex w-full max-w-[1440px] flex-col px-5 py-12 sm:px-8 md:py-16 lg:px-12">
+            <div className="flex min-h-[min(70vh,720px)] flex-col overflow-hidden border border-black/10 dark:border-white/10">
             <MessageScroller className="min-h-0 flex-1">
               <MessageScrollerViewport>
                 <MessageScrollerContent aria-busy={isBusy} className="gap-4 p-4">
@@ -743,28 +721,8 @@ const ChatBotDemo = () => {
               <MessageScrollerButton />
             </MessageScroller>
 
-            {showStarterActions && (
-              <div className="border-t px-4 py-3">
-                <Suggestions>
-                  {suggestions.map((suggestion) => (
-                    <Suggestion
-                      key={suggestion}
-                      suggestion={suggestion}
-                      onClick={sendWithOptions}
-                    />
-                  ))}
-                  {/* Goes straight to the form — routing it through the model is the loop we are fixing. */}
-                  <Suggestion
-                    suggestion={t('support.suggestionHuman')}
-                    onClick={requestHumanSupport}
-                  />
-                </Suggestions>
-              </div>
-            )}
-
-            {/* Input is docked inside the chat panel so it reads as one conversation surface. */}
             <div
-              className="border-t p-3 sm:p-4"
+              className="border-t border-black/10 p-3 dark:border-white/10 sm:p-4"
               // Escape bubbles up from the textarea, which owns its own onKeyDown.
               onKeyDown={(event) => {
                 if (event.key === 'Escape' && pendingEditMessageId) {
@@ -812,8 +770,9 @@ const ChatBotDemo = () => {
                 </PromptInputToolbar>
               </PromptInput>
             </div>
-          </CardContent>
-        </Card>
+            </div>
+          </div>
+        </section>
 
         <SupportForm
           open={contactForm.open}
@@ -823,7 +782,7 @@ const ChatBotDemo = () => {
           messages={messages}
           setMessages={setMessages}
         />
-      </div>
+      </main>
     </MessageScrollerProvider>
   );
 };

--- a/app/[locale]/(landing)/support/page.tsx
+++ b/app/[locale]/(landing)/support/page.tsx
@@ -575,16 +575,18 @@ const ChatBotDemo = () => {
                                           {message.id.startsWith('error-') && (
                                             <Action
                                               onClick={() => {
-                                                const previousUserText = [...messages]
-                                                  .slice(
-                                                    0,
-                                                    messages.findIndex(
-                                                      (candidate) => candidate.id === message.id,
-                                                    ),
-                                                  )
+                                                const errorIndex = messages.findIndex(
+                                                  (candidate) => candidate.id === message.id,
+                                                );
+                                                const previousUser = messages
+                                                  .slice(0, errorIndex)
                                                   .reverse()
-                                                  .find((candidate) => candidate.role === 'user')
-                                                  ?.parts.filter((candidate) => candidate.type === 'text')
+                                                  .find((candidate) => candidate.role === 'user');
+                                                const previousUserText = previousUser?.parts
+                                                  .filter(
+                                                    (candidate): candidate is { type: 'text'; text: string } =>
+                                                      candidate.type === 'text',
+                                                  )
                                                   .map((candidate) => candidate.text.trim())
                                                   .find(Boolean);
 

--- a/app/[locale]/(landing)/support/reasoning-label.test.ts
+++ b/app/[locale]/(landing)/support/reasoning-label.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanReasoningLabel,
+  resolveStableReasoningLabel,
+} from "./reasoning-label";
+
+describe("cleanReasoningLabel", () => {
+  it("keeps long first lines by truncating instead of dropping them", () => {
+    const long =
+      "Searching Taurus and DxFeed integration for the user question about imports";
+    const label = cleanReasoningLabel(long);
+
+    expect(label).toBeTruthy();
+    expect(label.endsWith("…")).toBe(true);
+    expect(label.length).toBe(60);
+  });
+
+  it("uses only the first line", () => {
+    expect(cleanReasoningLabel("Recherche Taurus\nLe reste du raisonnement")).toBe(
+      "Recherche Taurus",
+    );
+  });
+});
+
+describe("resolveStableReasoningLabel", () => {
+  it("does not flicker to empty when the first line grows past 60 chars", () => {
+    const steps = [
+      "Search",
+      "Searching Taurus and DxFeed integration for the user",
+      "Searching Taurus and DxFeed integration for the user question about imports",
+      "Searching Taurus and DxFeed integration for the user question about imports\nBody",
+    ];
+
+    let locked: string | null = null;
+    const labels: string[] = [];
+
+    for (const [index, text] of steps.entries()) {
+      const isStreaming = index < steps.length - 1;
+      const resolved = resolveStableReasoningLabel({ text, isStreaming, locked });
+      locked = resolved.locked;
+      labels.push(resolved.label);
+    }
+
+    expect(labels.every((label) => label.length > 0)).toBe(true);
+    // Once the first line completes (newline), the locked title stays put.
+    expect(labels[3]).toBe(labels[2]);
+  });
+});

--- a/app/[locale]/(landing)/support/reasoning-label.ts
+++ b/app/[locale]/(landing)/support/reasoning-label.ts
@@ -1,0 +1,43 @@
+const MAX_REASONING_LABEL_LENGTH = 60;
+
+/** First-line title for the reasoning trigger — truncate, never drop to a static fallback. */
+export function cleanReasoningLabel(text: string): string {
+  const firstLine = text
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  if (!firstLine) return "";
+
+  const cleaned = firstLine
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/\*\*/g, "")
+    .replace(/[:.]+$/, "")
+    .trim();
+
+  if (!cleaned) return "";
+  return cleaned.length > MAX_REASONING_LABEL_LENGTH
+    ? `${cleaned.slice(0, MAX_REASONING_LABEL_LENGTH - 1)}…`
+    : cleaned;
+}
+
+/**
+ * Pure helper for tests / SSR: once the first line is complete, keep that title.
+ * While the first line is still streaming, return the live partial.
+ */
+export function resolveStableReasoningLabel(args: {
+  text: string;
+  isStreaming: boolean;
+  locked: string | null;
+}): { label: string; locked: string | null } {
+  const live = cleanReasoningLabel(args.text);
+  const firstLineComplete =
+    args.text.includes("\n") || (!args.isStreaming && live.length > 0);
+
+  let locked = args.locked;
+  if (firstLineComplete && live && !locked) {
+    locked = live;
+  }
+
+  return { label: locked ?? live, locked };
+}

--- a/app/api/ai/support/README.md
+++ b/app/api/ai/support/README.md
@@ -1,6 +1,8 @@
 # Deltalytix Support Assistant
 
-The support assistant answers product questions from the real repository and, crucially, never leaves a user stuck: a human hand-off is always one click away.
+The support assistant answers product questions from an in-memory clone of the
+repository and, crucially, never leaves a user stuck: a human hand-off is always
+one click away.
 
 ## Two escape hatches, always available
 
@@ -12,34 +14,42 @@ The UI (`app/[locale]/(landing)/support/page.tsx`) owns escalation, not the mode
 
 This is deliberate: routing "I want a human" through the model is exactly the loop we removed.
 
-## Knowledge: real search over the repo
+## Knowledge: repo clone + grep
 
-The agent reads the actual codebase through `lib/ai/search-codebase.ts`, backed by an
-in-memory index built in `lib/ai/codebase-index.ts` (`CORPUS_ROOTS` defines the scope:
-`content/**`, root markdown, `locales/**`, and application source under `app`, `components`,
-`lib`, `server`, `hooks`, `store`, `context`, plus `prisma/schema.prisma`).
+The agent reads the real codebase through `lib/ai/search-codebase.ts`, backed by an
+in-memory index in `lib/ai/codebase-index.ts`. `CORPUS_ROOTS` is the clone scope:
+`content/**`, root markdown, `locales/**`, application source under `app`,
+`components`, `lib`, `server`, `hooks`, `store`, `context`, plus
+`prisma/schema.prisma`.
 
-Tools exposed to the model (`tools/search-codebase.ts`):
+Default ranking prefers **source** over changelog prose so "how does X work"
+questions land in implementation. Tools also accept a `scope`:
 
-- **searchCodebase** — ranked keyword search (TF-IDF-ish scoring, doc/locale weighted above
-  source, locale-aware) returning the strongest files with surrounding context lines.
-- **grepCodebase** — regex grep with an optional glob filter, for exact strings (UI labels,
-  error messages, env vars, route names).
+- `source` — code + prisma (how the product actually works)
+- `docs` — markdown / release notes
+- `product` — docs + locale UI labels
+- `all` — everything (default)
+
+Tools (`tools/search-codebase.ts`):
+
+- **searchCodebase** — ranked keyword search with optional scope/locale.
+- **grepCodebase** — regex grep with optional glob + scope (primary tool for
+  symbols, routes, env vars, error strings).
 - **readCodebaseFile** — read a file or line range a search returned.
-- **listCodebaseFiles** — enumerate files matching a glob (e.g. every release note).
+- **listCodebaseFiles** — enumerate files matching a glob before grepping an area.
 
-The corpus is read from disk at runtime, so `next.config.ts` traces it into the serverless
-bundle via `SUPPORT_SEARCH_TRACE_INCLUDES`.
+The corpus is read from disk at runtime, so `next.config.ts` traces it into the
+serverless bundle via `SUPPORT_SEARCH_TRACE_INCLUDES`.
 
 ## Agent
 
-`lib/ai/support-agent.ts` — a `ToolLoopAgent`. Model defaults to `openai/gpt-5-mini` (via the
-Vercel AI Gateway; override with `SUPPORT_AGENT_MODEL`). Instructions stay short: use tools,
-search before answering, escalate when stuck, and do not re-introduce or title replies (the UI
-already greets the user).
+`lib/ai/support-agent.ts` — a `ToolLoopAgent`. Model defaults to `openai/gpt-5-mini`
+(via the Vercel AI Gateway; override with `SUPPORT_AGENT_MODEL`). Instructions tell
+the model to investigate with `grepCodebase(scope=source)` → `readCodebaseFile`
+before answering behavioural questions, and not to invent features from memory.
 
-The support page sends the current UI `locale` (`en` | `fr`) with every request. `prepareCall`
-appends a one-line locale hint so replies follow `/en` or `/fr`.
+The support page sends the current UI `locale` (`en` | `fr`) with every request.
+`prepareCall` appends a one-line locale hint so replies follow `/en` or `/fr`.
 
 ## Request flow
 

--- a/app/api/ai/support/README.md
+++ b/app/api/ai/support/README.md
@@ -49,7 +49,12 @@ the model to investigate with `grepCodebase(scope=source)` → `readCodebaseFile
 before answering behavioural questions, and not to invent features from memory.
 
 The support page sends the current UI `locale` (`en` | `fr`) with every request.
-`prepareCall` appends a one-line locale hint so replies follow `/en` or `/fr`.
+`prepareCall` prepends a hard locale rule so replies follow `/en` or `/fr`.
+
+OpenAI reasoning summaries are still often English over the API. For `/fr`, the
+UI translates the locked first-line title through
+`POST /api/ai/support/translate-label` (`openai/gpt-5-nano`, reasoning off) and
+keeps a shimmer skeleton until that title is ready.
 
 ## Request flow
 

--- a/app/api/ai/support/tools/search-codebase.ts
+++ b/app/api/ai/support/tools/search-codebase.ts
@@ -7,29 +7,38 @@ import {
   searchCodebase,
 } from "@/lib/ai/search-codebase";
 
+const corpusScopeSchema = z
+  .enum(["all", "source", "docs", "product"])
+  .optional()
+  .describe(
+    "Corpus slice. Use source for how the product works (app/lib/components/server/store/hooks/context + prisma). Use docs for release notes/markdown. Use product for docs + locale UI labels. Default all.",
+  );
+
 export const searchCodebaseTool = tool({
   description:
-    "Ranked keyword search across Deltalytix product docs (content/**), release notes, locale strings (every UI label lives there), and application source (app, components, lib, server, store, hooks, prisma schema). Start here for any question about features, imports, integrations, billing, dashboard behaviour, or self-hosting. Returns the strongest files with surrounding context lines.",
+    "Ranked keyword search over the Deltalytix repo clone (docs, locales, and application source). For how a feature works, set scope=source so results come from code instead of changelog prose. Returns the strongest files with surrounding context lines.",
   inputSchema: z.object({
     query: z
       .string()
       .describe(
-        "Keywords describing what to look up, e.g. 'Tradovate CSV import timezone' or 'subscription cancel billing portal'",
+        "Keywords describing what to look up, e.g. 'Tradovate OAuth connect' or 'subscription cancel billing portal'",
       ),
     locale: z
       .enum(["en", "fr"])
       .optional()
       .describe("Prefer documentation and locale strings in this language"),
+    scope: corpusScopeSchema,
   }),
-  execute: async ({ query, locale }) => {
-    const result = await searchCodebase(query, { locale });
+  execute: async ({ query, locale, scope }) => {
+    const result = await searchCodebase(query, { locale, scope });
 
     if (result.matchCount === 0) {
       return {
         found: false,
         query: result.query,
+        scope: result.scope,
         message:
-          "No matches. Try fewer or different keywords, or use grepCodebase with a specific identifier, UI label, or error string.",
+          "No matches. Try fewer keywords, switch scope (source vs docs), or use grepCodebase with a concrete identifier.",
         matches: [],
       };
     }
@@ -37,6 +46,7 @@ export const searchCodebaseTool = tool({
     return {
       found: true,
       query: result.query,
+      scope: result.scope,
       matchCount: result.matchCount,
       matches: result.matches,
     };
@@ -45,19 +55,20 @@ export const searchCodebaseTool = tool({
 
 export const grepCodebaseTool = tool({
   description:
-    "Regex grep over the Deltalytix repository (docs, locales, and source). Use this when you know an exact string to look for — a UI label, an error message, an env var, a function or route name — or to narrow a search to specific files with a glob. Prefer searchCodebase for open-ended questions.",
+    "Regex grep over the Deltalytix repo clone. Prefer this to understand real behaviour: search function names, route paths, env vars, error strings, and UI labels in source (scope=source, glob like 'app/**/*.ts' or 'lib/**/*.ts'). Then readCodebaseFile the hits.",
   inputSchema: z.object({
     pattern: z
       .string()
       .describe(
-        "JavaScript regular expression, e.g. 'RESEND_API_KEY' or 'stripe.*checkout'. Case-insensitive by default.",
+        "JavaScript regular expression, e.g. 'cancelSubscription' or 'stripe.*portal'. Case-insensitive by default.",
       ),
     glob: z
       .string()
       .optional()
       .describe(
-        "Optional path filter, comma-separated. Examples: 'content/updates/en/**/*.mdx', 'locales/**/*.ts', 'app/api/**/*.ts'",
+        "Optional path filter, comma-separated. Examples: 'lib/**/*.ts', 'app/api/**/*.ts', 'app/**/billing/**/*.tsx'",
       ),
+    scope: corpusScopeSchema,
     caseSensitive: z.boolean().optional().describe("Match case exactly (default false)"),
     contextLines: z
       .number()
@@ -67,19 +78,31 @@ export const grepCodebaseTool = tool({
       .optional()
       .describe("Lines of context around each match (default 2)"),
   }),
-  execute: async ({ pattern, glob, caseSensitive, contextLines }) => {
-    const result = await grepCodebase(pattern, { glob, caseSensitive, contextLines });
+  execute: async ({ pattern, glob, scope, caseSensitive, contextLines }) => {
+    const result = await grepCodebase(pattern, {
+      glob,
+      scope,
+      caseSensitive,
+      contextLines,
+    });
 
     if (result.error) {
-      return { found: false, pattern: result.pattern, error: result.error, matches: [] };
+      return {
+        found: false,
+        pattern: result.pattern,
+        scope: result.scope,
+        error: result.error,
+        matches: [],
+      };
     }
 
     if (result.matchCount === 0) {
       return {
         found: false,
         pattern: result.pattern,
+        scope: result.scope,
         message:
-          "No matches. Loosen the pattern, drop the glob, or fall back to searchCodebase.",
+          "No matches. Loosen the pattern, drop the glob, try scope=all, or fall back to searchCodebase.",
         matches: [],
       };
     }
@@ -87,6 +110,7 @@ export const grepCodebaseTool = tool({
     return {
       found: true,
       pattern: result.pattern,
+      scope: result.scope,
       matchCount: result.matchCount,
       truncated: result.truncated,
       matches: result.matches,
@@ -96,7 +120,7 @@ export const grepCodebaseTool = tool({
 
 export const readCodebaseFileTool = tool({
   description:
-    "Read a file (or a line range) that searchCodebase or grepCodebase returned. Use it when a snippet is not enough to answer confidently — for example to read a whole release note or a full locale section.",
+    "Read a file (or line range) from the repo clone. Use after grep/search when a snippet is not enough to explain behaviour confidently.",
   inputSchema: z.object({
     file: z
       .string()
@@ -109,12 +133,13 @@ export const readCodebaseFileTool = tool({
 
 export const listCodebaseFilesTool = tool({
   description:
-    "List searchable files matching a glob. Useful to discover what documentation exists, e.g. 'content/updates/en/**/*.mdx' to see every release note.",
+    "List files in the repo clone matching a glob. Useful to map a feature area before grepping, e.g. 'app/**/tradovate/**/*.ts' or 'lib/ibkr*.ts'.",
   inputSchema: z.object({
     glob: z
       .string()
       .optional()
-      .describe("Glob pattern, e.g. 'content/**/*.mdx' or 'locales/en/*.ts'"),
+      .describe("Glob pattern, e.g. 'app/**/billing/**' or 'lib/**/*stripe*'"),
+    scope: corpusScopeSchema,
   }),
-  execute: async ({ glob }) => listCodebaseFiles(glob),
+  execute: async ({ glob, scope }) => listCodebaseFiles(glob, { scope }),
 });

--- a/app/api/ai/support/translate-label/route.ts
+++ b/app/api/ai/support/translate-label/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { supportAgentLocaleSchema } from "@/app/api/ai/support/schema";
+import { translateReasoningLabel } from "@/lib/ai/translate-reasoning-label";
+
+export const maxDuration = 15;
+
+const requestSchema = z.object({
+  text: z.string().trim().min(1).max(200),
+  locale: supportAgentLocaleSchema,
+});
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const parsed = requestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid request", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const { text, locale } = parsed.data;
+
+    if (locale === "en") {
+      return NextResponse.json({ label: text });
+    }
+
+    const label = await translateReasoningLabel({ text, locale });
+    return NextResponse.json({ label });
+  } catch (error) {
+    console.error("[Support] translate-label error:", error);
+    return NextResponse.json(
+      { error: "Translation failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/ai/codebase-index.ts
+++ b/lib/ai/codebase-index.ts
@@ -4,6 +4,9 @@ import path from "node:path";
 
 export type CorpusKind = "doc" | "locale" | "source" | "schema";
 
+/** Tool-facing corpus slices — `source` is the live product behaviour. */
+export type CorpusScope = "all" | "source" | "docs" | "product";
+
 type CorpusRoot = {
   /** Repo-relative directory or file. */
   path: string;
@@ -13,12 +16,11 @@ type CorpusRoot = {
 };
 
 const DOC_EXTENSIONS = [".md", ".mdx"] as const;
-const SOURCE_EXTENSIONS = [".ts", ".tsx"] as const;
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".mjs"] as const;
 
 /**
- * Everything the support agent is allowed to search or read. Product docs and
- * locale strings answer most questions, but the agent also needs the real
- * source to explain behaviour that was never written down.
+ * In-memory clone of the product surface the support agent may search.
+ * Source trees are first-class: docs alone cannot explain runtime behaviour.
  */
 export const CORPUS_ROOTS: readonly CorpusRoot[] = [
   { path: "content", kind: "doc", extensions: DOC_EXTENSIONS },
@@ -36,6 +38,27 @@ export const CORPUS_ROOTS: readonly CorpusRoot[] = [
   { path: "context", kind: "source", extensions: SOURCE_EXTENSIONS },
   { path: "prisma/schema.prisma", kind: "schema", extensions: [".prisma"] },
 ];
+
+const SCOPE_KINDS: Record<CorpusScope, readonly CorpusKind[]> = {
+  all: ["doc", "locale", "source", "schema"],
+  /** Application code + schema — how the product actually works. */
+  source: ["source", "schema"],
+  /** Release notes and markdown docs only. */
+  docs: ["doc"],
+  /** User-facing copy + docs (labels, changelog), excluding implementation. */
+  product: ["doc", "locale"],
+};
+
+export function kindsForScope(scope: CorpusScope = "all"): readonly CorpusKind[] {
+  return SCOPE_KINDS[scope];
+}
+
+export function fileMatchesScope(
+  kind: CorpusKind,
+  scope: CorpusScope = "all",
+): boolean {
+  return kindsForScope(scope).includes(kind);
+}
 
 const IGNORED_DIRECTORY_NAMES = new Set([
   "node_modules",

--- a/lib/ai/search-codebase.test.ts
+++ b/lib/ai/search-codebase.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearCorpusCache } from "./codebase-index";
+import {
+  grepCodebase,
+  listCodebaseFiles,
+  readCodebaseFile,
+  searchCodebase,
+} from "./search-codebase";
+
+afterEach(() => {
+  clearCorpusCache();
+});
+
+describe("searchCodebase source-first ranking", () => {
+  it("ranks implementation ahead of changelog for product behaviour queries", async () => {
+    const result = await searchCodebase("tradovate oauth connect");
+
+    expect(result.matchCount).toBeGreaterThan(0);
+    expect(result.matches[0]?.kind).toBe("source");
+    expect(result.matches[0]?.file).toMatch(/tradovate/i);
+  });
+
+  it("can restrict results to the source corpus clone", async () => {
+    const result = await searchCodebase("dashboard calendar trades", {
+      scope: "source",
+    });
+
+    expect(result.scope).toBe("source");
+    expect(result.matchCount).toBeGreaterThan(0);
+    expect(
+      result.matches.every((match) => match.kind === "source" || match.kind === "schema"),
+    ).toBe(true);
+  });
+});
+
+describe("grepCodebase over source", () => {
+  it("finds symbols in lib/ with scope=source", async () => {
+    const result = await grepCodebase("ibkr-flex", {
+      scope: "source",
+      glob: "lib/**/*.ts",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.matchCount).toBeGreaterThan(0);
+    expect(result.matches.every((match) => match.file.startsWith("lib/"))).toBe(true);
+  });
+
+  it("rejects invalid regular expressions", async () => {
+    const result = await grepCodebase("(", { scope: "source" });
+
+    expect(result.matchCount).toBe(0);
+    expect(result.error).toMatch(/Invalid regular expression/i);
+  });
+});
+
+describe("read and list helpers", () => {
+  it("reads a known source file from the corpus clone", async () => {
+    const listed = await listCodebaseFiles("lib/ibkr-flex-client.ts", {
+      scope: "source",
+    });
+    expect(listed.files).toContain("lib/ibkr-flex-client.ts");
+
+    const file = await readCodebaseFile("lib/ibkr-flex-client.ts", {
+      startLine: 1,
+      endLine: 20,
+    });
+
+    expect(file.error).toBeUndefined();
+    expect(file.content).toContain("1:");
+    expect(file.totalLines).toBeGreaterThan(20);
+  });
+});

--- a/lib/ai/search-codebase.ts
+++ b/lib/ai/search-codebase.ts
@@ -1,25 +1,27 @@
 import path from "node:path";
 import {
   type CorpusKind,
+  type CorpusScope,
   type IndexedFile,
   createGlobMatcher,
+  fileMatchesScope,
   getCorpus,
   shouldLogSearchDebug,
 } from "./codebase-index";
 
-export { SUPPORT_SEARCH_TRACE_INCLUDES } from "./codebase-index";
-export type { CorpusKind } from "./codebase-index";
+export { SUPPORT_SEARCH_TRACE_INCLUDES, kindsForScope } from "./codebase-index";
+export type { CorpusKind, CorpusScope } from "./codebase-index";
 
-const MAX_FILES = 6;
+const MAX_FILES = 8;
 const MAX_BLOCKS_PER_FILE = 3;
 const CONTEXT_RADIUS = 3;
-const MAX_BLOCK_CHARS = 900;
+const MAX_BLOCK_CHARS = 1_200;
 const MAX_LINE_CHARS = 240;
 const MAX_TERM_OCCURRENCES = 8;
 
-const MAX_GREP_MATCHES = 25;
+const MAX_GREP_MATCHES = 40;
 const MAX_GREP_PATTERN_LENGTH = 200;
-const GREP_TIME_BUDGET_MS = 2_500;
+const GREP_TIME_BUDGET_MS = 3_500;
 
 const MAX_READ_LINES = 400;
 
@@ -32,19 +34,23 @@ const SEARCH_STOP_WORDS = new Set([
   "my", "me", "i", "we", "you", "your", "our", "it", "its", "this", "that",
   "about", "with", "from", "into", "please", "help", "need", "want",
   "documentation", "docs", "doc", "guide", "setup", "instructions", "information",
-  "details", "deltalytix", "app", "platform",
+  "details", "deltalytix", "app", "platform", "work", "works", "working",
   // French equivalents — the assistant answers in both languages.
   "le", "la", "les", "un", "une", "des", "de", "du", "et", "ou", "pour", "dans",
   "sur", "avec", "comment", "pourquoi", "quand", "est", "sont", "je", "tu", "il",
-  "nous", "vous", "mon", "ma", "mes", "aide", "besoin", "faire",
+  "nous", "vous", "mon", "ma", "mes", "aide", "besoin", "faire", "marche",
 ]);
 
-/** Weight by how likely a file is to hold a user-facing answer. */
+/**
+ * Default ranking prefers implementation over changelog prose so "how does X
+ * work" questions land in source. Docs/locales still win when the query only
+ * matches there, or when scope is narrowed to docs/product.
+ */
 const KIND_WEIGHT: Record<CorpusKind, number> = {
-  doc: 1.7,
-  locale: 1.3,
-  schema: 1.1,
-  source: 1,
+  source: 1.35,
+  schema: 1.25,
+  locale: 1.05,
+  doc: 0.85,
 };
 
 export type CodebaseSearchMatch = {
@@ -58,12 +64,14 @@ export type CodebaseSearchMatch = {
 
 export type CodebaseSearchResult = {
   query: string;
+  scope: CorpusScope;
   matchCount: number;
   matches: CodebaseSearchMatch[];
 };
 
 export type CodebaseGrepResult = {
   pattern: string;
+  scope: CorpusScope;
   matchCount: number;
   matches: CodebaseSearchMatch[];
   truncated: boolean;
@@ -277,20 +285,27 @@ function extractBlocks(file: IndexedFile, terms: SearchTerm[]): CodebaseSearchMa
   }));
 }
 
+async function corpusForScope(scope: CorpusScope): Promise<IndexedFile[]> {
+  const files = await getCorpus();
+  if (scope === "all") return files;
+  return files.filter((file) => fileMatchesScope(file.kind, scope));
+}
+
 export async function searchCodebase(
   query: string,
-  options?: { locale?: "en" | "fr"; limit?: number },
+  options?: { locale?: "en" | "fr"; limit?: number; scope?: CorpusScope },
 ): Promise<CodebaseSearchResult> {
   const trimmedQuery = query.trim();
+  const scope = options?.scope ?? "all";
   if (!trimmedQuery) {
-    return { query: trimmedQuery, matchCount: 0, matches: [] };
+    return { query: trimmedQuery, scope, matchCount: 0, matches: [] };
   }
 
-  const files = await getCorpus();
+  const files = await corpusForScope(scope);
   const terms = buildSearchTerms(trimmedQuery);
   const scored = scoreFiles(files, terms, trimmedQuery.toLowerCase(), options?.locale);
 
-  const fileLimit = Math.max(1, Math.min(options?.limit ?? MAX_FILES, 10));
+  const fileLimit = Math.max(1, Math.min(options?.limit ?? MAX_FILES, 12));
   const matches: CodebaseSearchMatch[] = [];
 
   for (const { file, score } of scored.slice(0, fileLimit)) {
@@ -302,6 +317,7 @@ export async function searchCodebase(
   if (shouldLogSearchDebug()) {
     console.log("[searchCodebase]", {
       query: trimmedQuery,
+      scope,
       locale: options?.locale,
       terms: terms.map((term) => term.term),
       corpusFiles: files.length,
@@ -309,7 +325,7 @@ export async function searchCodebase(
     });
   }
 
-  return { query: trimmedQuery, matchCount: matches.length, matches };
+  return { query: trimmedQuery, scope, matchCount: matches.length, matches };
 }
 
 export async function grepCodebase(
@@ -320,16 +336,19 @@ export async function grepCodebase(
     isRegex?: boolean;
     contextLines?: number;
     maxResults?: number;
+    scope?: CorpusScope;
   },
 ): Promise<CodebaseGrepResult> {
   const trimmedPattern = pattern.trim();
+  const scope = options?.scope ?? "all";
   if (!trimmedPattern) {
-    return { pattern: trimmedPattern, matchCount: 0, matches: [], truncated: false };
+    return { pattern: trimmedPattern, scope, matchCount: 0, matches: [], truncated: false };
   }
 
   if (trimmedPattern.length > MAX_GREP_PATTERN_LENGTH) {
     return {
       pattern: trimmedPattern,
+      scope,
       matchCount: 0,
       matches: [],
       truncated: false,
@@ -344,6 +363,7 @@ export async function grepCodebase(
   } catch (error) {
     return {
       pattern: trimmedPattern,
+      scope,
       matchCount: 0,
       matches: [],
       truncated: false,
@@ -351,7 +371,7 @@ export async function grepCodebase(
     };
   }
 
-  const files = await getCorpus();
+  const files = await corpusForScope(scope);
   const matchesGlob = createGlobMatcher(options?.glob);
   const contextRadius = Math.max(0, Math.min(options?.contextLines ?? 2, 6));
   const maxResults = Math.max(1, Math.min(options?.maxResults ?? MAX_GREP_MATCHES, MAX_GREP_MATCHES));
@@ -372,12 +392,16 @@ export async function grepCodebase(
     if (!matchesGlob(file.path)) continue;
     if (!regex.test(file.content)) continue;
 
+    // Reset lastIndex in case a future caller enables the global flag.
+    regex.lastIndex = 0;
+
     for (let index = 0; index < file.lines.length; index += 1) {
       if (matches.length >= maxResults) {
         truncated = true;
         break;
       }
       if (!regex.test(file.lines[index])) continue;
+      regex.lastIndex = 0;
 
       const start = Math.max(0, index - contextRadius);
       const end = Math.min(file.lines.length - 1, index + contextRadius);
@@ -399,13 +423,14 @@ export async function grepCodebase(
   if (shouldLogSearchDebug()) {
     console.log("[grepCodebase]", {
       pattern: trimmedPattern,
+      scope,
       glob: options?.glob,
       matchCount: matches.length,
       truncated,
     });
   }
 
-  return { pattern: trimmedPattern, matchCount: matches.length, matches, truncated };
+  return { pattern: trimmedPattern, scope, matchCount: matches.length, matches, truncated };
 }
 
 export async function readCodebaseFile(
@@ -457,14 +482,23 @@ export async function readCodebaseFile(
 
 export async function listCodebaseFiles(
   glob?: string,
-  limit = 40,
-): Promise<{ glob: string; fileCount: number; files: string[]; truncated: boolean }> {
-  const files = await getCorpus();
+  options?: { limit?: number; scope?: CorpusScope },
+): Promise<{
+  glob: string;
+  scope: CorpusScope;
+  fileCount: number;
+  files: string[];
+  truncated: boolean;
+}> {
+  const scope = options?.scope ?? "all";
+  const limit = options?.limit ?? 60;
+  const files = await corpusForScope(scope);
   const matchesGlob = createGlobMatcher(glob);
   const matched = files.filter((file) => matchesGlob(file.path)).map((file) => file.path);
 
   return {
     glob: glob?.trim() ?? "**/*",
+    scope,
     fileCount: matched.length,
     files: matched.slice(0, limit),
     truncated: matched.length > limit,

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -26,11 +26,16 @@ export const supportAgentCallOptionsSchema = z.object({
 
 export type SupportAgentCallOptions = z.infer<typeof supportAgentCallOptionsSchema>;
 
-const SUPPORT_AGENT_INSTRUCTIONS = `You are Deltalytix support. Use tools to answer product questions; do not invent features or UI labels.
+const SUPPORT_AGENT_INSTRUCTIONS = `You are Deltalytix support. You have an in-memory clone of the product codebase (app, components, lib, server, store, hooks, context, prisma, locales, docs). Investigate with tools — never invent features, routes, or UI labels.
 
-Tools: searchCodebase (default), grepCodebase (exact strings), readCodebaseFile, listCodebaseFiles, askForEmailForm. Search before answering; try a second query if the first is empty.
+How to answer "how does X work" questions:
+1. grepCodebase with scope=source (and a tight glob when you know the area) for symbols, routes, and error strings.
+2. readCodebaseFile the best hits until you understand the flow.
+3. searchCodebase(scope=source) for broader keyword discovery; use scope=docs or product only for release notes / UI copy.
 
-Call askForEmailForm when the user asks for a human, for billing/account issues, or when you cannot answer confidently. One clarifying question max, then escalate. The UI already greets the user and offers human support — do not re-introduce yourself or add reply titles.`;
+Search before answering. If the first search is empty, reword or switch tools. Prefer what the code does over what a changelog says.
+
+Call askForEmailForm for human requests, billing/account issues, or when you cannot answer confidently. One clarifying question max, then escalate. The UI already greets the user — do not re-introduce yourself or add reply titles.`;
 
 function getLocaleInstructions(locale: SupportAgentLocale): string {
   const language = locale === "fr" ? "French" : "English";
@@ -52,7 +57,7 @@ export const supportAgent = new ToolLoopAgent<SupportAgentCallOptions>({
     ...settings,
     instructions: buildSupportAgentInstructions(options.locale),
   }),
-  stopWhen: stepCountIs(12),
+  stopWhen: stepCountIs(16),
   providerOptions: {
     openai: {
       reasoningEffort: "low",

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -38,15 +38,28 @@ Search before answering. If the first search is empty, reword or switch tools. P
 Call askForEmailForm for human requests, billing/account issues, or when you cannot answer confidently. One clarifying question max, then escalate. The UI already greets the user — do not re-introduce yourself or add reply titles.`;
 
 function getLocaleInstructions(locale: SupportAgentLocale): string {
-  const language = locale === "fr" ? "French" : "English";
+  if (locale === "fr") {
+    return `LANGUE — PRIORITÉ ABSOLUE (UI fr)
+Tu dois raisonner et répondre UNIQUEMENT en français.
+- Les reasoning summaries / thought process affichés à l'utilisateur doivent être en français (pas d'anglais).
+- Commence chaque résumé de raisonnement par une courte ligne-titre en français, ex. "**Recherche de Taurus et DxFeed**" ou "**Vérification des variables d'environnement**".
+- Interdit: titres ou monologues internes en anglais ("Searching…", "The user is asking…", "Identifying…").
+- La réponse finale est aussi en français.
+Passe locale "fr" à askForEmailForm et searchCodebase.`;
+  }
 
-  return `Reply in ${language} (UI locale ${locale}). Pass locale "${locale}" to askForEmailForm and searchCodebase. Write user-facing answers only in ${language} — the UI localizes status labels itself.`;
+  return `LANGUAGE — highest priority (UI en)
+Reason and reply in English only.
+- Reasoning summaries / thought process shown in the UI must be English.
+- Start each reasoning summary with a short English title line, e.g. "**Searching Taurus and DxFeed**".
+Pass locale "en" to askForEmailForm and searchCodebase.`;
 }
 
 export function buildSupportAgentInstructions(locale: SupportAgentLocale): string {
-  return `${SUPPORT_AGENT_INSTRUCTIONS}
+  // Language first — models often overweight the start of the system prompt.
+  return `${getLocaleInstructions(locale)}
 
-${getLocaleInstructions(locale)}`;
+${SUPPORT_AGENT_INSTRUCTIONS}`;
 }
 
 export const supportAgent = new ToolLoopAgent<SupportAgentCallOptions>({

--- a/lib/ai/support-agent.ts
+++ b/lib/ai/support-agent.ts
@@ -40,7 +40,7 @@ Call askForEmailForm for human requests, billing/account issues, or when you can
 function getLocaleInstructions(locale: SupportAgentLocale): string {
   const language = locale === "fr" ? "French" : "English";
 
-  return `Reply in ${language} (UI locale ${locale}). Pass locale "${locale}" to askForEmailForm and searchCodebase. Keep reasoning short and in ${language}.`;
+  return `Reply in ${language} (UI locale ${locale}). Pass locale "${locale}" to askForEmailForm and searchCodebase. Write user-facing answers only in ${language} — the UI localizes status labels itself.`;
 }
 
 export function buildSupportAgentInstructions(locale: SupportAgentLocale): string {

--- a/lib/ai/translate-reasoning-label.test.ts
+++ b/lib/ai/translate-reasoning-label.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const generateText = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", () => ({
+  generateText,
+}));
+
+import { translateReasoningLabel } from "./translate-reasoning-label";
+
+describe("translateReasoningLabel", () => {
+  beforeEach(() => {
+    generateText.mockReset();
+  });
+
+  it("returns English text without calling the model", async () => {
+    await expect(
+      translateReasoningLabel({ text: "Searching docs", locale: "en" }),
+    ).resolves.toBe("Searching docs");
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it("asks the nano model to translate into French", async () => {
+    generateText.mockResolvedValue({ text: "Recherche dans la documentation" });
+
+    await expect(
+      translateReasoningLabel({
+        text: "Searching documentation",
+        locale: "fr",
+      }),
+    ).resolves.toBe("Recherche dans la documentation");
+
+    expect(generateText).toHaveBeenCalledOnce();
+    const call = generateText.mock.calls[0]?.[0];
+    expect(call.model).toBe("openai/gpt-5-nano");
+    expect(call.providerOptions?.openai?.reasoningEffort).toBe("none");
+    expect(call.prompt).toContain("French");
+    expect(call.prompt).toContain("Searching documentation");
+  });
+
+  it("falls back to the source text when the model returns empty", async () => {
+    generateText.mockResolvedValue({ text: "   " });
+
+    await expect(
+      translateReasoningLabel({ text: "Searching docs", locale: "fr" }),
+    ).resolves.toBe("Searching docs");
+  });
+});

--- a/lib/ai/translate-reasoning-label.ts
+++ b/lib/ai/translate-reasoning-label.ts
@@ -1,0 +1,42 @@
+import { generateText } from "ai";
+import type { SupportAgentLocale } from "@/app/api/ai/support/schema";
+
+/**
+ * Cheap, high-throughput model for short instruction tasks (title translation).
+ * Disable reasoning — latency matters more than depth here.
+ */
+export const REASONING_LABEL_TRANSLATE_MODEL =
+  process.env.REASONING_LABEL_TRANSLATE_MODEL ?? "openai/gpt-5-nano";
+
+const LOCALE_LANGUAGE: Record<SupportAgentLocale, string> = {
+  en: "English",
+  fr: "French",
+};
+
+export async function translateReasoningLabel(args: {
+  text: string;
+  locale: SupportAgentLocale;
+}): Promise<string> {
+  const source = args.text.trim();
+  if (!source) return "";
+  if (args.locale === "en") return source;
+
+  const language = LOCALE_LANGUAGE[args.locale];
+
+  const { text } = await generateText({
+    model: REASONING_LABEL_TRANSLATE_MODEL,
+    maxOutputTokens: 80,
+    providerOptions: {
+      openai: {
+        reasoningEffort: "none",
+      },
+    },
+    prompt: `Translate this short UI title into ${language}.
+Return only the translation — no quotes, no punctuation changes beyond what's needed, no explanation.
+
+Title:
+${source}`,
+  });
+
+  return text.trim().replace(/^["']|["']$/g, "") || source;
+}

--- a/locales/en/support.ts
+++ b/locales/en/support.ts
@@ -8,7 +8,7 @@ export default {
     copied: "Copied to clipboard",
     description:
       "Let us know what problem you’re experiencing or what you need help with in your trading journal. I’ll help collect the information needed for our support team.",
-    requestHumanSupport: "Request Human Support",
+    fillSupportRequest: "Fill out a support request through the form",
     contactInformation: "Contact Information",
     contactInformationDescription:
       "Please provide your contact details so our support team can reach you by email.",
@@ -42,10 +42,6 @@ export default {
       "Get quick answers from our AI assistant, built on our open knowledge base.",
     discordPrompt: "Can't find what you need?",
     generating: "Generating response…",
-    suggestionImport: "Help with importing trades",
-    suggestionBilling: "Billing or subscription question",
-    suggestionBug: "Report a bug or issue",
-    suggestionHuman: "Talk to a human",
     tool: {
       searchingDocs: "Searching product documentation...",
       grepping: "Searching the codebase...",

--- a/locales/fr/support.ts
+++ b/locales/fr/support.ts
@@ -8,7 +8,7 @@ export default {
     copied: "Copié dans le presse-papiers",
     description:
       "Faites-nous savoir quel problème vous rencontrez ou avec quoi vous avez besoin d'aide dans votre journal de trading. Je vous aiderai à collecter les informations nécessaires pour notre équipe de support.",
-    requestHumanSupport: "Demander une assistance humaine",
+    fillSupportRequest: "Remplir une demande de support via le formulaire",
     contactInformation: "Informations de contact",
     contactInformationDescription:
       "Veuillez fournir vos informations de contact pour que notre équipe de support puisse vous recontacter par email.",
@@ -46,10 +46,6 @@ export default {
       "Obtenez des réponses rapides de notre assistant IA, basé sur notre base de connaissances ouverte.",
     discordPrompt: "Vous ne trouvez pas ce qu'il vous faut ?",
     generating: "Génération de la réponse…",
-    suggestionImport: "Aide pour importer des trades",
-    suggestionBilling: "Question sur la facturation ou l'abonnement",
-    suggestionBug: "Signaler un bug ou un problème",
-    suggestionHuman: "Parler à un humain",
     tool: {
       searchingDocs:
         "Recherche dans la documentation produit...",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treats the support corpus as a real repo clone and steers the agent to **grep/read source** for “how does this work?” instead of answering from changelog prose.
- Adds corpus `scope` (`source` | `docs` | `product` | `all`) to search/grep/list tools, and rebalances ranking so implementation outranks release notes by default.
- Keeps **live model reasoning** in the UI (no static “Réflexion / Raisonnement / Génération…” titles).
- Fixes reasoning **flicker**: titles were dropping to i18n fallbacks when the first line grew past 60 chars — now truncate + lock the first complete model line.
- Hard locale-first system rule so `/fr` reasoning summaries should be French.

## Test plan
- [ ] Ask `/fr/support` a product question — titles should be live model text (ideally French), not “Réflexion…” / “Génération de la réponse…”
- [ ] Watch the thinking row while streaming — title should grow then lock, not flash to a different placeholder
- [ ] Ask `/en/support` — same stable behavior
- [ ] Ask how Tradovate connect / billing cancel / calendar trades work — expect source-backed answers
- [ ] `bunx vitest run --exclude '.claude/**' --exclude '.codex/**' 'app/[locale]/(landing)/support/reasoning-label.test.ts'`
- [ ] `SUPPORT_SEARCH_DEBUG=0 bunx vitest run --exclude '.claude/**' --exclude '.codex/**' lib/ai/search-codebase.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe206-c01f-70b8-8a5a-fe4bf19bbfb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe206-c01f-70b8-8a5a-fe4bf19bbfb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

