### PR TITLE
Redesign dashboard widgets on a shared design system

### DIFF
--- a/app/[locale]/dashboard/components/accounts/account-card.tsx
+++ b/app/[locale]/dashboard/components/accounts/account-card.tsx
@@ -1,13 +1,24 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { cn } from "@/lib/utils"
-import { useI18n } from "@/locales/client"
+import { useCurrentLocale, useI18n } from "@/locales/client"
 import { TradeProgressChart } from "./trade-progress-chart"
 import { Account } from "@/context/data-provider"
 import { WidgetSize } from '../../types/dashboard'
 import { Loader2 } from "lucide-react"
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetStat,
+  WidgetStatList,
+  formatCount,
+  formatCurrency,
+  formatTicks,
+  isCompactSize,
+  widgetHeaderPadding,
+  widgetType,
+} from "../widgets"
 
 interface AccountCardProps {
   account: Account
@@ -29,7 +40,8 @@ export function AccountCard({
   showRithmicBalance = false,
 }: AccountCardProps) {
   const t = useI18n()
-  
+  const locale = useCurrentLocale()
+
   // Extract metrics from account (computed server-side)
   const metrics = account.metrics
   const isConfigured = metrics?.isConfigured ?? false
@@ -40,10 +52,18 @@ export function AccountCard({
   const remainingLoss = metrics?.remainingLoss ?? 0
 
   const isCarouselLayout = layout === 'carousel'
+  const compact = isCompactSize(size)
   const showChart = size === 'large' || size === 'extra-large'
   const accountLabel = account.propfirm
     ? `${account.propfirm} (${account.number})`
     : account.number || t('propFirm.card.unnamedAccount')
+
+  const daysToPayment = account.nextPaymentDate
+    ? Math.floor((new Date(account.nextPaymentDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+    : null
+  const paymentIsImminent = daysToPayment !== null && daysToPayment < 5
+
+  const isDrawdownBreached = remainingLoss <= 0
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (!onClick) return
@@ -54,12 +74,17 @@ export function AccountCard({
   }
 
   return (
-    <Card
+    /*
+     * One card per account is real grouping: each account is a separate subject.
+     * Inside it there are no more cards — the sections are separated by spacing
+     * and by the one rule under the header.
+     */
+    <WidgetCard
       className={cn(
-        "flex flex-col cursor-pointer hover:border-primary/50 transition-colors shadow-xs hover:shadow-md",
+        "cursor-pointer motion-safe:transition-colors hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
         isCarouselLayout
           ? "h-full w-full max-w-full min-h-0"
-          : size === 'small' || size === 'small-long'
+          : compact
             ? "w-72"
             : "w-96"
       )}
@@ -69,205 +94,176 @@ export function AccountCard({
       onClick={onClick}
       onKeyDown={handleKeyDown}
     >
-      <CardHeader className={cn(
-        "flex-none pb-2",
-        size === 'small' || size === 'small-long' ? "p-2" : "p-3"
-      )}>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2 min-w-0 w-full">
-            <div className="truncate w-full">
-              <CardTitle className={cn(
-                "truncate flex items-center gap-2 w-full",
-                size === 'small' || size === 'small-long' ? "text-xs" : "text-sm"
-              )}>
-
-                <div className="flex w-full justify-between min-w-0">
-                  <span className="truncate">{account.propfirm || t('propFirm.card.unnamedAccount')}</span>
-                  {
-                    account.nextPaymentDate && (
-                      <div className={cn(
-                        "self-center ml-2 shrink-0",
-                        size === 'small' || size === 'small-long' ? "text-xs" : "text-xs",
-                        Math.floor((new Date(account.nextPaymentDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24)) < 5 ? 'text-red-500 blink' : 'text-muted-foreground'
-                      )}>
-                        {Math.floor((new Date(account.nextPaymentDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24))}
-                        {t('propFirm.card.daysBeforeNextPayment')}
-                      </div>
-                    )
-                  }
-                </div>
-              </CardTitle>
-              <p className={cn(
-                "text-muted-foreground truncate",
-                size === 'small' || size === 'small-long' ? "text-xs" : "text-xs"
-              )}>
-                {account.number}
-              </p>
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className={cn(
-        "flex-1 pt-0",
-        isCarouselLayout
-          ? "flex min-h-0 flex-col overflow-hidden p-3"
-          : size === 'small' || size === 'small-long'
-            ? "p-2 space-y-1.5"
-            : "p-3 space-y-2"
-      )}>
-        <div className="flex justify-between items-baseline">
-          <span className={cn(
-            "text-muted-foreground",
-            size === 'small' || size === 'small-long' ? "text-xs" : "text-sm"
-          )}>{t('propFirm.card.balance')}</span>
-          <span className={cn(
-            "font-semibold truncate ml-2",
-            size === 'small' || size === 'small-long' ? "text-sm" : "text-base"
-          )}>${currentBalance.toFixed(2)}</span>
-        </div>
-        {showRithmicBalance && (
-          <div className="flex justify-between items-baseline">
-            <span className={cn(
-              "text-muted-foreground",
-              size === 'small' || size === 'small-long' ? "text-xs" : "text-xs"
-            )}>{t('propFirm.card.rithmicBalance')}</span>
-            {rithmicBalanceLoading ? (
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                {t('propFirm.card.rithmicBalanceLoading')}
-              </span>
-            ) : rithmicBalance != null ? (
-              <span className={cn(
-                "font-medium truncate ml-2",
-                size === 'small' || size === 'small-long' ? "text-xs" : "text-sm"
-              )}>{Number.isFinite(rithmicBalance) ? `$${rithmicBalance.toFixed(2)}` : "—"}</span>
-            ) : (
-              <span className="text-xs text-muted-foreground">—</span>
-            )}
-          </div>
+      <div
+        className={cn(
+          "flex shrink-0 items-start justify-between gap-2 border-b",
+          widgetHeaderPadding(size),
         )}
+      >
+        <div className="flex min-w-0 flex-col gap-1">
+          <h3 className={cn(widgetType.title, "truncate")}>
+            {account.propfirm || t('propFirm.card.unnamedAccount')}
+          </h3>
+          {/* An account number is an operational identifier: mono is correct here. */}
+          <span className={cn(widgetType.mono, "truncate text-muted-foreground")}>
+            {account.number}
+          </span>
+        </div>
+        {daysToPayment !== null && (
+          <span
+            className={cn(
+              widgetType.caption,
+              "shrink-0 text-right",
+              paymentIsImminent && "text-destructive",
+            )}
+          >
+            {formatCount(daysToPayment, locale)}
+            {t('propFirm.card.daysBeforeNextPayment')}
+          </span>
+        )}
+      </div>
+
+      <WidgetBody
+        size={size}
+        className={cn(
+          "flex flex-col gap-4",
+          isCarouselLayout && "overflow-hidden",
+        )}
+      >
+        <WidgetStatList>
+          <WidgetStat
+            label={t('propFirm.card.balance')}
+            value={formatCurrency(currentBalance, locale)}
+          />
+          {showRithmicBalance && rithmicBalanceLoading && (
+            <WidgetStat
+              label={t('propFirm.card.rithmicBalance')}
+              value={
+                <span className="inline-flex items-center gap-1 font-normal text-muted-foreground">
+                  <Loader2 aria-hidden className="h-3 w-3 motion-safe:animate-spin" />
+                  {t('propFirm.card.rithmicBalanceLoading')}
+                </span>
+              }
+            />
+          )}
+          {showRithmicBalance && !rithmicBalanceLoading && rithmicBalance != null && Number.isFinite(rithmicBalance) && (
+            <WidgetStat
+              label={t('propFirm.card.rithmicBalance')}
+              value={formatCurrency(rithmicBalance, locale)}
+            />
+          )}
+        </WidgetStatList>
+
         {isConfigured ? (
-          <div className={cn(
-            isCarouselLayout
-              ? "flex min-h-0 flex-1 flex-col gap-2"
-              : size === 'small' || size === 'small-long'
-                ? "space-y-1.5"
-                : "space-y-2"
-          )}>
+          <div
+            className={cn(
+              "flex flex-col gap-4",
+              isCarouselLayout && "min-h-0 flex-1",
+            )}
+          >
             {/* Trade Progress Chart - only show for larger sizes */}
             {showChart && account.payouts && (
               <TradeProgressChart
                 account={account}
+                size={size}
                 fillHeight={isCarouselLayout}
               />
             )}
 
-            {/* Profit Target Section */}
-            <div className="space-y-1">
-              <div className="flex justify-between text-xs">
-                <span className="text-muted-foreground">{t('propFirm.card.remainingToTarget')}</span>
-                <span>${remainingToTarget.toFixed(2)}</span>
-              </div>
+            {/* Distance to the profit target. The bar encodes distance from a
+                boundary, so the boundary itself is stated, not implied. */}
+            <div className="flex flex-col gap-1.5">
+              <WidgetStat
+                label={t('propFirm.card.remainingToTarget')}
+                value={formatCurrency(remainingToTarget, locale)}
+              />
               <Progress
                 value={progress}
-                className={cn(
-                  size === 'small' || size === 'small-long' ? "h-1" : "h-1.5"
-                )}
-                indicatorClassName={cn(
-                  "transition-colors duration-300",
-                  "bg-[hsl(var(--chart-6))]",
-                  progress <= 20 ? "opacity-20" :
-                    progress <= 40 ? "opacity-40" :
-                      progress <= 60 ? "opacity-60" :
-                        progress <= 80 ? "opacity-80" :
-                          "opacity-100"
-                )}
+                className={compact ? "h-1" : "h-1.5"}
+                indicatorClassName="bg-foreground"
               />
+              <span className={widgetType.caption}>
+                {t('propFirm.card.target')}: {formatCurrency(account.profitTarget ?? 0, locale)}
+              </span>
             </div>
 
-            {/* Drawdown Section */}
-            <div className="space-y-1">
-              <div className="flex justify-between text-xs">
-                <span className="text-muted-foreground">{t('propFirm.card.drawdown')}</span>
-                <span className={cn(
-                  "font-medium",
-                  remainingLoss > account.drawdownThreshold * 0.5 ? "text-success" :
-                    remainingLoss > account.drawdownThreshold * 0.2 ? "text-warning" : "text-destructive"
-                )}>
-                  {remainingLoss > 0
-                    ? t('propFirm.card.remainingLoss', { amount: remainingLoss.toFixed(2) })
-                    : t('propFirm.card.drawdownBreached')}
-                </span>
-              </div>
+            {/* Distance to the drawdown boundary. Color marks only the breach,
+                which is a genuine state, and the words say so too. */}
+            <div className="flex flex-col gap-1.5">
+              <WidgetStat
+                label={t('propFirm.card.drawdown')}
+                value={
+                  isDrawdownBreached
+                    ? t('propFirm.card.drawdownBreached')
+                    : t('propFirm.card.remainingLoss', { amount: formatTicks(remainingLoss, locale, { maximumFractionDigits: 2 }) })
+                }
+                toneClassName={isDrawdownBreached ? "text-destructive" : undefined}
+              />
               <Progress
                 value={drawdownProgress}
-                className={cn(
-                  size === 'small' || size === 'small-long' ? "h-1" : "h-1.5"
-                )}
-                indicatorClassName={cn(
-                  "transition-colors duration-300",
-                  "bg-destructive",
-                  drawdownProgress <= 20 ? "opacity-20" :
-                    drawdownProgress <= 40 ? "opacity-40" :
-                      drawdownProgress <= 60 ? "opacity-60" :
-                        drawdownProgress <= 80 ? "opacity-80" :
-                          "opacity-100"
-                )}
+                className={compact ? "h-1" : "h-1.5"}
+                indicatorClassName={isDrawdownBreached ? "bg-destructive" : "bg-foreground"}
               />
+              <span className={widgetType.caption}>
+                {t('propFirm.card.maxLoss', { amount: formatTicks(account.drawdownThreshold ?? 0, locale, { maximumFractionDigits: 2 }) })}
+              </span>
             </div>
 
             {/* Consistency Section - only show for larger sizes */}
             {metrics && (size === 'large' || size === 'extra-large') && (
-              <div className="space-y-1 pt-2 border-t">
-                <div className="flex justify-between text-xs">
-                  <span className="text-muted-foreground">{t('propFirm.card.consistency')}</span>
-                  <span className={cn(
-                    "font-medium",
-                    !metrics.hasProfitableData ? "text-muted-foreground italic" :
-                      (metrics.isConsistent || account.consistencyPercentage === 100) ? "text-success" : "text-destructive"
-                  )}>
-                    {!metrics.hasProfitableData ? t('propFirm.status.unprofitable') :
-                      (metrics.isConsistent || account.consistencyPercentage === 100) ? t('propFirm.status.consistent') : t('propFirm.status.inconsistent')}
-                  </span>
-                </div>
-                <div className="flex justify-between text-xs text-muted-foreground">
-                  <span>{t('propFirm.card.maxAllowedDailyProfit')}</span>
-                  <span>${metrics.maxAllowedDailyProfit?.toFixed(2) || '-'}</span>
-                </div>
-                <div className="flex justify-between text-xs text-muted-foreground">
-                  <span>{t('propFirm.card.highestDailyProfit')}</span>
-                  <span>${metrics.highestProfitDay?.toFixed(2) || '-'}</span>
-                </div>
-                
-                {/* Trading Days Section */}
-                {metrics && (
-                  <div className="flex justify-between text-xs text-muted-foreground">
-                    <span>{t('propFirm.card.tradingDays')}</span>
-                    <span className={cn(
-                      "font-medium",
-                      metrics.validTradingDays === metrics.totalTradingDays ? "text-success" : "text-warning"
-                    )}>
-                      {metrics.validTradingDays}/{metrics.totalTradingDays}
-                      {account.minPnlToCountAsDay && account.minPnlToCountAsDay > 0 && (
-                        <span className="ml-1 text-xs opacity-75">
-                          (≥${account.minPnlToCountAsDay})
+              <WidgetStatList>
+                <WidgetStat
+                  label={t('propFirm.card.consistency')}
+                  value={
+                    !metrics.hasProfitableData
+                      ? t('propFirm.status.unprofitable')
+                      : (metrics.isConsistent || account.consistencyPercentage === 100)
+                        ? t('propFirm.status.consistent')
+                        : t('propFirm.status.inconsistent')
+                  }
+                  toneClassName={cn(
+                    !metrics.hasProfitableData && "text-muted-foreground",
+                    metrics.hasProfitableData
+                      && !(metrics.isConsistent || account.consistencyPercentage === 100)
+                      && "text-destructive",
+                  )}
+                />
+                <WidgetStat
+                  label={t('propFirm.card.maxAllowedDailyProfit')}
+                  value={
+                    metrics.maxAllowedDailyProfit != null
+                      ? formatCurrency(metrics.maxAllowedDailyProfit, locale)
+                      : formatCurrency(0, locale)
+                  }
+                />
+                <WidgetStat
+                  label={t('propFirm.card.highestDailyProfit')}
+                  value={formatCurrency(metrics.highestProfitDay ?? 0, locale)}
+                />
+                <WidgetStat
+                  label={t('propFirm.card.tradingDays')}
+                  value={
+                    <>
+                      {formatCount(metrics.validTradingDays, locale)}
+                      {'/'}
+                      {formatCount(metrics.totalTradingDays, locale)}
+                      {account.minPnlToCountAsDay && account.minPnlToCountAsDay > 0 ? (
+                        <span className={cn(widgetType.caption, "ml-1")}>
+                          {`(≥${formatCurrency(account.minPnlToCountAsDay, locale)})`}
                         </span>
-                      )}
-                    </span>
-                  </div>
-                )}
-              </div>
+                      ) : null}
+                    </>
+                  }
+                />
+              </WidgetStatList>
             )}
           </div>
         ) : (
-          <p className={cn(
-            "text-muted-foreground text-center pt-2",
-            size === 'small' || size === 'small-long' ? "text-xs" : "text-sm"
-          )}>
+          <p className={widgetType.label}>
             {t('propFirm.card.needsConfiguration')}
           </p>
         )}
-      </CardContent>
-    </Card>
+      </WidgetBody>
+    </WidgetCard>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/accounts/account-table.tsx
+++ b/app/[locale]/dashboard/components/accounts/account-table.tsx
@@ -1,14 +1,21 @@
 'use client'
 
 import { format } from "date-fns"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
 import { useI18n, useCurrentLocale } from "@/locales/client"
-import { Badge } from "@/components/ui/badge"
 import { X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { fr, enUS } from 'date-fns/locale'
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog'
+import {
+  formatCurrency,
+  formatPercent,
+  formatTicks,
+  pnlTone,
+  pnlToneClass,
+  widgetType,
+} from "../widgets"
 
 interface DailyMetric {
   date: Date
@@ -36,8 +43,11 @@ interface AccountTableProps {
   onEditPayout?: (payout: { id: string, amount: number, date: Date, status: string, propfirmSharingPercentage?: number | null }) => void
 }
 
-export function AccountTable({ 
-  accountNumber, 
+/** Every numeric column is right-aligned in both the head and the body. */
+const numericCell = "text-right tabular-nums"
+
+export function AccountTable({
+  accountNumber,
   startingBalance,
   profitTarget,
   dailyMetrics,
@@ -54,7 +64,7 @@ export function AccountTable({
   // Helper function to safely calculate percentage of target
   const calculatePercentageOfTarget = (runningBalance: number, startingBalance: number, profitTarget: number) => {
     if (profitTarget <= 0) return '-'
-    return `${((runningBalance - startingBalance) / profitTarget * 100).toFixed(1)}%`
+    return formatPercent((runningBalance - startingBalance) / profitTarget * 100, locale)
   }
 
   // Check if account is configured and has no pending changes
@@ -65,18 +75,21 @@ export function AccountTable({
       <div className="space-y-4">
         <div className="rounded-md border">
           <Table className="min-w-[760px]">
+            <TableCaption className="sr-only">
+              {t('propFirm.dailyStats.title')} {accountNumber}
+            </TableCaption>
             {renderTableHeader()}
             <TableBody>
               <TableRow>
-                <TableCell colSpan={7} className="h-[400px] text-center relative">
-                  <div className="absolute inset-0 backdrop-blur-[2px] bg-background/80 flex flex-col items-center justify-center gap-2">
-                    <h3 className="font-semibold text-lg">
-                      {hasPendingChanges 
-                        ? t('propFirm.setup.saveFirst.title') 
+                <TableCell colSpan={8} className="h-[400px] text-center relative">
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background">
+                    <h3 className="text-sm font-medium">
+                      {hasPendingChanges
+                        ? t('propFirm.setup.saveFirst.title')
                         : t('propFirm.setup.configureFirst.title')}
                     </h3>
-                    <p className="text-muted-foreground">
-                      {hasPendingChanges 
+                    <p className={widgetType.label}>
+                      {hasPendingChanges
                         ? t('propFirm.setup.saveFirst.description')
                         : t('propFirm.setup.configureFirst.description')}
                     </p>
@@ -94,10 +107,10 @@ export function AccountTable({
   const sortedMetrics = [...dailyMetrics].sort((a, b) => a.date.getTime() - b.date.getTime())
 
   // Split metrics into before and after reset
-  const metricsBeforeReset = resetDate 
+  const metricsBeforeReset = resetDate
     ? sortedMetrics.filter(metric => metric.date < resetDate)
     : []
-  
+
   const metricsAfterReset = resetDate
     ? sortedMetrics.filter(metric => metric.date > resetDate)
     : sortedMetrics
@@ -111,13 +124,13 @@ export function AccountTable({
       <TableHeader className="sticky top-0 bg-background z-10">
         <TableRow>
           <TableHead>{t('propFirm.dailyStats.date')}</TableHead>
-          <TableHead className="text-right">{t('propFirm.dailyStats.pnl')}</TableHead>
-          <TableHead className="text-right">{t('propFirm.dailyStats.balance')}</TableHead>
-          <TableHead className="text-right">{t('propFirm.dailyStats.target')}</TableHead>
-          <TableHead className="text-right">{t('propFirm.consistency.modal.percentageOfTotal')}</TableHead>
-          <TableHead className="text-right">{t('propFirm.dailyStats.maxAllowed')}</TableHead>
-          <TableHead className="text-right">{t('propFirm.dailyStats.status')}</TableHead>
-          <TableHead className="text-right">{t('propFirm.dailyStats.payout')}</TableHead>
+          <TableHead className={numericCell}>{t('propFirm.dailyStats.pnl')}</TableHead>
+          <TableHead className={numericCell}>{t('propFirm.dailyStats.balance')}</TableHead>
+          <TableHead className={numericCell}>{t('propFirm.dailyStats.target')}</TableHead>
+          <TableHead className={numericCell}>{t('propFirm.consistency.modal.percentageOfTotal')}</TableHead>
+          <TableHead className={numericCell}>{t('propFirm.dailyStats.maxAllowed')}</TableHead>
+          <TableHead>{t('propFirm.dailyStats.status')}</TableHead>
+          <TableHead className={numericCell}>{t('propFirm.dailyStats.payout')}</TableHead>
         </TableRow>
       </TableHeader>
     )
@@ -147,50 +160,43 @@ export function AccountTable({
     return (
       <TableRow key={metric.date.toISOString()}>
         <TableCell>{format(metric.date, 'PP', { locale: dateLocale })}</TableCell>
-        <TableCell className={cn(
-          "text-right font-medium",
-          metric.pnl > 0 ? "text-green-500" : metric.pnl < 0 ? "text-destructive" : ""
-        )}>
-          ${metric.pnl.toFixed(2)}
+        {/* The sign travels with the figure, so the tone is never the only cue. */}
+        <TableCell className={cn(numericCell, "font-medium", pnlToneClass(pnlTone(metric.pnl)))}>
+          {formatCurrency(metric.pnl, locale)}
         </TableCell>
-        <TableCell className="text-right">
-          ${runningBalance.toFixed(2)}
+        <TableCell className={numericCell}>
+          {formatCurrency(runningBalance, locale)}
         </TableCell>
-        <TableCell className="text-right">
+        <TableCell className={numericCell}>
           {calculatePercentageOfTarget(runningBalance, startingBalance, profitTarget)}
         </TableCell>
-        <TableCell className="text-right">
-          {percentageOfTotal !== null ? `${percentageOfTotal.toFixed(1)}%` : '-'}
+        <TableCell className={numericCell}>
+          {percentageOfTotal !== null ? formatPercent(percentageOfTotal, locale) : '-'}
         </TableCell>
-        <TableCell className="text-right font-medium">
-          ${maxAllowedDailyProfit.toFixed(2)}
+        <TableCell className={cn(numericCell, "font-medium")}>
+          {formatCurrency(maxAllowedDailyProfit, locale)}
         </TableCell>
-        <TableCell className={cn(
-          "text-right font-medium",
-          !isConsistent ? "text-destructive" : "text-green-500"
-        )}>
+        <TableCell className={cn("font-medium", !isConsistent && "text-destructive")}>
           {isConsistent ? t('propFirm.status.consistent') : t('propFirm.status.inconsistent')}
         </TableCell>
-        <TableCell className="text-right">
+        <TableCell className={numericCell}>
           {metric.payout && (
             <div className="flex items-center justify-end gap-2">
-              <div 
+              <div
                 className={cn(
-                  "flex items-center gap-2",
-                  onEditPayout && "cursor-pointer hover:opacity-80 transition-opacity"
+                  "flex items-center justify-end gap-2",
+                  onEditPayout && "cursor-pointer motion-safe:transition-opacity hover:opacity-80"
                 )}
                 onClick={() => onEditPayout?.(metric.payout!)}
               >
-                <span className={cn(
-                  metric.payout.status === 'PAID' && "text-destructive font-medium"
-                )}>
-                  -${metric.payout.amount.toFixed(2)}
+                {/* A payout leaves the account, so it carries its own minus sign.
+                    Its status is ordinary metadata: plain text, not a pill. */}
+                <span className="font-medium">
+                  {formatCurrency(-metric.payout.amount, locale)}
                 </span>
-                <Badge 
-                  variant={metric.payout.status === 'PENDING' ? 'secondary' : 'default'}
-                >
+                <span className={widgetType.caption}>
                   {metric.payout.status}
-                </Badge>
+                </span>
               </div>
               {onDeletePayout && (
                 <AlertDialog>
@@ -198,7 +204,8 @@ export function AccountTable({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-6 w-6 p-0 hover:bg-destructive/10 hover:text-destructive"
+                      className="h-6 w-6 p-0 hover:text-destructive"
+                      aria-label={t('propFirm.payout.delete')}
                     >
                       <X className="h-3 w-3" />
                     </Button>
@@ -207,7 +214,7 @@ export function AccountTable({
                     <AlertDialogHeader>
                       <AlertDialogTitle>{t('propFirm.payout.delete')}</AlertDialogTitle>
                       <AlertDialogDescription>
-                        {t('propFirm.payout.deleteConfirm')} ${metric.payout!.amount.toFixed(2)} on {format(metric.payout!.date, 'PP', { locale: dateLocale })}
+                        {t('propFirm.payout.deleteConfirm')} ${formatTicks(metric.payout!.amount, locale, { maximumFractionDigits: 2 })} on {format(metric.payout!.date, 'PP', { locale: dateLocale })}
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
@@ -232,7 +239,7 @@ export function AccountTable({
 
   function renderTotalRow(metrics: typeof sortedMetrics, totalPnL: number, runningBalance: number) {
     // Calculate total payouts
-    const totalPayouts = metrics.reduce((sum, metric) => 
+    const totalPayouts = metrics.reduce((sum, metric) =>
       sum + (metric.payout?.status === 'PAID' ? metric.payout.amount : 0), 0)
 
     // Calculate profits after payouts
@@ -241,42 +248,36 @@ export function AccountTable({
     // Calculate the base amount for consistency (profit target until exceeded)
     const baseAmount = profitsAfterPayouts <= profitTarget ? profitTarget : profitsAfterPayouts
     const maxAllowedDailyProfit = baseAmount * (consistencyPercentage / 100)
-    
+
     // Check if any daily PnL exceeds the max allowed
     const hasInconsistentDays = metrics.some(metric => metric.pnl > maxAllowedDailyProfit)
 
     return (
       <TableRow className="bg-muted/50 font-medium">
         <TableCell>{t('calendar.modal.total')}</TableCell>
-        <TableCell className={cn(
-          "text-right",
-          totalPnL > 0 ? "text-green-500" : totalPnL < 0 ? "text-destructive" : ""
-        )}>
-          ${totalPnL.toFixed(2)}
+        <TableCell className={cn(numericCell, pnlToneClass(pnlTone(totalPnL)))}>
+          {formatCurrency(totalPnL, locale)}
         </TableCell>
-        <TableCell className="text-right">
-          ${runningBalance.toFixed(2)}
+        <TableCell className={numericCell}>
+          {formatCurrency(runningBalance, locale)}
         </TableCell>
-        <TableCell className="text-right">
+        <TableCell className={numericCell}>
           {calculatePercentageOfTarget(runningBalance, startingBalance, profitTarget)}
         </TableCell>
-        <TableCell className="text-right">
-          {totalPnL > 0 ? '100%' : '-'}
+        <TableCell className={numericCell}>
+          {totalPnL > 0 ? formatPercent(100, locale) : '-'}
         </TableCell>
-        <TableCell className="text-right">
-          ${maxAllowedDailyProfit.toFixed(2)}
+        <TableCell className={numericCell}>
+          {formatCurrency(maxAllowedDailyProfit, locale)}
         </TableCell>
-        <TableCell className={cn(
-          "text-right",
-          hasInconsistentDays ? "text-destructive" : "text-green-500"
-        )}>
-          {hasInconsistentDays ? 
-            t('propFirm.consistency.inconsistent') : 
+        <TableCell className={cn(hasInconsistentDays && "text-destructive")}>
+          {hasInconsistentDays ?
+            t('propFirm.consistency.inconsistent') :
             t('propFirm.consistency.consistent')
           }
         </TableCell>
-        <TableCell className="text-right">
-          -${totalPayouts.toFixed(2)}
+        <TableCell className={numericCell}>
+          {formatCurrency(-totalPayouts, locale)}
         </TableCell>
       </TableRow>
     )
@@ -286,11 +287,14 @@ export function AccountTable({
     <div className="min-w-0 space-y-8">
       {resetDate && metricsBeforeReset.length > 0 && (
         <div>
-          <div className="mb-2 text-sm font-medium text-muted-foreground">
+          <div className={cn(widgetType.section, "mb-2")}>
             {t('propFirm.beforeReset')}
           </div>
           <div className="rounded-md border">
             <Table className="min-w-[760px]">
+              <TableCaption className="sr-only">
+                {t('propFirm.dailyStats.title')} {accountNumber} {t('propFirm.beforeReset')}
+              </TableCaption>
               {renderTableHeader()}
               <TableBody>
                 {(() => {
@@ -317,15 +321,17 @@ export function AccountTable({
       )}
 
       {resetDate && (
-        <div className="rounded-md border bg-yellow-100/50 dark:bg-yellow-900/20 p-4">
+        /* The reset is a boundary between two periods, not an alarm: it is a
+           labelled row of facts, with no color band around it. */
+        <div className="rounded-md border p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <div className="font-medium">{t('propFirm.resetDate.label')}</div>
-              <div className="text-sm text-muted-foreground">{format(resetDate, 'PP', { locale: dateLocale })}</div>
+            <div className="flex flex-col gap-1">
+              <span className={widgetType.label}>{t('propFirm.resetDate.label')}</span>
+              <span className={widgetType.value}>{format(resetDate, 'PP', { locale: dateLocale })}</span>
             </div>
-            <div className="sm:text-right">
-              <div className="text-sm text-muted-foreground">{t('propFirm.startingBalance')}</div>
-              <div className="font-medium">${startingBalance.toFixed(2)}</div>
+            <div className="flex flex-col gap-1 sm:items-end">
+              <span className={widgetType.label}>{t('propFirm.startingBalance')}</span>
+              <span className={widgetType.value}>{formatCurrency(startingBalance, locale)}</span>
             </div>
           </div>
         </div>
@@ -333,12 +339,15 @@ export function AccountTable({
 
       <div>
         {resetDate && (
-          <div className="mb-2 text-sm font-medium text-muted-foreground">
+          <div className={cn(widgetType.section, "mb-2")}>
             {t('propFirm.afterReset')}
           </div>
         )}
         <div className="rounded-md border">
           <Table className="min-w-[760px]">
+            <TableCaption className="sr-only">
+              {t('propFirm.dailyStats.title')} {accountNumber}
+            </TableCaption>
             {renderTableHeader()}
             <TableBody>
               {(() => {
@@ -364,4 +373,4 @@ export function AccountTable({
       </div>
     </div>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -27,7 +26,6 @@ import {
   Table,
   RefreshCw,
 } from "lucide-react"
-import { InfoBubble } from "@/components/ui/info-bubble"
 import { Calendar } from "@/components/ui/calendar"
 import { format, Locale } from "date-fns"
 import { cn, calculateTradingDays } from "@/lib/utils"
@@ -81,6 +79,16 @@ import {
   useSortable,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetHeader,
+  formatCount,
+  formatTicks,
+  isCompactSize,
+  widgetPadding,
+  widgetType,
+} from '../widgets'
 
 
 interface Payout {
@@ -635,7 +643,7 @@ function PayoutDialog({
                 >
                   {isDeleting ? (
                     <>
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      <Loader2 className="w-4 h-4 mr-2 motion-safe:animate-spin" />
                       {t('common.deleting')}
                     </>
                   ) : (
@@ -650,7 +658,7 @@ function PayoutDialog({
                 <AlertDialogHeader>
                   <AlertDialogTitle>{t('propFirm.payout.delete')}</AlertDialogTitle>
                   <AlertDialogDescription>
-                    {t('propFirm.payout.deleteConfirm')} ${existingPayout.amount.toFixed(2)} on {format(existingPayout.date, 'PP', { locale: dateLocale })}
+                    {t('propFirm.payout.deleteConfirm')} ${formatTicks(existingPayout.amount, locale, { maximumFractionDigits: 2 })} on {format(existingPayout.date, 'PP', { locale: dateLocale })}
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -662,7 +670,7 @@ function PayoutDialog({
                   >
                     {isDeleting ? (
                       <>
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        <Loader2 className="w-4 h-4 mr-2 motion-safe:animate-spin" />
                         {t('common.deleting')}
                       </>
                     ) : (
@@ -692,7 +700,7 @@ function PayoutDialog({
           >
             {isLoading ? (
               <>
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                <Loader2 className="w-4 h-4 mr-2 motion-safe:animate-spin" />
                 {t('common.saving')}
               </>
             ) : existingPayout ? (
@@ -1272,7 +1280,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
       title={t("rithmic.balances.refreshTitle")}
     >
       {rithmicBalancesLoading ? (
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        <Loader2 className="h-3.5 w-3.5 motion-safe:animate-spin" />
       ) : (
         <RefreshCw className="h-3.5 w-3.5" />
       )}
@@ -1283,28 +1291,30 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
   )
 
   const unconfiguredAccountsBanner = (unconfiguredAccounts.length > 0 && !isLoading) && (
-    <div className="border-b border-orange-200/30 bg-orange-50/40 dark:border-orange-700/30 dark:bg-orange-950/30">
+    /* A prompt to act, not an alarm: the words carry the state, so no color
+       band, no pulsing dot, and no pill around each account id. */
+    <div className="shrink-0 border-b bg-muted/40">
       <div className="px-3 py-2 sm:px-4">
         <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex shrink-0 items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-orange-400 motion-safe:animate-pulse" />
-            <span className="text-sm font-medium text-orange-700 dark:text-orange-300">
+            <span className={widgetType.section}>
               {t('propFirm.status.needsConfiguration')}:
             </span>
           </div>
-          <div className="flex min-w-0 gap-2 overflow-x-auto pb-1">
+          <div className="flex min-w-0 items-center gap-3 overflow-x-auto pb-1">
             {unconfiguredAccounts.map((accountNumber) => (
               <div
                 key={accountNumber}
-                className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-orange-100 dark:bg-orange-900/50"
+                className="inline-flex items-center gap-1"
               >
-                <span className="text-xs font-medium text-orange-800 dark:text-orange-200">
+                <span className={cn(widgetType.mono, "text-muted-foreground")}>
                   {accountNumber}
                 </span>
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="relative h-5 w-5 p-0 after:absolute after:inset-[-10px] hover:bg-orange-200 dark:hover:bg-orange-800/50"
+                  className="relative h-5 w-5 p-0 after:absolute after:inset-[-10px]"
+                  aria-label={t('propFirm.setup.message')}
                   onClick={() => {
                     const tempAccount = {
                       id: '',
@@ -1322,7 +1332,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                     setSelectedAccountForTable(tempAccount as any)
                   }}
                 >
-                  <Settings className="h-3 w-3 text-orange-600 dark:text-orange-400" />
+                  <Settings className="h-3 w-3 text-muted-foreground" />
                 </Button>
               </div>
             ))}
@@ -1544,42 +1554,25 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
   }
 
   return (
-    <Card className="w-full h-full min-w-0 flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 min-h-10" : "p-3 sm:p-4 min-h-14"
-        )}
-      >
-        <div className="flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
-            >
-              {t('propFirm.title')}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={size === 'small' ? 'size-3.5' : 'size-4'}
-            >
-              <p>{t('propFirm.description')}</p>
-            </InfoBubble>
-          </div>
-          <div className="flex min-w-0 flex-wrap items-center gap-2 sm:justify-end">
+    <WidgetCard className="w-full">
+      <WidgetHeader
+        size={size}
+        title={t('propFirm.title')}
+        description={t('propFirm.description')}
+        className="flex-wrap"
+        actions={
+          <>
             <Button
               variant="outline"
               size="sm"
               onClick={() => setAccountGroupBoardOpen(true)}
               className={cn(
                 "gap-1.5",
-                size === "small" ? "h-7 px-2 text-xs" : "h-8 px-2 sm:px-3"
+                isCompactSize(size) ? "h-7 px-2 text-xs" : "h-8 px-2 sm:px-3"
               )}
             >
               <Settings className="h-3.5 w-3.5" />
-              <span className={cn((size === "small") && "sr-only", "hidden min-[420px]:inline")}>
+              <span className={cn(isCompactSize(size) && "sr-only", "hidden min-[420px]:inline")}>
                 {t("filters.manageAccounts")}
               </span>
             </Button>
@@ -1588,33 +1581,34 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
               <Button
                 variant="outline"
                 size="sm"
-                className={cn(size === "small" ? "h-7 px-2" : "h-8")}
+                className={cn(isCompactSize(size) ? "h-7 px-2" : "h-8")}
                 onClick={() => void refreshRithmicBalances()}
                 disabled={rithmicBalancesLoading}
                 title={t("rithmic.balances.refreshTitle")}
               >
                 {rithmicBalancesLoading ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Loader2 className="h-3.5 w-3.5 motion-safe:animate-spin" />
                 ) : (
                   <RefreshCw className="h-3.5 w-3.5" />
                 )}
-                <span className={cn("ml-1.5", size === "small" && "sr-only")}>
+                <span className={cn("ml-1.5", isCompactSize(size) && "sr-only")}>
                   {t("rithmic.balances.refresh")}
                 </span>
               </Button>
             )}
             {chartsTableToggle}
-          </div>
-        </div>
-      </CardHeader>
+          </>
+        }
+      />
 
       {unconfiguredAccountsBanner}
 
-      <CardContent
+      <WidgetBody
+        size={size}
+        flush
         className={cn(
-          "flex-1 overflow-hidden",
-          view === "table" && "p-0",
-          useMobileAccountCarousel && "flex min-h-0 flex-col p-0"
+          "overflow-hidden",
+          useMobileAccountCarousel && "flex min-h-0 flex-col"
         )}
       >
         {useMobileAccountCarousel ? (
@@ -1630,7 +1624,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
               return (
                 <div className="flex h-full min-h-0 flex-col gap-2">
                   {slide.groupName && (
-                    <p className="shrink-0 px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    <p className={cn(widgetType.section, "shrink-0 px-1")}>
                       {slide.groupName}
                     </p>
                   )}
@@ -1648,45 +1642,30 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
             }}
           />
         ) : view === "cards" ? (
-          <div className="flex-1 overflow-y-auto h-full">
-            <div className="mt-4">
-              <div className="space-y-6">
-                {sortedGroupEntries.map(({ group, accounts: orderedAccounts }, groupIndex) => {
-                  // Generate a consistent color for each group based on group index
-                  const groupColors = [
-                    'border-blue-200/50 bg-blue-50/30 dark:border-blue-800/30 dark:bg-blue-950/20',
-                    'border-purple-200/50 bg-purple-50/30 dark:border-purple-800/30 dark:bg-purple-950/20',
-                    'border-green-200/50 bg-green-50/30 dark:border-green-800/30 dark:bg-green-950/20',
-                    'border-orange-200/50 bg-orange-50/30 dark:border-orange-800/30 dark:bg-orange-950/20',
-                    'border-pink-200/50 bg-pink-50/30 dark:border-pink-800/30 dark:bg-pink-950/20',
-                    'border-cyan-200/50 bg-cyan-50/30 dark:border-cyan-800/30 dark:bg-cyan-950/20',
-                  ];
-
-                  const groupColorClass = groupColors[groupIndex % groupColors.length];
-
+          <div className="h-full flex-1 overflow-y-auto">
+            <div className={cn("flex flex-col gap-6", widgetPadding(size))}>
+                {sortedGroupEntries.map(({ group, accounts: orderedAccounts }) => {
+                  /*
+                   * A group is a heading plus its row of cards. The old colored
+                   * bands encoded nothing but the group's index, so they are
+                   * gone: spacing and the heading carry the grouping.
+                   */
                   return (
-                    <div
-                      key={group.id}
-                      className={cn(
-                        "relative border-l-4 rounded-r-lg",
-                        groupColorClass,
-                        "transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-md motion-reduce:transition-none"
-                      )}
-                    >
-                      {/* Group header with subtle styling */}
-                      <div className="px-4 py-3 border-b border-current/10">
-                        <div className="flex items-center justify-between">
-                          <h3 className="text-sm font-semibold text-foreground/80 tracking-wide uppercase">
-                            {group.name}
-                          </h3>
-                          <div className="text-xs text-muted-foreground bg-white/50 dark:bg-black/20 px-2 py-1 rounded-full">
-                            {orderedAccounts.length} {orderedAccounts.length === 1 ? 'account' : 'accounts'}
-                          </div>
-                        </div>
+                    <section key={group.id} className="flex min-w-0 flex-col gap-2">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <h3 className={widgetType.section}>
+                          {group.name}
+                        </h3>
+                        <span className={widgetType.caption}>
+                          {formatCount(orderedAccounts.length, locale)}{' '}
+                          {orderedAccounts.length === 1
+                            ? t('propFirm.renewal.account')
+                            : t('propFirm.renewal.accounts')}
+                        </span>
                       </div>
 
                       {/* Cards container with optimized spacing */}
-                      <div className="p-4 pt-3">
+                      <div>
                         <DndContext
                           sensors={sensors}
                           collisionDetection={closestCenter}
@@ -1714,7 +1693,7 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                           </SortableContext>
                         </DndContext>
                       </div>
-                    </div>
+                    </section>
                   );
                 })}
 
@@ -1723,26 +1702,22 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                   if (sortedUngroupedAccounts.length === 0) return null;
 
                   return (
-                    <div
-                      className={cn(
-                        "relative border-l-4 border-gray-200/50 bg-gray-50/30 dark:border-gray-700/30 dark:bg-gray-900/20 rounded-r-lg",
-                        "transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-md motion-reduce:transition-none"
-                      )}
-                    >
+                    <section className="flex min-w-0 flex-col gap-2">
                       {/* Ungrouped header */}
-                      <div className="px-4 py-3 border-b border-gray-200/20 dark:border-gray-700/20">
-                        <div className="flex items-center justify-between">
-                          <h3 className="text-sm font-semibold text-muted-foreground tracking-wide uppercase">
-                            {t('propFirm.ungrouped')}
-                          </h3>
-                          <div className="text-xs text-muted-foreground bg-white/50 dark:bg-black/20 px-2 py-1 rounded-full">
-                            {sortedUngroupedAccounts.length} {sortedUngroupedAccounts.length === 1 ? 'account' : 'accounts'}
-                          </div>
-                        </div>
+                      <div className="flex items-baseline justify-between gap-2">
+                        <h3 className={widgetType.section}>
+                          {t('propFirm.ungrouped')}
+                        </h3>
+                        <span className={widgetType.caption}>
+                          {formatCount(sortedUngroupedAccounts.length, locale)}{' '}
+                          {sortedUngroupedAccounts.length === 1
+                            ? t('propFirm.renewal.account')
+                            : t('propFirm.renewal.accounts')}
+                        </span>
                       </div>
 
                       {/* Cards container */}
-                      <div className="p-4 pt-3">
+                      <div>
                         <DndContext
                           sensors={sensors}
                           collisionDetection={closestCenter}
@@ -1770,10 +1745,9 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
                           </SortableContext>
                         </DndContext>
                       </div>
-                    </div>
+                    </section>
                   );
                 })()}
-              </div>
             </div>
           </div>
         ) : (
@@ -1781,9 +1755,9 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
             {accountsTableView}
           </div>
         )}
-      </CardContent>
+      </WidgetBody>
 
       {dialogs}
-    </Card>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/accounts/accounts-table-view.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-table-view.tsx
@@ -19,11 +19,22 @@ import { Progress } from "@/components/ui/progress"
 import { useAccountOrderStore } from "@/store/account-order-store"
 import { useAccountsGroupExpansionStore } from "../../../../../store/accounts-group-expansion-store"
 import { DataTableColumnHeader } from "../tables/column-header"
-import { CheckCircle, ChevronDown, ChevronRight, Loader2, XCircle } from "lucide-react"
+import { ChevronDown, ChevronRight, Loader2, XCircle } from "lucide-react"
 import {
   getPrimaryRithmicBalance,
   RithmicAccountBalance,
 } from "@/lib/rithmic-api"
+import {
+  formatCount,
+  formatCurrency,
+  formatTicks,
+  widgetType,
+} from "../widgets"
+
+/** Numeric cells are right-aligned and share one right edge with their header. */
+const numericCell = "text-right tabular-nums"
+/** A value the data does not have. Never an em dash in interface copy. */
+const NO_VALUE = "-"
 
 type AccountGroupRow = {
   kind: "group"
@@ -230,6 +241,7 @@ function AccountsTableSection({
   totalSummary?: SummaryRow | null
 }) {
   const t = useI18n()
+  const locale = useCurrentLocale()
   const expanded = useAccountsGroupExpansionStore((state) => state.expanded)
   const setExpanded = useAccountsGroupExpansionStore((state) => state.setExpanded)
   const tableWrapperRef = useRef<HTMLDivElement | null>(null)
@@ -322,83 +334,82 @@ function AccountsTableSection({
         )
       case "account":
       case "propfirm":
-        return <span className="text-sm text-muted-foreground">—</span>
+        return <span className="text-sm text-muted-foreground">{NO_VALUE}</span>
       case "startDate":
         return (
-          <div className="text-sm text-muted-foreground text-center">—</div>
+          <div className="text-sm text-muted-foreground text-center">{NO_VALUE}</div>
         )
       case "funded":
         return (
-          <div className="flex items-center justify-center text-xs text-muted-foreground">
-            {summary.summary.fundedCount}/{summary.accountCount}
+          <div className={cn(numericCell, widgetType.label)}>
+            {formatCount(summary.summary.fundedCount, locale)}/{formatCount(summary.accountCount, locale)}
           </div>
         )
       case "balance":
         return (
-          <div className="text-right font-semibold">
-            ${summary.summary.totalBalance.toFixed(2)}
+          <div className={cn(numericCell, "font-semibold")}>
+            {formatCurrency(summary.summary.totalBalance, locale)}
           </div>
         )
       case "rithmicBalance":
         return summary.summary.rithmicBalanceCount > 0 ? (
-          <div className="text-right font-semibold">
-            ${summary.summary.totalRithmicBalance.toFixed(2)}
+          <div className={cn(numericCell, "font-semibold")}>
+            {formatCurrency(summary.summary.totalRithmicBalance, locale)}
           </div>
         ) : (
-          <div className="text-right text-sm text-muted-foreground">—</div>
+          <div className={cn(numericCell, "text-muted-foreground")}>{NO_VALUE}</div>
         )
       case "targetProgress": {
         const isConfigured = summary.summary.configuredCount > 0
         if (!isConfigured) {
           return (
-            <div className="text-xs text-muted-foreground">
+            <div className={widgetType.label}>
               {t("accounts.table.notConfigured")}
             </div>
           )
         }
         return (
           <div className="min-w-[160px] space-y-1">
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span>{t("accounts.table.remaining")}</span>
-              <span>${summary.summary.totalRemainingToTarget.toFixed(2)}</span>
+            <div className="flex items-center justify-between gap-2">
+              <span className={widgetType.label}>{t("accounts.table.remaining")}</span>
+              <span className={cn(widgetType.label, "tabular-nums")}>
+                {formatCurrency(summary.summary.totalRemainingToTarget, locale)}
+              </span>
             </div>
             <Progress
               value={summary.summary.averageProgress}
               className="h-1.5"
-              indicatorClassName={cn(
-                "transition-colors duration-300",
-                "bg-[hsl(var(--chart-6))]"
-              )}
+              indicatorClassName="bg-foreground"
             />
           </div>
         )
       }
       case "totalPayout":
         return (
-          <div className="text-right font-semibold">
-            ${summary.summary.totalPayouts.toFixed(2)}
+          <div className={cn(numericCell, "font-semibold")}>
+            {formatCurrency(summary.summary.totalPayouts, locale)}
           </div>
         )
       case "totalFee":
         return (
-          <div className="text-right font-semibold">
-            ${summary.summary.totalFee.toFixed(2)}
+          <div className={cn(numericCell, "font-semibold")}>
+            {formatCurrency(summary.summary.totalFee, locale)}
           </div>
         )
       case "drawdown":
         return (
-          <div className="text-right text-sm text-muted-foreground">
-            ${summary.summary.totalRemainingLoss.toFixed(2)}
+          <div className={cn(numericCell, "text-muted-foreground")}>
+            {formatCurrency(summary.summary.totalRemainingLoss, locale)}
           </div>
         )
       case "consistency":
       case "maxDailyProfit":
       case "tradingDays":
         return (
-          <div className="text-right text-sm text-muted-foreground">—</div>
+          <div className={cn(numericCell, "text-muted-foreground")}>{NO_VALUE}</div>
         )
       default:
-        return <span className="text-sm text-muted-foreground">—</span>
+        return <span className="text-sm text-muted-foreground">{NO_VALUE}</span>
     }
   }
 
@@ -409,16 +420,24 @@ function AccountsTableSection({
           className="w-full border-separate border-spacing-0 text-sm"
           style={{ minWidth: table.getTotalSize() }}
         >
-          <thead className="sticky top-0 z-10 bg-muted/90 backdrop-blur-xs shadow-xs border-b [&_tr]:border-b">
+          <caption className="sr-only">{t("accounts.table.total")}</caption>
+          <thead className="sticky top-0 z-10 border-b bg-card [&_tr]:border-b">
             {table.getHeaderGroups().map((headerGroup) => (
-              <tr
-                key={headerGroup.id}
-                className="border-b transition-colors hover:bg-muted/50"
-              >
+              <tr key={headerGroup.id} className="border-b">
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
-                    className="whitespace-nowrap px-2 py-2 text-left text-xs font-semibold bg-muted/90 border-r border-border last:border-r-0 first:border-l align-middle text-muted-foreground sm:px-3 sm:text-sm"
+                    scope="col"
+                    aria-sort={
+                      header.column.getIsSorted() === "asc"
+                        ? "ascending"
+                        : header.column.getIsSorted() === "desc"
+                          ? "descending"
+                          : header.column.getCanSort()
+                            ? "none"
+                            : undefined
+                    }
+                    className="whitespace-nowrap border-b bg-card px-2 py-2 text-left align-middle text-xs font-medium text-muted-foreground sm:px-3"
                     style={{ width: header.getSize() }}
                   >
                     {header.isPlaceholder
@@ -443,7 +462,7 @@ function AccountsTableSection({
                     {table.getVisibleLeafColumns().map((column) => (
                       <td
                         key={`${entry.summary.id}-${column.id}`}
-                        className="px-2 py-2 text-xs border-r border-border/50 last:border-r-0 first:border-l align-middle sm:px-3 sm:text-sm"
+                        className="px-2 py-2 align-middle text-xs sm:px-3 sm:text-sm"
                         style={{ width: column.getSize() }}
                       >
                         {renderSummaryCell(column.id, entry.summary)}
@@ -458,8 +477,7 @@ function AccountsTableSection({
                 <tr
                   key={row.id}
                   className={cn(
-                    "border-b border-border transition-all duration-75 hover:bg-muted/40",
-                    rowIndex % 2 === 1 && "bg-muted/20",
+                    "border-b border-border motion-safe:transition-colors hover:bg-muted/40",
                     row.getCanExpand() && "bg-muted/30 font-medium",
                     isDrawdownBreached(row.original) && "opacity-50",
                     (row.getCanExpand() || row.depth > 0) && "cursor-pointer"
@@ -476,7 +494,7 @@ function AccountsTableSection({
                     <td
                       key={cell.id}
                       className={cn(
-                        "px-2 py-2 text-xs border-r border-border/50 last:border-r-0 first:border-l align-middle sm:px-3 sm:text-sm",
+                        "px-2 py-2 align-middle text-xs sm:px-3 sm:text-sm",
                         row.depth > 0 && cell.column.id === "account" && "pl-6"
                       )}
                       style={{ width: cell.column.getSize() }}
@@ -527,6 +545,7 @@ export function AccountsTableView({
 }: AccountsTableViewProps) {
   const t = useI18n()
   const currentLocale = useCurrentLocale()
+  const locale = currentLocale
   const dateFormatter = useMemo(
     () => new Intl.DateTimeFormat(currentLocale, { dateStyle: "medium" }),
     [currentLocale]
@@ -548,7 +567,7 @@ export function AccountsTableView({
                 event.stopPropagation()
                 row.toggleExpanded()
               }}
-              className="flex items-center justify-center h-6 w-6 rounded hover:bg-muted/60 transition-colors"
+              className="flex h-6 w-6 items-center justify-center rounded hover:bg-muted/60 motion-safe:transition-colors"
               aria-label={
                 row.getIsExpanded()
                   ? t("accounts.table.collapseGroup")
@@ -581,7 +600,7 @@ export function AccountsTableView({
                 {row.original.name} ({row.original.accounts.length})
               </span>
             ) : (
-              <span className="text-sm text-muted-foreground">—</span>
+              <span className="text-sm text-muted-foreground">{NO_VALUE}</span>
             )}
           </div>
         ),
@@ -603,16 +622,18 @@ export function AccountsTableView({
           />
         ),
         cell: ({ row }) => (
-          <div className="flex flex-col min-w-[160px]">
+          <div className="flex min-w-[160px] flex-col">
             {isGroupRow(row.original) ? (
-              <span className="text-sm text-muted-foreground">—</span>
+              <span className="text-sm text-muted-foreground">{NO_VALUE}</span>
             ) : (
               <>
-                <span className="font-medium truncate">
+                {/* An account number is an operational identifier, so mono is
+                    the right role here — unlike money, which never is. */}
+                <span className={cn(widgetType.mono, "truncate text-foreground")}>
                   {row.original.number}
                 </span>
                 {row.original.accountSizeName && (
-                  <span className="text-xs text-muted-foreground truncate">
+                  <span className={cn(widgetType.caption, "truncate")}>
                     {row.original.accountSizeName}
                   </span>
                 )}
@@ -644,7 +665,7 @@ export function AccountsTableView({
         cell: ({ row }) => (
           <div className="min-w-[160px] font-medium truncate">
             {isGroupRow(row.original)
-              ? "—"
+              ? NO_VALUE
               : row.original.propfirm || t("propFirm.card.unnamedAccount")}
           </div>
         ),
@@ -674,13 +695,13 @@ export function AccountsTableView({
         cell: ({ row }) => {
           if (isGroupRow(row.original)) {
             return (
-              <div className="text-sm text-muted-foreground text-center">—</div>
+              <div className="text-sm text-muted-foreground text-center">{NO_VALUE}</div>
             )
           }
           const startDate = getAccountStartDate(row.original)
           if (!startDate) {
             return (
-              <div className="text-sm text-muted-foreground text-center">—</div>
+              <div className="text-sm text-muted-foreground text-center">{NO_VALUE}</div>
             )
           }
           return (
@@ -714,30 +735,22 @@ export function AccountsTableView({
           <DataTableColumnHeader
             column={column}
             title={t("accounts.table.funded")}
+            align="right"
           />
         ),
         cell: ({ row }) => {
           if (isGroupRow(row.original)) {
             return (
-              <div className="flex items-center justify-center text-xs text-muted-foreground">
-                {row.original.summary.fundedCount}/{row.original.accounts.length}
+              <div className={cn(numericCell, widgetType.label)}>
+                {formatCount(row.original.summary.fundedCount, locale)}/{formatCount(row.original.accounts.length, locale)}
               </div>
             )
           }
           const isFunded = row.original.isPerformance === true
+          /* Funded status is ordinary metadata: a word, not a colored glyph. */
           return (
-            <div className="flex items-center justify-center">
-              {isFunded ? (
-                <>
-                  <CheckCircle className="h-4 w-4 text-success text-green-500" />
-                  <span className="sr-only">{t("accounts.table.fundedYes")}</span>
-                </>
-              ) : (
-                <>
-                  <XCircle className="h-4 w-4 text-muted-foreground/60" />
-                  <span className="sr-only">{t("accounts.table.fundedNo")}</span>
-                </>
-              )}
+            <div className={cn("text-xs", !isFunded && "text-muted-foreground")}>
+              {isFunded ? t("accounts.table.fundedYes") : t("accounts.table.fundedNo")}
             </div>
           )
         },
@@ -764,6 +777,7 @@ export function AccountsTableView({
           <DataTableColumnHeader
             column={column}
             title={t("accounts.table.balance")}
+            align="right"
           />
         ),
         cell: ({ row }) => {
@@ -771,8 +785,8 @@ export function AccountsTableView({
             ? row.original.summary.totalBalance
             : getAccountBalance(row.original)
           return (
-            <div className="text-right font-medium">
-              ${currentBalance?.toFixed(2)}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCurrency(currentBalance ?? 0, locale)}
             </div>
           )
         },
@@ -799,16 +813,17 @@ export function AccountsTableView({
                 <DataTableColumnHeader
                   column={column}
                   title={t("accounts.table.rithmicBalance")}
+                  align="right"
                 />
               ),
               cell: ({ row }: { row: any }) => {
                 if (isGroupRow(row.original)) {
                   return row.original.summary.rithmicBalanceCount > 0 ? (
-                    <div className="text-right font-medium">
-                      ${row.original.summary.totalRithmicBalance.toFixed(2)}
+                    <div className={cn(numericCell, "font-medium")}>
+                      {formatCurrency(row.original.summary.totalRithmicBalance, locale)}
                     </div>
                   ) : (
-                    <div className="text-right text-sm text-muted-foreground">—</div>
+                    <div className={cn(numericCell, "text-muted-foreground")}>{NO_VALUE}</div>
                   )
                 }
 
@@ -825,17 +840,17 @@ export function AccountsTableView({
                 ) {
                   return (
                     <div className="flex items-center justify-end gap-1 text-xs text-muted-foreground">
-                      <Loader2 className="h-3 w-3 animate-spin" />
+                      <Loader2 aria-hidden className="h-3 w-3 motion-safe:animate-spin" />
                     </div>
                   )
                 }
 
                 return rithmicBalance != null ? (
-                  <div className="text-right font-medium">
-                    ${rithmicBalance.toFixed(2)}
+                  <div className={cn(numericCell, "font-medium")}>
+                    {formatCurrency(rithmicBalance, locale)}
                   </div>
                 ) : (
-                  <div className="text-right text-sm text-muted-foreground">—</div>
+                  <div className={cn(numericCell, "text-muted-foreground")}>{NO_VALUE}</div>
                 )
               },
               sortingFn: (rowA: any, rowB: any) => {
@@ -861,6 +876,7 @@ export function AccountsTableView({
           <DataTableColumnHeader
             column={column}
             title={t("accounts.table.totalPayout")}
+            align="right"
           />
         ),
         cell: ({ row }) => {
@@ -868,8 +884,8 @@ export function AccountsTableView({
             ? row.original.summary.totalPayouts
             : getAccountTotalPayouts(row.original)
           return (
-            <div className="text-right font-medium">
-              ${totalPayouts.toFixed(2)}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCurrency(totalPayouts, locale)}
             </div>
           )
         },
@@ -892,6 +908,7 @@ export function AccountsTableView({
           <DataTableColumnHeader
             column={column}
             title={t("accounts.table.totalFee")}
+            align="right"
           />
         ),
         cell: ({ row }) => {
@@ -899,8 +916,8 @@ export function AccountsTableView({
             ? row.original.summary.totalFee
             : getAccountTotalFee(row.original)
           return (
-            <div className="text-right font-medium">
-              ${totalFee.toFixed(2)}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCurrency(totalFee, locale)}
             </div>
           )
         },
@@ -941,7 +958,7 @@ export function AccountsTableView({
 
           if (!isConfigured) {
             return (
-              <div className="text-xs text-muted-foreground">
+              <div className={widgetType.label}>
                 {t("accounts.table.notConfigured")}
               </div>
             )
@@ -949,17 +966,16 @@ export function AccountsTableView({
 
           return (
             <div className="min-w-[160px] space-y-1">
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>{t("accounts.table.remaining")}</span>
-                <span>${remainingToTarget.toFixed(2)}</span>
+              <div className="flex items-center justify-between gap-2">
+                <span className={widgetType.label}>{t("accounts.table.remaining")}</span>
+                <span className={cn(widgetType.label, "tabular-nums")}>
+                  {formatCurrency(remainingToTarget, locale)}
+                </span>
               </div>
               <Progress
                 value={progress}
                 className="h-1.5"
-                indicatorClassName={cn(
-                  "transition-colors duration-300",
-                  "bg-[hsl(var(--chart-6))]"
-                )}
+                indicatorClassName="bg-foreground"
               />
             </div>
           )
@@ -985,13 +1001,14 @@ export function AccountsTableView({
           <DataTableColumnHeader
             column={column}
             title={t("accounts.table.drawdownRemaining")}
+            align="right"
           />
         ),
         cell: ({ row }) => {
           if (isGroupRow(row.original)) {
             return (
-              <div className="text-right text-sm text-muted-foreground">
-                ${row.original.summary.totalRemainingLoss.toFixed(2)}
+              <div className={cn(numericCell, "text-muted-foreground")}>
+                {formatCurrency(row.original.summary.totalRemainingLoss, locale)}
               </div>
             )
           }
@@ -1001,30 +1018,29 @@ export function AccountsTableView({
 
           if (!isConfigured) {
             return (
-              <div className="text-xs text-muted-foreground">
+              <div className={widgetType.label}>
                 {t("accounts.table.notConfigured")}
               </div>
             )
           }
 
+          /* Distance from the drawdown boundary. The boundary is named in the
+             caption instead of being implied by a green/amber/red ramp; color
+             marks only the breach, which is a real state. */
+          const isBreached = remainingLoss <= 0
           return (
-            <div className="text-right text-sm">
-              <span
-                className={cn(
-                  "font-medium",
-                  remainingLoss > (row.original.drawdownThreshold ?? 0) * 0.5
-                    ? "text-success"
-                    : remainingLoss >
-                      (row.original.drawdownThreshold ?? 0) * 0.2
-                      ? "text-warning"
-                      : "text-destructive"
-                )}
-              >
-                {remainingLoss > 0
-                  ? t("propFirm.card.remainingLoss", {
-                    amount: remainingLoss.toFixed(2),
-                  })
-                  : t("propFirm.card.drawdownBreached")}
+            <div className={cn(numericCell, "flex flex-col items-end gap-0.5")}>
+              <span className={cn("font-medium", isBreached && "text-destructive")}>
+                {isBreached
+                  ? t("propFirm.card.drawdownBreached")
+                  : t("propFirm.card.remainingLoss", {
+                    amount: formatTicks(remainingLoss, locale, { maximumFractionDigits: 2 }),
+                  })}
+              </span>
+              <span className={widgetType.caption}>
+                {t("propFirm.card.maxLoss", {
+                  amount: formatTicks(row.original.drawdownThreshold ?? 0, locale, { maximumFractionDigits: 2 }),
+                })}
               </span>
             </div>
           )
@@ -1057,20 +1073,20 @@ export function AccountsTableView({
         cell: ({ row }) => {
           if (isGroupRow(row.original)) {
             return (
-              <div className="text-sm text-muted-foreground text-center">—</div>
+              <div className="text-sm text-muted-foreground text-center">{NO_VALUE}</div>
             )
           }
           const metrics = row.original.metrics
           if (!metrics?.isConfigured) {
             return (
-              <div className="text-xs text-muted-foreground">
+              <div className={widgetType.label}>
                 {t("accounts.table.notConfigured")}
               </div>
             )
           }
           if (!metrics.hasProfitableData) {
             return (
-              <div className="text-xs text-muted-foreground italic">
+              <div className={widgetType.label}>
                 {t("propFirm.status.unprofitable")}
               </div>
             )
@@ -1081,7 +1097,7 @@ export function AccountsTableView({
             <div
               className={cn(
                 "text-xs font-medium",
-                isConsistent ? "text-success" : "text-destructive"
+                !isConsistent && "text-destructive"
               )}
             >
               {isConsistent
@@ -1119,23 +1135,24 @@ export function AccountsTableView({
           <DataTableColumnHeader
             column={column}
             title={t("propFirm.card.highestDailyProfit")}
+            align="right"
           />
         ),
         cell: ({ row }) => {
           if (isGroupRow(row.original)) {
             return (
-              <div className="text-right text-sm text-muted-foreground">—</div>
+              <div className="text-right text-sm text-muted-foreground">{NO_VALUE}</div>
             )
           }
           const maxDailyProfit = row.original.metrics?.highestProfitDay
           if (maxDailyProfit === undefined) {
             return (
-              <div className="text-right text-sm text-muted-foreground">—</div>
+              <div className="text-right text-sm text-muted-foreground">{NO_VALUE}</div>
             )
           }
           return (
-            <div className="text-right text-sm font-medium">
-              ${maxDailyProfit.toFixed(2)}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCurrency(maxDailyProfit, locale)}
             </div>
           )
         },
@@ -1158,18 +1175,19 @@ export function AccountsTableView({
           <DataTableColumnHeader
             column={column}
             title={t("propFirm.card.tradingDays")}
+            align="right"
           />
         ),
         cell: ({ row }) => {
           if (isGroupRow(row.original)) {
             return (
-              <div className="text-right text-sm text-muted-foreground">—</div>
+              <div className="text-right text-sm text-muted-foreground">{NO_VALUE}</div>
             )
           }
           const metrics = row.original.metrics
           if (!metrics?.isConfigured) {
             return (
-              <div className="text-xs text-muted-foreground">
+              <div className={widgetType.label}>
                 {t("accounts.table.notConfigured")}
               </div>
             )
@@ -1177,17 +1195,8 @@ export function AccountsTableView({
           const totalTradingDays = metrics.totalTradingDays ?? 0
           const validTradingDays = metrics.validTradingDays ?? 0
           return (
-            <div className="text-right text-sm">
-              <span
-                className={cn(
-                  "font-medium",
-                  validTradingDays === totalTradingDays
-                    ? "text-success"
-                    : "text-warning"
-                )}
-              >
-                {validTradingDays}/{totalTradingDays}
-              </span>
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCount(validTradingDays, locale)}/{formatCount(totalTradingDays, locale)}
             </div>
           )
         },

--- a/app/[locale]/dashboard/components/accounts/accounts-toolbar.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-toolbar.tsx
@@ -146,7 +146,7 @@ export function AccountsToolbar({
 
           <Button
             variant="ghost"
-            className="h-10 w-10 rounded-full p-0 transition-[transform] duration-150 active:scale-95"
+            className="h-10 w-10 rounded-full p-0 motion-safe:transition-transform motion-safe:duration-150 motion-safe:active:scale-95"
             aria-label={t("accounts.toolbar.searchAccounts")}
             title={t("accounts.toolbar.searchAccounts")}
             onClick={() => setSearchOpen(true)}
@@ -158,7 +158,7 @@ export function AccountsToolbar({
 
           <Button
             variant="ghost"
-            className="h-10 w-10 rounded-full p-0 transition-[transform] duration-150 active:scale-95"
+            className="h-10 w-10 rounded-full p-0 motion-safe:transition-transform motion-safe:duration-150 motion-safe:active:scale-95"
             aria-label={t("accounts.toolbar.createGroup")}
             title={t("accounts.toolbar.createGroup")}
             onClick={() => setCreateGroupOpen(true)}
@@ -168,7 +168,7 @@ export function AccountsToolbar({
 
           <Button
             variant="ghost"
-            className="h-10 w-10 rounded-full p-0 transition-[transform] duration-150 active:scale-95"
+            className="h-10 w-10 rounded-full p-0 motion-safe:transition-transform motion-safe:duration-150 motion-safe:active:scale-95"
             aria-label={t("accounts.toolbar.editGroups")}
             title={t("accounts.toolbar.editGroups")}
             onClick={() => setAccountGroupBoardOpen(true)}
@@ -214,7 +214,7 @@ export function AccountsToolbar({
             </Button>
             <Button onClick={() => void handleCreateGroup()} disabled={isCreating || !groupName.trim()}>
               {isCreating ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 aria-hidden className="h-4 w-4 motion-safe:animate-spin" />
               ) : (
                 t("accounts.toolbar.createGroup")
               )}

--- a/app/[locale]/dashboard/components/accounts/propfirms-comparison-table.tsx
+++ b/app/[locale]/dashboard/components/accounts/propfirms-comparison-table.tsx
@@ -11,15 +11,29 @@ import {
 import {
   Table,
   TableBody,
+  TableCaption,
   TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { useCurrentLocale } from '@/locales/client';
 import { propFirms, AccountSize } from './config';
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetHeader,
+  formatCount,
+  formatCurrency,
+  formatPercent,
+} from '../widgets';
+
+/** A value the compared account does not define. */
+const NO_VALUE = '-';
 
 export function ComparisonTable() {
+  const locale = useCurrentLocale();
   const [firstSelection, setFirstSelection] = useState<{
     propFirm: string;
     account: string;
@@ -37,16 +51,25 @@ export function ComparisonTable() {
     : null;
 
   const renderValue = (value: any) => {
-    if (value === null) return '-';
+    if (value === null || value === undefined) return NO_VALUE;
     if (typeof value === 'boolean') return value ? 'Yes' : 'No';
     if (typeof value === 'number') {
       if (value >= 1000) {
-        return `$${value.toLocaleString()}`;
+        return formatCurrency(value, locale, { maximumFractionDigits: 0 });
       }
-      return value;
+      return formatCount(value, locale);
     }
     return value;
   };
+
+  /*
+   * Peer figures share one precision, picked once in the shared formatters
+   * rather than re-derived per row with template strings.
+   */
+  const money = (v: any) =>
+    v === null || v === undefined ? NO_VALUE : formatCurrency(Number(v), locale, { maximumFractionDigits: 0 });
+  const percent = (v: any) =>
+    v === null || v === undefined ? NO_VALUE : formatPercent(Number(v), locale);
 
   const comparisonFields: {
     label: string;
@@ -54,26 +77,24 @@ export function ComparisonTable() {
     format?: (value: any) => string;
   }[] = [
     { label: 'Account Name', key: 'name' },
-    { label: 'Price', key: 'price', format: (v) => `$${v}` },
-    { label: 'Price with Promo', key: 'priceWithPromo', format: (v) => `$${v}` },
-    { label: 'Target', key: 'target', format: (v) => `$${v}` },
-    { label: 'Daily Loss', key: 'dailyLoss', format: (v) => v ? `$${v}` : '-' },
-    { label: 'Drawdown', key: 'drawdown', format: (v) => `$${v}` },
+    { label: 'Price', key: 'price', format: money },
+    { label: 'Price with Promo', key: 'priceWithPromo', format: money },
+    { label: 'Target', key: 'target', format: money },
+    { label: 'Daily Loss', key: 'dailyLoss', format: money },
+    { label: 'Drawdown', key: 'drawdown', format: money },
     { label: 'Min Days', key: 'minDays' },
-    { label: 'Consistency', key: 'consistency', format: (v) => v ? `${v}%` : '-' },
+    { label: 'Consistency', key: 'consistency', format: percent },
     { label: 'Trading News Allowed', key: 'tradingNewsAllowed' },
-    { label: 'Profit Sharing', key: 'profitSharing', format: (v) => `${v}%` },
-    { label: 'Min Payout', key: 'minPayout', format: (v) => `$${v}` },
+    { label: 'Profit Sharing', key: 'profitSharing', format: percent },
+    { label: 'Min Payout', key: 'minPayout', format: money },
     { label: 'Max Funded Accounts', key: 'maxFundedAccounts' },
   ];
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Prop Firm Comparison</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="flex gap-4 mb-6">
+    <WidgetCard>
+      <WidgetHeader title="Prop firm comparison" />
+      <WidgetBody className="overflow-auto">
+        <div className="mb-6 flex gap-4">
           <div className="flex-1">
             <Select
               value={firstSelection?.propFirm}
@@ -165,49 +186,54 @@ export function ComparisonTable() {
 
         {(firstAccount || secondAccount) && (
           <Table>
+            <TableCaption className="sr-only">
+              Feature by feature comparison of the two selected prop firm accounts
+            </TableCaption>
             <TableHeader>
               <TableRow>
-                <TableHead>Feature</TableHead>
-                <TableHead>
+                <TableHead scope="col">Feature</TableHead>
+                {/* Both value columns hold a mix of words and figures, so they
+                    are aligned as text and the numbers stay tabular. */}
+                <TableHead scope="col">
                   {firstAccount
                     ? `${propFirms[firstSelection!.propFirm].name} - ${
                         firstAccount.name
                       }`
-                    : '-'}
+                    : NO_VALUE}
                 </TableHead>
-                <TableHead>
+                <TableHead scope="col">
                   {secondAccount
                     ? `${propFirms[secondSelection!.propFirm].name} - ${
                         secondAccount.name
                       }`
-                    : '-'}
+                    : NO_VALUE}
                 </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {comparisonFields.map(({ label, key, format }) => (
                 <TableRow key={key}>
-                  <TableCell className="font-medium">{label}</TableCell>
-                  <TableCell>
+                  <TableCell scope="row" className="font-medium">{label}</TableCell>
+                  <TableCell className={cn('tabular-nums')}>
                     {firstAccount
                       ? format
                         ? format(firstAccount[key])
                         : renderValue(firstAccount[key])
-                      : '-'}
+                      : NO_VALUE}
                   </TableCell>
-                  <TableCell>
+                  <TableCell className={cn('tabular-nums')}>
                     {secondAccount
                       ? format
                         ? format(secondAccount[key])
                         : renderValue(secondAccount[key])
-                      : '-'}
+                      : NO_VALUE}
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         )}
-      </CardContent>
-    </Card>
+      </WidgetBody>
+    </WidgetCard>
   );
-} 
+}

--- a/app/[locale]/dashboard/components/accounts/trade-progress-chart.tsx
+++ b/app/[locale]/dashboard/components/accounts/trade-progress-chart.tsx
@@ -1,12 +1,28 @@
 'use client'
 
-import { Line, LineChart, CartesianGrid, XAxis, YAxis, ResponsiveContainer, ReferenceLine, Tooltip } from "recharts"
+import { Line, LineChart, XAxis, YAxis, ResponsiveContainer, Tooltip } from "recharts"
 import { ChartContainer } from "@/components/ui/chart"
 import { cn } from "@/lib/utils"
-import { useI18n } from "@/locales/client"
+import { useCurrentLocale, useI18n } from "@/locales/client"
 import { useMemo } from "react"
 import { Account } from "@/context/data-provider"
 import { useTradesStore } from "@/store/trades-store"
+import { WidgetSize } from "../../types/dashboard"
+import {
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetTooltip,
+  WidgetZeroLine,
+  axisProps,
+  chartColors,
+  chartMargin,
+  formatCompactCurrency,
+  formatCurrency,
+  formatTicks,
+  pnlTone,
+  pnlToneClass,
+  widgetType,
+} from "../widgets"
 
 // Add interface for event type
 interface ChartEvent {
@@ -35,15 +51,31 @@ interface TradeProgressChartProps {
   account: Account
   className?: string
   fillHeight?: boolean
+  size?: WidgetSize
+}
+
+/**
+ * A payout's status is genuine state, so it earns a color — but the status word
+ * always travels with it in the tooltip, so the color is never the only signal.
+ */
+function payoutColor(status: string): string {
+  switch (status) {
+    case 'PAID': return chartColors.win
+    case 'REFUSED': return chartColors.loss
+    case 'VALIDATED': return chartColors.foreground
+    default: return chartColors.neutral
+  }
 }
 
 export function TradeProgressChart({
   account,
   className,
   fillHeight = false,
+  size = 'medium',
 }: TradeProgressChartProps) {
   const t = useI18n()
-  
+  const locale = useCurrentLocale()
+
   // Prefer filtered trades from account (buffer-aware), fallback to store
   const allTrades = useTradesStore(state => state.trades)
   const trades = useMemo(() => {
@@ -51,31 +83,34 @@ export function TradeProgressChart({
     return allTrades.filter(trade => trade.accountNumber === account.number)
   }, [allTrades, account.trades, account.number])
 
+  // Three series: the balance is the subject, the two boundaries are the
+  // thresholds it is measured against. Colors come from theme tokens so the
+  // chart survives the theme swap without a `darkMode` branch.
   const chartConfig = {
     balance: {
       label: t('propFirm.chart.balance'),
-      color: "#2563eb",
+      color: chartColors.foreground,
     },
     drawdown: {
       label: t('propFirm.chart.drawdownLevel'),
-      color: "#dc2626",
+      color: chartColors.loss,
     },
     target: {
       label: t('propFirm.chart.profitTarget'),
-      color: "#16a34a",
+      color: chartColors.win,
     },
     payout: {
       label: t('propFirm.chart.payout'),
-      color: "#9333ea",
+      color: chartColors.neutral,
     }
   }
 
   // Extract account properties
-  const { 
-    startingBalance, 
-    drawdownThreshold, 
-    profitTarget, 
-    trailingDrawdown = false, 
+  const {
+    startingBalance,
+    drawdownThreshold,
+    profitTarget,
+    trailingDrawdown = false,
     trailingStopProfit,
     payouts = [],
     resetDate
@@ -108,7 +143,7 @@ export function TradeProgressChart({
   const chartData = allEvents.reduce((acc, event, index) => {
     let balance: number
     let highestBalance: number
-    
+
     if (event.isReset) {
       // Reset the balance to starting balance
       balance = startingBalance
@@ -116,17 +151,17 @@ export function TradeProgressChart({
     } else {
       const prevBalance = index > 0 ? acc[index - 1].balance : startingBalance
       balance = prevBalance + event.amount
-      
+
       // Calculate highest balance up to this point
       const previousHighest = index > 0 ? acc[index - 1].highestBalance : startingBalance
       highestBalance = event.isPayout ? previousHighest : Math.max(previousHighest, balance)
     }
-    
+
     // Calculate drawdown level based on trailing or fixed drawdown
     let drawdownLevel
     if (trailingDrawdown) {
       const profitMade = Math.max(0, highestBalance - startingBalance)
-      
+
       // If we've hit trailing stop profit, lock the drawdown to that level
       if (trailingStopProfit && profitMade >= trailingStopProfit) {
         drawdownLevel = (startingBalance + trailingStopProfit) - drawdownThreshold
@@ -154,22 +189,12 @@ export function TradeProgressChart({
     }]
   }, [] as ChartDataPoint[])
 
-  const getPayoutColor = (status: string) => {
-    switch (status) {
-      case 'PENDING': return '#9CA3AF'
-      case 'VALIDATED': return '#F97316'
-      case 'REFUSED': return '#DC2626'
-      case 'PAID': return '#16A34A'
-      default: return '#9CA3AF'
-    }
-  }
-
   const renderDot = (props: any) => {
     const { cx, cy, payload, index } = props
     if (typeof cx !== 'number' || typeof cy !== 'number') {
       return <circle key={`dot-${index}-empty`} cx={cx} cy={cy} r={0} fill="none" />
     }
-    
+
     if (payload?.isReset) {
       return (
         <circle
@@ -177,13 +202,13 @@ export function TradeProgressChart({
           cx={cx}
           cy={cy}
           r={5}
-          fill="#ff6b6b"
-          stroke="white"
+          fill={chartColors.primary}
+          stroke="hsl(var(--card))"
           strokeWidth={2}
         />
       )
     }
-    
+
     if (payload?.isPayout) {
       return (
         <circle
@@ -191,13 +216,13 @@ export function TradeProgressChart({
           cx={cx}
           cy={cy}
           r={4}
-          fill={getPayoutColor(payload.payoutStatus || '')}
-          stroke="white"
+          fill={payoutColor(payload.payoutStatus || '')}
+          stroke="hsl(var(--card))"
           strokeWidth={1}
         />
       )
     }
-    
+
     return <circle key={`dot-${index}-empty`} cx={cx} cy={cy} r={0} fill="none" />
   }
 
@@ -205,7 +230,7 @@ export function TradeProgressChart({
     <div
       className={cn(
         "w-full",
-        fillHeight ? "flex min-h-0 flex-1 flex-col" : "space-y-2"
+        fillHeight ? "flex min-h-0 flex-1 flex-col gap-1.5" : "flex flex-col gap-1.5"
       )}
     >
       <ChartContainer
@@ -217,80 +242,66 @@ export function TradeProgressChart({
       >
         {chartData.length > 0 ? (
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart
-              data={chartData}
-              margin={{
-                top: 20,
-                right: 30,
-                left: 20,
-                bottom: 20,
-              }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
+            <LineChart data={chartData} margin={chartMargin(size)}>
+              <WidgetChartGrid />
               <XAxis
                 dataKey="tradeIndex"
-                tickLine={false}
-                axisLine={true}
-                tickMargin={8}
+                {...axisProps(size)}
                 tick={false}
               />
               <YAxis
-                tickFormatter={(value) => `$${value.toLocaleString()}`}
+                {...axisProps(size)}
+                width={52}
+                tickFormatter={(value: number) => formatCompactCurrency(value, locale)}
                 domain={[
                   (dataMin: number) => Math.floor(Math.min(dataMin, startingBalance - drawdownThreshold) / 1000) * 1000,
                   (dataMax: number) => Math.ceil(Math.max(dataMax, startingBalance + profitTarget) / 1000) * 1000
                 ]}
-                axisLine={true}
               />
               <Tooltip
-                cursor={{ stroke: '#666', strokeWidth: 1, strokeDasharray: '3 3' }}
+                cursor={{ stroke: chartColors.grid, strokeWidth: 1, strokeDasharray: '3 3' }}
                 content={({ active, payload }) => {
-                  if (active && payload && payload.length) {
-                    const data = payload[0].payload as ChartDataPoint;
-                    return (
-                      <div className="bg-background/80 backdrop-blur-lg p-2 border rounded shadow-xs text-xs space-y-0.5">
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium">#{data.tradeIndex}</span>
-                          <span className="text-muted-foreground">{data.date}</span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-blue-600">${data.balance.toLocaleString()}</span>
-                          {!data.isPayout && !data.isReset && (
-                            <span className={cn(
-                              "text-sm",
-                              data.pnl >= 0 ? "text-green-600" : "text-red-600"
-                            )}>
-                              {data.pnl >= 0 ? '+' : ''}{data.pnl.toLocaleString()}
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-red-600">DD: ${data.drawdownLevel.toLocaleString()}</span>
-                          <span className="text-blue-600">High: ${data.highestBalance.toLocaleString()}</span>
-                        </div>
-                        {data.isReset && (
-                          <div className="flex items-center gap-2 text-red-500">
-                            <span className="font-medium">{t('propFirm.chart.accountReset')}</span>
-                          </div>
-                        )}
-                        {data.isPayout && data.payoutStatus && (
-                          <div className={cn(
-                            "flex items-center gap-2",
-                            {
-                              "text-gray-500": data.payoutStatus === 'PENDING',
-                              "text-orange-500": data.payoutStatus === 'VALIDATED',
-                              "text-red-500": data.payoutStatus === 'REFUSED',
-                              "text-green-500": data.payoutStatus === 'PAID',
-                            }
-                          )}>
-                            <span>${data.payoutAmount.toLocaleString()}</span>
-                            <span className="text-xs">({data.payoutStatus.toLowerCase()})</span>
-                          </div>
-                        )}
-                      </div>
-                    )
-                  }
-                  return null
+                  if (!active || !payload || !payload.length) return null
+                  const data = payload[0].payload as ChartDataPoint
+                  const rows = [
+                    {
+                      label: t('propFirm.chart.balance'),
+                      value: formatCurrency(data.balance, locale),
+                    },
+                    ...(!data.isPayout && !data.isReset
+                      ? [{
+                          label: t('propFirm.dailyStats.pnl'),
+                          value: formatCurrency(data.pnl, locale, { signDisplay: 'always' as const }),
+                          toneClassName: pnlToneClass(pnlTone(data.pnl)),
+                        }]
+                      : []),
+                    {
+                      label: t('propFirm.chart.drawdownLevel'),
+                      value: formatCurrency(data.drawdownLevel, locale),
+                      color: chartColors.loss,
+                    },
+                    ...(data.isPayout && data.payoutStatus
+                      ? [{
+                          label: `${t('propFirm.chart.payout')} (${data.payoutStatus.toLowerCase()})`,
+                          value: formatCurrency(data.payoutAmount, locale),
+                          color: payoutColor(data.payoutStatus),
+                        }]
+                      : []),
+                  ]
+                  const highestBalanceCaption = t('propFirm.chart.highestBalance', {
+                    amount: formatTicks(data.highestBalance, locale, { maximumFractionDigits: 2 }),
+                  })
+                  return (
+                    <WidgetTooltip
+                      title={`${t('propFirm.chart.tradeNumber', { number: data.tradeIndex })} · ${data.date}`}
+                      rows={rows}
+                      caption={
+                        data.isReset
+                          ? `${highestBalanceCaption} · ${t('propFirm.chart.accountReset')}`
+                          : highestBalanceCaption
+                      }
+                    />
+                  )
                 }}
               />
               <Line
@@ -300,6 +311,7 @@ export function TradeProgressChart({
                 stroke={chartConfig.balance.color}
                 strokeWidth={2}
                 dot={renderDot}
+                isAnimationActive={false}
               />
               <Line
                 type="monotone"
@@ -309,6 +321,7 @@ export function TradeProgressChart({
                 strokeWidth={1.5}
                 strokeDasharray="3 3"
                 dot={false}
+                isAnimationActive={false}
               />
               <Line
                 type="monotone"
@@ -318,26 +331,21 @@ export function TradeProgressChart({
                 strokeWidth={2}
                 strokeDasharray="5 5"
                 dot={false}
+                isAnimationActive={false}
               />
-              <ReferenceLine
-                y={startingBalance}
-                stroke="#666"
-                strokeDasharray="3 3"
-                label={{
-                  value: t('propFirm.chart.startingBalance'),
-                  position: "right",
-                  fill: "#666",
-                  fontSize: 12,
-                }}
-              />
+              {/* The honest baseline for this chart is the starting balance, not
+                  screen zero: every level above is profit, every level below is
+                  drawdown. It is stated in the caption, not only drawn. */}
+              <WidgetZeroLine y={startingBalance} />
             </LineChart>
           </ResponsiveContainer>
         ) : (
-          <div className="flex h-full items-center justify-center">
-            <p className="text-muted-foreground">{t('propFirm.chart.noTrades')}</p>
-          </div>
+          <WidgetEmpty message={t('propFirm.chart.noTrades')} />
         )}
       </ChartContainer>
+      <p className={widgetType.caption}>
+        {t('propFirm.chart.startingBalance')}: {formatCurrency(startingBalance, locale)}
+      </p>
     </div>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/calendar/charts.tsx
+++ b/app/[locale]/dashboard/components/calendar/charts.tsx
@@ -1,29 +1,46 @@
 "use client"
 
 import React from 'react'
-import { BarChart, Bar, Cell, Tooltip, ResponsiveContainer, Legend, XAxis, YAxis, CartesianGrid, LineChart, Line, ComposedChart, ReferenceLine } from "recharts"
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import {
-  ChartConfig,
-  ChartContainer,
-} from "@/components/ui/chart"
+  Bar,
+  BarChart,
+  Cell,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import { cn } from "@/lib/utils"
 import { CalendarEntry } from "@/app/[locale]/dashboard/types/calendar"
+import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
 import {
   BarChartLoadingSkeleton,
   ComposedChartLoadingSkeleton,
   LOADING_MOCK_CALENDAR_DISTRIBUTION,
   LOADING_MOCK_CALENDAR_EQUITY,
 } from "@/app/[locale]/dashboard/components/charts/chart-loading-skeleton"
-import { useTheme } from "@/context/theme-provider"
 import { useData } from "@/context/data-provider"
 import { useI18n, useCurrentLocale } from '@/locales/client'
-import { Skeleton } from "@/components/ui/skeleton"
+import {
+  axisProps,
+  chartColors,
+  chartMargin,
+  chartTickFontSize,
+  formatCompactCurrency,
+  formatCurrency,
+  formatPercent,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetSkeleton,
+  WidgetTooltip,
+  WidgetZeroLine,
+  widgetType,
+} from "../widgets"
 
 interface ChartsProps {
   dayData: CalendarEntry | undefined;
@@ -31,38 +48,121 @@ interface ChartsProps {
   isLoading?: boolean;
 }
 
-const chartConfig = {
-  pnl: {
-    label: "P&L Distribution",
-    color: "hsl(var(--success))",
-  },
-  equity: {
-    label: "Equity Variation",
-    color: "hsl(var(--chart-2))",
-  },
-} satisfies ChartConfig
+/** Charts live inside a modal, which is already a surface: no card around them. */
+const CHART_SIZE: WidgetSize = "medium"
 
-const formatCurrency = (value: number | undefined | null) => {
-  if (value == null) return '$0.00'
-  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+interface EquityDatum {
+  time: string
+  date: string
+  balance: number
+  pnl: number
+  tradeNumber: number
+}
+
+interface DistributionDatum {
+  name: string
+  value: number
+  account: string
+}
+
+/** Title on the left, the qualifier that makes it auditable on the right. */
+function ChartSectionHeader({
+  title,
+  caption,
+}: {
+  title: React.ReactNode
+  caption: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+      <h4 className={widgetType.section}>{title}</h4>
+      <span className={widgetType.caption}>{caption}</span>
+    </div>
+  )
+}
+
+function EquityTooltip({
+  active,
+  payload,
+  isWeekly,
+  t,
+  locale,
+}: {
+  active?: boolean
+  payload?: Array<{ payload: EquityDatum }>
+  isWeekly: boolean
+  t: ReturnType<typeof useI18n>
+  locale: string
+}) {
+  if (!active || !payload || payload.length === 0) return null
+  const data = payload[0].payload
+  return (
+    <WidgetTooltip
+      title={isWeekly ? data.date : data.time}
+      rows={[
+        {
+          label: t('calendar.charts.tradePnl'),
+          value: formatCurrency(data.pnl, locale),
+          toneClassName: pnlToneClass(pnlTone(data.pnl)),
+        },
+        {
+          label: t('calendar.charts.balance'),
+          value: formatCurrency(data.balance, locale),
+        },
+      ]}
+      caption={`${t('calendar.charts.tradeNumber')}: ${data.tradeNumber}`}
+    />
+  )
+}
+
+function DistributionTooltip({
+  active,
+  payload,
+  totalPnL,
+  t,
+  locale,
+}: {
+  active?: boolean
+  payload?: Array<{ payload: DistributionDatum }>
+  totalPnL: number
+  t: ReturnType<typeof useI18n>
+  locale: string
+}) {
+  if (!active || !payload || payload.length === 0) return null
+  const data = payload[0].payload
+  const share = totalPnL !== 0 ? (data.value / totalPnL) * 100 : null
+  return (
+    <WidgetTooltip
+      title={data.name}
+      rows={[
+        {
+          label: t('calendar.charts.accountPnl'),
+          value: formatCurrency(data.value, locale),
+          toneClassName: pnlToneClass(pnlTone(data.value)),
+        },
+      ]}
+      caption={
+        share !== null
+          ? `${formatPercent(share, locale)} ${t('calendar.charts.ofTotal')}`
+          : undefined
+      }
+    />
+  )
 }
 
 export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
-  const { effectiveTheme } = useTheme()
-  const isDarkMode = effectiveTheme === 'dark'
   const t = useI18n()
   const locale = useCurrentLocale()
   const { isLoading: globalIsLoading } = useData()
   const showLoading =
     dayData === undefined && (isLoading === true || globalIsLoading)
-  
+
   // Calculate data for charts
-  const { accountPnL, equityChartData, chartData, totalPnL, calculateCommonDomain } = React.useMemo(() => {
+  const { equityChartData, chartData, totalPnL, calculateCommonDomain } = React.useMemo(() => {
     if (showLoading || !dayData?.trades?.length) {
       return {
-        accountPnL: {},
-        equityChartData: [],
-        chartData: [],
+        equityChartData: [] as EquityDatum[],
+        chartData: [] as DistributionDatum[],
         totalPnL: 0,
         calculateCommonDomain: [0, 0] as [number, number]
       };
@@ -77,7 +177,7 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
     }, {} as Record<string, number>);
 
     // Convert to chart data format and sort
-    const chartData = Object.entries(accountPnL)
+    const chartData: DistributionDatum[] = Object.entries(accountPnL)
       .map(([account, pnl]) => ({
         name: account,
         value: pnl,
@@ -88,7 +188,7 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
     const totalPnL = chartData.reduce((sum, item) => sum + item.value, 0);
 
     // Calculate equity chart data
-    const equityChartData = [...dayData.trades]
+    const equityChartData: EquityDatum[] = [...dayData.trades]
       .sort((a, b) => new Date(a.entryDate).getTime() - new Date(b.entryDate).getTime())
       .map((trade, index) => {
         const runningBalance = dayData.trades
@@ -96,9 +196,9 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
           .reduce((sum, t) => sum + (t.pnl - (t.commission || 0)), 0);
         return {
           time: new Date(trade.entryDate).toLocaleTimeString(locale),
-          date: new Date(trade.entryDate).toLocaleDateString(locale, { 
-            weekday: 'short', 
-            month: 'short', 
+          date: new Date(trade.entryDate).toLocaleDateString(locale, {
+            weekday: 'short',
+            month: 'short',
             day: 'numeric',
           }),
           balance: runningBalance,
@@ -121,7 +221,7 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
 
     const overallMin = Math.min(distributionMin, equityMin);
     const overallMax = Math.max(distributionMax, equityMax);
-    
+
     const padding = (overallMax - overallMin) * 0.1;
     const calculateCommonDomain = [
       Math.floor((overallMin - padding) / 100) * 100,
@@ -129,7 +229,6 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
     ] as [number, number];
 
     return {
-      accountPnL,
       equityChartData,
       chartData,
       totalPnL,
@@ -139,17 +238,13 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
 
   if (showLoading) {
     return (
-      <div className="space-y-4">
-        <Card className="w-full">
-          <CardHeader>
-            <CardTitle className="text-base md:text-lg">
-              {isWeekly ? t('calendar.charts.weeklyEquityVariation') : t('calendar.charts.equityVariation')}
-            </CardTitle>
-            <CardDescription className="text-xs md:text-sm">
-              <Skeleton className="h-4 w-36" />
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="h-[200px] md:h-[250px]">
+      <div className="flex flex-col gap-6">
+        <section className="flex flex-col gap-2">
+          <ChartSectionHeader
+            title={isWeekly ? t('calendar.charts.weeklyEquityVariation') : t('calendar.charts.equityVariation')}
+            caption={<WidgetSkeleton className="inline-block h-3 w-36 align-middle" />}
+          />
+          <div className="h-[200px] md:h-[250px]">
             <ComposedChartLoadingSkeleton
               data={LOADING_MOCK_CALENDAR_EQUITY}
               xDataKey="time"
@@ -157,19 +252,15 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
               lineDataKey="balance"
               loadingLabel={t("equity.loading")}
             />
-          </CardContent>
-        </Card>
+          </div>
+        </section>
 
-        <Card className="w-full">
-          <CardHeader>
-            <CardTitle className="text-base md:text-lg">
-              {isWeekly ? t('calendar.charts.weeklyPnlDistribution') : t('calendar.charts.dailyPnlDistribution')}
-            </CardTitle>
-            <CardDescription className="text-xs md:text-sm">
-              <Skeleton className="h-4 w-44" />
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="h-[250px] md:h-[300px] pb-8 md:pb-16">
+        <section className="flex flex-col gap-2">
+          <ChartSectionHeader
+            title={isWeekly ? t('calendar.charts.weeklyPnlDistribution') : t('calendar.charts.dailyPnlDistribution')}
+            caption={<WidgetSkeleton className="inline-block h-3 w-44 align-middle" />}
+          />
+          <div className="h-[250px] md:h-[300px]">
             <BarChartLoadingSkeleton
               data={LOADING_MOCK_CALENDAR_DISTRIBUTION}
               xDataKey="name"
@@ -178,223 +269,166 @@ export function Charts({ dayData, isWeekly = false, isLoading }: ChartsProps) {
               marginVariant="calendar"
               loadingLabel={t("equity.loading")}
             />
-          </CardContent>
-        </Card>
+          </div>
+        </section>
       </div>
     )
   }
 
   if (!dayData?.trades?.length) {
-    return (
-      <div className="h-full flex items-center justify-center">
-        <p className="text-muted-foreground">{t('calendar.charts.noTradeData')}</p>
-      </div>
-    )
+    return <WidgetEmpty message={t('calendar.charts.noTradeData')} />
   }
 
-  // Generate colors based on theme
-  const colors = isDarkMode 
-    ? ['#8b5cf6', '#6366f1', '#3b82f6', '#0ea5e9', '#06b6d4', '#14b8a6']  // Dark mode colors
-    : ['#a78bfa', '#818cf8', '#60a5fa', '#38bdf8', '#22d3ee', '#2dd4bf']  // Light mode colors
-
-  const EquityTooltip = ({ active, payload, label }: any) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload
-      return (
-        <div className="bg-background p-2 border rounded shadow-xs text-xs md:text-sm">
-          <p className="font-semibold">{isWeekly ? data.date : data.time}</p>
-          {payload.map((entry: any, index: number) => (
-            <p key={index} className={`font-bold ${entry.dataKey === 'pnl' ? (entry.value >= 0 ? 'text-green-600' : 'text-red-600') : 'text-blue-600'}`}>
-              {entry.name}: {formatCurrency(entry.value)}
-            </p>
-          ))}
-          <p className="text-muted-foreground text-xs">
-            {t('calendar.charts.tradeNumber')}: {data.tradeNumber}
-          </p>
-        </div>
-      )
-    }
-    return null
-  }
-
-  const DistributionTooltip = ({ active, payload }: any) => {
-    if (active && payload?.[0]) {
-      const data = payload[0].payload
-      const percentage = data.account !== 'total' 
-        ? ((data.value / totalPnL) * 100).toFixed(1)
-        : '100'
-      return (
-        <div className="bg-background p-2 border rounded shadow-xs text-xs md:text-sm">
-          <p className="font-semibold">{data.name}</p>
-          <p className={`font-bold ${data.value >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-            {formatCurrency(data.value)}
-          </p>
-          {data.account !== 'total' && (
-            <p className="text-muted-foreground">
-              {percentage}% {t('calendar.charts.ofTotal')}
-            </p>
-          )}
-        </div>
-      )
-    }
-    return null
-  }
+  const finalBalance = equityChartData[equityChartData.length - 1]?.balance ?? 0
 
   return (
-    <div className="space-y-4">
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle className="text-base md:text-lg">
-            {isWeekly ? t('calendar.charts.weeklyEquityVariation') : t('calendar.charts.equityVariation')}
-          </CardTitle>
-          <CardDescription className="text-xs md:text-sm">
-            {t('calendar.charts.finalBalance')}: {formatCurrency(equityChartData[equityChartData.length - 1]?.balance || 0)}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="h-[200px] md:h-[250px]">
-          <ChartContainer config={chartConfig} className="h-full w-full">
-            <ResponsiveContainer width="100%" height="100%">
-              <ComposedChart
-                data={equityChartData}
-                margin={{ 
-                  top: 10, 
-                  right: 8, 
-                  left: 35, 
-                  bottom: 40 
+    <div className="flex flex-col gap-6">
+      <section className="flex flex-col gap-2">
+        <ChartSectionHeader
+          title={isWeekly ? t('calendar.charts.weeklyEquityVariation') : t('calendar.charts.equityVariation')}
+          caption={
+            <>
+              {t('calendar.charts.finalBalance')}:{' '}
+              <span className={cn(widgetType.value, pnlToneClass(pnlTone(finalBalance)))}>
+                {formatCurrency(finalBalance, locale)}
+              </span>
+            </>
+          }
+        />
+        <div className="h-[200px] md:h-[250px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart
+              data={equityChartData}
+              margin={chartMargin(CHART_SIZE)}
+            >
+              <WidgetChartGrid />
+              <XAxis
+                dataKey={isWeekly ? "date" : "time"}
+                {...axisProps(CHART_SIZE)}
+                angle={-45}
+                textAnchor="end"
+                height={44}
+                tickFormatter={(value: string) => {
+                  if (isWeekly) {
+                    return value;
+                  }
+                  const [hours, minutes] = value.split(':');
+                  return `${hours}:${minutes}`;
                 }}
+              />
+              <YAxis
+                {...axisProps(CHART_SIZE)}
+                tickFormatter={(value: number) => formatCompactCurrency(value, locale)}
+                domain={calculateCommonDomain}
+                width={56}
+              />
+              <WidgetZeroLine />
+              <Tooltip
+                content={<EquityTooltip isWeekly={isWeekly} t={t} locale={locale} />}
+                wrapperStyle={{ zIndex: 1000 }}
+                cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+              />
+              <Bar
+                dataKey="pnl"
+                name={t('calendar.charts.tradePnl')}
+                isAnimationActive={false}
               >
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis 
-                  dataKey={isWeekly ? "date" : "time"}
-                  angle={-45}
-                  textAnchor="end"
-                  height={40}
-                  tick={{ fontSize: '10px' }}
-                  tickFormatter={(value) => {
-                    if (isWeekly) {
-                      return value;
-                    }
-                    const [hours, minutes] = value.split(':');
-                    return `${hours}:${minutes}`;
-                  }}
-                />
-                <YAxis
-                  tickFormatter={(value) => formatCurrency(value)}
-                  domain={calculateCommonDomain}
-                  tick={{ fontSize: '10px' }}
-                  width={50}
-                />
-                <Tooltip 
-                  content={<EquityTooltip />}
-                  wrapperStyle={{ zIndex: 1000 }}
-                  cursor={{ strokeWidth: 2 }}
-                />
-                <Bar
-                  dataKey="pnl"
-                  name={t('calendar.charts.tradePnl')}
-                  opacity={0.8}
-                >
-                  {equityChartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={entry.pnl >= 0 ? 'hsl(var(--success))' : 'hsl(var(--destructive))'}
-                      className="transition-all duration-300 ease-in-out hover:opacity-70"
-                    />
-                  ))}
-                </Bar>
-                <Line
-                  type="stepAfter"
-                  dataKey="balance"
-                  stroke={chartConfig.equity.color}
-                  strokeWidth={2}
-                  dot={false}
-                  activeDot={false}
-                  name={t('calendar.charts.balance')}
-                />
-              </ComposedChart>
-            </ResponsiveContainer>
-          </ChartContainer>
-        </CardContent>
-      </Card>
+                {equityChartData.map((entry) => (
+                  <Cell
+                    key={`equity-${entry.tradeNumber}`}
+                    fill={pnlToneFill(pnlTone(entry.pnl))}
+                  />
+                ))}
+              </Bar>
+              <Line
+                type="stepAfter"
+                dataKey="balance"
+                stroke={chartColors.foreground}
+                strokeWidth={2}
+                dot={false}
+                activeDot={false}
+                isAnimationActive={false}
+                name={t('calendar.charts.balance')}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
 
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle className="text-base md:text-lg">
-            {isWeekly ? t('calendar.charts.weeklyPnlDistribution') : t('calendar.charts.dailyPnlDistribution')}
-          </CardTitle>
-          <CardDescription className="text-xs md:text-sm">
-            {isWeekly ? t('calendar.charts.weeklyTotalPnlAfterComm') : t('calendar.charts.totalPnlAfterComm')}: {formatCurrency(totalPnL)}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="h-[250px] md:h-[300px] pb-8 md:pb-16">
-          <ChartContainer config={chartConfig} className="h-full w-full">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                margin={{ 
-                  top: 10, 
-                  right: 16, 
-                  left: 35, 
-                  bottom: 60 
+      <section className="flex flex-col gap-2">
+        <ChartSectionHeader
+          title={isWeekly ? t('calendar.charts.weeklyPnlDistribution') : t('calendar.charts.dailyPnlDistribution')}
+          caption={
+            <>
+              {isWeekly ? t('calendar.charts.weeklyTotalPnlAfterComm') : t('calendar.charts.totalPnlAfterComm')}:{' '}
+              <span className={cn(widgetType.value, pnlToneClass(pnlTone(totalPnL)))}>
+                {formatCurrency(totalPnL, locale)}
+              </span>
+            </>
+          }
+        />
+        <div className="h-[250px] md:h-[300px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={chartMargin(CHART_SIZE)}
+              barCategoryGap={4}
+            >
+              <WidgetChartGrid />
+              <XAxis
+                type="category"
+                dataKey="name"
+                {...axisProps(CHART_SIZE)}
+                height={64}
+                interval={0}
+                tick={(props: { x: number; y: number; payload: { value: string } }) => {
+                  const { x, y, payload } = props;
+                  return (
+                    <g transform={`translate(${x},${y})`}>
+                      <text
+                        dy={8}
+                        dx={-4}
+                        textAnchor="end"
+                        transform="rotate(-45)"
+                        fontSize={chartTickFontSize(CHART_SIZE)}
+                        fill={chartColors.tick}
+                      >
+                        {payload.value}
+                      </text>
+                    </g>
+                  );
                 }}
-                barCategoryGap={4}
+              />
+              <YAxis
+                type="number"
+                {...axisProps(CHART_SIZE)}
+                tickFormatter={(value: number) => formatCompactCurrency(value, locale)}
+                domain={calculateCommonDomain}
+                width={56}
+              />
+              <WidgetZeroLine />
+              <Tooltip
+                content={<DistributionTooltip totalPnL={totalPnL} t={t} locale={locale} />}
+                wrapperStyle={{ zIndex: 1000 }}
+                cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+              />
+              <Bar
+                dataKey="value"
+                barSize={20}
+                name={t('calendar.charts.accountPnl')}
+                isAnimationActive={false}
               >
-                <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                <XAxis 
-                  type="category" 
-                  dataKey="name"
-                  axisLine={false}
-                  tickLine={false}
-                  height={60}
-                  interval={0}
-                  tick={(props) => {
-                    const { x, y, payload } = props;
-                    return (
-                      <g transform={`translate(${x},${y})`}>
-                        <text
-                          dy={8}
-                          dx={-4}
-                          textAnchor="end"
-                          transform="rotate(-45)"
-                          className="text-[8px] md:text-[10px] fill-current"
-                        >
-                          {payload.value}
-                        </text>
-                      </g>
-                    );
-                  }}
-                />
-                <YAxis 
-                  type="number"
-                  tickFormatter={(value) => formatCurrency(value)}
-                  domain={calculateCommonDomain}
-                  tick={{ fontSize: '10px' }}
-                  width={50}
-                />
-                <ReferenceLine y={0} stroke="hsl(var(--muted-foreground))" />
-                <Tooltip 
-                  content={<DistributionTooltip />}
-                  wrapperStyle={{ zIndex: 1000 }}
-                  cursor={{ fillOpacity: 0.3 }}
-                />
-                <Bar 
-                  dataKey="value" 
-                  barSize={20}
-                  name={t('calendar.charts.accountPnl')}
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={entry.value >= 0 ? colors[index % colors.length] : `hsl(var(--destructive))`}
-                      className="transition-all duration-300 ease-in-out hover:opacity-80"
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          </ChartContainer>
-        </CardContent>
-      </Card>
+                {chartData.map((entry) => (
+                  <Cell
+                    key={`distribution-${entry.account}`}
+                    fill={pnlToneFill(pnlTone(entry.value))}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
     </div>
   )
 }

--- a/app/[locale]/dashboard/components/calendar/daily-comment.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-comment.tsx
@@ -1,13 +1,6 @@
 "use client";
 
 import React from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -19,8 +12,8 @@ import { format } from "date-fns";
 import { useUserStore } from "../../../../../store/user-store";
 import { useMoodStore } from "@/store/widgets/mood-store";
 
-import { Skeleton } from "@/components/ui/skeleton";
 import { TiptapEditor } from "@/components/tiptap-editor";
+import { WidgetSkeleton, widgetType } from "../widgets";
 
 interface DailyCommentProps {
   dayData: CalendarEntry | undefined;
@@ -144,9 +137,7 @@ export function DailyComment({ dayData, selectedDate }: DailyCommentProps) {
         )}
       >
         {isLoading ? (
-          <div className="space-y-3">
-            <Skeleton className="h-[400px] w-full" />
-          </div>
+          <WidgetSkeleton className="h-[400px] w-full" />
         ) : (
           <TiptapEditor
             key={`${(selectedDate instanceof Date ? selectedDate : new Date(selectedDate)).toISOString()}-${comment ? "has-content" : "no-content"}`}
@@ -159,14 +150,17 @@ export function DailyComment({ dayData, selectedDate }: DailyCommentProps) {
           />
         )}
       </div>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3 pt-2">
         {isSavingComment && (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
+          <div className={cn(widgetType.label, "flex items-center gap-2")}>
+            <Loader2
+              aria-hidden
+              className="h-3.5 w-3.5 motion-safe:animate-spin"
+            />
             {t("calendar.charts.saving")}
           </div>
         )}
-        {saveError && <p className="text-sm text-destructive">{saveError}</p>}
+        {saveError && <p className="text-xs text-destructive">{saveError}</p>}
         <Button
           onClick={handleSaveComment}
           disabled={isLoading || isSavingComment || !comment.trim()}

--- a/app/[locale]/dashboard/components/calendar/daily-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-modal.tsx
@@ -29,6 +29,13 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 import { useUserStore } from "../../../../../store/user-store";
 import { TradeTableReview } from "../tables/trade-table-review";
 import StatisticsWidget from "../statistics/statistics-widget";
+import {
+  formatCount,
+  formatCurrency,
+  pnlTone,
+  pnlToneClass,
+  widgetType,
+} from "../widgets";
 
 interface CalendarModalProps {
   isOpen: boolean;
@@ -45,15 +52,12 @@ interface DailyTabsProps {
   layout: "dialog" | "drawer";
 }
 
-const formatSignedCurrency = (value: number) => {
-  const formatted = Math.abs(value).toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 0,
+/** Whole-dollar money for the modal header. Sans + tabular-nums, sign on the number. */
+const formatSignedCurrency = (value: number, locale: string) =>
+  formatCurrency(value, locale, {
     maximumFractionDigits: 0,
+    signDisplay: "always",
   });
-  return value < 0 ? `-${formatted}` : `+${formatted}`;
-};
 
 function DailyTabs({ selectedDate, dayData, isLoading, layout }: DailyTabsProps) {
   const t = useI18n();
@@ -164,19 +168,18 @@ export function CalendarModal({
               {dayData && (
                 <span
                   className={cn(
-                    "text-sm font-semibold shrink-0",
-                    dayData.pnl >= 0
-                      ? "text-green-600 dark:text-green-400"
-                      : "text-red-600 dark:text-red-400",
+                    widgetType.value,
+                    "shrink-0",
+                    pnlToneClass(pnlTone(dayData.pnl)),
                   )}
                 >
-                  {formatSignedCurrency(dayData.pnl)}
+                  {formatSignedCurrency(dayData.pnl, locale)}
                 </span>
               )}
             </div>
             <DrawerDescription className="text-xs">
               {tradeCount > 0
-                ? `${tradeCount} ${tradeCount > 1 ? t("calendar.trades") : t("calendar.trade")}`
+                ? `${formatCount(tradeCount, locale)} ${tradeCount > 1 ? t("calendar.trades") : t("calendar.trade")}`
                 : t("calendar.modal.noTrades")}
             </DrawerDescription>
           </DrawerHeader>

--- a/app/[locale]/dashboard/components/calendar/daily-mood.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-mood.tsx
@@ -3,18 +3,14 @@
 import React from 'react'
 import { Frown, Meh, Smile } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { cn } from "@/lib/utils"
 import { CalendarEntry } from "@/app/[locale]/dashboard/types/calendar"
 import { toast } from "sonner"
 import { useI18n } from '@/locales/client'
 import { saveMood, getMoodForDay } from '@/server/journal'
 import { format } from 'date-fns'
 import { useUserStore } from '../../../../../store/user-store'
+import { widgetType } from "../widgets"
 
 interface DailyMoodProps {
   dayData: CalendarEntry | undefined;
@@ -24,11 +20,19 @@ interface DailyMoodProps {
 
 const STORAGE_KEY = 'daily_mood'
 
+type MoodValue = 'bad' | 'okay' | 'great'
+
+const MOOD_ICONS = {
+  bad: Frown,
+  okay: Meh,
+  great: Smile,
+} as const
+
 export function DailyMood({ dayData, isWeekly = false, selectedDate }: DailyMoodProps) {
   const user = useUserStore(state => state.user)
   const t = useI18n()
-  const [isLoading, setIsLoading] = React.useState<'bad' | 'okay' | 'great' | null>(null)
-  const [selectedMood, setSelectedMood] = React.useState<'bad' | 'okay' | 'great' | null>(null)
+  const [isLoading, setIsLoading] = React.useState<MoodValue | null>(null)
+  const [selectedMood, setSelectedMood] = React.useState<MoodValue | null>(null)
 
   // Load mood from localStorage or fetch from server on mount
   React.useEffect(() => {
@@ -38,7 +42,7 @@ export function DailyMood({ dayData, isWeekly = false, selectedDate }: DailyMood
       // Check localStorage first
       const focusedDay = selectedDate.toISOString().split('T')[0]
       const storedMoodData = localStorage.getItem(STORAGE_KEY)
-      
+
       if (storedMoodData) {
         const storedMood = JSON.parse(storedMoodData)
         if (storedMood.date === focusedDay) {
@@ -52,7 +56,7 @@ export function DailyMood({ dayData, isWeekly = false, selectedDate }: DailyMood
         const dateKey = format(selectedDate, 'yyyy-MM-dd')
         const mood = await getMoodForDay(dateKey)
         if (mood) {
-          setSelectedMood(mood.mood as 'bad' | 'okay' | 'great')
+          setSelectedMood(mood.mood as MoodValue)
           // Update localStorage
           localStorage.setItem(STORAGE_KEY, JSON.stringify({
             mood: mood.mood,
@@ -67,7 +71,7 @@ export function DailyMood({ dayData, isWeekly = false, selectedDate }: DailyMood
     loadMood()
   }, [user?.id, selectedDate])
 
-  const handleMoodSelect = async (mood: 'bad' | 'okay' | 'great') => {
+  const handleMoodSelect = async (mood: MoodValue) => {
     if (!user?.id) {
       toast.error(t('auth.required'))
       return
@@ -81,7 +85,7 @@ export function DailyMood({ dayData, isWeekly = false, selectedDate }: DailyMood
       const dateKey = format(selectedDate, 'yyyy-MM-dd')
       await saveMood(mood, [], dateKey)
       setSelectedMood(mood)
-      
+
       // Save to localStorage
       const focusedDay = date.toISOString().split('T')[0]
       localStorage.setItem(STORAGE_KEY, JSON.stringify({
@@ -98,116 +102,62 @@ export function DailyMood({ dayData, isWeekly = false, selectedDate }: DailyMood
     }
   }
 
-  if (!dayData?.trades?.length) {
-    return (
-      <div className="space-y-4">
-        <Card className="flex flex-col">
-          <CardHeader className="pb-1 flex-1">
-            <CardTitle className="text-base md:text-lg">
-              {isWeekly ? t('calendar.charts.weeklyMood') : t('calendar.charts.howWasYourDay')}
-            </CardTitle>
-          </CardHeader>
-          {!isWeekly && (
-            <CardContent className="pt-2 mt-auto">
-              <div className="flex justify-around items-center">
-                <Button
-                  variant="ghost"
-                  size="lg"
-                  className={`flex flex-col items-center h-auto py-2 px-4 ${selectedMood === 'bad' ? 'text-red-500' : ''}`}
-                  onClick={() => handleMoodSelect('bad')}
-                  disabled={isLoading !== null}
-                >
-                  <Frown className={`h-6 w-6 ${isLoading === 'bad' ? 'animate-pulse' : ''}`} />
-                </Button>
-                
-                <Button
-                  variant="ghost"
-                  size="lg"
-                  className={`flex flex-col items-center h-auto py-2 px-4 ${selectedMood === 'okay' ? 'text-yellow-500' : ''}`}
-                  onClick={() => handleMoodSelect('okay')}
-                  disabled={isLoading !== null}
-                >
-                  <Meh className={`h-6 w-6 ${isLoading === 'okay' ? 'animate-pulse' : ''}`} />
-                </Button>
-                
-                <Button
-                  variant="ghost"
-                  size="lg"
-                  className={`flex flex-col items-center h-auto py-2 px-4 ${selectedMood === 'great' ? 'text-green-500' : ''}`}
-                  onClick={() => handleMoodSelect('great')}
-                  disabled={isLoading !== null}
-                >
-                  <Smile className={`h-6 w-6 ${isLoading === 'great' ? 'animate-pulse' : ''}`} />
-                </Button>
-              </div>
-              <p className="text-sm text-muted-foreground mt-4 text-center">
-                {t('calendar.modal.noTrades')}
-              </p>
-            </CardContent>
-          )}
-          {isWeekly && (
-            <CardContent className="pt-2 mt-auto">
-              <p className="text-sm text-muted-foreground">
-                {t('calendar.charts.weeklyMoodNotAvailable')}
-              </p>
-            </CardContent>
-          )}
-        </Card>
-      </div>
-    )
-  }
+  const moods: { value: MoodValue; label: string }[] = [
+    { value: 'bad', label: t('mood.bad') },
+    { value: 'okay', label: t('mood.okay') },
+    { value: 'great', label: t('mood.great') },
+  ]
 
+  const hasTrades = Boolean(dayData?.trades?.length)
+
+  /*
+   * This sits inside a modal, which is already a surface: a titled group with
+   * spacing, not a card. Mood is ordinary metadata, so it stays monochrome and
+   * every state carries its own text label.
+   */
   return (
-    <div className="space-y-4">
-      <Card className="flex flex-col">
-        <CardHeader className="pb-1 flex-1">
-          <CardTitle className="text-base md:text-lg">
-            {isWeekly ? t('calendar.charts.weeklyMood') : t('calendar.charts.howWasYourDay')}
-          </CardTitle>
-        </CardHeader>
-        {!isWeekly && (
-          <CardContent className="pt-2 mt-auto">
-            <div className="flex justify-around items-center">
-              <Button
-                variant="ghost"
-                size="lg"
-                className={`flex flex-col items-center h-auto py-2 px-4 ${selectedMood === 'bad' ? 'text-red-500' : ''}`}
-                onClick={() => handleMoodSelect('bad')}
-                disabled={isLoading !== null}
-              >
-                <Frown className={`h-6 w-6 ${isLoading === 'bad' ? 'animate-pulse' : ''}`} />
-              </Button>
-              
-              <Button
-                variant="ghost"
-                size="lg"
-                className={`flex flex-col items-center h-auto py-2 px-4 ${selectedMood === 'okay' ? 'text-yellow-500' : ''}`}
-                onClick={() => handleMoodSelect('okay')}
-                disabled={isLoading !== null}
-              >
-                <Meh className={`h-6 w-6 ${isLoading === 'okay' ? 'animate-pulse' : ''}`} />
-              </Button>
-              
-              <Button
-                variant="ghost"
-                size="lg"
-                className={`flex flex-col items-center h-auto py-2 px-4 ${selectedMood === 'great' ? 'text-green-500' : ''}`}
-                onClick={() => handleMoodSelect('great')}
-                disabled={isLoading !== null}
-              >
-                <Smile className={`h-6 w-6 ${isLoading === 'great' ? 'animate-pulse' : ''}`} />
-              </Button>
-            </div>
-          </CardContent>
-        )}
-        {isWeekly && (
-          <CardContent className="pt-2 mt-auto">
-            <p className="text-sm text-muted-foreground">
-              {t('calendar.charts.weeklyMoodNotAvailable')}
-            </p>
-          </CardContent>
-        )}
-      </Card>
-    </div>
+    <section className="flex flex-col gap-2">
+      <h4 className={widgetType.section}>
+        {isWeekly ? t('calendar.charts.weeklyMood') : t('calendar.charts.howWasYourDay')}
+      </h4>
+      {isWeekly ? (
+        <p className={widgetType.label}>
+          {t('calendar.charts.weeklyMoodNotAvailable')}
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-1">
+            {moods.map(({ value, label }) => {
+              const Icon = MOOD_ICONS[value]
+              const isSelected = selectedMood === value
+              return (
+                <Button
+                  key={value}
+                  type="button"
+                  variant={isSelected ? 'secondary' : 'ghost'}
+                  size="sm"
+                  aria-pressed={isSelected}
+                  className="h-8 gap-1.5 px-2"
+                  onClick={() => handleMoodSelect(value)}
+                  disabled={isLoading !== null}
+                >
+                  <Icon
+                    aria-hidden
+                    className={cn(
+                      "h-4 w-4",
+                      isLoading === value && "motion-safe:animate-pulse",
+                    )}
+                  />
+                  <span className="text-xs">{label}</span>
+                </Button>
+              )
+            })}
+          </div>
+          {!hasTrades && (
+            <p className={widgetType.label}>{t('calendar.modal.noTrades')}</p>
+          )}
+        </>
+      )}
+    </section>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/calendar/daily-stats.tsx
+++ b/app/[locale]/dashboard/components/calendar/daily-stats.tsx
@@ -1,38 +1,25 @@
 "use client"
 
 import React from 'react'
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
 import { CalendarEntry } from "@/app/[locale]/dashboard/types/calendar"
-import { useI18n } from '@/locales/client'
-import { DailyMood } from './daily-mood'
+import { useCurrentLocale, useI18n } from '@/locales/client'
+import {
+  WidgetMetric,
+  formatCount,
+  formatCurrency,
+  formatDuration,
+  pnlTone,
+  pnlToneClass,
+} from "../widgets"
 
 interface DailyStatsProps {
   dayData: CalendarEntry | undefined;
   isWeekly?: boolean;
 }
 
-const formatCurrency = (value: number | undefined | null) => {
-  if (value == null) return '$0.00'
-  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-}
-
-const formatDuration = (seconds: number) => {
-  const hours = Math.floor(seconds / 3600)
-  const minutes = Math.floor((seconds % 3600) / 60)
-  const remainingSeconds = Math.floor(seconds % 60)
-  
-  if (hours > 0) return `${hours}h ${minutes}m ${remainingSeconds}s`
-  if (minutes > 0) return `${minutes}m ${remainingSeconds}s`
-  return `${remainingSeconds}s`
-}
-
 export function DailyStats({ dayData, isWeekly = false }: DailyStatsProps) {
   const t = useI18n()
+  const locale = useCurrentLocale()
 
   // Calculate stats
   const { totalPnL, avgTimeInPosition, accountCount, maxDrawdown, maxProfit } = React.useMemo(() => {
@@ -98,71 +85,47 @@ export function DailyStats({ dayData, isWeekly = false }: DailyStatsProps) {
     return null
   }
 
+  const tradeCount = dayData.trades.length
+
+  /*
+   * The modal is already a surface: these four figures are a stat row separated
+   * by spacing, not four nested cards. Only the P&L values carry tone, and each
+   * one keeps its sign so the color is never the only signal.
+   */
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
-        <Card className="flex flex-col">
-          <CardHeader className="pb-1 flex-1">
-            <CardTitle className="text-base md:text-lg">
-              {isWeekly ? t('calendar.charts.weeklyPnlAfterComm') : t('calendar.charts.dailyPnlAfterComm')}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="pt-2 mt-auto">
-            <p className={`text-xl md:text-2xl font-bold ${totalPnL >= 0 ? 'text-[hsl(var(--success))]' : 'text-[hsl(var(--destructive))]'}`}>
-              {formatCurrency(totalPnL)}
-            </p>
-            <p className="text-xs md:text-sm text-muted-foreground mt-1">
-              {t('calendar.charts.across')} {accountCount} {accountCount > 1 
-                ? t('calendar.charts.accounts') 
-                : t('calendar.charts.account')}
-            </p>
-          </CardContent>
-        </Card>
+    <div className="grid grid-cols-2 gap-x-6 gap-y-4 lg:grid-cols-4">
+      <WidgetMetric
+        size="small"
+        label={isWeekly ? t('calendar.charts.weeklyPnlAfterComm') : t('calendar.charts.dailyPnlAfterComm')}
+        value={formatCurrency(totalPnL, locale)}
+        toneClassName={pnlToneClass(pnlTone(totalPnL))}
+        caption={`${t('calendar.charts.across')} ${formatCount(accountCount, locale)} ${accountCount > 1
+          ? t('calendar.charts.accounts')
+          : t('calendar.charts.account')}`}
+      />
 
-        <Card className="flex flex-col">
-          <CardHeader className="pb-1 flex-1">
-            <CardTitle className="text-base md:text-lg">
-              {isWeekly ? t('calendar.charts.weeklyAvgTimeInPosition') : t('calendar.charts.avgTimeInPosition')}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="pt-2 mt-auto">
-            <p className="text-xl md:text-2xl font-bold">
-              {formatDuration(avgTimeInPosition)}
-            </p>
-            <p className="text-xs md:text-sm text-muted-foreground mt-1">
-              {t('calendar.charts.over')} {dayData.trades.length} {dayData.trades.length > 1 
-                ? t('calendar.charts.trades') 
-                : t('calendar.charts.trade')}
-            </p>
-          </CardContent>
-        </Card>
+      <WidgetMetric
+        size="small"
+        label={isWeekly ? t('calendar.charts.weeklyAvgTimeInPosition') : t('calendar.charts.avgTimeInPosition')}
+        value={formatDuration(avgTimeInPosition)}
+        caption={`${t('calendar.charts.over')} ${formatCount(tradeCount, locale)} ${tradeCount > 1
+          ? t('calendar.charts.trades')
+          : t('calendar.charts.trade')}`}
+      />
 
-        <Card className="flex flex-col">
-          <CardHeader className="pb-1 flex-1">
-            <CardTitle className="text-base md:text-lg">
-              {isWeekly ? t('calendar.charts.weeklyMaxDrawdown') : t('calendar.charts.dailyMaxDrawdown')}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="pt-2 mt-auto">
-            <p className={`text-xl md:text-2xl font-bold ${maxDrawdown > 0 ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'}`}>
-              -{formatCurrency(maxDrawdown)}
-            </p>
-          </CardContent>
-        </Card>
+      <WidgetMetric
+        size="small"
+        label={isWeekly ? t('calendar.charts.weeklyMaxDrawdown') : t('calendar.charts.dailyMaxDrawdown')}
+        value={formatCurrency(-maxDrawdown, locale)}
+        toneClassName={pnlToneClass(pnlTone(-maxDrawdown))}
+      />
 
-        <Card className="flex flex-col">
-          <CardHeader className="pb-1 flex-1">
-            <CardTitle className="text-base md:text-lg">
-              {isWeekly ? t('calendar.charts.weeklyMaxProfit') : t('calendar.charts.dailyMaxProfit')}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="pt-2 mt-auto">
-            <p className={`text-xl md:text-2xl font-bold ${maxProfit > 0 ? 'text-green-600 dark:text-green-400' : 'text-muted-foreground'}`}>
-              {formatCurrency(maxProfit)}
-            </p>
-          </CardContent>
-        </Card>
-      </div>
+      <WidgetMetric
+        size="small"
+        label={isWeekly ? t('calendar.charts.weeklyMaxProfit') : t('calendar.charts.dailyMaxProfit')}
+        value={formatCurrency(maxProfit, locale)}
+        toneClassName={pnlToneClass(pnlTone(maxProfit))}
+      />
     </div>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/calendar/mood-selector.tsx
+++ b/app/[locale]/dashboard/components/calendar/mood-selector.tsx
@@ -2,14 +2,14 @@
 
 import React from 'react'
 import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
 import { Frown, Meh, Smile } from "lucide-react"
+import { cn } from "@/lib/utils"
 import { useI18n } from '@/locales/client'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { saveMood, getMoodForDay } from '@/server/journal'
 import { toast } from "sonner"
 import { format } from 'date-fns'
 import { useUserStore } from '../../../../../store/user-store'
+import { WidgetBody, WidgetCard, WidgetHeader } from "../widgets"
 
 interface MoodSelectorProps {
   onMoodSelect?: (mood: 'bad' | 'okay' | 'great') => void;
@@ -17,16 +17,24 @@ interface MoodSelectorProps {
 
 const STORAGE_KEY = 'daily_mood'
 
+type MoodValue = 'bad' | 'okay' | 'great'
+
 type StoredMood = {
-  mood: 'bad' | 'okay' | 'great';
+  mood: MoodValue;
   date: string;
 }
+
+const MOOD_ICONS = {
+  bad: Frown,
+  okay: Meh,
+  great: Smile,
+} as const
 
 export function MoodSelector({ onMoodSelect }: MoodSelectorProps) {
   const t = useI18n()
   const user = useUserStore(state => state.user)
-  const [isLoading, setIsLoading] = React.useState<'bad' | 'okay' | 'great' | null>(null)
-  const [selectedMood, setSelectedMood] = React.useState<'bad' | 'okay' | 'great' | null>(null)
+  const [isLoading, setIsLoading] = React.useState<MoodValue | null>(null)
+  const [selectedMood, setSelectedMood] = React.useState<MoodValue | null>(null)
 
   // Load mood from localStorage or fetch from server on mount
   React.useEffect(() => {
@@ -36,7 +44,7 @@ export function MoodSelector({ onMoodSelect }: MoodSelectorProps) {
       // Check localStorage first
       const today = new Date().toISOString().split('T')[0]
       const storedMoodData = localStorage.getItem(STORAGE_KEY)
-      
+
       if (storedMoodData) {
         const storedMood: StoredMood = JSON.parse(storedMoodData)
         if (storedMood.date === today) {
@@ -50,7 +58,7 @@ export function MoodSelector({ onMoodSelect }: MoodSelectorProps) {
         const dateKey = format(new Date(), 'yyyy-MM-dd')
         const mood = await getMoodForDay(dateKey)
         if (mood) {
-          setSelectedMood(mood.mood as 'bad' | 'okay' | 'great')
+          setSelectedMood(mood.mood as MoodValue)
           // Update localStorage
           localStorage.setItem(STORAGE_KEY, JSON.stringify({
             mood: mood.mood,
@@ -65,7 +73,7 @@ export function MoodSelector({ onMoodSelect }: MoodSelectorProps) {
     loadMood()
   }, [user?.id])
 
-  const handleMoodSelect = async (mood: 'bad' | 'okay' | 'great') => {
+  const handleMoodSelect = async (mood: MoodValue) => {
     if (!user?.id) {
       toast.error(t('auth.required'))
       return
@@ -76,7 +84,7 @@ export function MoodSelector({ onMoodSelect }: MoodSelectorProps) {
       await saveMood(mood)
       setSelectedMood(mood)
       onMoodSelect?.(mood)
-      
+
       // Save to localStorage
       const today = new Date().toISOString().split('T')[0]
       localStorage.setItem(STORAGE_KEY, JSON.stringify({
@@ -93,80 +101,49 @@ export function MoodSelector({ onMoodSelect }: MoodSelectorProps) {
     }
   }
 
-  const getMoodButtonStyle = (moodType: 'bad' | 'okay' | 'great') => {
-    if (selectedMood === moodType) {
-      switch (moodType) {
-        case 'bad': return 'text-red-500'
-        case 'okay': return 'text-yellow-500'
-        case 'great': return 'text-green-500'
-      }
-    }
-    return ''
-  }
+  const moods: { value: MoodValue; label: string }[] = [
+    { value: 'bad', label: t('mood.bad') },
+    { value: 'okay', label: t('mood.okay') },
+    { value: 'great', label: t('mood.great') },
+  ]
 
+  /*
+   * Mood is ordinary metadata, so it stays monochrome: selection is carried by
+   * one encoding (the pressed button) plus the visible label, never by a
+   * colored pill or an emoji standing in for the word.
+   */
   return (
-    <Card className="h-full">
-      <div className="flex items-center justify-between h-full p-2">
-        <span className="text-sm font-medium">{t('mood.question')}</span>
-        <div className="flex items-center gap-2">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={`h-6 w-6 p-0 hover:text-red-500 ${getMoodButtonStyle('bad')}`}
-                  onClick={() => handleMoodSelect('bad')}
-                  disabled={isLoading !== null}
-                >
-                  <Frown className={`h-3 w-3 ${isLoading === 'bad' ? 'animate-pulse' : ''}`} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {t('mood.bad')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={`h-6 w-6 p-0 hover:text-yellow-500 ${getMoodButtonStyle('okay')}`}
-                  onClick={() => handleMoodSelect('okay')}
-                  disabled={isLoading !== null}
-                >
-                  <Meh className={`h-3 w-3 ${isLoading === 'okay' ? 'animate-pulse' : ''}`} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {t('mood.okay')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={`h-6 w-6 p-0 hover:text-green-500 ${getMoodButtonStyle('great')}`}
-                  onClick={() => handleMoodSelect('great')}
-                  disabled={isLoading !== null}
-                >
-                  <Smile className={`h-3 w-3 ${isLoading === 'great' ? 'animate-pulse' : ''}`} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {t('mood.great')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+    <WidgetCard>
+      <WidgetHeader size="small" title={t('mood.question')} />
+      <WidgetBody size="small" className="flex items-center">
+        <div className="flex w-full flex-wrap items-center gap-1">
+          {moods.map(({ value, label }) => {
+            const Icon = MOOD_ICONS[value]
+            const isSelected = selectedMood === value
+            return (
+              <Button
+                key={value}
+                type="button"
+                variant={isSelected ? 'secondary' : 'ghost'}
+                size="sm"
+                aria-pressed={isSelected}
+                className="h-7 gap-1.5 px-2"
+                onClick={() => handleMoodSelect(value)}
+                disabled={isLoading !== null}
+              >
+                <Icon
+                  aria-hidden
+                  className={cn(
+                    "h-3.5 w-3.5",
+                    isLoading === value && "motion-safe:animate-pulse",
+                  )}
+                />
+                <span className="text-xs">{label}</span>
+              </Button>
+            )
+          })}
         </div>
-      </div>
-    </Card>
+      </WidgetBody>
+    </WidgetCard>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/calendar/responsive-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/responsive-calendar.tsx
@@ -11,8 +11,6 @@ import {
 } from "@/lib/calendar-timezone"
 import { fr, enUS } from 'date-fns/locale'
 import { ChevronLeft, ChevronRight, Newspaper, Calendar, CalendarDays } from "lucide-react"
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
@@ -33,6 +31,19 @@ import { useFinancialEventsStore } from "@/store/widgets/financial-events-store"
 import { useUserStore } from "@/store/user-store"
 import { Account } from "@/context/data-provider"
 import { HIDDEN_GROUP_NAME } from "../filters/account-group-board"
+import {
+  WidgetCard,
+  WidgetHeader,
+  WidgetBody,
+  WidgetFooter,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  widgetType,
+} from "../widgets"
 
 
 const WEEKDAYS_SUNDAY_START = [
@@ -55,45 +66,27 @@ const WEEKDAYS_MONDAY_START = [
   'calendar.weekdays.sun'
 ] as const
 
-
-const formatCurrency = (value: number, options?: { minimumFractionDigits?: number; maximumFractionDigits?: number; signed?: boolean }) => {
-  const formatted = value.toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: options?.minimumFractionDigits ?? 0,
-    maximumFractionDigits: options?.maximumFractionDigits ?? 0
+/** Whole-dollar money for the dense grid. Sans + tabular-nums, sign on the number. */
+function signedWholeCurrency(value: number, locale: string) {
+  return formatCurrency(value, locale, {
+    maximumFractionDigits: 0,
+    signDisplay: "always",
   })
-  if (options?.signed && value > 0) {
-    return `+${formatted}`
-  }
-  return formatted
-}
-
-const formatCurrencyCompact = (value: number) => {
-  const absValue = Math.abs(value)
-  const sign = value > 0 ? '+' : value < 0 ? '-' : ''
-  if (absValue >= 1_000_000) {
-    return `${sign}$${(absValue / 1_000_000).toFixed(1)}M`
-  }
-  if (absValue >= 1_000) {
-    return `${sign}$${(absValue / 1_000).toFixed(1)}K`
-  }
-  return formatCurrency(value, { signed: true })
 }
 
 function ResponsiveCurrency({
   value,
+  locale,
   className,
-  options,
 }: {
   value: number
+  locale: string
   className?: string
-  options?: { minimumFractionDigits?: number; maximumFractionDigits?: number }
 }) {
   return (
     <>
-      <span className={cn("sm:hidden", className)}>{formatCurrencyCompact(value)}</span>
-      <span className={cn("hidden sm:inline", className)}>{formatCurrency(value, { ...options, signed: true })}</span>
+      <span className={cn("sm:hidden", className)}>{formatCompactCurrency(value, locale)}</span>
+      <span className={cn("hidden sm:inline", className)}>{signedWholeCurrency(value, locale)}</span>
     </>
   )
 }
@@ -102,15 +95,15 @@ const truncateAccountNumber = (accountNumber: string, maxLength: number = 15): s
   if (accountNumber.length <= maxLength) {
     return accountNumber
   }
-  
+
   // Always show last 3 digits
   const lastThree = accountNumber.slice(-3)
   const remainingLength = maxLength - 3 - 1 // -1 for the ellipsis
-  
+
   if (remainingLength <= 0) {
     return `...${lastThree}`
   }
-  
+
   // Show beginning + ellipsis + last 3 digits
   const beginning = accountNumber.slice(0, remainingLength)
   return `${beginning}...${lastThree}`
@@ -141,22 +134,10 @@ const getEventImportanceStars = (importance: string): ImpactLevel => {
 
 function EventBadge({ events, impactLevels }: { events: FinancialEvent[], impactLevels: ImpactLevel[] }) {
   const t = useI18n()
+  const locale = useCurrentLocale()
   // Filter events by impact level
   const filteredEvents = events.filter(e => impactLevels.includes(getEventImportanceStars(e.importance)))
   if (filteredEvents.length === 0) return null
-
-  // Get the highest importance level for color coding
-  const highestImportance = filteredEvents.reduce((highest, event) => {
-    const level = getEventImportanceStars(event.importance)
-    const levelIndex = IMPACT_LEVELS.indexOf(level)
-    return Math.max(highest, levelIndex)
-  }, 0)
-
-  const badgeStyles = {
-    2: "bg-background text-foreground border-border hover:bg-accent",
-    1: "bg-background text-foreground border-border hover:bg-accent",
-    0: "bg-background text-foreground border-border hover:bg-accent"
-  }
 
   return (
     <CalendarResponsiveOverlay
@@ -164,23 +145,23 @@ function EventBadge({ events, impactLevels }: { events: FinancialEvent[], impact
       drawerTitle={t('calendar.events.title')}
       drawerDescription={String(filteredEvents.length)}
       trigger={({ onClick }) => (
-        <Badge
-          variant="outline"
+        <button
+          type="button"
+          aria-label={`${t('calendar.events.title')}: ${formatCount(filteredEvents.length, locale)}`}
           className={cn(
-            "h-4 px-1.5 text-[8px] sm:text-[9px] font-medium cursor-pointer relative z-0 w-auto justify-center items-center gap-1",
-            badgeStyles[highestImportance as keyof typeof badgeStyles],
-            "transition-[background-color,color,border-color,box-shadow,transform] duration-200 ease-in-out motion-reduce:transition-none",
-            "hover:scale-110 hover:shadow-md",
-            "active:scale-95"
+            "flex h-4 items-center justify-center gap-0.5 rounded-sm border bg-background px-1",
+            "text-[8px] font-medium tabular-nums text-foreground sm:text-[9px]",
+            "hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
           )}
           onClick={(e) => {
             e.stopPropagation()
             onClick?.()
           }}
         >
-          <Newspaper className="h-2.5 w-2.5" />
-          {filteredEvents.length}
-        </Badge>
+          <Newspaper className="h-2.5 w-2.5" aria-hidden />
+          {formatCount(filteredEvents.length, locale)}
+        </button>
       )}
     >
       <HourlyFinancialTimeline
@@ -195,90 +176,47 @@ function EventBadge({ events, impactLevels }: { events: FinancialEvent[], impact
 
 function RenewalBadgeContent({ renewals }: { renewals: Account[] }) {
   const t = useI18n()
+  const locale = useCurrentLocale()
 
   return (
-    <div className="p-4 sm:p-6">
-      {/* Header */}
-      <div className="flex items-center gap-2 mb-4 sm:mb-6">
-        <div className="p-2 rounded-lg bg-blue-50 dark:bg-blue-900">
-          <Calendar className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <h3 className="font-semibold text-sm sm:text-base text-foreground truncate">{t('propFirm.renewal.title')}</h3>
-          <p className="text-xs text-muted-foreground">{renewals.length} {renewals.length === 1 ? t('propFirm.renewal.account') : t('propFirm.renewal.accounts')}</p>
-        </div>
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-col gap-1">
+        <h3 className={widgetType.title}>{t('propFirm.renewal.title')}</h3>
+        <p className={widgetType.caption}>
+          {formatCount(renewals.length, locale)}{' '}
+          {renewals.length === 1 ? t('propFirm.renewal.account') : t('propFirm.renewal.accounts')}
+        </p>
       </div>
 
-      {/* Account List with max height and scrolling */}
-      <div className="space-y-2 sm:space-y-3 max-h-[60vh] overflow-y-auto scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
+      {/* Account list: rows separated by a rule, never a card each */}
+      <ul className="max-h-[60vh] divide-y overflow-y-auto">
         {renewals.map((account) => (
-          <div
-            key={account.id}
-            className="group relative p-3 sm:p-4 rounded-lg border bg-card hover:bg-muted/50 hover:border-border transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-xs motion-reduce:transition-none"
-          >
-            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 sm:gap-3">
-              {/* Account Info */}
-              <div className="flex-1 min-w-0">
-                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 mb-2">
-                  {account.propfirm ? (
-                    <>
-                      <div className="font-semibold text-sm text-foreground truncate">
-                        {account.propfirm}
-                      </div>
-                      <div className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full inline-block w-fit">
-                        <span className="block" title={account.number}>
-                          {truncateAccountNumber(account.number, 12)}
-                        </span>
-                      </div>
-                    </>
-                  ) : (
-                    <div className="font-semibold text-sm text-foreground">
-                      <span className="block" title={account.number}>
-                        {truncateAccountNumber(account.number, 18)}
-                      </span>
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex flex-wrap items-center gap-1 sm:gap-2 text-xs text-muted-foreground">
-                  <div className="px-2 py-1 bg-blue-50 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded-md font-medium whitespace-nowrap">
-                    {account.paymentFrequency?.toLowerCase()} {t('propFirm.renewal.frequency')}
-                  </div>
-                  {account.autoRenewal && (
-                    <div className="flex items-center gap-1 px-2 py-1 bg-green-50 dark:bg-green-900 text-green-700 dark:text-green-300 rounded-md whitespace-nowrap">
-                      <div className="w-1.5 h-1.5 bg-green-500 rounded-full shrink-0"></div>
-                      <span className="text-xs font-medium">{t('propFirm.renewal.notification')}</span>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Price */}
-              <div className="text-left sm:text-right shrink-0">
-                <div className="font-bold text-base sm:text-lg text-blue-600 dark:text-blue-400 mb-1">
-                  {account.price != null && formatCurrency(account.price, { maximumFractionDigits: 2 })}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {account.paymentFrequency?.toLowerCase()}
-                </div>
-              </div>
+          <li key={account.id} className="flex items-start justify-between gap-3 py-2.5">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="truncate text-sm font-medium text-foreground" title={account.number}>
+                {account.propfirm
+                  ? account.propfirm
+                  : truncateAccountNumber(account.number, 18)}
+              </span>
+              <span className={widgetType.caption}>
+                {account.propfirm ? `${truncateAccountNumber(account.number, 12)} · ` : ''}
+                {account.paymentFrequency?.toLowerCase()} {t('propFirm.renewal.frequency')}
+                {account.autoRenewal ? ` · ${t('propFirm.renewal.notification')}` : ''}
+              </span>
             </div>
-
-            {/* Subtle hover effect line */}
-            <div className="absolute bottom-0 left-3 right-3 sm:left-4 sm:right-4 h-0.5 bg-linear-to-r from-blue-500/0 via-blue-500/50 to-blue-500/0 opacity-0 group-hover:opacity-100 transition-opacity duration-200"></div>
-          </div>
-        ))}
-      </div>
-
-      {/* Footer */}
-      {renewals.length > 0 && (
-        <div className="mt-3 sm:mt-4 pt-3 sm:pt-4 border-t">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-0 text-xs text-muted-foreground">
-            <span>{t('propFirm.renewal.totalAccounts')}: {renewals.length}</span>
-            <span className="truncate">
-              {t('propFirm.renewal.nextRenewal')}: {renewals[0]?.nextPaymentDate ? format(new Date(renewals[0].nextPaymentDate), 'MMM dd, yyyy') : 'N/A'}
+            <span className={cn(widgetType.value, "shrink-0 text-right")}>
+              {account.price != null ? formatCurrency(account.price, locale) : null}
             </span>
-          </div>
+          </li>
+        ))}
+      </ul>
+
+      {renewals.length > 0 && (
+        <div className={cn(widgetType.caption, "flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t pt-3")}>
+          <span>{t('propFirm.renewal.totalAccounts')}: {formatCount(renewals.length, locale)}</span>
+          <span className="truncate">
+            {t('propFirm.renewal.nextRenewal')}: {renewals[0]?.nextPaymentDate ? format(new Date(renewals[0].nextPaymentDate), 'MMM dd, yyyy') : 'N/A'}
+          </span>
         </div>
       )}
     </div>
@@ -287,6 +225,7 @@ function RenewalBadgeContent({ renewals }: { renewals: Account[] }) {
 
 function RenewalBadge({ renewals }: { renewals: Account[] }) {
   const t = useI18n()
+  const locale = useCurrentLocale()
 
   if (renewals.length === 0) return null
 
@@ -296,23 +235,23 @@ function RenewalBadge({ renewals }: { renewals: Account[] }) {
       popoverSideOffset={8}
       drawerTitle={t('propFirm.renewal.title')}
       trigger={({ onClick }) => (
-        <Badge
-          variant="outline"
+        <button
+          type="button"
+          aria-label={`${t('propFirm.renewal.title')}: ${formatCount(renewals.length, locale)}`}
           className={cn(
-            "h-4 px-1.5 text-[8px] sm:text-[9px] font-medium cursor-pointer relative z-0 w-auto justify-center items-center gap-1",
-            "bg-primary/10 text-primary border-primary/20 hover:bg-primary/20 dark:bg-primary/15 dark:border-primary/30 dark:hover:bg-primary/25",
-            "transition-[background-color,color,border-color,box-shadow,transform] duration-200 ease-in-out motion-reduce:transition-none",
-            "hover:scale-110 hover:shadow-md",
-            "active:scale-95"
+            "flex h-4 items-center justify-center gap-0.5 rounded-sm border bg-background px-1",
+            "text-[8px] font-medium tabular-nums text-foreground sm:text-[9px]",
+            "hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
           )}
           onClick={(e) => {
             e.stopPropagation()
             onClick?.()
           }}
         >
-          <Calendar className="h-2.5 w-2.5" />
-          {renewals.length}
-        </Badge>
+          <Calendar className="h-2.5 w-2.5" aria-hidden />
+          {formatCount(renewals.length, locale)}
+        </button>
       )}
     >
       <RenewalBadgeContent renewals={renewals} />
@@ -415,7 +354,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
   const renewalsByDate = useMemo(() => {
     const hiddenGroup = groups.find(g => g.name === HIDDEN_GROUP_NAME);
     const hiddenAccountIds = hiddenGroup ? new Set(hiddenGroup.accounts.map(a => a.id)) : new Set();
-    
+
     const map = new Map<string, Account[]>();
     accounts.forEach(account => {
       if (hiddenAccountIds.has(account.id) || !account.nextPaymentDate) return;
@@ -437,7 +376,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
   // Pre-compute day calculations (maxProfit, maxDrawdown) for all days
   const dayCalculations = useMemo(() => {
     const calculations = new Map<string, { maxProfit: number; maxDrawdown: number }>();
-    
+
     Object.entries(calendarData).forEach(([dateString, dayData]) => {
       if (!dayData.trades || dayData.trades.length === 0) {
         calculations.set(dateString, { maxProfit: 0, maxDrawdown: 0 });
@@ -445,10 +384,10 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
       }
 
       // Create a copy to avoid mutating original
-      const sortedTrades = [...dayData.trades].sort((a, b) => 
+      const sortedTrades = [...dayData.trades].sort((a, b) =>
         new Date(a.entryDate).getTime() - new Date(b.entryDate).getTime()
       );
-      
+
       const equity = [0];
       let cumulative = 0;
       sortedTrades.forEach(trade => {
@@ -476,7 +415,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
 
       calculations.set(dateString, { maxProfit: maxRU, maxDrawdown: maxDD });
     });
-    
+
     return calculations;
   }, [calendarData]);
 
@@ -528,202 +467,238 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
     }, 0)
   }, [])
 
+  const periodTotal = viewMode === 'daily' ? monthlyTotal : yearTotal
+  const periodTone = pnlTone(periodTotal)
+
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between space-y-0 border-b shrink-0 p-2 sm:p-4 min-h-[56px]"
-      >
-        <div className="flex items-center justify-between sm:justify-start gap-2 sm:gap-3 min-w-0">
-          <CardTitle className="text-sm sm:text-lg font-semibold truncate capitalize">
+    <WidgetCard>
+      <WidgetHeader
+        size="large"
+        className="flex-col items-stretch gap-2 sm:flex-row sm:items-center"
+        title={
+          <span className="capitalize">
             {viewMode === 'daily'
               ? format(currentDate, 'MMMM yyyy', { locale: dateLocale })
               : format(currentDate, 'yyyy', { locale: dateLocale })}
-          </CardTitle>
-          <div className={cn(
-            "text-xs sm:text-base font-semibold shrink-0",
-            (viewMode === 'daily' ? monthlyTotal : yearTotal) >= 0
-              ? "text-green-600 dark:text-green-400"
-              : "text-red-600 dark:text-red-400"
-          )}>
-            <ResponsiveCurrency value={viewMode === 'daily' ? monthlyTotal : yearTotal} />
-          </div>
-        </div>
-        <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-4">
-          {/* Impact Level Filter */}
-          <div className={cn("flex items-center gap-2", hideFiltersOnMobile && "max-sm:hidden")}>
-            <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-              {t('calendar.importanceFilter.title')}
-            </span>
-            <ImportanceFilter
-              value={impactLevels}
-              onValueChange={setImpactLevels}
-              className="h-8"
+          </span>
+        }
+        actions={
+          <div className="flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-2">
+            {/* Impact Level Filter */}
+            <div className={cn("flex items-center gap-2", hideFiltersOnMobile && "max-sm:hidden")}>
+              <span className={cn(widgetType.label, "whitespace-nowrap")}>
+                {t('calendar.importanceFilter.title')}
+              </span>
+              <ImportanceFilter
+                value={impactLevels}
+                onValueChange={setImpactLevels}
+                className="h-8"
+              />
+            </div>
+            <CountryFilter
+              countries={countries}
+              value={selectedCountries}
+              onValueChange={setSelectedCountries}
+              className={cn("h-8", hideFiltersOnMobile && "max-sm:hidden")}
             />
+            {/* View mode toggle */}
+            <div className="flex items-center gap-0.5">
+              <Button
+                type="button"
+                variant={viewMode === 'daily' ? 'secondary' : 'ghost'}
+                size="sm"
+                aria-pressed={viewMode === 'daily'}
+                aria-label={t('calendar.viewMode.daily')}
+                className="h-7 px-2"
+                onClick={() => setViewMode('daily')}
+              >
+                <Calendar className="h-4 w-4 sm:mr-1" aria-hidden />
+                <span className="hidden text-xs sm:inline">{t('calendar.viewMode.daily')}</span>
+              </Button>
+              <Button
+                type="button"
+                variant={viewMode === 'weekly' ? 'secondary' : 'ghost'}
+                size="sm"
+                aria-pressed={viewMode === 'weekly'}
+                aria-label={t('calendar.viewMode.weekly')}
+                className="h-7 px-2"
+                onClick={() => setViewMode('weekly')}
+              >
+                <CalendarDays className="h-4 w-4 sm:mr-1" aria-hidden />
+                <span className="hidden text-xs sm:inline">{t('calendar.viewMode.weekly')}</span>
+              </Button>
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => viewMode === 'daily' ? handlePrevMonth() : setCurrentDate(new Date(getYear(currentDate) - 1, 0, 1))}
+                className="h-7 w-7 sm:h-8 sm:w-8"
+                aria-label={viewMode === 'daily' ? "Previous month" : "Previous year"}
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden />
+              </Button>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => viewMode === 'daily' ? handleNextMonth() : setCurrentDate(new Date(getYear(currentDate) + 1, 0, 1))}
+                className="h-7 w-7 sm:h-8 sm:w-8"
+                aria-label={viewMode === 'daily' ? "Next month" : "Next year"}
+              >
+                <ChevronRight className="h-4 w-4" aria-hidden />
+              </Button>
+            </div>
           </div>
-          <CountryFilter
-            countries={countries}
-            value={selectedCountries}
-            onValueChange={setSelectedCountries}
-            className={cn("h-8", hideFiltersOnMobile && "max-sm:hidden")}
-          />
-          <div className="flex items-center gap-1 sm:gap-1.5">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => viewMode === 'daily' ? handlePrevMonth() : setCurrentDate(new Date(getYear(currentDate) - 1, 0, 1))}
-              className="h-7 w-7 sm:h-8 sm:w-8"
-              aria-label={viewMode === 'daily' ? "Previous month" : "Previous year"}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => viewMode === 'daily' ? handleNextMonth() : setCurrentDate(new Date(getYear(currentDate) + 1, 0, 1))}
-              className="h-7 w-7 sm:h-8 sm:w-8"
-              aria-label={viewMode === 'daily' ? "Next month" : "Next year"}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="flex-1 min-h-0 p-1 sm:p-4">
+        }
+      >
+        <span className={cn(widgetType.value, "shrink-0", pnlToneClass(periodTone))}>
+          <ResponsiveCurrency value={periodTotal} locale={locale} />
+        </span>
+      </WidgetHeader>
+      <WidgetBody size="large" className="p-1 sm:p-4">
         {viewMode === 'daily' ? (
           <div
             role="grid"
             aria-label={format(currentDate, 'MMMM yyyy', { locale: dateLocale })}
+            className="h-full"
           >
-            <div role="row" className="grid grid-cols-7 sm:grid-cols-8 gap-x-px mb-0.5 sm:mb-1">
+            <div role="row" className="mb-0.5 grid grid-cols-7 gap-x-px sm:mb-1 sm:grid-cols-8">
               {WEEKDAYS.map((day) => (
-                <div key={day} role="columnheader" className="text-center font-medium text-[10px] sm:text-[11px] text-muted-foreground truncate px-px">
+                <div key={day} role="columnheader" className={cn(widgetType.label, "truncate px-px text-center font-medium")}>
                   <span className="sm:hidden">{translateWeekdayShort(day, locale)}</span>
                   <span className="hidden sm:inline">{translateWeekday(t, day)}</span>
                 </div>
               ))}
-              <div role="columnheader" className="hidden sm:block text-center font-medium text-[11px] text-muted-foreground">
+              <div role="columnheader" className={cn(widgetType.label, "hidden text-center font-medium sm:block")}>
                 {t('calendar.weekdays.weekly')}
               </div>
             </div>
-            <div className="grid grid-cols-7 sm:grid-cols-8 auto-rows-fr rounded-lg h-[calc(100%-16px)] sm:h-[calc(100%-20px)]">
+            <div className="grid h-[calc(100%-16px)] auto-rows-fr grid-cols-7 rounded-lg sm:h-[calc(100%-20px)] sm:grid-cols-8">
               {calendarDays.map((date, index) => {
                 const dateString = calendarDateKeyFromZoned(date)
                 const dayData = calendarData[dateString]
                 // Check if it's the last day of the week (Saturday for Sunday start, Sunday for Monday start)
                 const isLastDayOfWeek = weekStartsOnMonday ? getDay(date) === 0 : getDay(date) === 6
                 const isCurrentMonth = isSameMonth(date, currentDate)
+                const isToday = isTodayInTimezone(date, timezone)
                 const dateEvents = filteredEventsByDate.get(dateString) || []
                 const dateRenewals = renewalsByDate.get(dateString) || []
                 const calculations = dayCalculations.get(dateString) || { maxProfit: 0, maxDrawdown: 0 }
                 const maxProfit = calculations.maxProfit
                 const maxDrawdown = calculations.maxDrawdown
+                const dayTone = dayData ? pnlTone(dayData.pnl) : "neutral"
+                const dayLabel = format(date, 'EEEE, MMMM d, yyyy', { locale: dateLocale })
+                const accessibleName = dayData
+                  ? `${dayLabel}, ${signedWholeCurrency(dayData.pnl, locale)}, ${formatCount(dayData.tradeNumber, locale)} ${dayData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`
+                  : `${dayLabel}, ${t('calendar.noTrades')}`
 
                 return (
                   <React.Fragment key={dateString}>
                     <div
+                      role="gridcell"
                       className={cn(
-                        "relative h-full w-full text-left transition-[background-color,color,box-shadow] motion-reduce:transition-none rounded-none min-h-[44px] sm:min-h-0",
-                        "ring-1 ring-border hover:ring-primary hover:z-10",
-                        dayData && dayData.pnl >= 0
-                          ? "bg-green-50 dark:bg-green-900/20"
-                          : dayData && dayData.pnl < 0
-                            ? "bg-red-50 dark:bg-red-900/20"
-                            : "bg-card",
-                        !isCurrentMonth && "",
-                        isTodayInTimezone(date, timezone) && "ring-blue-500 bg-blue-500/5 z-10",
+                        "relative h-full min-h-[44px] w-full sm:min-h-0",
+                        "rounded-none ring-1 ring-border",
+                        isToday && "z-10 ring-foreground",
                         index === 0 && "rounded-tl-lg",
                         index === 35 && "rounded-bl-lg",
                       )}
                     >
+                      {/* P&L sign is the one thing on this cell that earns color. */}
+                      {dayData && dayTone !== "neutral" ? (
+                        <span
+                          aria-hidden
+                          className="pointer-events-none absolute inset-0 opacity-[0.10]"
+                          style={{ backgroundColor: pnlToneFill(dayTone) }}
+                        />
+                      ) : null}
                       <button
                         type="button"
-                        aria-label={format(date, 'EEEE, MMMM d, yyyy', { locale: dateLocale })}
-                        className="absolute inset-0 cursor-pointer rounded-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                        aria-label={accessibleName}
+                        aria-current={isToday ? "date" : undefined}
+                        className={cn(
+                          "absolute inset-0 flex cursor-pointer flex-col p-0.5 text-left sm:p-1",
+                          "rounded-none outline-none hover:z-10 hover:ring-1 hover:ring-foreground/40",
+                          "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                          "motion-safe:transition-shadow motion-safe:duration-150 motion-safe:ease-out",
+                          !isCurrentMonth && "opacity-50",
+                        )}
                         onClick={() => setSelectedDate(date)}
-                      />
-                      <div className="relative h-full flex flex-col pointer-events-none p-0.5 sm:p-1">
-                        <div className="flex justify-between items-start gap-0">
-                          <span className={cn(
-                            "text-[10px] sm:text-[11px] font-medium min-w-[12px] sm:min-w-[14px] text-center leading-none",
-                            isTodayInTimezone(date, timezone) && "text-primary font-semibold",
-                            !isCurrentMonth && "opacity-50"
-                          )}>
-                            {format(date, 'd')}
-                          </span>
-                          <div className="pointer-events-auto relative z-10 flex flex-col gap-px">
+                      >
+                        <span
+                          className={cn(
+                            "min-w-[12px] text-center text-[10px] font-medium leading-none sm:min-w-[14px] sm:text-[11px]",
+                            isToday ? "font-semibold text-foreground" : "text-muted-foreground",
+                          )}
+                        >
+                          {format(date, 'd')}
+                        </span>
+                        <span className="flex min-h-0 flex-1 flex-col justify-end gap-px sm:gap-0.5">
+                          {dayData ? (
+                            <span className={cn(
+                              "truncate text-center text-[10px] font-semibold leading-tight tabular-nums sm:text-[11px]",
+                              pnlToneClass(dayTone),
+                            )}>
+                              <ResponsiveCurrency value={dayData.pnl} locale={locale} />
+                            </span>
+                          ) : (
+                            <span aria-hidden className="invisible text-center text-[10px] font-semibold sm:text-[11px]">$0</span>
+                          )}
+                          {/* An empty day stays empty: the cell's own blankness says
+                              there were no trades, so labelling it adds noise. */}
+                          {dayData && (
+                            <span className={cn(widgetType.caption, "truncate text-center text-[10px] leading-tight sm:text-[9px]")}>
+                              <span className="sm:hidden">{formatCount(dayData.tradeNumber, locale)}</span>
+                              <span className="hidden sm:inline">
+                                {`${formatCount(dayData.tradeNumber, locale)} ${dayData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`}
+                              </span>
+                            </span>
+                          )}
+                          {dayData && showMaxProfitAndDrawdown && (
+                            <>
+                              <span className={cn(widgetType.caption, "hidden truncate text-center text-[9px] tabular-nums sm:block")}>
+                                {t('calendar.maxProfit')}: {formatCurrency(maxProfit, locale, { maximumFractionDigits: 0 })}
+                              </span>
+                              <span className={cn(widgetType.caption, "hidden truncate text-center text-[9px] tabular-nums sm:block")}>
+                                {t('calendar.maxDD')}: {formatCurrency(-maxDrawdown, locale, { maximumFractionDigits: 0 })}
+                              </span>
+                            </>
+                          )}
+                        </span>
+                      </button>
+                      {/* Event and renewal affordances sit above the day button, never inside it */}
+                      {(dateEvents.length > 0 || dateRenewals.length > 0) && (
+                        <div className="pointer-events-none absolute right-0.5 top-0.5 z-20 flex flex-col items-end gap-px">
+                          <div className="pointer-events-auto flex flex-col items-end gap-px">
                             {dateEvents.length > 0 && <EventBadge events={dateEvents} impactLevels={impactLevels} />}
                             {dateRenewals.length > 0 && <RenewalBadge renewals={dateRenewals} />}
                           </div>
                         </div>
-                        <div className="flex-1 flex flex-col justify-end gap-px sm:gap-0.5 min-h-0">
-                          {dayData ? (
-                            <div className={cn(
-                              "text-[10px] sm:text-[11px] font-semibold truncate text-center leading-tight",
-                              dayData.pnl >= 0
-                                ? "text-green-600 dark:text-green-400"
-                                : "text-red-600 dark:text-red-400",
-                              !isCurrentMonth && "opacity-50"
-                            )}>
-                              <ResponsiveCurrency value={dayData.pnl} />
-                            </div>
-                          ) : (
-                            <div className={cn(
-                              "text-[10px] sm:text-[11px] font-semibold invisible text-center",
-                              !isCurrentMonth && "opacity-50"
-                            )}>$0</div>
-                          )}
-                          {dayData && (
-                            <div className={cn(
-                              "text-[10px] sm:text-[9px] text-muted-foreground truncate text-center leading-tight",
-                              !isCurrentMonth && "opacity-50"
-                            )}>
-                              <span className="sm:hidden">{dayData.tradeNumber}</span>
-                              <span className="hidden sm:inline">
-                                {`${dayData.tradeNumber} ${dayData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`}
-                              </span>
-                            </div>
-                          )}
-                          {dayData && showMaxProfitAndDrawdown && (
-                            <>
-                              <div className={cn(
-                                "hidden sm:block text-[9px] text-green-600 dark:text-green-400 truncate text-center",
-                                !isCurrentMonth && "opacity-50"
-                              )}>
-                                {t('calendar.maxProfit')}: {formatCurrency(maxProfit)}
-                              </div>
-                              <div className={cn(
-                                "hidden sm:block text-[9px] text-red-600 dark:text-red-400 truncate text-center",
-                                !isCurrentMonth && "opacity-50"
-                              )}>
-                                {t('calendar.maxDD')}: -{formatCurrency(maxDrawdown)}
-                              </div>
-                            </>
-                          )}
-                        </div>
-                      </div>
+                      )}
                     </div>
                     {isLastDayOfWeek && (() => {
                       const weeklyTotal = calculateWeeklyTotal(index, calendarDays, calendarData)
+                      const weeklyTone = pnlTone(weeklyTotal)
                       return (
                         <button
                           type="button"
-                          aria-label={`${t('calendar.weekdays.weekly')}, ${format(date, 'MMMM d, yyyy', { locale: dateLocale })}`}
+                          aria-label={`${t('calendar.weekdays.weekly')}, ${format(date, 'MMMM d, yyyy', { locale: dateLocale })}, ${signedWholeCurrency(weeklyTotal, locale)}`}
                           className={cn(
-                            "hidden sm:flex h-full w-full items-center justify-center rounded-none cursor-pointer",
-                            "ring-1 ring-border hover:ring-primary hover:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                            "hidden h-full w-full cursor-pointer items-center justify-center rounded-none sm:flex",
+                            "ring-1 ring-border outline-none hover:z-10 hover:ring-foreground/40",
+                            "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                            "motion-safe:transition-shadow motion-safe:duration-150 motion-safe:ease-out",
                             index === 6 && "rounded-tr-lg",
                             index === 41 && "rounded-br-lg"
                           )}
                           onClick={() => setSelectedWeekDate(date)}
                         >
-                          <div className={cn(
-                            "text-[11px] font-semibold truncate px-0.5",
-                            weeklyTotal >= 0
-                              ? "text-green-600 dark:text-green-400"
-                              : "text-red-600 dark:text-red-400"
+                          <span className={cn(
+                            "truncate px-0.5 text-[11px] font-semibold tabular-nums",
+                            pnlToneClass(weeklyTone),
                           )}>
-                            {formatCurrency(weeklyTotal, { signed: true })}
-                          </div>
+                            {signedWholeCurrency(weeklyTotal, locale)}
+                          </span>
                         </button>
                       )
                     })()}
@@ -738,7 +713,7 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
             year={getYear(currentDate)}
           />
         )}
-      </CardContent>
+      </WidgetBody>
       <CalendarModal
         isOpen={selectedDate !== null && selectedDate !== undefined}
         onOpenChange={(open) => {
@@ -757,53 +732,16 @@ export default function ResponsiveCalendarPnl({ calendarData, hideFiltersOnMobil
         calendarData={calendarData}
         isLoading={isLoading}
       />
-      <CardFooter className="flex justify-end p-2 sm:p-4">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between w-full">
-          <div className="hidden sm:flex items-center gap-2">
-            <span className="text-xs sm:text-sm text-muted-foreground">
-              {t('calendar.viewOptions.showMaxProfitAndDD')}
-            </span>
-            <Switch
-              checked={showMaxProfitAndDrawdown}
-              onCheckedChange={setShowMaxProfitAndDrawdown}
-              className="data-[state=checked]:bg-primary"
-            />
-          </div>
-          {/* View Mode Toggle */}
-          <div className="flex items-center justify-end gap-1 border rounded-md p-0.5 bg-muted w-full sm:w-auto">
-            <Button
-              type="button"
-              variant={viewMode === 'daily' ? 'default' : 'ghost'}
-              size="sm"
-              aria-pressed={viewMode === 'daily'}
-              aria-label={t('calendar.viewMode.daily')}
-              className={cn(
-                "h-7 flex-1 sm:flex-none px-2 transition-colors font-semibold",
-                viewMode === 'daily' && "bg-primary text-primary-foreground shadow-sm"
-              )}
-              onClick={() => setViewMode('daily')}
-            >
-              <Calendar className="h-4 w-4 sm:mr-1" />
-              <span className="text-xs hidden sm:inline">{t('calendar.viewMode.daily')}</span>
-            </Button>
-            <Button
-              type="button"
-              variant={viewMode === 'weekly' ? 'default' : 'ghost'}
-              size="sm"
-              aria-pressed={viewMode === 'weekly'}
-              aria-label={t('calendar.viewMode.weekly')}
-              className={cn(
-                "h-7 flex-1 sm:flex-none px-2 transition-colors font-semibold",
-                viewMode === 'weekly' && "bg-primary text-primary-foreground shadow-sm"
-              )}
-              onClick={() => setViewMode('weekly')}
-            >
-              <CalendarDays className="h-4 w-4 sm:mr-1" />
-              <span className="text-xs hidden sm:inline">{t('calendar.viewMode.weekly')}</span>
-            </Button>
-          </div>
-        </div>
-      </CardFooter>
-    </Card>
+      <WidgetFooter size="large" className="hidden sm:flex">
+        <label htmlFor="calendar-show-max" className={widgetType.label}>
+          {t('calendar.viewOptions.showMaxProfitAndDD')}
+        </label>
+        <Switch
+          id="calendar-show-max"
+          checked={showMaxProfitAndDrawdown}
+          onCheckedChange={setShowMaxProfitAndDrawdown}
+        />
+      </WidgetFooter>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/calendar/weekly-calendar.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-calendar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from "react"
-import { format, eachWeekOfInterval, getWeek, getMonth, getYear, addDays, getDay } from "date-fns"
+import { format, eachWeekOfInterval, getWeek, getMonth, getYear, addDays } from "date-fns"
 import { fr, enUS } from 'date-fns/locale'
 import { cn } from "@/lib/utils"
 import { Trade } from "@/prisma/generated/prisma/browser"
@@ -19,43 +19,37 @@ import {
 } from "@/components/ui/accordion"
 import { useUserStore } from "../../../../../store/user-store"
 import { CalendarResponsiveOverlay } from "./calendar-responsive-overlay"
+import {
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  widgetType,
+} from "../widgets"
 
-const formatCurrency = (value: number, options?: { signed?: boolean }) => {
-  const formatted = value.toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0
+/** Whole-dollar money for the dense grid. Sans + tabular-nums, sign on the number. */
+function signedWholeCurrency(value: number, locale: string) {
+  return formatCurrency(value, locale, {
+    maximumFractionDigits: 0,
+    signDisplay: "always",
   })
-  if (options?.signed && value > 0) {
-    return `+${formatted}`
-  }
-  return formatted
-}
-
-const formatCurrencyCompact = (value: number) => {
-  const absValue = Math.abs(value)
-  const sign = value > 0 ? '+' : value < 0 ? '-' : ''
-  if (absValue >= 1_000_000) {
-    return `${sign}$${(absValue / 1_000_000).toFixed(1)}M`
-  }
-  if (absValue >= 1_000) {
-    return `${sign}$${(absValue / 1_000).toFixed(1)}K`
-  }
-  return formatCurrency(value, { signed: true })
 }
 
 function ResponsiveCurrency({
   value,
+  locale,
   className,
 }: {
   value: number
+  locale: string
   className?: string
 }) {
   return (
     <>
-      <span className={cn("sm:hidden", className)}>{formatCurrencyCompact(value)}</span>
-      <span className={cn("hidden sm:inline", className)}>{formatCurrency(value, { signed: true })}</span>
+      <span className={cn("sm:hidden", className)}>{formatCompactCurrency(value, locale)}</span>
+      <span className={cn("hidden sm:inline", className)}>{signedWholeCurrency(value, locale)}</span>
     </>
   )
 }
@@ -70,26 +64,25 @@ function WeekDetailContent({
   pnl,
   trades,
   dateLocale,
+  locale,
   t,
 }: {
   weekStart: Date
   pnl: number
   trades: { [key: string]: { trades: Trade[], pnl: number } }
   dateLocale: typeof enUS
+  locale: string
   t: ReturnType<typeof useI18n>
 }) {
   return (
     <div className="sm:p-4">
-      <div className="hidden sm:flex items-center justify-between mb-4">
-        <h4 className="font-semibold text-sm">
+      <div className="mb-4 hidden items-baseline justify-between gap-3 sm:flex">
+        <h4 className={widgetType.title}>
           {format(weekStart, 'MMM d', { locale: dateLocale })} - {format(addDays(weekStart, 6), 'MMM d, yyyy', { locale: dateLocale })}
         </h4>
-        <div className={cn(
-          "text-sm font-semibold",
-          pnl > 0 ? "text-green-600 dark:text-green-400" : pnl < 0 ? "text-red-600 dark:text-red-400" : "text-muted-foreground"
-        )}>
-          {formatCurrency(pnl, { signed: true })}
-        </div>
+        <span className={cn(widgetType.value, "shrink-0", pnlToneClass(pnlTone(pnl)))}>
+          {signedWholeCurrency(pnl, locale)}
+        </span>
       </div>
       <div className="max-h-[400px] overflow-y-auto pr-2">
         {Object.entries(trades).length > 0 ? (
@@ -97,53 +90,48 @@ function WeekDetailContent({
             {Object.entries(trades).map(([date, { trades: dayTrades, pnl: dayPnl }]) => (
               <AccordionItem key={date} value={date}>
                 <AccordionTrigger className="px-2 hover:no-underline">
-                  <div className="flex items-center justify-between w-full pr-4">
-                    <div className="flex flex-col items-start">
-                      <h5 className="text-sm font-medium">
+                  <div className="flex w-full items-center justify-between gap-3 pr-4">
+                    <div className="flex min-w-0 flex-col items-start gap-0.5">
+                      <h5 className="truncate text-sm font-medium">
                         {format(new Date(date), 'EEEE, MMM d, yyyy', { locale: dateLocale })}
                       </h5>
-                      <span className="text-xs text-muted-foreground">
-                        {dayTrades.length} {t('calendar.trades')}
+                      <span className={widgetType.caption}>
+                        {formatCount(dayTrades.length, locale)} {t('calendar.trades')}
                       </span>
                     </div>
-                    <div className={cn(
-                      "text-sm font-semibold",
-                      dayPnl > 0 ? "text-green-600 dark:text-green-400" : dayPnl < 0 ? "text-red-600 dark:text-red-400" : "text-muted-foreground"
-                    )}>
-                      {formatCurrency(dayPnl, { signed: true })}
-                    </div>
+                    <span className={cn(widgetType.value, "shrink-0", pnlToneClass(pnlTone(dayPnl)))}>
+                      {signedWholeCurrency(dayPnl, locale)}
+                    </span>
                   </div>
                 </AccordionTrigger>
                 <AccordionContent>
-                  <div className="space-y-2 pt-2">
+                  {/* Trade rows sit on a shared rule, never in a box each */}
+                  <ul className="divide-y">
                     {dayTrades.map((trade, index) => (
-                      <div
+                      <li
                         key={index}
-                        className="flex items-center justify-between p-2 rounded-lg bg-muted/50"
+                        className="flex items-center justify-between gap-3 py-2"
                       >
-                        <div className="flex flex-col">
-                          <span className="text-sm font-medium">{trade.instrument}</span>
-                          <span className="text-xs text-muted-foreground">
+                        <div className="flex min-w-0 flex-col gap-0.5">
+                          <span className="truncate text-sm font-medium">{trade.instrument}</span>
+                          <span className={cn(widgetType.mono, "text-muted-foreground")}>
                             {format(new Date(trade.entryDate), 'HH:mm', { locale: dateLocale })}
                           </span>
                         </div>
-                        <div className={cn(
-                          "text-sm font-semibold",
-                          trade.pnl > 0 ? "text-green-600 dark:text-green-400" : trade.pnl < 0 ? "text-red-600 dark:text-red-400" : "text-muted-foreground"
-                        )}>
-                          {formatCurrency(trade.pnl, { signed: true })}
-                        </div>
-                      </div>
+                        <span className={cn(widgetType.value, "shrink-0", pnlToneClass(pnlTone(trade.pnl)))}>
+                          {signedWholeCurrency(trade.pnl, locale)}
+                        </span>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 </AccordionContent>
               </AccordionItem>
             ))}
           </Accordion>
         ) : (
-          <div className="text-sm text-muted-foreground text-center py-4">
+          <p className={cn(widgetType.label, "py-4 text-center")}>
             {t('calendar.noTrades')}
-          </div>
+          </p>
         )}
       </div>
     </div>
@@ -213,39 +201,38 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
   ));
 
   return (
-    <div className="flex flex-col gap-1 sm:gap-2 p-1 sm:p-2 h-full min-h-0">
+    <div className="flex h-full min-h-0 flex-col gap-1 p-1 sm:gap-2 sm:p-2">
       <div
-        className="overflow-x-auto overscroll-x-contain -mx-1 px-1 sm:mx-0 sm:px-0 sm:overflow-visible"
+        className="-mx-1 overflow-x-auto overscroll-x-contain px-1 sm:mx-0 sm:overflow-visible sm:px-0"
         role="region"
         aria-label={String(year)}
       >
-        <div className="min-w-[680px] sm:min-w-0 flex flex-col gap-1 sm:gap-2">
-          {/* Month Headers and Totals */}
+        <div className="flex min-w-[680px] flex-col gap-1 sm:min-w-0 sm:gap-2">
+          {/* Month headers and totals */}
           <div className="grid grid-cols-12 gap-0.5 sm:gap-1">
             {Array.from({ length: 12 }, (_, i) => {
               const monthlyPnl = getMonthPnl(i)
               return (
-                <div key={i} className="flex flex-col gap-0.5 sm:gap-1 min-w-0">
-                  <div className="text-center text-[10px] sm:text-xs font-medium text-muted-foreground truncate">
+                <div key={i} className="flex min-w-0 flex-col gap-0.5 sm:gap-1">
+                  <div className={cn(widgetType.label, "truncate text-center font-medium")}>
                     {format(new Date(year, i, 1), 'MMM', { locale: dateLocale })}
                   </div>
-                  <div className={cn(
-                    "text-center text-[10px] sm:text-xs font-semibold px-0.5 sm:px-1 py-0.5 rounded transition-colors truncate",
-                    monthlyPnl > 0
-                      ? "text-green-700 dark:text-green-400 bg-green-50/50 dark:bg-green-950/30"
-                      : monthlyPnl < 0
-                        ? "text-red-600 dark:text-red-400/90 bg-red-50/50 dark:bg-red-950/30"
-                        : "text-muted-foreground bg-muted/20"
-                  )}>
-                    <ResponsiveCurrency value={monthlyPnl} />
+                  {/* The sign is on the number, so tone is never the only signal */}
+                  <div
+                    className={cn(
+                      "truncate px-0.5 text-center text-[10px] font-semibold tabular-nums sm:px-1 sm:text-xs",
+                      pnlToneClass(pnlTone(monthlyPnl)),
+                    )}
+                  >
+                    <ResponsiveCurrency value={monthlyPnl} locale={locale} />
                   </div>
                 </div>
               )
             })}
           </div>
 
-          {/* Weeks Grid */}
-          <div className="grid grid-cols-12 gap-0.5 sm:gap-1 flex-1">
+          {/* Weeks grid */}
+          <div className="grid flex-1 grid-cols-12 gap-0.5 sm:gap-1">
             {Array.from({ length: 12 }, (_, monthIndex) => {
               const monthWeeks = weeksToDisplay.filter(weekStart => {
                 const weekYear = getYear(weekStart);
@@ -261,14 +248,14 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
               }
 
               return (
-                <div key={monthIndex} className="flex flex-col gap-0.5 sm:gap-1 min-w-0">
+                <div key={monthIndex} className="flex min-w-0 flex-col gap-0.5 sm:gap-1">
                   {allWeeks.map((weekStart, weekIndex) => {
                     if (!weekStart) {
                       return (
                         <div
                           key={weekIndex}
                           aria-hidden="true"
-                          className="min-h-10 sm:min-h-12 flex-1 rounded border bg-muted/10 dark:bg-muted/5"
+                          className="min-h-10 flex-1 rounded ring-1 ring-border sm:min-h-12"
                         />
                       )
                     }
@@ -277,37 +264,48 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
                     const trades = getWeekTrades(weekStart)
                     const weekNumber = getWeek(weekStart, { locale: dateLocale })
                     const weekRange = `${format(weekStart, 'MMM d', { locale: dateLocale })} - ${format(addDays(weekStart, 6), 'MMM d, yyyy', { locale: dateLocale })}`
-                    const ariaLabel = `${t('calendar.week')} ${weekNumber}, ${formatCurrency(pnl, { signed: true })}`
+                    const tone = pnlTone(pnl)
+                    const ariaLabel = `${t('calendar.week')} ${weekNumber}, ${signedWholeCurrency(pnl, locale)}`
 
                     return (
                       <CalendarResponsiveOverlay
                         key={`${weekStart.toISOString()}-${weekIndex}`}
                         popoverClassName="w-[400px] p-0 z-50"
                         drawerTitle={weekRange}
-                        drawerDescription={formatCurrencyCompact(pnl)}
+                        drawerDescription={signedWholeCurrency(pnl, locale)}
                         trigger={({ onClick }) => (
                           <button
                             type="button"
                             aria-label={ariaLabel}
                             className={cn(
-                              "flex w-full flex-col items-center justify-center rounded border p-0.5 sm:p-1 min-h-10 sm:min-h-12 flex-1 cursor-pointer",
-                              "transition-all duration-200 hover:scale-[1.02] hover:shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
-                              pnl > 0
-                                ? "bg-green-50/80 dark:bg-green-950/40 text-green-700 dark:text-green-400 border-green-100 dark:border-green-900/50"
-                                : pnl < 0
-                                  ? "bg-red-50/60 dark:bg-red-950/30 text-red-600 dark:text-red-400/90 border-red-100/80 dark:border-red-900/40"
-                                  : "bg-muted/20 dark:bg-muted/10 text-muted-foreground border-border"
+                              "relative flex min-h-10 w-full flex-1 cursor-pointer flex-col items-center justify-center rounded p-0.5 sm:min-h-12 sm:p-1",
+                              "ring-1 ring-border outline-none hover:z-10 hover:ring-foreground/40",
+                              "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                              "motion-safe:transition-shadow motion-safe:duration-150 motion-safe:ease-out",
                             )}
                             onClick={(e) => {
                               e.stopPropagation()
                               onClick?.()
                             }}
                           >
-                            <span className="hidden sm:block text-[10px] font-medium text-muted-foreground leading-none">
+                            {/* P&L sign is the one thing on this cell that earns color. */}
+                            {tone !== "neutral" ? (
+                              <span
+                                aria-hidden
+                                className="pointer-events-none absolute inset-0 rounded opacity-[0.10]"
+                                style={{ backgroundColor: pnlToneFill(tone) }}
+                              />
+                            ) : null}
+                            <span className={cn(widgetType.label, "hidden leading-none tabular-nums sm:block")}>
                               {weekNumber}
                             </span>
-                            <span className="text-[10px] sm:text-xs font-bold leading-tight truncate max-w-full px-0.5">
-                              <ResponsiveCurrency value={pnl} />
+                            <span
+                              className={cn(
+                                "max-w-full truncate px-0.5 text-[10px] font-semibold leading-tight tabular-nums sm:text-xs",
+                                pnlToneClass(tone),
+                              )}
+                            >
+                              <ResponsiveCurrency value={pnl} locale={locale} />
                             </span>
                           </button>
                         )}
@@ -317,6 +315,7 @@ export default function WeeklyCalendarPnl({ calendarData, year }: WeeklyCalendar
                           pnl={pnl}
                           trades={trades}
                           dateLocale={dateLocale}
+                          locale={locale}
                           t={t}
                         />
                       </CalendarResponsiveOverlay>

--- a/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
+++ b/app/[locale]/dashboard/components/calendar/weekly-modal.tsx
@@ -13,6 +13,13 @@ import { useI18n, useCurrentLocale } from "@/locales/client"
 import { calendarDateKeyFromZoned } from "@/lib/calendar-timezone"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { cn } from "@/lib/utils"
+import {
+  formatCount,
+  formatCurrency,
+  pnlTone,
+  pnlToneClass,
+  widgetType,
+} from "../widgets"
 
 interface WeeklyModalProps {
   isOpen: boolean;
@@ -22,15 +29,12 @@ interface WeeklyModalProps {
   isLoading: boolean;
 }
 
-const formatSignedCurrency = (value: number) => {
-  const formatted = Math.abs(value).toLocaleString('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 0,
+/** Whole-dollar money for the modal header. Sans + tabular-nums, sign on the number. */
+const formatSignedCurrency = (value: number, locale: string) =>
+  formatCurrency(value, locale, {
     maximumFractionDigits: 0,
+    signDisplay: 'always',
   })
-  return value < 0 ? `-${formatted}` : `+${formatted}`
-}
 
 function WeeklyTabs({
   weeklyData,
@@ -124,17 +128,16 @@ export function WeeklyModal({
             <div className="flex items-baseline justify-between gap-3">
               <DrawerTitle className="text-base capitalize truncate">{dateRange}</DrawerTitle>
               <span className={cn(
-                "text-sm font-semibold shrink-0",
-                weeklyData.pnl >= 0
-                  ? "text-green-600 dark:text-green-400"
-                  : "text-red-600 dark:text-red-400"
+                widgetType.value,
+                "shrink-0",
+                pnlToneClass(pnlTone(weeklyData.pnl)),
               )}>
-                {formatSignedCurrency(weeklyData.pnl)}
+                {formatSignedCurrency(weeklyData.pnl, locale)}
               </span>
             </div>
             <DrawerDescription className="text-xs">
               {weeklyData.tradeNumber > 0
-                ? `${weeklyData.tradeNumber} ${weeklyData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`
+                ? `${formatCount(weeklyData.tradeNumber, locale)} ${weeklyData.tradeNumber > 1 ? t('calendar.trades') : t('calendar.trade')}`
                 : t('calendar.modal.noTrades')}
             </DrawerDescription>
           </DrawerHeader>

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -4,23 +4,40 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   Cell,
   ComposedChart,
   Line,
   LineChart,
   Pie,
   PieChart,
-  ReferenceLine,
   ResponsiveContainer,
   XAxis,
   YAxis,
 } from "recharts";
-import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
+import {
+  WidgetChartGrid,
+  WidgetSkeleton,
+  WidgetZeroLine,
+  axisProps,
+  chartColors,
+  chartMargin,
+  isCompactSize,
+} from "../widgets";
 
-const MUTED_BAR_FILL = "hsl(var(--muted-foreground) / 0.35)";
+/**
+ * Loading geometry for the dashboard charts.
+ *
+ * Every placeholder mirrors the margins, axis gutters, and bar sizes of the
+ * real chart it stands in for, so nothing shifts when the data lands. Colors
+ * come from theme tokens, and the only motion is the shared skeleton pulse,
+ * which is inert under `prefers-reduced-motion`.
+ */
+
+/** The one placeholder fill: a neutral magnitude, never a colored series. */
+const MUTED_BAR_FILL = chartColors.neutral;
+const MUTED_FILL_OPACITY = 0.35;
 const DEFAULT_LOADING_LABEL = "Loading chart data...";
 
 interface ChartLoadingContainerProps {
@@ -53,25 +70,17 @@ export function getChartMargins(
   size: WidgetSize = "medium",
   variant: ChartMarginVariant = "default",
 ) {
-  if (variant === "hourly") {
-    return size === "small"
-      ? { left: 0, right: 4, top: 4, bottom: 20 }
-      : { left: 0, right: 8, top: 8, bottom: 24 };
-  }
-
-  if (variant === "calendar") {
-    return { left: 10, right: 16, top: 8, bottom: 35 };
-  }
-
-  if (size === "small") {
-    return { left: 10, right: 4, top: 4, bottom: 20 };
-  }
-
-  if (size === "large") {
-    return { left: 10, right: 12, top: 12, bottom: 28 };
-  }
-
-  return { left: 10, right: 8, top: 8, bottom: 24 };
+  // The real charts all plot on `chartMargin(size)` now, so the skeleton uses
+  // the same frame for every variant and the plot never shifts on load.
+  const base = chartMargin(size);
+  // The calendar charts carry a taller category axis under the plot.
+  const bottom = variant === "calendar" ? base.bottom + 24 : base.bottom;
+  return {
+    left: base.left,
+    right: base.right,
+    top: base.top,
+    bottom,
+  };
 }
 
 export function getAxisDimensions(
@@ -80,7 +89,7 @@ export function getAxisDimensions(
 ) {
   return {
     yAxisWidth,
-    xAxisHeight: size === "small" ? 20 : 24,
+    xAxisHeight: isCompactSize(size) ? 20 : 24,
   };
 }
 
@@ -89,6 +98,8 @@ export function getSignedDomain(values: number[]) {
     return [0, 0] as [number, number];
   }
 
+  // A length encoding needs its zero: the headroom only ever extends away
+  // from the baseline, never crops it.
   const min = Math.min(...values);
   const max = Math.max(...values);
   return [Math.min(min * 1.1, 0), Math.max(max * 1.1, 0)] as [number, number];
@@ -107,10 +118,11 @@ export function ChartAxisSkeletonOverlay({
   size = "medium",
   margin,
   yAxisWidth = 60,
-  xAxisHeight = size === "small" ? 20 : 24,
+  xAxisHeight = isCompactSize(size) ? 20 : 24,
   yTickCount = 5,
   xTickCount = 6,
 }: ChartAxisSkeletonOverlayProps) {
+  const compact = isCompactSize(size);
   return (
     <>
       <div
@@ -123,7 +135,7 @@ export function ChartAxisSkeletonOverlay({
         }}
       >
         {Array.from({ length: yTickCount }).map((_, i) => (
-          <Skeleton key={`y-${i}`} className="h-3 w-10" />
+          <WidgetSkeleton key={`y-${i}`} className="h-2.5 w-10" />
         ))}
       </div>
       <div
@@ -136,9 +148,9 @@ export function ChartAxisSkeletonOverlay({
         }}
       >
         {Array.from({ length: xTickCount }).map((_, i) => (
-          <Skeleton
+          <WidgetSkeleton
             key={`x-${i}`}
-            className={cn(size === "small" ? "h-3 w-8" : "h-3.5 w-10")}
+            className={cn(compact ? "h-2.5 w-6" : "h-3 w-8")}
           />
         ))}
       </div>
@@ -173,16 +185,17 @@ export function BarChartLoadingSkeleton({
   xTickCount = 6,
   loadingLabel,
 }: BarChartLoadingSkeletonProps) {
+  const compact = isCompactSize(size);
   const margin = getChartMargins(size, marginVariant);
   const { xAxisHeight } = getAxisDimensions(size, yAxisWidth);
   const values = data.map((row) => Number(row[yDataKey]));
   const yDomain = domain ?? getSignedDomain(values);
-  const barSize = maxBarSize ?? (size === "small" ? 25 : 40);
+  const barSize = maxBarSize ?? (compact ? 25 : 40);
 
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="animate-pulse"
+      className="motion-safe:animate-pulse"
     >
       <ChartAxisSkeletonOverlay
         size={size}
@@ -193,38 +206,35 @@ export function BarChartLoadingSkeleton({
       />
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={data} margin={margin}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            className="text-border dark:opacity-[0.12] opacity-[0.2]"
-          />
+          <WidgetChartGrid />
           <XAxis
             dataKey={xDataKey}
-            tickLine={false}
-            axisLine={false}
+            {...axisProps(size)}
             height={xAxisHeight}
             tick={false}
-            minTickGap={size === "small" ? 30 : 50}
+            minTickGap={compact ? 30 : 50}
           />
           <YAxis
-            tickLine={false}
-            axisLine={false}
+            {...axisProps(size)}
             width={yAxisWidth}
-            tickMargin={4}
             tick={false}
             domain={yDomain}
           />
-          {showReferenceLine ? (
-            <ReferenceLine y={0} stroke="hsl(var(--border))" />
-          ) : null}
+          {showReferenceLine ? <WidgetZeroLine /> : null}
           <Bar
             dataKey={yDataKey}
             radius={[3, 3, 0, 0]}
             maxBarSize={barSize}
-            className="transition-none"
             fill={MUTED_BAR_FILL}
+            fillOpacity={MUTED_FILL_OPACITY}
+            isAnimationActive={false}
           >
             {data.map((_, index) => (
-              <Cell key={`skeleton-cell-${index}`} fill={MUTED_BAR_FILL} />
+              <Cell
+                key={`skeleton-cell-${index}`}
+                fill={MUTED_BAR_FILL}
+                fillOpacity={MUTED_FILL_OPACITY}
+              />
             ))}
           </Bar>
         </BarChart>
@@ -250,13 +260,14 @@ export function LineChartLoadingSkeleton({
   showReferenceLine = true,
   loadingLabel,
 }: LineChartLoadingSkeletonProps) {
+  const compact = isCompactSize(size);
   const margin = getChartMargins(size);
   const { yAxisWidth, xAxisHeight } = getAxisDimensions(size);
 
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="animate-pulse"
+      className="motion-safe:animate-pulse"
     >
       <ChartAxisSkeletonOverlay
         size={size}
@@ -266,40 +277,24 @@ export function LineChartLoadingSkeleton({
       />
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data} margin={margin}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            className="text-border dark:opacity-[0.12] opacity-[0.2]"
-          />
+          <WidgetChartGrid />
           <XAxis
             dataKey={xDataKey}
-            tickLine={false}
-            axisLine={false}
+            {...axisProps(size)}
             height={xAxisHeight}
             tick={false}
-            minTickGap={size === "small" ? 30 : 50}
+            minTickGap={compact ? 30 : 50}
           />
-          <YAxis
-            tickLine={false}
-            axisLine={false}
-            width={yAxisWidth}
-            tickMargin={4}
-            tick={false}
-          />
-          {showReferenceLine ? (
-            <ReferenceLine
-              y={0}
-              stroke="hsl(var(--muted-foreground))"
-              strokeDasharray="3 3"
-              strokeOpacity={0.5}
-            />
-          ) : null}
+          <YAxis {...axisProps(size)} width={yAxisWidth} tick={false} />
+          {showReferenceLine ? <WidgetZeroLine /> : null}
           <Line
             type="monotone"
             dataKey={yDataKey}
             stroke={MUTED_BAR_FILL}
+            strokeOpacity={MUTED_FILL_OPACITY}
             strokeWidth={2}
             dot={false}
-            className="transition-none"
+            isAnimationActive={false}
           />
         </LineChart>
       </ResponsiveContainer>
@@ -316,6 +311,7 @@ export function DonutChartLoadingSkeleton({
   size = "medium",
   loadingLabel,
 }: DonutChartLoadingSkeletonProps) {
+  const compact = isCompactSize(size);
   const mockData = [
     { name: "a", value: 55 },
     { name: "b", value: 10 },
@@ -325,7 +321,7 @@ export function DonutChartLoadingSkeleton({
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="animate-pulse flex flex-col"
+      className="motion-safe:animate-pulse flex flex-col"
     >
       <div className="flex-1 min-h-0">
         <ResponsiveContainer width="100%" height="100%">
@@ -333,33 +329,39 @@ export function DonutChartLoadingSkeleton({
             <Pie
               data={mockData}
               cx="50%"
-              cy="45%"
-              innerRadius={size === "small" ? "60%" : "65%"}
-              outerRadius={size === "small" ? "80%" : "85%"}
+              cy="50%"
+              innerRadius={compact ? "60%" : "65%"}
+              outerRadius={compact ? "80%" : "85%"}
               paddingAngle={2}
               dataKey="value"
               startAngle={90}
               endAngle={-270}
               stroke="hsl(var(--background))"
               strokeWidth={1}
+              isAnimationActive={false}
             >
               {mockData.map((_, index) => (
-                <Cell key={`skeleton-cell-${index}`} fill={MUTED_BAR_FILL} />
+                <Cell
+                  key={`skeleton-cell-${index}`}
+                  fill={MUTED_BAR_FILL}
+                  fillOpacity={MUTED_FILL_OPACITY}
+                />
               ))}
             </Pie>
           </PieChart>
         </ResponsiveContainer>
       </div>
+      {/* Matches the direct-label row the real donut renders underneath. */}
       <div
         className={cn(
           "flex items-center justify-center gap-4 shrink-0",
-          size === "small" ? "pb-1" : "pb-2 pt-2",
+          compact ? "pt-1" : "pt-3",
         )}
       >
         {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton
+          <WidgetSkeleton
             key={`legend-${i}`}
-            className={cn(size === "small" ? "h-3 w-16" : "h-3.5 w-20")}
+            className={cn(compact ? "h-2.5 w-14" : "h-3 w-20")}
           />
         ))}
       </div>
@@ -384,13 +386,14 @@ export function ComposedChartLoadingSkeleton({
   lineDataKey,
   loadingLabel,
 }: ComposedChartLoadingSkeletonProps) {
+  const compact = isCompactSize(size);
   const margin = getChartMargins(size, "calendar");
   const { yAxisWidth, xAxisHeight } = getAxisDimensions(size);
 
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="animate-pulse"
+      className="motion-safe:animate-pulse"
     >
       <ChartAxisSkeletonOverlay
         size={size}
@@ -401,43 +404,39 @@ export function ComposedChartLoadingSkeleton({
       />
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart data={data} margin={margin}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            className="text-border dark:opacity-[0.12] opacity-[0.2]"
-          />
+          <WidgetChartGrid />
           <XAxis
             dataKey={xDataKey}
-            tickLine={false}
-            axisLine={false}
+            {...axisProps(size)}
             height={xAxisHeight}
             tick={false}
           />
-          <YAxis
-            tickLine={false}
-            axisLine={false}
-            width={yAxisWidth}
-            tickMargin={4}
-            tick={false}
-          />
-          <ReferenceLine y={0} stroke="hsl(var(--border))" />
+          <YAxis {...axisProps(size)} width={yAxisWidth} tick={false} />
+          <WidgetZeroLine />
           <Bar
             dataKey={barDataKey}
             radius={[3, 3, 0, 0]}
-            maxBarSize={size === "small" ? 20 : 30}
-            className="transition-none"
+            maxBarSize={compact ? 20 : 30}
             fill={MUTED_BAR_FILL}
+            fillOpacity={MUTED_FILL_OPACITY}
+            isAnimationActive={false}
           >
             {data.map((_, index) => (
-              <Cell key={`bar-${index}`} fill={MUTED_BAR_FILL} />
+              <Cell
+                key={`bar-${index}`}
+                fill={MUTED_BAR_FILL}
+                fillOpacity={MUTED_FILL_OPACITY}
+              />
             ))}
           </Bar>
           <Line
             type="stepAfter"
             dataKey={lineDataKey}
             stroke={MUTED_BAR_FILL}
+            strokeOpacity={MUTED_FILL_OPACITY}
             strokeWidth={2}
             dot={false}
-            className="transition-none"
+            isAnimationActive={false}
           />
         </ComposedChart>
       </ResponsiveContainer>

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -1,233 +1,239 @@
 "use client";
 
 import * as React from "react";
-import {
-  PieChart,
-  Pie,
-  Cell,
-  ResponsiveContainer,
-  Tooltip,
-  Legend,
-  Label,
-} from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Label } from "recharts";
+
 import { useData } from "@/context/data-provider";
 import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
+
 import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton";
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetFooter,
+  WidgetHeader,
+  WidgetTooltip,
+  chartColors,
+  formatCount,
+  formatCurrency,
+  formatPercent,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  widgetType,
+} from "../widgets";
 
 interface CommissionsPnLChartProps {
   size?: WidgetSize;
 }
 
-
-const chartConfig = {
-  pnl: {
-    label: "Net P/L",
-    color: "hsl(var(--chart-win))",
-  },
-  commissions: {
-    label: "Commissions",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
-
-const formatCurrency = (value: number) =>
-  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
+interface CommissionsSlice {
+  key: "pnl" | "commissions";
+  name: string;
+  /** Share of the combined gross magnitude, 0-100. */
+  value: number;
+  color: string;
+  /** The signed amount the slice stands for, in USD. */
+  raw: number;
+  toneClassName?: string;
+}
 
 export default function CommissionsPnLChart({
   size = "medium",
 }: CommissionsPnLChartProps) {
   const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
+  const locale = useCurrentLocale();
+  const compact = isCompactSize(size);
 
-
-  const chartData = React.useMemo(() => {
-    const totalPnL = trades.reduce((sum, trade) => sum + trade.pnl, 0);
-    const totalCommissions = trades.reduce(
+  const chartData = React.useMemo<CommissionsSlice[]>(() => {
+    const pnl = trades.reduce((sum, trade) => sum + trade.pnl, 0);
+    const commissions = trades.reduce(
       (sum, trade) => sum + trade.commission,
       0,
     );
-    const total = Math.abs(totalPnL) + Math.abs(totalCommissions);
-    const pnlPercent = total > 0 ? Number(((Math.abs(totalPnL) / total) * 100).toFixed(2)) : 0;
-    const commPercent = total > 0 ? Number(((Math.abs(totalCommissions) / total) * 100).toFixed(2)) : 0;
+    // A donut encodes share of a whole, so the parts have to be non negative.
+    // The whole here is the combined gross magnitude of both figures; the
+    // signed amounts are stated verbatim under the plot so nothing is hidden.
+    const total = Math.abs(pnl) + Math.abs(commissions);
+    const pnlPercent = total > 0 ? (Math.abs(pnl) / total) * 100 : 0;
+    const commPercent = total > 0 ? (Math.abs(commissions) / total) * 100 : 0;
+
     return [
       {
+        key: "pnl",
         name: t("commissions.legend.netPnl"),
         value: pnlPercent,
-        color: chartConfig.pnl.color,
-        raw: totalPnL,
+        // The only figure here that carries a sign, so the only one that earns color.
+        color: pnlToneFill(pnlTone(pnl)),
+        raw: pnl,
+        toneClassName: pnlToneClass(pnlTone(pnl)),
       },
       {
+        key: "commissions",
         name: t("commissions.legend.commissions"),
         value: commPercent,
-        color: chartConfig.commissions.color,
-        raw: totalCommissions,
+        // A cost magnitude, not a signed result: it stays monochrome.
+        color: chartColors.neutral,
+        raw: commissions,
       },
     ];
   }, [trades, t]);
 
+  const hasData = trades.length > 0 && chartData.some((slice) => slice.value > 0);
 
-  const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: any }> }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
-          <div className="grid gap-2">
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("commissions.tooltip.type")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.name}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("commissions.tooltip.amount")}
-              </span>
-              <span className="font-bold">{formatCurrency(data.raw)}</span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("commissions.tooltip.percentage")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.value.toFixed(2)}%</span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-    return null;
-  };
-
-
-  const renderColorfulLegendText = (value: string, entry: any) => {
-    return <span className="text-xs text-muted-foreground">{value}</span>;
-  };
-
-
-  // Pie radii for consistency with trade-distribution
-  const getInnerRadius = () => (size === 'small' ? '60%' : '65%');
-  const getOuterRadius = () => (size === 'small' ? '80%' : '85%');
+  const innerRadius = compact ? "60%" : "65%";
+  const outerRadius = compact ? "80%" : "85%";
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
-            >
-              {t("commissions.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === 'small' ? "size-3.5" : "size-4")}
-            >
-              <p>{t("commissions.tooltip.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === 'small' ? "p-1" : "p-2 sm:p-4"
-        )}
-      >
-        <div className="w-full h-full">
-          {isLoading ? (
-            <DonutChartLoadingSkeleton size={size} />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="45%"
-                innerRadius={getInnerRadius()}
-                outerRadius={getOuterRadius()}
-                paddingAngle={2}
-                dataKey="value"
-                nameKey="name"
-                startAngle={90}
-                endAngle={-270}
-                stroke="hsl(var(--background))"
-                strokeWidth={1}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={entry.color}
-                    className="transition-opacity duration-300 ease-out hover:opacity-80 dark:brightness-90"
-                  />
-                ))}
-                {/* Centered percentage labels */}
-                <Label
-                  position="center"
-                  content={(props: any) => {
-                    if (!props.viewBox) return null;
-                    const viewBox = props.viewBox;
-                    if (!viewBox.cx || !viewBox.cy) return null;
-                    const cx = viewBox.cx;
-                    const cy = viewBox.cy;
-                    const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1);
-                    return chartData.map((entry, index) => {
-                      const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
-                      const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
-                      const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("commissions.title")}
+        description={t("commissions.tooltip.description")}
+      />
+      <WidgetBody size={size} className="flex min-h-0 flex-col gap-4">
+        {isLoading ? (
+          <DonutChartLoadingSkeleton size={size} />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t("widgets.empty.noTrades")} />
+        ) : (
+          <>
+            <div className="min-h-0 flex-1">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={innerRadius}
+                    outerRadius={outerRadius}
+                    paddingAngle={2}
+                    dataKey="value"
+                    nameKey="name"
+                    startAngle={90}
+                    endAngle={-270}
+                    stroke="hsl(var(--background))"
+                    strokeWidth={1}
+                    isAnimationActive={false}
+                  >
+                    {chartData.map((entry) => (
+                      <Cell key={entry.key} fill={entry.color} />
+                    ))}
+                    {/* Direct labels on the arcs: two series never earn a legend. */}
+                    <Label
+                      position="center"
+                      content={(props: any) => {
+                        const viewBox = props?.viewBox;
+                        if (!viewBox?.cx || !viewBox?.cy) return null;
+                        const { cx, cy } = viewBox;
+                        const labelRadius = Math.min(cx, cy) * (compact ? 0.95 : 1.1);
+                        return (
+                          <>
+                            {chartData.map((entry, index) => {
+                              if (entry.value <= 5) return null;
+                              const precedingShare = chartData
+                                .slice(0, index)
+                                .reduce((acc, curr) => acc + curr.value, 0);
+                              const angle =
+                                -90 +
+                                (360 * (entry.value / 100)) / 2 +
+                                (360 * precedingShare) / 100;
+                              const x =
+                                cx + labelRadius * Math.cos((angle * Math.PI) / 180);
+                              const y =
+                                cy + labelRadius * Math.sin((angle * Math.PI) / 180);
+                              return (
+                                <text
+                                  key={entry.key}
+                                  x={x}
+                                  y={y}
+                                  textAnchor="middle"
+                                  dominantBaseline="middle"
+                                  className="fill-muted-foreground tabular-nums"
+                                  style={{ fontSize: compact ? 10 : 11 }}
+                                >
+                                  {formatPercent(entry.value, locale, {
+                                    maximumFractionDigits: 0,
+                                  })}
+                                </text>
+                              );
+                            })}
+                          </>
+                        );
+                      }}
+                    />
+                  </Pie>
+                  <Tooltip
+                    cursor={false}
+                    isAnimationActive={false}
+                    content={({ active, payload }: any) => {
+                      if (!active || !payload?.length) return null;
+                      const slice = payload[0].payload as CommissionsSlice;
                       return (
-                        <text
-                          key={index}
-                          x={x}
-                          y={y}
-                          textAnchor="middle"
-                          dominantBaseline="middle"
-                          className="fill-muted-foreground font-medium translate-y-2"
-                          style={{ fontSize: size === 'small' ? '10px' : '12px' }}
-                        >
-                          {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
-                        </text>
+                        <WidgetTooltip
+                          title={slice.name}
+                          rows={[
+                            {
+                              label: t("commissions.tooltip.amount"),
+                              value: formatCurrency(slice.raw, locale),
+                              toneClassName: slice.toneClassName,
+                            },
+                            {
+                              label: t("commissions.tooltip.percentage"),
+                              value: formatPercent(slice.value, locale),
+                            },
+                          ]}
+                        />
                       );
-                    });
-                  }}
-                />
-              </Pie>
-              <Legend
-                verticalAlign="bottom"
-                align="center"
-                iconSize={8}
-                iconType="circle"
-                formatter={renderColorfulLegendText}
-                wrapperStyle={{
-                  paddingTop: size === 'small' ? 0 : 16
-                }}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === 'small' ? '10px' : '12px',
-                  zIndex: 1000
-                }}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* The exact, auditable figures behind the shares. */}
+            <div className="flex shrink-0 flex-col gap-1.5">
+              {chartData.map((slice) => (
+                <div
+                  key={slice.key}
+                  className="flex items-center justify-between gap-3"
+                >
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span
+                      aria-hidden
+                      className="size-2 shrink-0 rounded-[2px]"
+                      style={{ backgroundColor: slice.color }}
+                    />
+                    <span className={cn(widgetType.label, "truncate")}>
+                      {slice.name}
+                    </span>
+                  </div>
+                  <span
+                    className={cn(
+                      widgetType.value,
+                      "shrink-0 text-right",
+                      slice.toneClassName,
+                    )}
+                  >
+                    {formatCurrency(slice.raw, locale)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </WidgetBody>
+      <WidgetFooter size={size}>
+        <span>USD</span>
+        <span className="tabular-nums">
+          {formatCount(trades.length)} {t("tickDistribution.tooltip.trades")}
+        </span>
+      </WidgetFooter>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/contract-quantity.tsx
+++ b/app/[locale]/dashboard/components/charts/contract-quantity.tsx
@@ -4,48 +4,55 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
-  Cell,
+  ResponsiveContainer,
 } from "recharts";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { ChartConfig, ChartContainer } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { Trade } from "@/prisma/generated/prisma/browser";
+import { cn } from "@/lib/utils";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_HOURLY_QUANTITY,
 } from "./chart-loading-skeleton";
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetFooter,
+  WidgetHeader,
+  WidgetTooltip,
+  axisProps,
+  chartColors,
+  chartMargin,
+  formatCount,
+  isCompactSize,
+} from "../widgets";
 
 interface ContractQuantityChartProps {
   size?: WidgetSize;
 }
 
-const chartConfig = {
-  totalQuantity: {
-    label: "Total Number of Contracts",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
+interface HourQuantityDatum {
+  hour: number;
+  totalQuantity: number;
+  tradeCount: number;
+}
 
 export default function ContractQuantityChart({
   size = "medium",
 }: ContractQuantityChartProps) {
   const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
+  const locale = useCurrentLocale();
+  const compact = isCompactSize(size);
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<HourQuantityDatum[]>(() => {
     const hourlyData: {
       [hour: string]: { totalQuantity: number; count: number };
     } = {};
@@ -72,103 +79,115 @@ export default function ContractQuantityChart({
       .sort((a, b) => a.hour - b.hour);
   }, [trades]);
 
-  const maxTradeCount = Math.max(...chartData.map((data) => data.tradeCount));
+  const totals = React.useMemo(
+    () =>
+      chartData.reduce(
+        (acc, row) => ({
+          trades: acc.trades + row.tradeCount,
+          contracts: acc.contracts + row.totalQuantity,
+        }),
+        { trades: 0, contracts: 0 },
+      ),
+    [chartData],
+  );
 
-  const getColor = (count: number) => {
-    const intensity = Math.max(0.2, count / maxTradeCount);
-    return `hsl(var(--chart-loss) / ${intensity})`;
-  };
+  const hasData = totals.trades > 0;
 
-  const CustomTooltip = ({ active, payload, label }: any) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      return (
-        <div className="bg-background p-2 border rounded shadow-xs">
-          <p className="font-semibold">{`${label}${t("contracts.tooltip.hour")} - ${(label + 1) % 24}${t("contracts.tooltip.hour")}`}</p>
-          <p className="font-bold">
-            {t("contracts.tooltip.totalContracts")}: {data.totalQuantity}
-          </p>
-          <p>
-            {t("contracts.tooltip.numberOfTrades")}: {data.tradeCount}
-          </p>
-        </div>
-      );
-    }
-    return null;
-  };
+  const hourRangeLabel = React.useCallback(
+    (hour: number) =>
+      `${hour}${t("contracts.tooltip.hour")} - ${(hour + 1) % 24}${t("contracts.tooltip.hour")}`,
+    [t],
+  );
 
   return (
-    <Card>
-      <CardHeader className="sm:min-h-[120px] flex flex-col items-stretch space-y-0 border-b p-6">
-        <CardTitle>{t("contracts.title")}</CardTitle>
-        <CardDescription>{t("contracts.description")}</CardDescription>
-      </CardHeader>
-      <CardContent className="px-2 sm:p-6">
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("contracts.title")}
+        description={t("contracts.description")}
+      />
+      <WidgetBody size={size} flush className={cn(compact ? "p-1" : "p-2")}>
         {isLoading ? (
-          <div className="aspect-auto h-[350px] w-full">
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_HOURLY_QUANTITY}
-              xDataKey="hour"
-              yDataKey="totalQuantity"
-              marginVariant="hourly"
-              yAxisWidth={45}
-              xTickCount={8}
-            />
-          </div>
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_HOURLY_QUANTITY}
+            xDataKey="hour"
+            yDataKey="totalQuantity"
+            marginVariant="hourly"
+            yAxisWidth={45}
+            xTickCount={8}
+          />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t("widgets.empty.noTrades")} />
         ) : (
-        <ChartContainer
-          config={chartConfig}
-          className="aspect-auto h-[350px] w-full"
-        >
-          <BarChart
-            data={chartData}
-            margin={{
-              left: 12,
-              right: 12,
-              top: 12,
-              bottom: 12,
-            }}
-          >
-            <CartesianGrid
-              strokeDasharray="3 3"
-              className="text-border dark:opacity-[0.12] opacity-[0.2]"
-            />
-            <XAxis
-              dataKey="hour"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              tickFormatter={(value: number) =>
-                `${value}${t("contracts.tooltip.hour")}`
-              }
-              ticks={[0, 3, 6, 9, 12, 15, 18, 21]}
-            />
-            <YAxis
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              tickFormatter={(value: number) => value.toFixed(0)}
-              label={{
-                value: t("contracts.axis.contracts"),
-                angle: -90,
-                position: "insideLeft",
-              }}
-            />
-            <Tooltip content={<CustomTooltip />} />
-            <Bar
-              dataKey="totalQuantity"
-              radius={[4, 4, 0, 0]}
-              className="transition-all duration-300 ease-in-out"
-            >
-              {chartData.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={getColor(entry.tradeCount)} />
-              ))}
-            </Bar>
-          </BarChart>
-        </ChartContainer>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={chartMargin(size)}>
+              <WidgetChartGrid />
+              <XAxis
+                dataKey="hour"
+                {...axisProps(size)}
+                height={compact ? 20 : 24}
+                tickFormatter={(value: number) =>
+                  `${value}${t("contracts.tooltip.hour")}`
+                }
+                ticks={
+                  compact ? [0, 6, 12, 18] : [0, 3, 6, 9, 12, 15, 18, 21]
+                }
+              />
+              <YAxis
+                {...axisProps(size)}
+                width={compact ? 36 : 44}
+                // A count of contracts: unsigned, so the domain starts at zero
+                // and bar length reads as magnitude directly.
+                allowDecimals={false}
+                tickFormatter={(value: number) => formatCount(value, locale)}
+              />
+              <Tooltip
+                cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                isAnimationActive={false}
+                wrapperStyle={{ zIndex: 1000 }}
+                content={({ active, payload }: any) => {
+                  if (!active || !payload?.length) return null;
+                  const row = payload[0].payload as HourQuantityDatum;
+                  return (
+                    <WidgetTooltip
+                      title={hourRangeLabel(row.hour)}
+                      rows={[
+                        {
+                          label: t("contracts.tooltip.totalContracts"),
+                          value: formatCount(row.totalQuantity, locale),
+                        },
+                        {
+                          label: t("contracts.tooltip.numberOfTrades"),
+                          value: formatCount(row.tradeCount, locale),
+                        },
+                      ]}
+                    />
+                  );
+                }}
+              />
+              <Bar
+                dataKey="totalQuantity"
+                radius={[3, 3, 0, 0]}
+                maxBarSize={compact ? 25 : 40}
+                // Volume is an unsigned magnitude, so it stays monochrome; bar
+                // length already carries how busy the hour was.
+                fill={chartColors.neutral}
+                isAnimationActive={false}
+              />
+            </BarChart>
+          </ResponsiveContainer>
         )}
-      </CardContent>
-    </Card>
+      </WidgetBody>
+      <WidgetFooter size={size}>
+        <span>{t("contracts.axis.contracts")} · UTC</span>
+        <span className="tabular-nums">
+          {formatCount(totals.contracts, locale)}{" "}
+          {t("contracts.axis.contracts")} ·{" "}
+          {formatCount(totals.trades, locale)}{" "}
+          {t("tickDistribution.tooltip.trades")}
+        </span>
+      </WidgetFooter>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/daily-tick-target.tsx
+++ b/app/[locale]/dashboard/components/charts/daily-tick-target.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Target, Plus, Minus, ArrowUp, ArrowDown } from "lucide-react"
+import { Target, Plus, Minus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
 import {
@@ -11,7 +10,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { InfoBubble } from "@/components/ui/info-bubble"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { Switch } from "@/components/ui/switch"
@@ -24,29 +22,54 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { useI18n } from "@/locales/client"
+import { useCurrentLocale, useI18n } from "@/locales/client"
 import { useData } from "@/context/data-provider"
 import { useDailyTickTargetStore } from "@/store/widgets/daily-tick-target-store"
 import { useTickDetailsStore } from "@/store/tick-details-store"
 import { useEffect, useState } from "react"
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetFooter,
+  WidgetHeader,
+  WidgetMetric,
+  WidgetStat,
+  WidgetStatList,
+  formatCount,
+  formatPercent,
+  formatTicks,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  widgetType,
+} from "../widgets"
 
 interface DailyTickTargetProps {
   size?: WidgetSize
 }
 
+/** Local calendar date, so a trade never slides into the wrong day via UTC. */
+function formatLocalDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 export default function DailyTickTargetChart({ size = 'medium' }: DailyTickTargetProps) {
   const { formattedTrades: trades, dateRange } = useData()
   const t = useI18n()
+  const locale = useCurrentLocale()
   const tickDetails = useTickDetailsStore(state => state.tickDetails)
   const [targetValue, setTargetValue] = useState('')
   const [isDialogOpen, setIsDialogOpen] = useState(false)
-  // Add selectedDate state
-  const [selectedDate, setSelectedDate] = useState<string>(new Date().toISOString().split('T')[0])
-  
-  const { 
-    getTodayTarget, 
-    getTodayProgress, 
-    setTarget, 
+  const compact = isCompactSize(size)
+
+  const {
+    getTodayTarget,
+    getTodayProgress,
+    setTarget,
     updateCurrent,
     displayMode,
     setDisplayMode,
@@ -57,53 +80,36 @@ export default function DailyTickTargetChart({ size = 'medium' }: DailyTickTarge
     getProgress // Added getProgress
   } = useDailyTickTargetStore()
 
+  // The period this widget answers for: the active date filter, or today.
+  const period = React.useMemo(() => {
+    if (dateRange && dateRange.from) {
+      const from = formatLocalDate(dateRange.from)
+      return { from, to: dateRange.to ? formatLocalDate(dateRange.to) : from }
+    }
+    const today = formatLocalDate(new Date())
+    return { from: today, to: today }
+  }, [dateRange])
+
+  // The from date is the key the target is stored under.
+  const selectedDate = period.from
+
   // Use selectedDate for fetching progress
   const todayTarget = getTarget(selectedDate)
   const progress = getProgress(selectedDate) || { current: 0, target: 0, percentage: 0, positive: 0, negative: 0, total: 0 }
 
-  // Calculate current day's ticks from trades
-  useEffect(() => {
-    // Determine display date/range based on date filter or today
-    let fromDate: string
-    let toDate: string
-    
-    if (dateRange && dateRange.from) {
-      // If there's a date filter, use the date range
-      // Use local date formatting to avoid timezone issues
-      const formatLocalDate = (date: Date) => {
-        const year = date.getFullYear()
-        const month = String(date.getMonth() + 1).padStart(2, '0')
-        const day = String(date.getDate()).padStart(2, '0')
-        return `${year}-${month}-${day}`
-      }
-      
-      fromDate = formatLocalDate(dateRange.from)
-      toDate = dateRange.to ? formatLocalDate(dateRange.to) : fromDate
-    } else {
-      // No date filter, use today's date
-      const today = new Date()
-      const year = today.getFullYear()
-      const month = String(today.getMonth() + 1).padStart(2, '0')
-      const day = String(today.getDate()).padStart(2, '0')
-      const todayStr = `${year}-${month}-${day}`
-      fromDate = todayStr
-      toDate = todayStr
-    }
-    
-    // Use the from date as the selected date for storage
-    setSelectedDate(fromDate)
-
+  // Calculate the period's ticks from trades
+  const breakdown = React.useMemo(() => {
     // Filter trades for the selected period (even if trades array is empty)
     const displayTrades = trades.filter(trade => {
       // Validate that entryDate exists and is valid
       if (!trade.entryDate) return false
-      
+
       const entryDate = new Date(trade.entryDate)
       if (isNaN(entryDate.getTime())) return false
-      
+
       const tradeDate = entryDate.toISOString().split('T')[0]
       // Check if trade date is within the range
-      return tradeDate >= fromDate && tradeDate <= toDate
+      return tradeDate >= period.from && tradeDate <= period.to
     })
 
     // Calculate ticks breakdown for the period (even if no trades)
@@ -111,41 +117,54 @@ export default function DailyTickTargetChart({ size = 'medium' }: DailyTickTarge
     let positiveTicks = 0
     let negativeTicks = 0
     let totalAbsoluteTicks = 0
-    
-    if (displayTrades.length > 0) {
-      displayTrades.forEach(trade => {
-        // Validate required fields
-        if (!trade.pnl || !trade.quantity || !trade.instrument) return
-        
-        // Fix ticker matching logic - sort by length descending to match longer tickers first
-        const matchingTicker = Object.keys(tickDetails)
-          .sort((a, b) => b.length - a.length)
-          .find(ticker => trade.instrument.includes(ticker))
-        
-        // Use tickValue (monetary value per tick) instead of tickSize (minimum price increment)
-        const tickValue = matchingTicker ? tickDetails[matchingTicker].tickValue : 1
-        
-        // Calculate PnL per contract first
-        const pnlPerContract = Number(trade.pnl) / Number(trade.quantity)
-        if (isNaN(pnlPerContract)) return
-        
-        const ticks = Math.round(pnlPerContract / tickValue)
-        if (!isNaN(ticks)) {
-          totalTicks += ticks
-          totalAbsoluteTicks += Math.abs(ticks)
-          
-          if (ticks > 0) {
-            positiveTicks += ticks
-          } else {
-            negativeTicks += ticks
-          }
-        }
-      })
-    }
+    let tradeCount = 0
 
-    // Always update current ticks for the period with breakdown (even if zero)
-    updateCurrent(fromDate, totalTicks, positiveTicks, negativeTicks, totalAbsoluteTicks)
-  }, [trades, tickDetails, updateCurrent, dateRange])
+    displayTrades.forEach(trade => {
+      // Validate required fields
+      if (!trade.pnl || !trade.quantity || !trade.instrument) return
+
+      // Fix ticker matching logic - sort by length descending to match longer tickers first
+      const matchingTicker = Object.keys(tickDetails)
+        .sort((a, b) => b.length - a.length)
+        .find(ticker => trade.instrument.includes(ticker))
+
+      // Use tickValue (monetary value per tick) instead of tickSize (minimum price increment)
+      const tickValue = matchingTicker ? tickDetails[matchingTicker].tickValue : 1
+
+      // Calculate PnL per contract first. Guarded so a zero quantity can never
+      // reach the widget as NaN or Infinity.
+      const quantity = Number(trade.quantity)
+      if (!quantity) return
+      const pnlPerContract = Number(trade.pnl) / quantity
+      if (!Number.isFinite(pnlPerContract) || !tickValue) return
+
+      const ticks = Math.round(pnlPerContract / tickValue)
+      if (Number.isFinite(ticks)) {
+        tradeCount += 1
+        totalTicks += ticks
+        totalAbsoluteTicks += Math.abs(ticks)
+
+        if (ticks > 0) {
+          positiveTicks += ticks
+        } else {
+          negativeTicks += ticks
+        }
+      }
+    })
+
+    return { totalTicks, positiveTicks, negativeTicks, totalAbsoluteTicks, tradeCount }
+  }, [trades, tickDetails, period])
+
+  // Always update current ticks for the period with breakdown (even if zero)
+  useEffect(() => {
+    updateCurrent(
+      period.from,
+      breakdown.totalTicks,
+      breakdown.positiveTicks,
+      breakdown.negativeTicks,
+      breakdown.totalAbsoluteTicks,
+    )
+  }, [period.from, breakdown, updateCurrent])
 
   const handleSaveTarget = () => {
     const targetDate = selectedDate
@@ -164,266 +183,217 @@ export default function DailyTickTargetChart({ size = 'medium' }: DailyTickTarge
     setTarget(targetDate, newTarget)
   }
 
-  const isTargetSet = todayTarget && todayTarget.target > 0
+  const isTargetSet = Boolean(todayTarget && todayTarget.target > 0)
   const isOverTarget = progress.current > progress.target && progress.target > 0
 
-  return (
-    <Card className="h-full flex flex-col">
-      <CardHeader 
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle 
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
-            >
-              {t('widgets.dailyTickTarget.title')}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === 'small' ? "size-3.5" : "size-4")}
-            >
-              <p>{t('widgets.dailyTickTarget.tooltip')}</p>
-            </InfoBubble>
-            
-            {/* Points/Ticks Toggle */}
-            <div className="flex items-center gap-2 ml-2">
-              <TooltipProvider>
-                <UITooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center gap-1.5">
-                      <span className={cn(
-                        "text-xs",
-                        displayMode === 'ticks' ? "font-medium" : "text-muted-foreground"
-                      )}>
-                        {t('widgets.dailyTickTarget.displayMode.ticks')}
-                      </span>
-                      <Switch
-                        checked={displayMode === 'points'}
-                        onCheckedChange={(checked) => setDisplayMode(checked ? 'points' : 'ticks')}
-                        className="h-4 w-8"
-                      />
-                      <span className={cn(
-                        "text-xs",
-                        displayMode === 'points' ? "font-medium" : "text-muted-foreground"
-                      )}>
-                        {t('widgets.dailyTickTarget.displayMode.points')}
-                      </span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    <p>{t('widgets.dailyTickTarget.displayMode.tooltip')}</p>
-                  </TooltipContent>
-                </UITooltip>
-              </TooltipProvider>
-            </div>
-          </div>
-          
-          {/* Target controls */}
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => handleQuickIncrement(-1)}
-              className="h-6 w-6 p-0 hover:bg-muted"
-            >
-              <Minus className="h-3 w-3" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => handleQuickIncrement(1)}
-              className="h-6 w-6 p-0 hover:bg-muted"
-            >
-              <Plus className="h-3 w-3" />
-            </Button>
-            
-            {/* Target setting dialog */}
-            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-              <DialogTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 w-6 p-0 hover:bg-muted"
-                >
-                  <Target className="h-3 w-3" />
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle className="text-balance">{t('widgets.dailyTickTarget.setTarget')}</DialogTitle>
-                  <DialogDescription className="text-pretty">
-                    {t('widgets.dailyTickTarget.setTargetDescription')}
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-2">
-                    <label className="text-sm font-medium">
-                      {t('widgets.dailyTickTarget.target')} ({displayMode === 'points' ? t('widgets.dailyTickTarget.displayMode.points') : t('widgets.dailyTickTarget.displayMode.ticks')})
-                    </label>
-                    <Input
-                      type="number"
-                      value={targetValue}
-                      onChange={(e) => setTargetValue(e.target.value)}
-                      placeholder={Math.round(convertToDisplayValue(progress.target)).toString()}
-                      className="w-full"
-                    />
-                  </div>
-                  <div className="flex justify-end gap-2">
-                    <Button
-                      variant="outline"
-                      onClick={() => setIsDialogOpen(false)}
-                    >
-                      {t('common.cancel')}
-                    </Button>
-                    <Button onClick={handleSaveTarget}>
-                      {t('common.save')}
-                    </Button>
-                  </div>
-                </div>
-              </DialogContent>
-            </Dialog>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent 
-        className={cn(
-          "flex-1 min-h-0",
-          size === 'small' ? "p-1" : "p-2 sm:p-4"
-        )}
-      >
-        <div className="w-full h-full flex flex-col justify-center gap-4">
-          {/* Current vs Target Display */}
-          <div className="flex items-center justify-center gap-4 border-b pb-2">
-            <div className="flex flex-col items-center gap-1">
-              <span className={cn(
-                "text-muted-foreground uppercase tracking-wide",
-                size === 'small' ? "text-xs" : "text-sm"
-              )}>
-                {t('widgets.dailyTickTarget.current')}
-              </span>
-              <span className={cn(
-                "font-bold",
-                isOverTarget ? "text-green-500" : "text-foreground",
-                size === 'small' ? "text-xl" : "text-3xl"
-              )}>
-                {Math.round(convertToDisplayValue(progress.current))}
-                <span className="text-sm font-normal ml-1 text-muted-foreground">
-                  {getDisplayUnit()}{progress.current !== 1 ? 's' : ''}
-                </span>
-              </span>
-            </div>
-            
-            <div className="flex flex-col items-center">
-              <span className="text-muted-foreground text-lg">/</span>
-            </div>
-            
-            <div className="flex flex-col items-center gap-1">
-              <span className={cn(
-                "text-muted-foreground uppercase tracking-wide",
-                size === 'small' ? "text-xs" : "text-sm"
-              )}>
-                {t('widgets.dailyTickTarget.target')}
-              </span>
-              <span className={cn(
-                "font-bold",
-                size === 'small' ? "text-xl" : "text-3xl"
-              )}>
-                {Math.round(convertToDisplayValue(progress.target))}
-                <span className="text-sm font-normal ml-1 text-muted-foreground">
-                  {getDisplayUnit()}{progress.target !== 1 ? 's' : ''}
-                </span>
-              </span>
-            </div>
-          </div>
-          
-          {/* Breakdown Display */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="flex items-center gap-2 bg-green-50 dark:bg-green-900/20 p-2 rounded-md">
-              <ArrowUp className="h-4 w-4 text-green-500" />
-              <div className="flex flex-col gap-0.5">
-                <span className={cn(
-                  "text-xs text-muted-foreground",
-                  size === 'small' ? "text-2xs" : "text-xs"
-                )}>
-                  {t('widgets.dailyTickTarget.positive')}
-                </span>
-                <span className={cn(
-                  "font-semibold text-green-500",
-                  size === 'small' ? "text-sm" : "text-base"
-                )}>
-                  {Math.round(convertToDisplayValue(progress.positive))}
-                </span>
-              </div>
-            </div>
-            
-            <div className="flex items-center gap-2 bg-red-50 dark:bg-red-900/20 p-2 rounded-md">
-              <ArrowDown className="h-4 w-4 text-red-500" />
-              <div className="flex flex-col gap-0.5">
-                <span className={cn(
-                  "text-xs text-muted-foreground",
-                  size === 'small' ? "text-2xs" : "text-xs"
-                )}>
-                  {t('widgets.dailyTickTarget.negative')}
-                </span>
-                <span className={cn(
-                  "font-semibold text-red-500",
-                  size === 'small' ? "text-sm" : "text-base"
-                )}>
-                  {Math.round(convertToDisplayValue(progress.negative))}
-                </span>
-              </div>
-            </div>
-          </div>
+  const unitLabel =
+    displayMode === 'points'
+      ? t('widgets.dailyTickTarget.displayMode.points')
+      : t('widgets.dailyTickTarget.displayMode.ticks')
 
-          {/* Progress Bar */}
-          {isTargetSet && (
-            <div className="space-y-1">
-              <div className="flex justify-between items-center">
-                <span className={cn(
-                  "text-muted-foreground",
-                  size === 'small' ? "text-2xs" : "text-xs"
-                )}>
-                  {t('widgets.dailyTickTarget.progress')}
-                </span>
-                <span className={cn(
-                  "font-medium",
-                  isOverTarget ? "text-green-500" : "text-foreground",
-                  size === 'small' ? "text-2xs" : "text-xs"
-                )}>
-                  {Math.round(progress.percentage)}%
-                </span>
-              </div>
-              <Progress 
-                value={progress.percentage} 
+  // One precision for every peer figure on the widget: points can land on a
+  // quarter, ticks are whole.
+  const formatUnit = React.useCallback(
+    (ticks: number) =>
+      formatTicks(convertToDisplayValue(ticks), locale, {
+        maximumFractionDigits: displayMode === 'points' ? 2 : 0,
+      }),
+    [convertToDisplayValue, displayMode, locale],
+  )
+
+  const periodLabel =
+    period.from === period.to ? period.from : `${period.from} - ${period.to}`
+
+  const actions = (
+    <>
+      {/* Points/Ticks Toggle */}
+      <TooltipProvider>
+        <UITooltip>
+          <TooltipTrigger asChild>
+            <div className="flex items-center gap-1.5">
+              <span
                 className={cn(
-                  "h-2",
-                  isOverTarget ? "bg-green-100 dark:bg-green-900/20" : ""
+                  "text-xs",
+                  displayMode === 'ticks' ? "font-medium" : "text-muted-foreground",
                 )}
+              >
+                {t('widgets.dailyTickTarget.displayMode.ticks')}
+              </span>
+              <Switch
+                checked={displayMode === 'points'}
+                onCheckedChange={(checked) => setDisplayMode(checked ? 'points' : 'ticks')}
+                aria-label={t('widgets.dailyTickTarget.displayMode.tooltip')}
+                className="h-4 w-8"
+              />
+              <span
+                className={cn(
+                  "text-xs",
+                  displayMode === 'points' ? "font-medium" : "text-muted-foreground",
+                )}
+              >
+                {t('widgets.dailyTickTarget.displayMode.points')}
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p>{t('widgets.dailyTickTarget.displayMode.tooltip')}</p>
+          </TooltipContent>
+        </UITooltip>
+      </TooltipProvider>
+
+      {/* Target controls */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => handleQuickIncrement(-1)}
+        aria-label={`${t('widgets.dailyTickTarget.target')} -1 ${unitLabel}`}
+        className="h-6 w-6 p-0"
+      >
+        <Minus className="h-3 w-3" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => handleQuickIncrement(1)}
+        aria-label={`${t('widgets.dailyTickTarget.target')} +1 ${unitLabel}`}
+        className="h-6 w-6 p-0"
+      >
+        <Plus className="h-3 w-3" />
+      </Button>
+
+      {/* Target setting dialog */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={t('widgets.dailyTickTarget.setTarget')}
+            className="h-6 w-6 p-0"
+          >
+            <Target className="h-3 w-3" />
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="text-balance">{t('widgets.dailyTickTarget.setTarget')}</DialogTitle>
+            <DialogDescription className="text-pretty">
+              {t('widgets.dailyTickTarget.setTargetDescription')}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">
+                {t('widgets.dailyTickTarget.target')} ({unitLabel})
+              </label>
+              <Input
+                type="number"
+                value={targetValue}
+                onChange={(e) => setTargetValue(e.target.value)}
+                placeholder={Math.round(convertToDisplayValue(progress.target)).toString()}
+                className="w-full"
               />
             </div>
-          )}
-
-          {/* No target set message */}
-          {!isTargetSet && (
-            <div className="flex flex-col items-center gap-2 text-center py-2">
-              <Target className="h-6 w-6 text-muted-foreground/50" />
-              <span className={cn(
-                "text-muted-foreground",
-                size === 'small' ? "text-xs" : "text-sm"
-              )}>
-                {t('widgets.dailyTickTarget.noTargetSet')}
-              </span>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setIsDialogOpen(false)}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button onClick={handleSaveTarget}>
+                {t('common.save')}
+              </Button>
             </div>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+
+  const hasEvidence = breakdown.tradeCount > 0 || isTargetSet
+
+  return (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.dailyTickTarget.title')}
+        description={t('widgets.dailyTickTarget.tooltip')}
+        actions={actions}
+      />
+      {!hasEvidence ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.dailyTickTarget.noTargetSet')}
+        />
+      ) : (
+        <WidgetBody size={size} className="flex flex-col justify-center gap-4">
+          {/* The focal figure, at full precision, with its target beneath it. */}
+          <WidgetMetric
+            size={size}
+            label={t('widgets.dailyTickTarget.current')}
+            value={`${formatUnit(progress.current)} ${unitLabel}`}
+            toneClassName={pnlToneClass(pnlTone(progress.current))}
+            caption={
+              isTargetSet
+                ? `${t('widgets.dailyTickTarget.target')} ${formatUnit(progress.target)} ${unitLabel}`
+                : t('widgets.dailyTickTarget.noTargetSet')
+            }
+          />
+
+          {/* Breakdown: the sign sits on the number, color only reinforces it. */}
+          <WidgetStatList>
+            <WidgetStat
+              label={t('widgets.dailyTickTarget.positive')}
+              value={formatUnit(progress.positive)}
+              toneClassName={pnlToneClass(pnlTone(progress.positive))}
+            />
+            <WidgetStat
+              label={t('widgets.dailyTickTarget.negative')}
+              value={formatUnit(progress.negative)}
+              toneClassName={pnlToneClass(pnlTone(progress.negative))}
+            />
+            <WidgetStat
+              label={t('widgets.dailyTickTarget.total')}
+              value={formatUnit(progress.total)}
+            />
+          </WidgetStatList>
+
+          {/* Progress toward the target: a completion share, so it runs from zero. */}
+          {isTargetSet ? (
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <span className={widgetType.label}>
+                  {t('widgets.dailyTickTarget.progress')}
+                </span>
+                <span
+                  className={cn(
+                    widgetType.value,
+                    "shrink-0 text-right",
+                    isOverTarget ? pnlToneClass('positive') : undefined,
+                  )}
+                >
+                  {formatPercent(progress.percentage, locale, {
+                    maximumFractionDigits: 0,
+                  })}
+                </span>
+              </div>
+              <Progress
+                value={progress.percentage}
+                className={cn(compact ? "h-1.5" : "h-2")}
+                aria-label={t('widgets.dailyTickTarget.progress')}
+              />
+            </div>
+          ) : null}
+        </WidgetBody>
+      )}
+      <WidgetFooter size={size}>
+        <span>{unitLabel}</span>
+        <span className="tabular-nums">
+          {periodLabel} · {formatCount(breakdown.tradeCount, locale)}{" "}
+          {t('tickDistribution.tooltip.trades')}
+        </span>
+      </WidgetFooter>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
@@ -4,23 +4,37 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Cell,
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig, ChartContainer } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { cn } from "@/lib/utils";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { useI18n, useCurrentLocale } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import { fr, enUS } from "date-fns/locale";
 import { useUserStore } from "@/store/user-store";
+import {
+  axisProps,
+  chartMargin,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetTooltip,
+  WidgetZeroLine,
+} from "../widgets";
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_DATE_PNL,
@@ -45,28 +59,7 @@ interface TooltipProps {
   label?: string;
 }
 
-const chartConfig = {
-  pnl: {
-    label: "Daily P/L",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
-
-const formatCurrency = (value: number) => {
-  const absValue = Math.abs(value);
-  if (absValue >= 1000000) {
-    return `${value < 0 ? "-" : ""}$${(absValue / 1000000).toFixed(1)}M`;
-  }
-  if (absValue >= 1000) {
-    return `${value < 0 ? "-" : ""}$${(absValue / 1000).toFixed(1)}k`;
-  }
-  return `${value < 0 ? "-" : ""}$${absValue.toFixed(0)}`;
-};
-
-const positiveColor = "hsl(var(--chart-2))"; // Green color
-const negativeColor = "hsl(var(--chart-loss))"; // Orangish color
-
-const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
+const CustomTooltip = ({ active, payload }: TooltipProps) => {
   const t = useI18n();
   const locale = useCurrentLocale();
   const { timezone } = useUserStore();
@@ -76,24 +69,26 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
     const data = payload[0].payload;
     const date = new Date(data.date + "T00:00:00Z");
     return (
-      <div className="bg-background p-2 border rounded shadow-xs">
-        <p className="font-semibold">
-          {formatInTimeZone(date, timezone, "MMM d, yyyy", {
-            locale: dateLocale,
-          })}
-        </p>
-        <p
-          className={`font-bold ${data.pnl >= 0 ? "text-green-600" : "text-red-600"}`}
-        >
-          {t("pnl.tooltip.pnl")}: {formatCurrency(data.pnl)}
-        </p>
-        <p>
-          {t("pnl.tooltip.longTrades")}: {data.longNumber}
-        </p>
-        <p>
-          {t("pnl.tooltip.shortTrades")}: {data.shortNumber}
-        </p>
-      </div>
+      <WidgetTooltip
+        title={formatInTimeZone(date, timezone, "MMM d, yyyy", {
+          locale: dateLocale,
+        })}
+        rows={[
+          {
+            label: t("pnl.tooltip.pnl"),
+            value: formatCurrency(data.pnl, locale),
+            toneClassName: pnlToneClass(pnlTone(data.pnl)),
+          },
+          {
+            label: t("pnl.tooltip.longTrades"),
+            value: formatCount(data.longNumber, locale),
+          },
+          {
+            label: t("pnl.tooltip.shortTrades"),
+            value: formatCount(data.shortNumber, locale),
+          },
+        ]}
+      />
     );
   }
   return null;
@@ -121,138 +116,74 @@ export default function PNLChart({ size = "medium" }: PNLChartProps) {
     [calendarData],
   );
 
-  const maxPnL = Math.max(...chartData.map((d) => d.pnl));
-  const minPnL = Math.min(...chartData.map((d) => d.pnl));
-
-  const getChartHeight = () => {
-    switch (size) {
-      case "small":
-        return "h-[140px]";
-      case "medium":
-        return "h-[200px]";
-      case "large":
-        return "h-[240px]";
-      default:
-        return "h-[200px]";
-    }
-  };
-
-  const getChartMargins = () => {
-    switch (size) {
-      case "small":
-        return { left: 10, right: 4, top: 4, bottom: 20 };
-      case "medium":
-        return { left: 10, right: 8, top: 8, bottom: 24 };
-      case "large":
-        return { left: 10, right: 12, top: 12, bottom: 28 };
-      default:
-        return { left: 10, right: 8, top: 8, bottom: 24 };
-    }
-  };
-
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("pnl.title")}
+        description={t("pnl.description")}
+      />
+      <WidgetBody
+        size={size}
+        flush
+        className={cn(isCompactSize(size) ? "p-1" : "p-2")}
       >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnl.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnl.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_DATE_PNL}
+            xDataKey="date"
+            yDataKey="pnl"
+            marginVariant="default"
+          />
+        ) : chartData.length === 0 ? (
+          <WidgetEmpty size={size} message={t("chat.noTradesAvailable")} />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={chartMargin(size)}>
+              <WidgetChartGrid />
+              <XAxis
+                dataKey="date"
+                {...axisProps(size)}
+                height={isCompactSize(size) ? 20 : 24}
+                minTickGap={isCompactSize(size) ? 30 : 50}
+                tickFormatter={(value) => {
+                  const date = new Date(value + "T00:00:00Z");
+                  return formatInTimeZone(date, timezone, "MMM d", {
+                    locale: dateLocale,
+                  });
+                }}
+              />
+              <YAxis
+                {...axisProps(size)}
+                width={56}
+                tickFormatter={(value: number) =>
+                  formatCompactCurrency(value, locale)
+                }
+              />
+              <WidgetZeroLine />
+              <Tooltip
+                content={<CustomTooltip />}
+                cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                wrapperStyle={{ zIndex: 1000 }}
+              />
+              <Bar
+                dataKey="pnl"
+                radius={[3, 3, 0, 0]}
+                maxBarSize={isCompactSize(size) ? 25 : 40}
+                isAnimationActive={false}
+              >
+                {chartData.map((entry, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={pnlToneFill(pnlTone(entry.pnl))}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
         )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_DATE_PNL}
-              xDataKey="date"
-              yDataKey="pnl"
-              marginVariant="default"
-            />
-          ) : (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={chartData} margin={getChartMargins()}>
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  minTickGap={size === "small" ? 30 : 50}
-                  tickFormatter={(value) => {
-                    const date = new Date(value + "T00:00:00Z");
-                    return formatInTimeZone(date, timezone, "MMM d", {
-                      locale: dateLocale,
-                    });
-                  }}
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="pnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={entry.pnl >= 0 ? positiveColor : negativeColor}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+      </WidgetBody>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
@@ -4,22 +4,37 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   Cell,
   ResponsiveContainer,
-  ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { Switch } from "@/components/ui/switch";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
+import {
+  axisProps,
+  chartMargin,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  formatPercent,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  widgetType,
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetTooltip,
+  WidgetZeroLine,
+} from "../widgets";
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_SIDE_PNL,
@@ -29,62 +44,55 @@ interface PnLBySideChartProps {
   size?: WidgetSize;
 }
 
-const chartConfig = {
-  pnl: {
-    label: "P/L",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
+interface SideDatum {
+  side: string;
+  pnl: number;
+  tradeCount: number;
+  winCount: number;
+  isAverage: boolean;
+}
 
-const formatCurrency = (value: number) =>
-  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
+interface SideTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: SideDatum }>;
+  t: ReturnType<typeof useI18n>;
+  locale: string;
+}
 
-const CustomTooltip = ({ active, payload, label }: any) => {
-  const t = useI18n();
-  if (active && payload && payload.length) {
-    const data = payload[0].payload;
-    return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
-        <div className="grid gap-2">
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlBySide.tooltip.side")}
-            </span>
-            <span className="font-bold text-muted-foreground">{data.side}</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {data.isAverage ? t("pnlBySide.tooltip.averageTotal") : "Total"}{" "}
-              P/L
-            </span>
-            <span className="font-bold">{formatCurrency(data.pnl)}</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlBySide.tooltip.winRate")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {((data.winCount / data.tradeCount) * 100).toFixed(1)}%
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlBySide.tooltip.trades")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.tradeCount} {t("pnlBySide.tooltip.trades")} ({data.winCount}{" "}
-              {data.winCount === 1
-                ? t("pnlBySide.tooltip.wins")
-                : t("pnlBySide.tooltip.wins_plural")}
-              )
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-  return null;
-};
+function SideTooltip({ active, payload, t, locale }: SideTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0].payload;
+  const winRate =
+    data.tradeCount > 0 ? (data.winCount / data.tradeCount) * 100 : 0;
+
+  return (
+    <WidgetTooltip
+      title={data.side}
+      rows={[
+        {
+          label: data.isAverage
+            ? t("pnlBySide.tooltip.averageTotal")
+            : t("pnl.tooltip.pnl"),
+          value: formatCurrency(data.pnl, locale),
+          toneClassName: pnlToneClass(pnlTone(data.pnl)),
+        },
+        {
+          label: t("pnlBySide.tooltip.winRate"),
+          value: formatPercent(winRate, locale),
+        },
+        {
+          label: t("pnlBySide.tooltip.trades"),
+          value: formatCount(data.tradeCount, locale),
+        },
+      ]}
+      caption={`${formatCount(data.winCount, locale)} ${
+        data.winCount === 1
+          ? t("pnlBySide.tooltip.wins")
+          : t("pnlBySide.tooltip.wins_plural")
+      }`}
+    />
+  );
+}
 
 export default function PnLBySideChart({
   size = "medium",
@@ -92,8 +100,9 @@ export default function PnLBySideChart({
   const { formattedTrades: trades, isLoading } = useData();
   const [showAverage, setShowAverage] = React.useState(true);
   const t = useI18n();
+  const locale = useCurrentLocale();
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<SideDatum[]>(() => {
     const longTrades = trades.filter(
       (trade) => trade.side?.toLowerCase() === "long",
     );
@@ -135,136 +144,85 @@ export default function PnLBySideChart({
 
   const maxPnL = Math.max(...chartData.map((d) => d.pnl));
   const minPnL = Math.min(...chartData.map((d) => d.pnl));
-  const absMax = Math.max(Math.abs(maxPnL), Math.abs(minPnL));
+  const hasData = chartData.some((entry) => entry.tradeCount > 0);
 
-  const getColor = (value: number) => {
-    const ratio = Math.abs(value / absMax);
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-4";
-    const intensity = Math.max(0.2, ratio);
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
+  const switchId = React.useId();
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnlBySide.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlBySide.description")}</p>
-            </InfoBubble>
-          </div>
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("pnlBySide.title")}
+        description={t("pnlBySide.description")}
+        actions={
           <div className="flex items-center gap-2">
-            <span
-              className={cn(
-                "text-muted-foreground",
-                size === "small" ? "text-xs" : "text-sm",
-              )}
-            >
+            <label htmlFor={switchId} className={widgetType.label}>
               {t("pnlBySide.toggle.showAverage")}
-            </span>
+            </label>
             <Switch
+              id={switchId}
               checked={showAverage}
               onCheckedChange={setShowAverage}
-              className="data-[state=checked]:bg-primary"
             />
           </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
+        }
+      />
+      <WidgetBody
+        size={size}
+        flush
+        className={cn(isCompactSize(size) ? "p-1" : "p-2")}
       >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_SIDE_PNL}
-              xDataKey="side"
-              yDataKey="pnl"
-              showReferenceLine
-              xTickCount={2}
-            />
-          ) : (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                margin={
-                  size === "small"
-                    ? { left: 10, right: 4, top: 4, bottom: 20 }
-                    : { left: 10, right: 8, top: 8, bottom: 24 }
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_SIDE_PNL}
+            xDataKey="side"
+            yDataKey="pnl"
+            showReferenceLine
+            xTickCount={2}
+          />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t("chat.noTradesAvailable")} />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={chartMargin(size)}>
+              <WidgetChartGrid />
+              <XAxis
+                dataKey="side"
+                {...axisProps(size)}
+                height={isCompactSize(size) ? 20 : 24}
+              />
+              <YAxis
+                {...axisProps(size)}
+                width={56}
+                tickFormatter={(value: number) =>
+                  formatCompactCurrency(value, locale)
                 }
+                domain={[Math.min(minPnL * 1.1, 0), Math.max(maxPnL * 1.1, 0)]}
+              />
+              <WidgetZeroLine />
+              <Tooltip
+                content={<SideTooltip t={t} locale={locale} />}
+                cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                wrapperStyle={{ zIndex: 1000 }}
+              />
+              <Bar
+                dataKey="pnl"
+                radius={[3, 3, 0, 0]}
+                maxBarSize={isCompactSize(size) ? 25 : 40}
+                isAnimationActive={false}
               >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                />
-                <XAxis
-                  dataKey="side"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                  domain={[
-                    Math.min(minPnL * 1.1, 0),
-                    Math.max(maxPnL * 1.1, 0),
-                  ]}
-                />
-                <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="pnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={getColor(entry.pnl)} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                {chartData.map((entry, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={pnlToneFill(pnlTone(entry.pnl))}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </WidgetBody>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
@@ -4,20 +4,14 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   Cell,
   ResponsiveContainer,
-  ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { cn } from "@/lib/utils";
-import { Skeleton } from "@/components/ui/skeleton";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import {
   Select,
   SelectContent,
@@ -26,79 +20,48 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
 import { usePnLPerContractDailyStore } from "@/store/widgets/pnl-per-contract-daily-store";
 import { formatInTimeZone } from "date-fns-tz";
 import { fr, enUS } from "date-fns/locale";
 import { useUserStore } from "@/store/user-store";
-import { useCurrentLocale } from "@/locales/client";
-import { Button } from "@/components/ui/button";
+import {
+  BarChartLoadingSkeleton,
+  LOADING_MOCK_DATE_PNL,
+} from "./chart-loading-skeleton";
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetFooter,
+  WidgetHeader,
+  WidgetTooltip,
+  WidgetZeroLine,
+  axisProps,
+  chartMargin,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  formatPercent,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+} from "../widgets";
 
 interface PnLPerContractDailyChartProps {
   size?: WidgetSize;
 }
 
-const chartConfig = {
-  pnl: {
-    label: "Avg Net P/L per Contract",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
-
-const formatCurrency = (value: number) =>
-  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
-
-const CustomTooltip = ({ active, payload, label }: any) => {
-  const t = useI18n();
-  if (active && payload && payload.length) {
-    const data = payload[0].payload;
-    return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
-        <div className="grid gap-2">
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContractDaily.tooltip.date")}
-            </span>
-            <span className="font-bold text-muted-foreground">{data.date}</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContractDaily.tooltip.averagePnl")}
-            </span>
-            <span className="font-bold">{formatCurrency(data.averagePnl)}</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContractDaily.tooltip.totalPnl")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {formatCurrency(data.totalPnl)}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContractDaily.tooltip.trades")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.tradeCount} {t("pnlPerContractDaily.tooltip.trades")} (
-              {((data.winCount / data.tradeCount) * 100).toFixed(1)}%{" "}
-              {t("pnlPerContractDaily.tooltip.winRate")})
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContractDaily.tooltip.totalContracts")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.totalContracts} {t("pnlPerContractDaily.tooltip.contracts")}
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-  return null;
-};
+interface DailyRow {
+  date: string;
+  averagePnl: number;
+  totalPnl: number;
+  tradeCount: number;
+  winCount: number;
+  totalContracts: number;
+}
 
 export default function PnLPerContractDailyChart({
   size = "medium",
@@ -109,6 +72,7 @@ export default function PnLPerContractDailyChart({
   const t = useI18n();
   const locale = useCurrentLocale();
   const dateLocale = locale === "fr" ? fr : enUS;
+  const compact = isCompactSize(size);
 
   // Get unique instruments from trades
   const availableInstruments = React.useMemo(() => {
@@ -125,7 +89,7 @@ export default function PnLPerContractDailyChart({
     }
   }, [config.selectedInstrument, availableInstruments, setSelectedInstrument]);
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<DailyRow[]>(() => {
     if (!config.selectedInstrument) return [];
 
     // Filter trades for selected instrument
@@ -173,6 +137,7 @@ export default function PnLPerContractDailyChart({
     return Object.entries(dateGroups)
       .map(([date, data]) => ({
         date,
+        // Guarded: a day with no contracts is 0, never NaN.
         averagePnl:
           data.totalContracts > 0 ? data.totalPnl / data.totalContracts : 0,
         totalPnl: data.totalPnl,
@@ -183,528 +148,182 @@ export default function PnLPerContractDailyChart({
       .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   }, [trades, config.selectedInstrument, timezone]);
 
-  const maxPnL = Math.max(...chartData.map((d) => d.averagePnl));
-  const minPnL = Math.min(...chartData.map((d) => d.averagePnl));
-  const absMax = Math.max(Math.abs(maxPnL), Math.abs(minPnL));
+  // Bar length is a magnitude encoding, so the domain always contains zero;
+  // the 10% headroom only ever extends away from the baseline.
+  const yDomain = React.useMemo<[number, number]>(() => {
+    if (chartData.length === 0) return [0, 0];
+    const values = chartData.map((row) => row.averagePnl);
+    return [
+      Math.min(Math.min(...values) * 1.1, 0),
+      Math.max(Math.max(...values) * 1.1, 0),
+    ];
+  }, [chartData]);
 
-  const getColor = (value: number) => {
-    const ratio = Math.abs(value / absMax);
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-loss";
-    const intensity = Math.max(0.2, ratio);
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
+  const totals = React.useMemo(
+    () =>
+      chartData.reduce(
+        (acc, row) => ({
+          trades: acc.trades + row.tradeCount,
+          contracts: acc.contracts + row.totalContracts,
+        }),
+        { trades: 0, contracts: 0 },
+      ),
+    [chartData],
+  );
+
+  const hasData = chartData.length > 0;
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("pnlPerContractDaily.title")}
+        description={t("pnlPerContractDaily.description")}
+        actions={
+          <Select
+            value={config.selectedInstrument}
+            onValueChange={setSelectedInstrument}
+          >
+            <SelectTrigger
+              className={cn("w-[120px]", compact ? "h-7 text-xs" : "h-8 text-sm")}
+              aria-label={t("pnlPerContractDaily.selectInstrument")}
             >
-              {t("pnlPerContractDaily.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlPerContractDaily.description")}</p>
-            </InfoBubble>
-          </div>
-          <div className="flex items-center gap-2">
-            <Select
-              value={config.selectedInstrument}
-              onValueChange={setSelectedInstrument}
-            >
-              <SelectTrigger
-                className={cn(
-                  "w-[120px]",
-                  size === "small" ? "h-7 text-xs" : "h-8 text-sm",
-                )}
-              >
-                <SelectValue
-                  placeholder={t("pnlPerContractDaily.selectInstrument")}
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {availableInstruments.map((instrument) => (
-                  <SelectItem key={instrument} value={instrument}>
-                    {instrument}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            (() => {
-              const loadingMockData = [
-                {
-                  date: "2024-12-02",
-                  averagePnl: 12.444999999999999,
-                  totalPnl: 99.55999999999999,
-                  tradeCount: 8,
-                  winCount: 2,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2024-12-03",
-                  averagePnl: 59.32,
-                  totalPnl: 237.28,
-                  tradeCount: 4,
-                  winCount: 4,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2024-12-11",
-                  averagePnl: 28.069999999999997,
-                  totalPnl: 224.55999999999997,
-                  tradeCount: 8,
-                  winCount: 4,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2024-12-16",
-                  averagePnl: -34.43,
-                  totalPnl: -68.86,
-                  tradeCount: 2,
-                  winCount: 0,
-                  totalContracts: 2,
-                },
-                {
-                  date: "2024-12-17",
-                  averagePnl: -3.18,
-                  totalPnl: -6.36,
-                  tradeCount: 2,
-                  winCount: 0,
-                  totalContracts: 2,
-                },
-                {
-                  date: "2024-12-19",
-                  averagePnl: 48.90333333333333,
-                  totalPnl: 293.41999999999996,
-                  tradeCount: 6,
-                  winCount: 4,
-                  totalContracts: 6,
-                },
-                {
-                  date: "2024-12-20",
-                  averagePnl: 17.653333333333332,
-                  totalPnl: 105.92,
-                  tradeCount: 6,
-                  winCount: 2,
-                  totalContracts: 6,
-                },
-                {
-                  date: "2025-01-06",
-                  averagePnl: 59.32,
-                  totalPnl: 237.28,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2025-01-07",
-                  averagePnl: 74.94500000000001,
-                  totalPnl: 599.5600000000001,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-14",
-                  averagePnl: 28.07,
-                  totalPnl: 224.56,
-                  tradeCount: 6,
-                  winCount: 3,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-15",
-                  averagePnl: -3.18,
-                  totalPnl: -12.72,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2025-01-21",
-                  averagePnl: 28.07,
-                  totalPnl: 224.56,
-                  tradeCount: 6,
-                  winCount: 3,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-22",
-                  averagePnl: 59.32,
-                  totalPnl: 474.56,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-23",
-                  averagePnl: 74.945,
-                  totalPnl: 599.56,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-24",
-                  averagePnl: -34.43000000000001,
-                  totalPnl: -413.1600000000001,
-                  tradeCount: 9,
-                  winCount: 0,
-                  totalContracts: 12,
-                },
-                {
-                  date: "2025-01-28",
-                  averagePnl: -3.18,
-                  totalPnl: -38.160000000000004,
-                  tradeCount: 9,
-                  winCount: 0,
-                  totalContracts: 12,
-                },
-                {
-                  date: "2025-01-31",
-                  averagePnl: 59.32,
-                  totalPnl: 237.28,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2025-02-20",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 593.2,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-02-25",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-02-27",
-                  averagePnl: -96.93,
-                  totalPnl: -484.65000000000003,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-12",
-                  averagePnl: 21.82,
-                  totalPnl: 109.1,
-                  tradeCount: 3,
-                  winCount: 2,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-18",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -15.899999999999999,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-19",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -15.899999999999999,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-20",
-                  averagePnl: -65.67999999999999,
-                  totalPnl: -328.4,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-21",
-                  averagePnl: -34.43,
-                  totalPnl: -172.15,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-04-22",
-                  averagePnl: 17.65333333333333,
-                  totalPnl: 264.79999999999995,
-                  tradeCount: 9,
-                  winCount: 3,
-                  totalContracts: 15,
-                },
-                {
-                  date: "2025-04-23",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-04-24",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -47.699999999999996,
-                  tradeCount: 9,
-                  winCount: 0,
-                  totalContracts: 15,
-                },
-                {
-                  date: "2025-04-29",
-                  averagePnl: -34.42999999999999,
-                  totalPnl: -344.29999999999995,
-                  tradeCount: 6,
-                  winCount: 0,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-05-08",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-05-15",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-05-19",
-                  averagePnl: -34.43,
-                  totalPnl: -172.15,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-05-22",
-                  averagePnl: 28.07,
-                  totalPnl: 280.7,
-                  tradeCount: 6,
-                  winCount: 3,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-06-03",
-                  averagePnl: -34.43,
-                  totalPnl: -344.3,
-                  tradeCount: 6,
-                  winCount: 0,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-06-04",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -15.899999999999999,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-              ];
-              const maxP = Math.max(
-                ...loadingMockData.map((d) => d.averagePnl),
-              );
-              const minP = Math.min(
-                ...loadingMockData.map((d) => d.averagePnl),
-              );
-              const domainMin = Math.min(minP * 1.1, 0);
-              const domainMax = Math.max(maxP * 1.1, 0);
-              const margin =
-                size === "small"
-                  ? { left: 10, right: 4, top: 4, bottom: 20 }
-                  : { left: 10, right: 8, top: 8, bottom: 24 };
-              const yAxisWidth = 60;
-              const xAxisHeight = size === "small" ? 20 : 24;
-              return (
-                <div className={cn("w-full h-full animate-pulse relative")}>
-                  {/* Axis tick skeletons */}
-                  <div
-                    className="pointer-events-none absolute flex flex-col justify-between pr-2"
-                    style={{
-                      left: `${margin.left}px`,
-                      top: `${margin.top}px`,
-                      bottom: `${margin.bottom + xAxisHeight}px`,
-                      width: `${yAxisWidth}px`,
-                    }}
-                  >
-                    {Array.from({ length: 5 }).map((_, i) => (
-                      <Skeleton key={i} className="h-3 w-10" />
-                    ))}
-                  </div>
-                  <div
-                    className="pointer-events-none absolute flex items-center justify-between"
-                    style={{
-                      left: `${margin.left + yAxisWidth}px`,
-                      right: `${margin.right}px`,
-                      bottom: `${margin.bottom}px`,
-                      height: `${xAxisHeight}px`,
-                    }}
-                  >
-                    {Array.from({ length: 6 }).map((_, i) => (
-                      <Skeleton
-                        key={i}
-                        className={cn(
-                          size === "small" ? "h-3 w-8" : "h-3.5 w-10",
-                        )}
-                      />
-                    ))}
-                  </div>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={loadingMockData} margin={margin}>
-                      <CartesianGrid
-                        strokeDasharray="3 3"
-                        className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                      />
-                      <XAxis
-                        dataKey="date"
-                        tickLine={false}
-                        axisLine={false}
-                        height={size === "small" ? 20 : 24}
-                        tick={false}
-                        minTickGap={size === "small" ? 30 : 50}
-                      />
-                      <YAxis
-                        tickLine={false}
-                        axisLine={false}
-                        width={60}
-                        tickMargin={4}
-                        tick={false}
-                        domain={[domainMin, domainMax]}
-                      />
-                      <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                      <Bar
-                        dataKey="averagePnl"
-                        radius={[3, 3, 0, 0]}
-                        maxBarSize={size === "small" ? 25 : 40}
-                        className="transition-none"
-                        fill="hsl(var(--muted-foreground) / 0.35)"
-                      >
-                        {loadingMockData.map((_, index) => (
-                          <Cell
-                            key={`skeleton-cell-${index}`}
-                            fill="hsl(var(--muted-foreground) / 0.35)"
-                          />
-                        ))}
-                      </Bar>
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              );
-            })()
-          ) : chartData.length > 0 ? (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                margin={
-                  size === "small"
-                    ? { left: 10, right: 4, top: 4, bottom: 20 }
-                    : { left: 10, right: 8, top: 8, bottom: 24 }
-                }
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  minTickGap={size === "small" ? 30 : 50}
-                  tickFormatter={(value) => {
-                    const date = new Date(value);
-                    return formatInTimeZone(date, timezone, "MMM d", {
-                      locale: dateLocale,
-                    });
-                  }}
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                  domain={[
-                    Math.min(minPnL * 1.1, 0),
-                    Math.max(maxPnL * 1.1, 0),
-                  ]}
-                />
-                <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="averagePnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={getColor(entry.averagePnl)}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              {config.selectedInstrument
+              <SelectValue
+                placeholder={t("pnlPerContractDaily.selectInstrument")}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {availableInstruments.map((instrument) => (
+                <SelectItem key={instrument} value={instrument}>
+                  {instrument}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        }
+      />
+      <WidgetBody size={size} flush className={cn(compact ? "p-1" : "p-2")}>
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_DATE_PNL}
+            xDataKey="date"
+            yDataKey="pnl"
+            yAxisWidth={52}
+            showReferenceLine
+          />
+        ) : !hasData ? (
+          <WidgetEmpty
+            size={size}
+            message={
+              config.selectedInstrument
                 ? t("pnlPerContractDaily.noData")
-                : t("pnlPerContractDaily.selectInstrument")}
-            </div>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                : t("pnlPerContractDaily.selectInstrument")
+            }
+          />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={chartMargin(size)}>
+              <WidgetChartGrid />
+              <XAxis
+                dataKey="date"
+                {...axisProps(size)}
+                height={compact ? 20 : 24}
+                minTickGap={compact ? 30 : 50}
+                tickFormatter={(value: string) => {
+                  const date = new Date(value);
+                  return formatInTimeZone(date, timezone, "MMM d", {
+                    locale: dateLocale,
+                  });
+                }}
+              />
+              <YAxis
+                {...axisProps(size)}
+                width={compact ? 44 : 52}
+                tickFormatter={(value: number) =>
+                  formatCompactCurrency(value, locale)
+                }
+                domain={yDomain}
+              />
+              <WidgetZeroLine />
+              <Tooltip
+                cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                isAnimationActive={false}
+                wrapperStyle={{ zIndex: 1000 }}
+                content={({ active, payload }: any) => {
+                  if (!active || !payload?.length) return null;
+                  const row = payload[0].payload as DailyRow;
+                  // Guarded: a day can never divide by a zero trade count.
+                  const winRate =
+                    row.tradeCount > 0
+                      ? (row.winCount / row.tradeCount) * 100
+                      : 0;
+                  return (
+                    <WidgetTooltip
+                      title={formatInTimeZone(
+                        new Date(row.date),
+                        timezone,
+                        "MMM d, yyyy",
+                        { locale: dateLocale },
+                      )}
+                      rows={[
+                        {
+                          label: t("pnlPerContractDaily.tooltip.averagePnl"),
+                          value: formatCurrency(row.averagePnl, locale),
+                          toneClassName: pnlToneClass(pnlTone(row.averagePnl)),
+                        },
+                        {
+                          label: t("pnlPerContractDaily.tooltip.totalPnl"),
+                          value: formatCurrency(row.totalPnl, locale),
+                          toneClassName: pnlToneClass(pnlTone(row.totalPnl)),
+                        },
+                        {
+                          label: t("pnlPerContractDaily.tooltip.trades"),
+                          value: formatCount(row.tradeCount, locale),
+                        },
+                        {
+                          label: t("pnlPerContractDaily.tooltip.winRate"),
+                          value: formatPercent(winRate, locale),
+                        },
+                        {
+                          label: t("pnlPerContractDaily.tooltip.totalContracts"),
+                          value: formatCount(row.totalContracts, locale),
+                        },
+                      ]}
+                    />
+                  );
+                }}
+              />
+              <Bar
+                dataKey="averagePnl"
+                radius={[3, 3, 0, 0]}
+                maxBarSize={compact ? 25 : 40}
+                isAnimationActive={false}
+              >
+                {chartData.map((entry) => (
+                  <Cell
+                    key={entry.date}
+                    // Sign is the only meaning color carries here; magnitude is
+                    // already carried by bar length, so no intensity ramp.
+                    fill={pnlToneFill(pnlTone(entry.averagePnl))}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </WidgetBody>
+      <WidgetFooter size={size}>
+        <span className="truncate">
+          USD{config.selectedInstrument ? ` · ${config.selectedInstrument}` : ""}
+        </span>
+        <span className="shrink-0 tabular-nums">
+          {formatCount(totals.trades, locale)}{" "}
+          {t("tickDistribution.tooltip.trades")} ·{" "}
+          {formatCount(totals.contracts, locale)}{" "}
+          {t("pnlPerContractDaily.tooltip.contracts")}
+        </span>
+      </WidgetFooter>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
@@ -4,93 +4,64 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   Cell,
   ResponsiveContainer,
-  ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
+
 import { useData } from "@/context/data-provider";
-import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
+
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_AVERAGE_PNL,
 } from "./chart-loading-skeleton";
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetFooter,
+  WidgetHeader,
+  WidgetTooltip,
+  WidgetZeroLine,
+  axisProps,
+  chartMargin,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  formatPercent,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+} from "../widgets";
 
 interface PnLPerContractChartProps {
   size?: WidgetSize;
 }
 
-const chartConfig = {
-  pnl: {
-    label: "Avg P/L per Contract",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
-
-const formatCurrency = (value: number) =>
-  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
-
-const CustomTooltip = ({ active, payload, label }: any) => {
-  const t = useI18n();
-  if (active && payload && payload.length) {
-    const data = payload[0].payload;
-    return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
-        <div className="grid gap-2">
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContract.tooltip.averagePnl")}
-            </span>
-            <span className="font-bold">{formatCurrency(data.averagePnl)}</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContract.tooltip.totalPnl")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {formatCurrency(data.totalPnl)}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContract.tooltip.trades")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.tradeCount} {t("pnlPerContract.tooltip.trades")} (
-              {((data.winCount / data.tradeCount) * 100).toFixed(1)}%{" "}
-              {t("pnlPerContract.tooltip.winRate")})
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("pnlPerContract.tooltip.totalContracts")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.totalContracts} {t("pnlPerContract.tooltip.contracts")}
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-  return null;
-};
+interface InstrumentRow {
+  instrument: string;
+  averagePnl: number;
+  totalPnl: number;
+  tradeCount: number;
+  winCount: number;
+  totalContracts: number;
+}
 
 export default function PnLPerContractChart({
   size = "medium",
 }: PnLPerContractChartProps) {
   const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
+  const locale = useCurrentLocale();
+  const compact = isCompactSize(size);
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<InstrumentRow[]>(() => {
     // Group trades by instrument
     const instrumentGroups = trades.reduce(
       (acc, trade) => {
@@ -138,127 +109,139 @@ export default function PnLPerContractChart({
       .sort((a, b) => b.averagePnl - a.averagePnl); // Sort by average PnL descending
   }, [trades]);
 
-  const maxPnL = Math.max(...chartData.map((d) => d.averagePnl));
-  const minPnL = Math.min(...chartData.map((d) => d.averagePnl));
-  const absMax = Math.max(Math.abs(maxPnL), Math.abs(minPnL));
+  const totals = React.useMemo(
+    () =>
+      chartData.reduce(
+        (acc, row) => ({
+          trades: acc.trades + row.tradeCount,
+          contracts: acc.contracts + row.totalContracts,
+        }),
+        { trades: 0, contracts: 0 },
+      ),
+    [chartData],
+  );
 
-  const getColor = (value: number) => {
-    const ratio = Math.abs(value / absMax);
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-4";
-    const intensity = Math.max(0.2, ratio);
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
+  // Bar length is a magnitude encoding, so the domain always contains zero.
+  // The 10% headroom only ever extends away from the baseline.
+  const yDomain = React.useMemo<[number, number]>(() => {
+    if (chartData.length === 0) return [0, 0];
+    const values = chartData.map((row) => row.averagePnl);
+    return [
+      Math.min(Math.min(...values) * 1.1, 0),
+      Math.max(Math.max(...values) * 1.1, 0),
+    ];
+  }, [chartData]);
+
+  const hasData = chartData.length > 0;
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnlPerContract.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlPerContract.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_AVERAGE_PNL}
-              xDataKey="instrument"
-              yDataKey="averagePnl"
-              showReferenceLine
-            />
-          ) : (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                margin={
-                  size === "small"
-                    ? { left: 10, right: 4, top: 4, bottom: 20 }
-                    : { left: 10, right: 8, top: 8, bottom: 24 }
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("pnlPerContract.title")}
+        description={t("pnlPerContract.description")}
+      />
+      <WidgetBody size={size} className="min-h-0">
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_AVERAGE_PNL}
+            xDataKey="instrument"
+            yDataKey="averagePnl"
+            showReferenceLine
+          />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t("widgets.empty.noTrades")} />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={chartMargin(size)}>
+              <WidgetChartGrid />
+              <XAxis
+                dataKey="instrument"
+                {...axisProps(size)}
+                height={compact ? 32 : 40}
+                angle={-45}
+                textAnchor="end"
+                interval={0}
+              />
+              <YAxis
+                {...axisProps(size)}
+                width={compact ? 44 : 52}
+                tickFormatter={(value: number) =>
+                  formatCompactCurrency(value, locale)
                 }
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                />
-                <XAxis
-                  dataKey="instrument"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  angle={size === "small" ? -45 : -45}
-                  textAnchor="end"
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                  domain={[
-                    Math.min(minPnL * 1.1, 0),
-                    Math.max(maxPnL * 1.1, 0),
-                  ]}
-                />
-                <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="averagePnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={getColor(entry.averagePnl)}
+                domain={yDomain}
+              />
+              <WidgetZeroLine />
+              <Tooltip
+                cursor={{ fill: "hsl(var(--muted) / 0.4)" }}
+                isAnimationActive={false}
+                content={({ active, payload }: any) => {
+                  if (!active || !payload?.length) return null;
+                  const row = payload[0].payload as InstrumentRow;
+                  const winRate =
+                    row.tradeCount > 0
+                      ? (row.winCount / row.tradeCount) * 100
+                      : 0;
+                  return (
+                    <WidgetTooltip
+                      title={row.instrument}
+                      rows={[
+                        {
+                          label: t("pnlPerContract.tooltip.averagePnl"),
+                          value: formatCurrency(row.averagePnl, locale),
+                          toneClassName: pnlToneClass(pnlTone(row.averagePnl)),
+                        },
+                        {
+                          label: t("pnlPerContract.tooltip.totalPnl"),
+                          value: formatCurrency(row.totalPnl, locale),
+                          toneClassName: pnlToneClass(pnlTone(row.totalPnl)),
+                        },
+                        {
+                          label: t("pnlPerContract.tooltip.trades"),
+                          value: formatCount(row.tradeCount, locale),
+                        },
+                        {
+                          label: t("pnlPerContract.tooltip.winRate"),
+                          value: formatPercent(winRate, locale),
+                        },
+                        {
+                          label: t("pnlPerContract.tooltip.totalContracts"),
+                          value: formatCount(row.totalContracts, locale),
+                        },
+                      ]}
                     />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                  );
+                }}
+              />
+              <Bar
+                dataKey="averagePnl"
+                radius={[3, 3, 0, 0]}
+                maxBarSize={compact ? 25 : 40}
+                isAnimationActive={false}
+              >
+                {chartData.map((entry) => (
+                  <Cell
+                    key={entry.instrument}
+                    // Sign is the only meaning color carries here; magnitude is
+                    // already carried by bar length, so no opacity ramp.
+                    fill={pnlToneFill(pnlTone(entry.averagePnl))}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </WidgetBody>
+      <WidgetFooter size={size}>
+        <span>USD</span>
+        <span className="tabular-nums">
+          {formatCount(totals.trades, locale)}{" "}
+          {t("tickDistribution.tooltip.trades")} ·{" "}
+          {formatCount(totals.contracts, locale)}{" "}
+          {t("pnlPerContract.tooltip.contracts")}
+        </span>
+      </WidgetFooter>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
@@ -4,24 +4,40 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   Cell,
   ResponsiveContainer,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
+import type { CategoricalChartState } from "recharts/types/chart/types";
 import { useData } from "@/context/data-provider";
 import { Trade } from "@/prisma/generated/prisma/browser";
 import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import { Button } from "@/components/ui/button";
 import { useUserStore } from "../../../../../store/user-store";
+import {
+  axisProps,
+  chartMargin,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetChartInteractive,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetTooltip,
+  WidgetZeroLine,
+} from "../widgets";
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_HOURLY,
@@ -31,15 +47,43 @@ interface TimeOfDayTradeChartProps {
   size?: WidgetSize;
 }
 
-const chartConfig = {
-  avgPnl: {
-    label: "Average P/L",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
+interface HourDatum {
+  hour: number;
+  avgPnl: number;
+  tradeCount: number;
+}
 
-const formatCurrency = (value: number) =>
-  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
+function hourRangeLabel(hour: number) {
+  return `${hour}:00 - ${(hour + 1) % 24}:00`;
+}
+
+interface HourTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: HourDatum }>;
+  t: ReturnType<typeof useI18n>;
+  locale: string;
+}
+
+function HourTooltip({ active, payload, t, locale }: HourTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0].payload;
+  return (
+    <WidgetTooltip
+      title={hourRangeLabel(data.hour)}
+      rows={[
+        {
+          label: t("pnlTime.tooltip.averagePnl"),
+          value: formatCurrency(data.avgPnl, locale),
+          toneClassName: pnlToneClass(pnlTone(data.avgPnl)),
+        },
+        {
+          label: t("pnlTime.tooltip.trades"),
+          value: formatCount(data.tradeCount, locale),
+        },
+      ]}
+    />
+  );
+}
 
 export default function TimeOfDayTradeChart({
   size = "medium",
@@ -53,8 +97,9 @@ export default function TimeOfDayTradeChart({
   const timezone = useUserStore((state) => state.timezone);
   const [activeHour, setActiveHour] = React.useState<number | null>(null);
   const t = useI18n();
+  const locale = useCurrentLocale();
 
-  const handleClick = React.useCallback(() => {
+  const handleActivate = React.useCallback(() => {
     if (activeHour === null) return;
     if (hourFilter.hour === activeHour) {
       setHourFilter({ hour: null });
@@ -63,7 +108,14 @@ export default function TimeOfDayTradeChart({
     }
   }, [activeHour, hourFilter.hour, setHourFilter]);
 
-  const chartData = React.useMemo(() => {
+  const handleMouseMove = React.useCallback((state: CategoricalChartState) => {
+    const point = state?.activePayload?.[0]?.payload as HourDatum | undefined;
+    setActiveHour(point ? point.hour : null);
+  }, []);
+
+  const handleMouseLeave = React.useCallback(() => setActiveHour(null), []);
+
+  const chartData = React.useMemo<HourDatum[]>(() => {
     const hourlyData: { [hour: string]: { totalPnl: number; count: number } } =
       {};
 
@@ -89,191 +141,109 @@ export default function TimeOfDayTradeChart({
       .sort((a, b) => a.hour - b.hour);
   }, [trades, timezone]);
 
-  const maxTradeCount = Math.max(...chartData.map((data) => data.tradeCount));
-  const maxPnL = Math.max(...chartData.map((data) => data.avgPnl));
-  const minPnL = Math.min(...chartData.map((data) => data.avgPnl));
+  const hasData = chartData.some((entry) => entry.tradeCount > 0);
+  const hasFilter = hourFilter.hour !== null;
 
-  const getColor = (count: number) => {
-    const intensity = Math.max(0.2, count / maxTradeCount);
-    return `hsl(var(--chart-4) / ${intensity})`;
-  };
-
-  const CustomTooltip = ({ active, payload, label }: any) => {
-    React.useEffect(() => {
-      if (active && payload && payload.length) {
-        setActiveHour(payload[0].payload.hour);
-      } else {
-        setActiveHour(null);
-      }
-    }, [active, payload]);
-
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
-          <div className="grid gap-2">
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("pnlTime.tooltip.time")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {`${label}:00 - ${(label + 1) % 24}:00`}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("pnlTime.tooltip.averagePnl")}
-              </span>
-              <span className="font-bold">{formatCurrency(data.avgPnl)}</span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("pnlTime.tooltip.trades")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.tradeCount}{" "}
-                {data.tradeCount === 1
-                  ? t("pnlTime.tooltip.trade")
-                  : t("pnlTime.tooltip.trades_plural")}
-              </span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-    return null;
-  };
+  const interactiveLabel =
+    activeHour !== null
+      ? `${t("filters.title")}: ${hourRangeLabel(activeHour)}`
+      : `${t("filters.title")}: ${t("pnlTime.title")}`;
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === "small" ? "p-2 h-10" : "p-3 sm:p-4 h-14",
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnlTime.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlTime.description")}</p>
-            </InfoBubble>
-          </div>
-          {hourFilter.hour !== null && (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("pnlTime.title")}
+        description={t("pnlTime.description")}
+        actions={
+          hasFilter ? (
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 px-2 lg:px-3"
+              className="h-7 px-2"
               onClick={() => setHourFilter({ hour: null })}
             >
               {t("pnlTime.clearFilter")}
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
+          ) : null
+        }
+      />
+      <WidgetBody
+        size={size}
+        flush
+        className={cn(isCompactSize(size) ? "p-1" : "p-2")}
       >
-        <div className="w-full h-full cursor-pointer" onClick={handleClick}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_HOURLY}
-              xDataKey="hour"
-              yDataKey="avgPnl"
-              marginVariant="hourly"
-              yAxisWidth={45}
-              xTickCount={8}
-            />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="hour"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={(value) => `${value}h`}
-                ticks={
-                  size === "small"
-                    ? [0, 6, 12, 18]
-                    : [0, 3, 6, 9, 12, 15, 18, 21]
-                }
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatCurrency}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="avgPnl"
-                fill={chartConfig.avgPnl.color}
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={hourFilter.hour !== null ? 0.3 : 1}
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_HOURLY}
+            xDataKey="hour"
+            yDataKey="avgPnl"
+            marginVariant="hourly"
+            yAxisWidth={45}
+            xTickCount={8}
+          />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t("chat.noTradesAvailable")} />
+        ) : (
+          <WidgetChartInteractive
+            onActivate={handleActivate}
+            label={interactiveLabel}
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={chartMargin(size)}
+                onMouseMove={handleMouseMove}
+                onMouseLeave={handleMouseLeave}
               >
-                {chartData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.hour}`}
-                    fill={getColor(entry.tradeCount)}
-                    opacity={
-                      hourFilter.hour === entry.hour
-                        ? 1
-                        : hourFilter.hour !== null
-                          ? 0.3
-                          : 1
-                    }
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                <WidgetChartGrid />
+                <XAxis
+                  dataKey="hour"
+                  {...axisProps(size)}
+                  height={isCompactSize(size) ? 20 : 24}
+                  tickFormatter={(value) => `${value}h`}
+                  ticks={
+                    isCompactSize(size)
+                      ? [0, 6, 12, 18]
+                      : [0, 3, 6, 9, 12, 15, 18, 21]
+                  }
+                />
+                <YAxis
+                  {...axisProps(size)}
+                  width={52}
+                  tickFormatter={(value: number) =>
+                    formatCompactCurrency(value, locale)
+                  }
+                />
+                <WidgetZeroLine />
+                <Tooltip
+                  content={<HourTooltip t={t} locale={locale} />}
+                  cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                  wrapperStyle={{ zIndex: 1000 }}
+                />
+                <Bar
+                  dataKey="avgPnl"
+                  radius={[3, 3, 0, 0]}
+                  maxBarSize={isCompactSize(size) ? 25 : 40}
+                  isAnimationActive={false}
+                >
+                  {chartData.map((entry) => (
+                    <Cell
+                      key={`cell-${entry.hour}`}
+                      fill={pnlToneFill(pnlTone(entry.avgPnl))}
+                      fillOpacity={
+                        !hasFilter || hourFilter.hour === entry.hour ? 1 : 0.3
+                      }
+                      className="motion-safe:transition-opacity motion-safe:duration-150 motion-safe:ease-out"
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </WidgetChartInteractive>
+        )}
+      </WidgetBody>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/tick-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/tick-distribution.tsx
@@ -4,22 +4,35 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   ResponsiveContainer,
   Cell,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
+import type { CategoricalChartState } from "recharts/types/chart/types";
 import { useData } from "@/context/data-provider";
 import { cn } from "@/lib/utils";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { InfoBubble } from "@/components/ui/info-bubble";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
 import { Button } from "@/components/ui/button";
 import { useTickDetailsStore } from "@/store/tick-details-store";
+import {
+  axisProps,
+  chartColors,
+  chartMargin,
+  chartTickFontSize,
+  formatCount,
+  formatTicks,
+  isCompactSize,
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetChartInteractive,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetTooltip,
+} from "../widgets";
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_TICKS,
@@ -34,63 +47,34 @@ interface ChartDataPoint {
   count: number;
 }
 
-interface TooltipProps {
+interface TickTooltipProps {
   active?: boolean;
-  payload?: Array<{
-    payload: ChartDataPoint;
-  }>;
-  label?: string;
+  payload?: Array<{ payload: ChartDataPoint }>;
+  t: ReturnType<typeof useI18n>;
+  locale: string;
 }
 
-const chartConfig = {
-  count: {
-    label: "Count",
-    color: "hsl(var(--chart-7))",
-  },
-} satisfies ChartConfig;
-
-const CustomTooltip = ({ active, payload }: TooltipProps) => {
-  const t = useI18n();
-  if (active && payload && payload.length) {
-    const data = payload[0].payload;
-    return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
-        <div className="grid gap-2">
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("tickDistribution.tooltip.ticks")}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.ticks}{" "}
-              {parseInt(data.ticks) !== 1
-                ? t("tickDistribution.tooltip.ticks_plural")
-                : t("tickDistribution.tooltip.tick")}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t("tickDistribution.tooltip.trades")}
-            </span>
-            <span className="font-bold">
-              {data.count}{" "}
-              {data.count !== 1
-                ? t("tickDistribution.tooltip.trades_plural")
-                : t("tickDistribution.tooltip.trade")}
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-  return null;
-};
-
-const formatCount = (value: number) => {
-  if (value >= 1000) {
-    return `${(value / 1000).toFixed(1)}k`;
-  }
-  return value.toString();
-};
+function TickTooltip({ active, payload, t, locale }: TickTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0].payload;
+  const tickValue = Number(data.ticks.replace("+", ""));
+  const tickLabel = `${tickValue > 0 ? "+" : ""}${formatTicks(tickValue, locale)}`;
+  return (
+    <WidgetTooltip
+      title={`${tickLabel} ${
+        Math.abs(tickValue) === 1
+          ? t("tickDistribution.tooltip.tick")
+          : t("tickDistribution.tooltip.ticks_plural")
+      }`}
+      rows={[
+        {
+          label: t("tickDistribution.tooltip.trades"),
+          value: formatCount(data.count, locale),
+        },
+      ]}
+    />
+  );
+}
 
 export default function TickDistributionChart({
   size = "medium",
@@ -98,9 +82,11 @@ export default function TickDistributionChart({
   const { formattedTrades: trades, tickFilter, setTickFilter, isLoading } =
     useData();
   const tickDetails = useTickDetailsStore((state) => state.tickDetails);
+  const [activeTicks, setActiveTicks] = React.useState<string | null>(null);
   const t = useI18n();
+  const locale = useCurrentLocale();
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<ChartDataPoint[]>(() => {
     if (!trades.length) return [];
 
     // Create a map to store tick counts
@@ -137,163 +123,150 @@ export default function TickDistributionChart({
       );
   }, [trades, tickDetails]);
 
-  const handleBarClick = (data: any) => {
-    if (!data || !trades.length) return;
-    const clickedTicks = data.ticks;
-    if (tickFilter.value === clickedTicks) {
+  const handleActivate = React.useCallback(() => {
+    if (activeTicks === null) return;
+    if (tickFilter.value === activeTicks) {
       setTickFilter({ value: null });
     } else {
-      setTickFilter({ value: clickedTicks });
+      setTickFilter({ value: activeTicks });
     }
-  };
+  }, [activeTicks, tickFilter.value, setTickFilter]);
+
+  const handleMouseMove = React.useCallback((state: CategoricalChartState) => {
+    const point = state?.activePayload?.[0]?.payload as
+      | ChartDataPoint
+      | undefined;
+    setActiveTicks(point ? point.ticks : null);
+  }, []);
+
+  const handleMouseLeave = React.useCallback(() => setActiveTicks(null), []);
+
+  const hasFilter = Boolean(tickFilter.value);
+  const interactiveLabel =
+    activeTicks !== null
+      ? `${t("filters.title")}: ${activeTicks} ${t("tickDistribution.tooltip.ticks")}`
+      : `${t("filters.title")}: ${t("tickDistribution.title")}`;
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === "small" ? "p-2 h-10" : "p-3 sm:p-4 h-14",
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("tickDistribution.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("tickDistribution.description")}</p>
-            </InfoBubble>
-          </div>
-          {tickFilter.value && (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("tickDistribution.title")}
+        description={t("tickDistribution.description")}
+        actions={
+          hasFilter ? (
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 px-2 lg:px-3"
+              className="h-7 px-2"
               onClick={() => setTickFilter({ value: null })}
             >
               {t("tickDistribution.clearFilter")}
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
+          ) : null
+        }
+      />
+      <WidgetBody
+        size={size}
+        flush
+        className={cn(isCompactSize(size) ? "p-1" : "p-2")}
       >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_TICKS}
-              xDataKey="ticks"
-              yDataKey="count"
-              yAxisWidth={45}
-              showReferenceLine={false}
-              domain={[
-                0,
-                Math.max(...LOADING_MOCK_TICKS.map((d) => d.count)) * 1.1,
-              ]}
-            />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
-              onClick={(e) =>
-                e?.activePayload && handleBarClick(e.activePayload[0].payload)
-              }
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="ticks"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={(props) => {
-                  const { x, y, payload } = props;
-                  return (
-                    <g transform={`translate(${x},${y})`}>
-                      <text
-                        x={0}
-                        y={0}
-                        dy={size === "small" ? 8 : 4}
-                        textAnchor={size === "small" ? "end" : "middle"}
-                        fill="currentColor"
-                        fontSize={size === "small" ? 9 : 11}
-                        transform={
-                          size === "small" ? "rotate(-45)" : "rotate(0)"
-                        }
-                      >
-                        {payload.value}
-                      </text>
-                    </g>
-                  );
-                }}
-                interval="preserveStartEnd"
-                allowDataOverflow={true}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tickFormatter={formatCount}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="count"
-                fill={chartConfig.count.color}
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={tickFilter.value ? 0.3 : 1}
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_TICKS}
+            xDataKey="ticks"
+            yDataKey="count"
+            yAxisWidth={45}
+            showReferenceLine={false}
+            domain={[
+              0,
+              Math.max(...LOADING_MOCK_TICKS.map((d) => d.count)) * 1.1,
+            ]}
+          />
+        ) : chartData.length === 0 ? (
+          <WidgetEmpty size={size} message={t("chat.noTradesAvailable")} />
+        ) : (
+          <WidgetChartInteractive
+            onActivate={handleActivate}
+            label={interactiveLabel}
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={chartMargin(size)}
+                onMouseMove={handleMouseMove}
+                onMouseLeave={handleMouseLeave}
               >
-                {chartData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.ticks}`}
-                    opacity={
-                      tickFilter.value === entry.ticks
-                        ? 1
-                        : tickFilter.value
-                          ? 0.3
-                          : 1
-                    }
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                <WidgetChartGrid />
+                <XAxis
+                  dataKey="ticks"
+                  {...axisProps(size)}
+                  height={isCompactSize(size) ? 20 : 24}
+                  interval="preserveStartEnd"
+                  allowDataOverflow
+                  tick={(props: {
+                    x: number;
+                    y: number;
+                    payload: { value: string };
+                  }) => {
+                    const { x, y, payload } = props;
+                    return (
+                      <g transform={`translate(${x},${y})`}>
+                        <text
+                          x={0}
+                          y={0}
+                          dy={isCompactSize(size) ? 8 : 4}
+                          textAnchor={isCompactSize(size) ? "end" : "middle"}
+                          fill={chartColors.tick}
+                          fontSize={chartTickFontSize(size)}
+                          transform={
+                            isCompactSize(size) ? "rotate(-45)" : "rotate(0)"
+                          }
+                        >
+                          {payload.value}
+                        </text>
+                      </g>
+                    );
+                  }}
+                />
+                <YAxis
+                  {...axisProps(size)}
+                  width={45}
+                  tickFormatter={(value: number) => formatCount(value, locale)}
+                />
+                <Tooltip
+                  content={<TickTooltip t={t} locale={locale} />}
+                  cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                  wrapperStyle={{ zIndex: 1000 }}
+                />
+                <Bar
+                  dataKey="count"
+                  fill={chartColors.neutral}
+                  radius={[3, 3, 0, 0]}
+                  maxBarSize={isCompactSize(size) ? 25 : 40}
+                  isAnimationActive={false}
+                >
+                  {chartData.map((entry) => (
+                    <Cell
+                      key={`cell-${entry.ticks}`}
+                      fill={
+                        tickFilter.value === entry.ticks
+                          ? chartColors.primary
+                          : chartColors.neutral
+                      }
+                      fillOpacity={
+                        !hasFilter || tickFilter.value === entry.ticks ? 1 : 0.3
+                      }
+                      className="motion-safe:transition-opacity motion-safe:duration-150 motion-safe:ease-out"
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </WidgetChartInteractive>
+        )}
+      </WidgetBody>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/time-in-position.tsx
+++ b/app/[locale]/dashboard/components/charts/time-in-position.tsx
@@ -4,54 +4,57 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
-  Cell,
   ResponsiveContainer,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { Trade } from "@/prisma/generated/prisma/browser";
 import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_HOURLY_TIME,
 } from "./chart-loading-skeleton";
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetEmpty,
+  WidgetFooter,
+  WidgetHeader,
+  WidgetTooltip,
+  axisProps,
+  chartColors,
+  chartMargin,
+  formatCount,
+  formatDuration,
+  isCompactSize,
+} from "../widgets";
 
 interface TimeInPositionChartProps {
   size?: WidgetSize;
 }
 
-const chartConfig = {
-  avgTimeInPosition: {
-    label: "Average Time in Position",
-    color: "hsl(var(--chart-7))",
-  },
-} satisfies ChartConfig;
-
-const formatTime = (minutes: number) => {
-  const hours = Math.floor(minutes / 60);
-  const mins = Math.round(minutes % 60);
-  if (hours > 0) {
-    return mins > 0 ? `${hours}h${mins}m` : `${hours}h`;
-  }
-  return `${mins}m`;
-};
+interface HourDurationDatum {
+  hour: number;
+  /** Average holding time for the hour, in seconds. */
+  avgTimeInPosition: number;
+  tradeCount: number;
+}
 
 export default function TimeInPositionChart({
   size = "medium",
 }: TimeInPositionChartProps) {
   const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
+  const locale = useCurrentLocale();
+  const compact = isCompactSize(size);
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<HourDurationDatum[]>(() => {
     const hourlyData: { [hour: string]: { totalTime: number; count: number } } =
       {};
 
@@ -60,10 +63,10 @@ export default function TimeInPositionChart({
       hourlyData[i.toString()] = { totalTime: 0, count: 0 };
     }
 
-    // Sum up time in position and count trades for each hour in UTC
+    // Sum up time in position (seconds) and count trades for each hour in UTC
     trades.forEach((trade: Trade) => {
       const hour = formatInTimeZone(new Date(trade.entryDate), "UTC", "H");
-      hourlyData[hour].totalTime += trade.timeInPosition / 60; // Convert seconds to minutes
+      hourlyData[hour].totalTime += trade.timeInPosition;
       hourlyData[hour].count++;
     });
 
@@ -71,170 +74,115 @@ export default function TimeInPositionChart({
     return Object.entries(hourlyData)
       .map(([hour, data]) => ({
         hour: parseInt(hour),
+        // Guard the division: an hour with no trades is 0s, never NaN.
         avgTimeInPosition: data.count > 0 ? data.totalTime / data.count : 0,
         tradeCount: data.count,
       }))
       .sort((a, b) => a.hour - b.hour);
   }, [trades]);
 
-  const maxTradeCount = Math.max(...chartData.map((data) => data.tradeCount));
+  const totals = React.useMemo(
+    () =>
+      chartData.reduce(
+        (acc, row) => ({
+          trades: acc.trades + row.tradeCount,
+          time: acc.time + row.avgTimeInPosition * row.tradeCount,
+        }),
+        { trades: 0, time: 0 },
+      ),
+    [chartData],
+  );
 
-  const getColor = (count: number) => {
-    const intensity = Math.max(0.2, count / maxTradeCount);
-    return `hsl(var(--chart-8) / ${intensity})`;
-  };
-
-  const CustomTooltip = ({ active, payload, label }: any) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
-          <div className="grid gap-2">
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("timeInPosition.tooltip.time")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {`${label}:00 - ${(label + 1) % 24}:00`}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("timeInPosition.tooltip.averageDuration")}
-              </span>
-              <span className="font-bold">
-                {formatTime(data.avgTimeInPosition)}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("timeInPosition.tooltip.trades")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.tradeCount}{" "}
-                {data.tradeCount !== 1
-                  ? t("timeInPosition.tooltip.trades_plural")
-                  : t("timeInPosition.tooltip.trade")}
-              </span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-    return null;
-  };
+  const hasData = totals.trades > 0;
+  const overallAverage = hasData ? totals.time / totals.trades : 0;
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("timeInPosition.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("timeInPosition.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_HOURLY_TIME}
-              xDataKey="hour"
-              yDataKey="avgTimeInPosition"
-              marginVariant="hourly"
-              yAxisWidth={45}
-              xTickCount={8}
-            />
-          ) : (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("timeInPosition.title")}
+        description={t("timeInPosition.description")}
+      />
+      <WidgetBody size={size} flush className={cn(compact ? "p-1" : "p-2")}>
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_HOURLY_TIME}
+            xDataKey="hour"
+            yDataKey="avgTimeInPosition"
+            marginVariant="hourly"
+            yAxisWidth={45}
+            xTickCount={8}
+          />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t("widgets.empty.noTrades")} />
+        ) : (
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
+            <BarChart data={chartData} margin={chartMargin(size)}>
+              <WidgetChartGrid />
               <XAxis
                 dataKey="hour"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={(value) => `${value}h`}
+                {...axisProps(size)}
+                height={compact ? 20 : 24}
+                tickFormatter={(value: number) => `${value}h`}
                 ticks={
-                  size === "small"
-                    ? [0, 6, 12, 18]
-                    : [0, 3, 6, 9, 12, 15, 18, 21]
+                  compact ? [0, 6, 12, 18] : [0, 3, 6, 9, 12, 15, 18, 21]
                 }
               />
               <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatTime}
+                {...axisProps(size)}
+                width={compact ? 40 : 48}
+                // A duration is unsigned, so the length encoding sits on its
+                // natural zero baseline with no cropped domain.
+                tickFormatter={(value: number) => formatDuration(value)}
               />
               <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
+                cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                isAnimationActive={false}
+                wrapperStyle={{ zIndex: 1000 }}
+                content={({ active, payload }: any) => {
+                  if (!active || !payload?.length) return null;
+                  const row = payload[0].payload as HourDurationDatum;
+                  return (
+                    <WidgetTooltip
+                      title={`${row.hour}:00 - ${(row.hour + 1) % 24}:00`}
+                      rows={[
+                        {
+                          label: t("timeInPosition.tooltip.averageDuration"),
+                          value: formatDuration(row.avgTimeInPosition),
+                        },
+                        {
+                          label: t("timeInPosition.tooltip.trades"),
+                          value: formatCount(row.tradeCount, locale),
+                        },
+                      ]}
+                    />
+                  );
                 }}
               />
               <Bar
                 dataKey="avgTimeInPosition"
                 radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-              >
-                {chartData.map((entry, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={getColor(entry.tradeCount)}
-                  />
-                ))}
-              </Bar>
+                maxBarSize={compact ? 25 : 40}
+                // Holding time is an unsigned magnitude already carried by bar
+                // length, so it stays monochrome: no intensity ramp.
+                fill={chartColors.neutral}
+                isAnimationActive={false}
+              />
             </BarChart>
           </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+        )}
+      </WidgetBody>
+      <WidgetFooter size={size}>
+        <span>
+          {t("timeInPosition.tooltip.averageDuration")} · UTC
+        </span>
+        <span className="tabular-nums">
+          {formatDuration(overallAverage)} ·{" "}
+          {formatCount(totals.trades, locale)}{" "}
+          {t("tickDistribution.tooltip.trades")}
+        </span>
+      </WidgetFooter>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/charts/time-range-performance.tsx
+++ b/app/[locale]/dashboard/components/charts/time-range-performance.tsx
@@ -1,24 +1,51 @@
 "use client"
 
 import * as React from "react"
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Bar, BarChart, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts"
+
 import { useData } from "@/context/data-provider"
-import { cn } from "@/lib/utils"
-import { InfoBubble } from "@/components/ui/info-bubble"
 import { WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
-import { useI18n } from "@/locales/client"
+import { useCurrentLocale, useI18n } from "@/locales/client"
 import { Trade } from "@/prisma/generated/prisma/browser"
 import { Button } from "@/components/ui/button"
-import { ChartConfig } from "@/components/ui/chart"
 import { getTimeRangeKey } from "@/lib/time-range"
+
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_TIME_RANGE,
 } from "./chart-loading-skeleton"
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetChartInteractive,
+  WidgetEmpty,
+  WidgetFooter,
+  WidgetHeader,
+  WidgetTooltip,
+  WidgetZeroLine,
+  axisProps,
+  chartColors,
+  chartMargin,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  formatPercent,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+} from "../widgets"
 
 interface TimeRangePerformanceChartProps {
   size?: WidgetSize
+}
+
+interface TimeRangeRow {
+  range: string
+  avgPnl: number
+  winRate: number
+  trades: number
+  color: string
 }
 
 function getTimeRangeLabel(range: string): string {
@@ -36,24 +63,24 @@ function getTimeRangeLabel(range: string): string {
   return labels[range] || range
 }
 
-function getColorByWinRate(winRate: number): string {
-  if (winRate === 0) return "hsl(var(--muted-foreground))"
-  return winRate >= 50 ? "hsl(var(--chart-win))" : "hsl(var(--chart-loss))"
+/**
+ * Bar color states whether the bucket wins more often than it loses. It is
+ * always paired with the numeric win rate in the tooltip, so the meaning never
+ * rests on color alone.
+ */
+function getColorByWinRate(winRate: number, trades: number): string {
+  if (trades === 0) return chartColors.neutral
+  return winRate >= 50 ? chartColors.win : chartColors.loss
 }
-
-const chartConfig = {
-  avgPnl: {
-    label: "Average PnL",
-    color: "hsl(var(--chart-1))",
-  },
-} satisfies ChartConfig
 
 export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRangePerformanceChartProps) {
   const { formattedTrades: trades, timeRange, setTimeRange, isLoading } = useData()
   const t = useI18n()
+  const locale = useCurrentLocale()
+  const compact = isCompactSize(size)
   const [activeRange, setActiveRange] = React.useState<string | null>(null)
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<TimeRangeRow[]>(() => {
     const timeRangeData: Record<string, {
       totalPnl: number
       winCount: number
@@ -89,10 +116,26 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
         avgPnl: data.totalTrades > 0 ? data.totalPnl / data.totalTrades : 0,
         winRate,
         trades: data.totalTrades,
-        color: getColorByWinRate(winRate)
+        color: getColorByWinRate(winRate, data.totalTrades)
       }
     })
   }, [trades])
+
+  // Bar length is a magnitude encoding, so the domain always contains zero and
+  // the headroom only ever extends away from the baseline.
+  const yDomain = React.useMemo<[number, number]>(() => {
+    const values = chartData.map((row) => row.avgPnl)
+    if (values.length === 0) return [0, 0]
+    return [
+      Math.min(Math.min(...values) * 1.1, 0),
+      Math.max(Math.max(...values) * 1.1, 0),
+    ]
+  }, [chartData])
+
+  const totalTrades = React.useMemo(
+    () => chartData.reduce((sum, row) => sum + row.trades, 0),
+    [chartData],
+  )
 
   const handleClick = React.useCallback(() => {
     if (!activeRange) return
@@ -103,200 +146,133 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
     }
   }, [activeRange, timeRange.range, setTimeRange])
 
-  const CustomTooltip = ({ active, payload, label }: any) => {
-    React.useEffect(() => {
-      if (active && payload && payload.length) {
-        setActiveRange(payload[0].payload.range)
-      } else {
-        setActiveRange(null)
-      }
-    }, [active, payload])
-
-    if (active && payload && payload.length) {
-      const data = payload[0].payload
-      return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
-          <div className="grid gap-2">
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t('timeRangePerformance.tooltip.timeRange')}
-              </span>
-              <span className={cn(
-                "font-bold",
-                timeRange.range === data.range ? "text-primary" : "text-muted-foreground"
-              )}>
-                {getTimeRangeLabel(label)}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t('timeRangePerformance.tooltip.avgPnl')}
-              </span>
-              <span className="font-bold">
-                {data.avgPnl.toFixed(2)}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t('timeRangePerformance.tooltip.winRate')}
-              </span>
-              <span className="font-bold" style={{ color: data.color }}>
-                {data.winRate.toFixed(1)}%
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t('timeRangePerformance.tooltip.trades.one', { count: data.trades })}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.trades === 1 
-                  ? t('timeRangePerformance.tooltip.trades.one', { count: data.trades })
-                  : t('timeRangePerformance.tooltip.trades.other', { count: data.trades })
-                }
-              </span>
-            </div>
-          </div>
-        </div>
-      )
-    }
-    return null
-  }
+  const hasData = totalTrades > 0
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader 
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle 
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
-            >
-              {t('timeRangePerformance.title')}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === 'small' ? "size-3.5" : "size-4")}
-            >
-              <p>{t('timeRangePerformance.description')}</p>
-            </InfoBubble>
-          </div>
-          {timeRange.range && (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('timeRangePerformance.title')}
+        description={t('timeRangePerformance.description')}
+        actions={
+          timeRange.range ? (
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 px-2 lg:px-3"
+              className="h-7 px-2 text-xs font-normal text-muted-foreground motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out hover:text-foreground"
               onClick={() => setTimeRange({ range: null })}
             >
               {t('timeRangePerformance.clearFilter')}
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent 
-        className={cn(
-          "flex-1 min-h-0",
-          size === 'small' ? "p-1" : "p-2 sm:p-4"
+          ) : null
+        }
+      />
+      <WidgetBody size={size} className="min-h-0">
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_TIME_RANGE}
+            xDataKey="range"
+            yDataKey="avgPnl"
+            yAxisWidth={45}
+            showReferenceLine
+          />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t('widgets.empty.noTrades')} />
+        ) : (
+          <WidgetChartInteractive
+            onActivate={handleClick}
+            label={`${t('timeRangePerformance.title')}. ${t('timeRangePerformance.description')}`}
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} margin={chartMargin(size)}>
+                <WidgetChartGrid />
+                <XAxis
+                  dataKey="range"
+                  {...axisProps(size)}
+                  height={compact ? 32 : 24}
+                  angle={compact ? -45 : 0}
+                  textAnchor={compact ? 'end' : 'middle'}
+                  interval={0}
+                  tickFormatter={getTimeRangeLabel}
+                />
+                <YAxis
+                  {...axisProps(size)}
+                  width={compact ? 44 : 52}
+                  domain={yDomain}
+                  tickFormatter={(value: number) => formatCompactCurrency(value, locale)}
+                />
+                <WidgetZeroLine />
+                <Tooltip
+                  cursor={{ fill: "hsl(var(--muted) / 0.4)" }}
+                  isAnimationActive={false}
+                  content={({ active, payload }: any) => {
+                    const row: TimeRangeRow | undefined = active && payload?.length
+                      ? payload[0].payload
+                      : undefined
+                    // Recharts owns hover state; mirror it so a click knows the target.
+                    if ((row?.range ?? null) !== activeRange) {
+                      setActiveRange(row?.range ?? null)
+                    }
+                    if (!row) return null
+                    return (
+                      <WidgetTooltip
+                        title={getTimeRangeLabel(row.range)}
+                        rows={[
+                          {
+                            label: t('timeRangePerformance.tooltip.avgPnl'),
+                            value: formatCurrency(row.avgPnl, locale),
+                            toneClassName: pnlToneClass(pnlTone(row.avgPnl)),
+                          },
+                          {
+                            label: t('timeRangePerformance.tooltip.winRate'),
+                            value: formatPercent(row.winRate, locale),
+                          },
+                          {
+                            label: t('timeRangePerformance.tooltip.timeRange'),
+                            value: row.trades === 1
+                              ? t('timeRangePerformance.tooltip.trades.one', { count: row.trades })
+                              : t('timeRangePerformance.tooltip.trades.other', { count: formatCount(row.trades, locale) }),
+                          },
+                        ]}
+                        caption={
+                          timeRange.range === row.range
+                            ? t('timeRangePerformance.clearFilter')
+                            : undefined
+                        }
+                      />
+                    )
+                  }}
+                />
+                <Bar
+                  dataKey="avgPnl"
+                  fill={chartColors.neutral}
+                  radius={[3, 3, 0, 0]}
+                  maxBarSize={compact ? 25 : 40}
+                  isAnimationActive={false}
+                >
+                  {chartData.map((entry) => (
+                    <Cell
+                      key={`cell-${entry.range}`}
+                      fill={entry.color}
+                      // Dimming is the selection state, not decoration.
+                      opacity={
+                        timeRange.range && timeRange.range !== entry.range ? 0.3 : 1
+                      }
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </WidgetChartInteractive>
         )}
-      >
-        <div 
-          className="w-full h-full cursor-pointer" 
-          onClick={handleClick}
-        >
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_TIME_RANGE}
-              xDataKey="range"
-              yDataKey="avgPnl"
-              yAxisWidth={45}
-              showReferenceLine
-            />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === 'small'
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
-            >
-              <CartesianGrid 
-                strokeDasharray="3 3" 
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="range"
-                tickLine={false}
-                axisLine={false}
-                height={size === 'small' ? 20 : 24}
-                tickMargin={size === 'small' ? 4 : 8}
-                tick={(props) => {
-                  const { x, y, payload } = props;
-                  return (
-                    <g transform={`translate(${x},${y})`}>
-                      <text
-                        x={0}
-                        y={0}
-                        dy={size === 'small' ? 8 : 4}
-                        textAnchor={size === 'small' ? 'end' : 'middle'}
-                        fill="currentColor"
-                        fontSize={size === 'small' ? 9 : 11}
-                        transform={size === 'small' ? 'rotate(-45)' : 'rotate(0)'}
-                      >
-                        {getTimeRangeLabel(payload.value)}
-                      </text>
-                    </g>
-                  );
-                }}
-                interval="preserveStartEnd"
-                allowDataOverflow={true}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{ 
-                  fontSize: size === 'small' ? 9 : 11,
-                  fill: 'currentColor'
-                }}
-              />
-              <Tooltip 
-                content={<CustomTooltip />}
-                wrapperStyle={{ 
-                  fontSize: size === 'small' ? '10px' : '12px',
-                  zIndex: 1000
-                }} 
-              />
-              <Bar
-                dataKey="avgPnl"
-                fill={chartConfig.avgPnl.color}
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === 'small' ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={timeRange.range ? 0.3 : 1}
-              >
-                {chartData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.range}`}
-                    fill={entry.color}
-                    opacity={timeRange.range === entry.range ? 1 : (timeRange.range ? 0.3 : 1)}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+      </WidgetBody>
+      <WidgetFooter size={size}>
+        <span>USD</span>
+        <span className="tabular-nums">
+          {formatCount(totalTrades, locale)} {t('tickDistribution.tooltip.trades')}
+        </span>
+      </WidgetFooter>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -1,15 +1,26 @@
 "use client"
 
 import * as React from "react"
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend, Label } from "recharts"
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Label } from "recharts"
 import type { Props } from 'recharts/types/component/Label'
 import type { PolarViewBox } from 'recharts/types/util/types'
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useData } from "@/context/data-provider"
 import { cn } from "@/lib/utils"
 import { WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
-import { InfoBubble } from "@/components/ui/info-bubble"
-import { useI18n } from "@/locales/client"
+import { useCurrentLocale, useI18n } from "@/locales/client"
+import {
+  chartColors,
+  chartTickFontSize,
+  formatCount,
+  formatPercent,
+  isCompactSize,
+  WidgetBody,
+  WidgetCard,
+  WidgetChartLegend,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetTooltip,
+} from "../widgets"
 import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton"
 
 interface TradeDistributionProps {
@@ -23,179 +34,149 @@ interface ChartDataPoint {
   count: number;
 }
 
-interface TooltipProps {
+interface DistributionTooltipProps {
   active?: boolean;
-  payload?: Array<{
-    payload: ChartDataPoint;
-  }>;
+  payload?: Array<{ payload: ChartDataPoint }>;
+  t: ReturnType<typeof useI18n>;
+  locale: string;
 }
 
-const CustomTooltip = ({ active, payload }: TooltipProps) => {
-  const t = useI18n()
-  if (active && payload && payload.length) {
-    const data = payload[0].payload;
-    return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
-        <div className="grid gap-2">
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t('tradeDistribution.tooltip.type')}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.name}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t('tradeDistribution.tooltip.percentage')}
-            </span>
-            <span className="font-bold">
-              {data.value.toFixed(2)}%
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-  return null;
-};
+function DistributionTooltip({ active, payload, t, locale }: DistributionTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+  const data = payload[0].payload
+  return (
+    <WidgetTooltip
+      title={data.name}
+      rows={[
+        {
+          label: t('tradeDistribution.tooltip.percentage'),
+          value: formatPercent(data.value, locale, { maximumFractionDigits: 2 }),
+          color: data.color,
+        },
+        {
+          label: t('tradeDistribution.tooltip.type'),
+          value: formatCount(data.count, locale),
+        },
+      ]}
+    />
+  )
+}
 
 export default function TradeDistributionChart({ size = 'medium' }: TradeDistributionProps) {
   const { statistics: { nbWin, nbLoss, nbBe, nbTrades }, isLoading } = useData()
   const t = useI18n()
+  const locale = useCurrentLocale()
 
-  const chartData = React.useMemo(() => {
+  const chartData = React.useMemo<ChartDataPoint[]>(() => {
+    if (!nbTrades) return []
+
     const winRate = Number((nbWin / nbTrades * 100).toFixed(2))
     const lossRate = Number((nbLoss / nbTrades * 100).toFixed(2))
     const beRate = Number((nbBe / nbTrades * 100).toFixed(2))
 
     return [
-      { name: t('tradeDistribution.winWithCount', { count: nbWin, total: nbTrades }), value: winRate, color: 'hsl(var(--chart-win))', count: nbWin },
-      { name: t('tradeDistribution.breakevenWithCount', { count: nbBe, total: nbTrades }), value: beRate, color: 'hsl(var(--muted-foreground))', count: nbBe },
-      { name: t('tradeDistribution.lossWithCount', { count: nbLoss, total: nbTrades }), value: lossRate, color: 'hsl(var(--chart-loss))', count: nbLoss }
+      { name: t('tradeDistribution.winWithCount', { count: nbWin, total: nbTrades }), value: winRate, color: chartColors.win, count: nbWin },
+      { name: t('tradeDistribution.breakevenWithCount', { count: nbBe, total: nbTrades }), value: beRate, color: chartColors.neutral, count: nbBe },
+      { name: t('tradeDistribution.lossWithCount', { count: nbLoss, total: nbTrades }), value: lossRate, color: chartColors.loss, count: nbLoss }
     ]
   }, [nbWin, nbLoss, nbBe, nbTrades, t])
 
-  const renderColorfulLegendText = (value: string, entry: any) => {
-    return <span className="text-xs text-muted-foreground">{value}</span>;
-  }
-
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader 
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('tradeDistribution.title')}
+        description={t('tradeDistribution.description')}
+      />
+      <WidgetBody
+        size={size}
+        flush
+        className={cn("flex flex-col", isCompactSize(size) ? "p-1" : "p-2")}
       >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle 
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
-            >
-              {t('tradeDistribution.title')}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === 'small' ? "size-3.5" : "size-4")}
-            >
-              <p>{t('tradeDistribution.description')}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent 
-        className={cn(
-          "flex-1 min-h-0",
-          size === 'small' ? "p-1" : "p-2 sm:p-4"
-        )}
-      >
-        <div className="w-full h-full">
-          {isLoading ? (
-            <DonutChartLoadingSkeleton size={size} />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="45%"
-                innerRadius={size === 'small' ? "60%" : "65%"}
-                outerRadius={size === 'small' ? "80%" : "85%"}
-                paddingAngle={2}
-                dataKey="value"
-                startAngle={90}
-                endAngle={-270}
-                stroke="hsl(var(--background))"
-                strokeWidth={1}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell 
-                    key={`cell-${index}`} 
-                    fill={entry.color}
-                    className="transition-opacity duration-300 ease-out hover:opacity-80 dark:brightness-90"
+        {isLoading ? (
+          <DonutChartLoadingSkeleton size={size} />
+        ) : chartData.length === 0 ? (
+          <WidgetEmpty size={size} message={t("chat.noTradesAvailable")} />
+        ) : (
+          <>
+            <div className="min-h-0 flex-1">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={isCompactSize(size) ? "60%" : "65%"}
+                    outerRadius={isCompactSize(size) ? "80%" : "85%"}
+                    paddingAngle={2}
+                    dataKey="value"
+                    startAngle={90}
+                    endAngle={-270}
+                    stroke="hsl(var(--background))"
+                    strokeWidth={1}
+                    isAnimationActive={false}
+                  >
+                    {chartData.map((entry, index) => (
+                      <Cell
+                        key={`cell-${index}`}
+                        fill={entry.color}
+                      />
+                    ))}
+                    <Label
+                      position="center"
+                      content={(props: Props) => {
+                        if (!props.viewBox) return null;
+                        const viewBox = props.viewBox as PolarViewBox;
+                        if (!viewBox.cx || !viewBox.cy) return null;
+                        const cx = viewBox.cx;
+                        const cy = viewBox.cy;
+
+                        // Use a percentage of the distance from center to edge for label positioning
+                        const labelRadius = Math.min(cx, cy) * (isCompactSize(size) ? 0.95 : 1.1); // Position labels at 95% or 100% of available space
+
+                        return chartData.map((entry, index) => {
+                          const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
+                          const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
+                          const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
+                          return (
+                            <text
+                              key={index}
+                              x={x}
+                              y={y}
+                              textAnchor="middle"
+                              dominantBaseline="middle"
+                              fill={chartColors.tick}
+                              fontSize={chartTickFontSize(size)}
+                            >
+                              {entry.value > 5
+                                ? formatPercent(entry.value, locale, { maximumFractionDigits: 0 })
+                                : ''}
+                            </text>
+                          );
+                        });
+                      }}
+                    />
+                  </Pie>
+                  <Tooltip
+                    content={<DistributionTooltip t={t} locale={locale} />}
+                    wrapperStyle={{ zIndex: 1000 }}
                   />
-                ))}
-                <Label
-                  position="center"
-                  content={(props: Props) => {
-                    if (!props.viewBox) return null;
-                    const viewBox = props.viewBox as PolarViewBox;
-                    if (!viewBox.cx || !viewBox.cy) return null;
-                    const cx = viewBox.cx;
-                    const cy = viewBox.cy;
-
-                    // Use a percentage of the distance from center to edge for label positioning
-                    const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1); // Position labels at 95% or 100% of available space
-
-                    return chartData.map((entry, index) => {
-                      const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
-                      const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
-                      const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
-                      return (
-                        <text
-                          key={index}
-                          x={x}
-                          y={y}
-                          textAnchor="middle"
-                          dominantBaseline="middle"
-                          className="fill-muted-foreground font-medium translate-y-2"
-                          style={{ 
-                            fontSize: size === 'small' ? '10px' : '12px'
-                          }}
-                        >
-                          {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
-                        </text>
-                      );
-                    });
-                  }}
-                />
-              </Pie>
-              <Legend 
-                verticalAlign="bottom"
-                align="center"
-                iconSize={8}
-                iconType="circle"
-                formatter={renderColorfulLegendText}
-                wrapperStyle={{
-                  paddingTop: size === 'small' ? 0 : 16
-                }}
-              />
-              <Tooltip 
-                content={<CustomTooltip />}
-                wrapperStyle={{ 
-                  fontSize: size === 'small' ? '10px' : '12px',
-                  zIndex: 1000
-                }} 
-              />
-            </PieChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <WidgetChartLegend
+              className={cn(
+                "shrink-0 justify-center",
+                isCompactSize(size) ? "pt-1" : "pt-3",
+              )}
+              items={chartData.map((entry) => ({
+                label: entry.name,
+                color: entry.color,
+              }))}
+            />
+          </>
+        )}
+      </WidgetBody>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
@@ -4,22 +4,38 @@ import * as React from "react";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   Cell,
   ResponsiveContainer,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
+import type { CategoricalChartState } from "recharts/types/chart/types";
 import { useData } from "@/context/data-provider";
 import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
 import { translateWeekdayPnL } from "@/lib/translation-utils";
 import { Button } from "@/components/ui/button";
+import {
+  axisProps,
+  chartMargin,
+  formatCompactCurrency,
+  formatCount,
+  formatCurrency,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+  WidgetBody,
+  WidgetCard,
+  WidgetChartGrid,
+  WidgetChartInteractive,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetTooltip,
+  WidgetZeroLine,
+} from "../widgets";
 import {
   BarChartLoadingSkeleton,
   LOADING_MOCK_WEEKDAY,
@@ -31,42 +47,50 @@ interface WeekdayPNLChartProps {
   size?: WidgetSize;
 }
 
-const formatCurrency = (value: number) =>
-  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
+interface WeekdayDatum {
+  day: number;
+  pnl: number;
+  tradeCount: number;
+}
 
-const chartConfig = {
-  pnl: {
-    label: "PnL",
-    color: "hsl(var(--chart-1))",
-  },
-} satisfies ChartConfig;
+interface WeekdayTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: WeekdayDatum }>;
+  t: ReturnType<typeof useI18n>;
+  locale: string;
+}
+
+function WeekdayTooltip({ active, payload, t, locale }: WeekdayTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0].payload;
+  return (
+    <WidgetTooltip
+      title={translateWeekdayPnL(t, data.day)}
+      rows={[
+        {
+          label: t("weekdayPnl.tooltip.averagePnl"),
+          value: formatCurrency(data.pnl, locale),
+          toneClassName: pnlToneClass(pnlTone(data.pnl)),
+        },
+        {
+          label: t("weekdayPnl.tooltip.trades"),
+          value: formatCount(data.tradeCount, locale),
+        },
+      ]}
+    />
+  );
+}
 
 export default function WeekdayPNLChart({
   size = "medium",
 }: WeekdayPNLChartProps) {
   const { calendarData, weekdayFilter, setWeekdayFilter, isLoading } =
     useData();
-  const [darkMode, setDarkMode] = React.useState(false);
   const [activeDay, setActiveDay] = React.useState<number | null>(null);
   const t = useI18n();
+  const locale = useCurrentLocale();
 
-  React.useEffect(() => {
-    const isDarkMode = document.documentElement.classList.contains("dark");
-    setDarkMode(isDarkMode);
-
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.attributeName === "class") {
-          setDarkMode(document.documentElement.classList.contains("dark"));
-        }
-      });
-    });
-
-    observer.observe(document.documentElement, { attributes: true });
-    return () => observer.disconnect();
-  }, []);
-
-  const weekdayData = React.useMemo(() => {
+  const weekdayData = React.useMemo<WeekdayDatum[]>(() => {
     const weekdayTotals = daysOfWeek.reduce(
       (acc, day) => ({
         ...acc,
@@ -91,199 +115,128 @@ export default function WeekdayPNLChart({
     }));
   }, [calendarData]);
 
-  const maxPnL = Math.max(...weekdayData.map((d) => d.pnl));
-  const minPnL = Math.min(...weekdayData.map((d) => d.pnl));
+  const selectedDays = React.useMemo(
+    () => weekdayFilter.days ?? [],
+    [weekdayFilter.days],
+  );
+  const hasFilter = selectedDays.length > 0;
+  const hasData = weekdayData.some((entry) => entry.tradeCount > 0);
 
-  const getColor = (value: number) => {
-    const ratio = Math.abs((value - minPnL) / (maxPnL - minPnL));
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-loss";
-    const intensity = darkMode
-      ? Math.max(0.3, ratio) // Higher minimum intensity in dark mode
-      : Math.max(0.2, ratio); // Lower minimum intensity in light mode
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
-
-  const handleClick = React.useCallback(() => {
+  const handleActivate = React.useCallback(() => {
     if (activeDay === null) return;
-    const currentDays = weekdayFilter.days || [];
-    if (currentDays.includes(activeDay)) {
-      // Remove day from filter
-      setWeekdayFilter({ days: currentDays.filter(d => d !== activeDay) });
+    if (selectedDays.includes(activeDay)) {
+      setWeekdayFilter({ days: selectedDays.filter((d) => d !== activeDay) });
     } else {
-      // Add day to filter
-      setWeekdayFilter({ days: [...currentDays, activeDay] });
+      setWeekdayFilter({ days: [...selectedDays, activeDay] });
     }
-  }, [activeDay, weekdayFilter.days, setWeekdayFilter]);
+  }, [activeDay, selectedDays, setWeekdayFilter]);
 
-  const CustomTooltip = ({ active, payload, label }: any) => {
-    React.useEffect(() => {
-      if (active && payload && payload.length) {
-        setActiveDay(payload[0].payload.day);
-      } else {
-        setActiveDay(null);
-      }
-    }, [active, payload]);
+  const handleMouseMove = React.useCallback((state: CategoricalChartState) => {
+    const point = state?.activePayload?.[0]?.payload as
+      | WeekdayDatum
+      | undefined;
+    setActiveDay(point ? point.day : null);
+  }, []);
 
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
-          <div className="grid gap-2">
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("weekdayPnl.tooltip.day")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {translateWeekdayPnL(t, data.day)}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("weekdayPnl.tooltip.averagePnl")}
-              </span>
-              <span className="font-bold">{formatCurrency(data.pnl)}</span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("weekdayPnl.tooltip.trades")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.tradeCount}{" "}
-                {data.tradeCount !== 1
-                  ? t("weekdayPnl.tooltip.trades_plural")
-                  : t("weekdayPnl.tooltip.trade")}
-              </span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-    return null;
-  };
+  const handleMouseLeave = React.useCallback(() => setActiveDay(null), []);
+
+  const interactiveLabel =
+    activeDay !== null
+      ? `${t("filters.title")}: ${translateWeekdayPnL(t, activeDay)}`
+      : `${t("filters.title")}: ${t("weekdayPnl.title")}`;
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === "small" ? "p-2 h-10" : "p-3 sm:p-4 h-14",
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("weekdayPnl.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("weekdayPnl.description")}</p>
-            </InfoBubble>
-          </div>
-          {weekdayFilter.days && weekdayFilter.days.length > 0 && (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t("weekdayPnl.title")}
+        description={t("weekdayPnl.description")}
+        actions={
+          hasFilter ? (
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 px-2 lg:px-3"
+              className="h-7 px-2"
               onClick={() => setWeekdayFilter({ days: [] })}
             >
               {t("weekdayPnl.clearFilter")}
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
+          ) : null
+        }
+      />
+      <WidgetBody
+        size={size}
+        flush
+        className={cn(isCompactSize(size) ? "p-1" : "p-2")}
       >
-        <div className="w-full h-full cursor-pointer" onClick={handleClick}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_WEEKDAY}
-              xDataKey="day"
-              yDataKey="pnl"
-              yAxisWidth={45}
-              xTickCount={7}
-            />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={weekdayData}
-              margin={
-                size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="day"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={(value) => {
-                  const dayName = translateWeekdayPnL(t, value);
-                  return size === "small" ? dayName.slice(0, 3) : dayName;
-                }}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{
-                  fontSize: 8,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatCurrency}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="pnl"
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={weekdayFilter.days && weekdayFilter.days.length > 0 ? 0.3 : 1}
+        {isLoading ? (
+          <BarChartLoadingSkeleton
+            size={size}
+            data={LOADING_MOCK_WEEKDAY}
+            xDataKey="day"
+            yDataKey="pnl"
+            yAxisWidth={45}
+            xTickCount={7}
+          />
+        ) : !hasData ? (
+          <WidgetEmpty size={size} message={t("chat.noTradesAvailable")} />
+        ) : (
+          <WidgetChartInteractive
+            onActivate={handleActivate}
+            label={interactiveLabel}
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={weekdayData}
+                margin={chartMargin(size)}
+                onMouseMove={handleMouseMove}
+                onMouseLeave={handleMouseLeave}
               >
-                {weekdayData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.day}`}
-                    fill={getColor(entry.pnl)}
-                    className={cn(
-                      "transition-[opacity,filter,box-shadow] duration-300 ease-out",
-                      weekdayFilter.days && weekdayFilter.days.includes(entry.day) && "ring-2 ring-primary ring-offset-2"
-                    )}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+                <WidgetChartGrid />
+                <XAxis
+                  dataKey="day"
+                  {...axisProps(size)}
+                  height={isCompactSize(size) ? 20 : 24}
+                  tickFormatter={(value) => {
+                    const dayName = translateWeekdayPnL(t, value);
+                    return isCompactSize(size) ? dayName.slice(0, 3) : dayName;
+                  }}
+                />
+                <YAxis
+                  {...axisProps(size)}
+                  width={52}
+                  tickFormatter={(value: number) =>
+                    formatCompactCurrency(value, locale)
+                  }
+                />
+                <WidgetZeroLine />
+                <Tooltip
+                  content={<WeekdayTooltip t={t} locale={locale} />}
+                  cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }}
+                  wrapperStyle={{ zIndex: 1000 }}
+                />
+                <Bar
+                  dataKey="pnl"
+                  radius={[3, 3, 0, 0]}
+                  maxBarSize={isCompactSize(size) ? 25 : 40}
+                  isAnimationActive={false}
+                >
+                  {weekdayData.map((entry) => (
+                    <Cell
+                      key={`cell-${entry.day}`}
+                      fill={pnlToneFill(pnlTone(entry.pnl))}
+                      fillOpacity={
+                        !hasFilter || selectedDays.includes(entry.day) ? 1 : 0.3
+                      }
+                      className="motion-safe:transition-opacity motion-safe:duration-150 motion-safe:ease-out"
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </WidgetChartInteractive>
+        )}
+      </WidgetBody>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/chat/chat.tsx
+++ b/app/[locale]/dashboard/components/chat/chat.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { RotateCcw, MessageSquare } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
+import { WidgetBody, WidgetCard } from "../widgets";
 import {
   MessageScroller,
   MessageScrollerButton,
@@ -326,14 +326,14 @@ export default function ChatWidget({ size = "large" }: ChatWidgetProps) {
 
   return (
     <MessageScrollerProvider autoScroll>
-      <Card className="h-full flex flex-col bg-background relative overflow-clip">
+      <WidgetCard className="relative bg-background">
         <ChatHeader
           title="AI Assistant"
           onReset={handleReset}
           isLoading={isProcessingResponse}
           size={size}
         />
-        <CardContent className="flex-1 flex flex-col min-h-0 p-0 relative">
+        <WidgetBody flush className="relative flex flex-col">
           <MessageScroller className="flex-1 min-h-0">
             <MessageScrollerViewport>
               <MessageScrollerContent className="p-4" aria-busy={isProcessingResponse}>
@@ -673,7 +673,7 @@ export default function ChatWidget({ size = "large" }: ChatWidgetProps) {
           onFilesChange={setFiles}
           files={files}
         />
-      </CardContent>
+      </WidgetBody>
       {!isStarted && !isLoadingMessages && storedMessages.length === 0 && (
         <div className="absolute inset-0 bg-background/60 backdrop-blur-xs z-50 flex items-center justify-center p-4">
           <div className="w-full max-w-md p-4 sm:p-6 space-y-4 sm:space-y-6 text-center">
@@ -705,7 +705,7 @@ export default function ChatWidget({ size = "large" }: ChatWidgetProps) {
           </div>
         </div>
       )}
-    </Card>
+    </WidgetCard>
     </MessageScrollerProvider>
   );
 }

--- a/app/[locale]/dashboard/components/chat/header.tsx
+++ b/app/[locale]/dashboard/components/chat/header.tsx
@@ -1,14 +1,14 @@
 import { WidgetSize } from "../../types/dashboard"
-import { CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { RotateCcw } from "lucide-react"
 import { useI18n } from "@/locales/client"
+import { WidgetHeader, isCompactSize } from "../widgets"
 
 export function ChatHeader({
     onReset,
     isLoading,
-    size,
+    size = "medium",
 }: {
     title: string
     onReset: () => void
@@ -16,26 +16,23 @@ export function ChatHeader({
     size?: WidgetSize
 }) {
     const t = useI18n();
+    const compact = isCompactSize(size)
     return (
-        <CardHeader
-            className={cn(
-                "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-                size === "small-long" ? "p-2 h-[40px]" : "p-3 sm:p-4 h-[56px]",
-            )}
-        >
-            <div className="flex items-center gap-1.5">
-                <CardTitle className={cn("line-clamp-1", size === "small-long" ? "text-sm" : "text-base")}>{t('chat.title')}</CardTitle>
-            </div>
-            <Button
-                variant="ghost"
-                size="icon"
-                onClick={onReset}
-                disabled={isLoading}
-                className={cn("shrink-0", size === "small-long" ? "h-7 w-7" : "h-8 w-8")}
-                title="Reset Chat"
-            >
-                <RotateCcw className={cn(size === "small-long" ? "h-3.5 w-3.5" : "h-4 w-4")} />
-            </Button>
-        </CardHeader>
+        <WidgetHeader
+            size={size}
+            title={t('chat.title')}
+            actions={
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onReset}
+                    disabled={isLoading}
+                    className={cn("shrink-0", compact ? "h-7 w-7" : "h-8 w-8")}
+                    aria-label={t('chat.resetConversation')}
+                >
+                    <RotateCcw className={cn(compact ? "h-3.5 w-3.5" : "h-4 w-4")} />
+                </Button>
+            }
+        />
     )
 }

--- a/app/[locale]/dashboard/components/filters/tag-widget.tsx
+++ b/app/[locale]/dashboard/components/filters/tag-widget.tsx
@@ -7,8 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { Plus, X, Edit2, Trash2, Search } from 'lucide-react'
-import { InfoBubble } from '@/components/ui/info-bubble'
+import { Plus, Edit2, Trash2, Search } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
@@ -19,14 +18,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Tooltip,
@@ -52,6 +43,14 @@ import {
 } from "@/components/ui/alert-dialog"
 import { useTradesStore } from '../../../../../store/trades-store'
 import { useUserStore } from '../../../../../store/user-store'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  isCompactSize,
+  widgetType,
+} from '../widgets'
 
 interface TagType {
   id: string
@@ -285,44 +284,24 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
     setFilteredTags(filteredTags)
   }, [tags, searchQuery])
 
+  const compact = isCompactSize(size)
+  const iconClass = compact ? "h-3.5 w-3.5" : "h-4 w-4"
+  const actionButtonClass = compact ? "h-6 w-6" : "h-7 w-7"
+
   return (
     <>
-      <Card className="h-full flex flex-col">
-        <CardHeader 
-          className={cn(
-            "flex flex-row items-center justify-between space-y-0 pb-2 shrink-0",
-            size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-          )}
-        >
-          <div className="flex items-center justify-between w-full">
-            <div className="flex items-center gap-1.5">
-              <CardTitle 
-                className={cn(
-                  "line-clamp-1",
-                  size === 'small' ? "text-sm" : "text-base"
-                )}
-              >
-                {t('widgets.tags.title')}
-              </CardTitle>
-              <InfoBubble
-                side="top"
-                iconClassName={size === 'small' ? 'size-3.5' : 'size-4'}
-                contentClassName="max-w-[300px]"
-              >
-                <div className="space-y-1">
-                  <p className="font-medium wrap-break-word">{t('widgets.tags.description')}</p>
-                </div>
-              </InfoBubble>
-            </div>
-            <div className="flex items-center gap-2">
+      <WidgetCard>
+        <WidgetHeader
+          size={size}
+          title={t('widgets.tags.title')}
+          description={t('widgets.tags.description')}
+          actions={
+            <>
               {tagFilter.tags.length > 0 && (
                 <Button
                   variant="ghost"
                   size="sm"
-                  className={cn(
-                    "h-8 px-2 lg:px-3 text-xs hover:bg-muted/50",
-                    size === 'small' ? "h-6" : "h-8"
-                  )}
+                  className={cn("px-2 text-xs", compact ? "h-6" : "h-7")}
                   onClick={() => setTagFilter({ tags: [] })}
                 >
                   {t('widgets.tags.clearFilter')}
@@ -330,18 +309,14 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
               )}
               <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
                 <DialogTrigger asChild>
-                  <Button 
-                    variant="ghost" 
+                  <Button
+                    variant="ghost"
                     size="icon"
-                    className={cn(
-                      "shrink-0 hover:bg-muted/50",
-                      size === 'small' ? "h-6 w-6" : "h-8 w-8"
-                    )}
+                    className={cn("shrink-0", actionButtonClass)}
                     disabled={isLoading}
+                    aria-label={t('widgets.tags.addTag')}
                   >
-                    <Plus className={cn(
-                      size === 'small' ? "h-3.5 w-3.5" : "h-4 w-4"
-                    )} />
+                    <Plus className={iconClass} />
                   </Button>
                 </DialogTrigger>
                 <DialogContent className="sm:max-w-[425px]">
@@ -397,7 +372,7 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
                       <Button type="submit" disabled={isLoading}>
                         {isLoading ? (
                           <div className="flex items-center gap-2">
-                            <div className="h-4 w-4 animate-spin rounded-full border-2 border-background border-t-transparent" />
+                            <div className="h-4 w-4 rounded-full border-2 border-background border-t-transparent motion-safe:animate-spin" />
                             {t('widgets.tags.saving')}
                           </div>
                         ) : (
@@ -408,148 +383,136 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
                   </form>
                 </DialogContent>
               </Dialog>
-            </div>
+            </>
+          }
+        />
+        <WidgetBody size={size} className="flex flex-col gap-3 overflow-hidden">
+          {/* Search input: a form control, not a nested panel. */}
+          <div className="relative shrink-0">
+            <Search
+              aria-hidden
+              className={cn(
+                "pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground",
+                iconClass,
+              )}
+            />
+            <Input
+              placeholder={t('widgets.tags.searchPlaceholder')}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className={cn(
+                "pl-7",
+                // 16px on mobile so iOS does not zoom the viewport on focus (#404)
+                compact ? "h-7 text-base sm:text-xs" : "h-8 text-base sm:text-sm"
+              )}
+            />
           </div>
-        </CardHeader>
-        <CardContent 
-          className={cn(
-            "flex-1 min-h-0 overflow-hidden pt-0",
-            size === 'small' ? "px-1" : "px-2 sm:px-4"
-          )}
-        >
-          <div className="flex flex-col h-full space-y-3">
-            {/* Search input */}
-            <div className="flex items-center gap-2 shrink-0 bg-muted/30 rounded-md px-2">
-              <Search className={cn(
-                "text-muted-foreground",
-                size === 'small' ? "h-3.5 w-3.5" : "h-4 w-4"
-              )} />
-              <Input
-                placeholder={t('widgets.tags.searchPlaceholder')}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className={cn(
-                  "flex-1 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
-                  size === 'small' ? "h-7 text-base sm:text-xs" : "h-8 text-base sm:text-sm"
-                )}
-              />
-            </div>
 
-            {/* Tag filters */}
-            <div className="flex-1 min-h-0 -mx-1">
-              <ScrollArea 
-                className="h-full px-1"
+          {/* Tag filters */}
+          <div className="min-h-0 flex-1">
+              <ScrollArea
+                className="h-full"
                 type="hover"
               >
-                <div className={cn(
-                  "space-y-0.5",
-                  size === 'small' ? "min-h-[150px]" : "min-h-[200px]"
-                )}>
-                  {filteredTags.map((tag) => (
-                    <div
-                      key={tag.id}
-                      className={cn(
-                        "flex items-center justify-between rounded-md hover:bg-muted/50 transition-colors group",
-                        size === 'small' ? "p-1" : "p-1.5"
-                      )}
-                    >
-                      <div className="flex items-center gap-2 min-w-0">
-                        <Checkbox
-                          checked={tagFilter.tags.includes(tag.name)}
-                          onCheckedChange={(checked) => {
-                            setTagFilter(prev => ({
-                              tags: checked 
-                                ? [...prev.tags, tag.name]
-                                : prev.tags.filter(t => t !== tag.name)
-                            }))
-                          }}
-                          id={`tag-${tag.id}`}
-                          className={cn(
-                            size === 'small' ? "h-3.5 w-3.5" : "h-4 w-4"
-                          )}
-                        />
-                        <div
-                          className={cn(
-                            "rounded-full shrink-0",
-                            size === 'small' ? "w-2.5 h-2.5" : "w-3 h-3"
-                          )}
-                          style={{ backgroundColor: tag.color || '#CBD5E1' }}
-                        />
-                        <label
-                          htmlFor={`tag-${tag.id}`}
-                          className={cn(
-                            "font-medium cursor-pointer truncate flex-1",
-                            size === 'small' ? "text-xs" : "text-sm"
-                          )}
-                        >
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className={cn(
-                                  "font-medium cursor-pointer truncate flex-1",
-                                  size === 'small' ? "text-xs" : "text-sm"
-                                )}>
-                                  {tag.name.length > 35 ? `${tag.name.slice(0, 35)}...` : tag.name}
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent side="top" className="max-w-[300px]">
-                                <div className="space-y-1">
-                                  <p className="font-medium wrap-break-word">{tag.name}</p>
-                                  {tag.description && (
-                                    <p className="text-sm text-muted-foreground wrap-break-word whitespace-pre-wrap">{tag.description}</p>
-                                  )}
-                                </div>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        </label>
+                {filteredTags.length === 0 ? (
+                  <WidgetEmpty
+                    size={size}
+                    className="min-h-[150px]"
+                    message={searchQuery ? t('widgets.tags.noResults') : t('widgets.tags.noTags')}
+                  />
+                ) : (
+                  <div className="flex flex-col gap-0.5">
+                    {filteredTags.map((tag) => (
+                      <div
+                        key={tag.id}
+                        className={cn(
+                          "group flex items-center justify-between gap-2 rounded-md motion-safe:transition-colors hover:bg-muted/50",
+                          compact ? "p-1" : "p-1.5"
+                        )}
+                      >
+                        <div className="flex min-w-0 items-center gap-2">
+                          <Checkbox
+                            checked={tagFilter.tags.includes(tag.name)}
+                            onCheckedChange={(checked) => {
+                              setTagFilter(prev => ({
+                                tags: checked
+                                  ? [...prev.tags, tag.name]
+                                  : prev.tags.filter(t => t !== tag.name)
+                              }))
+                            }}
+                            id={`tag-${tag.id}`}
+                            className={compact ? "h-3.5 w-3.5" : "h-4 w-4"}
+                          />
+                          {/* A tag pill: monochrome unless the tag carries a
+                              user-chosen color, which is real information. */}
+                          <label
+                            htmlFor={`tag-${tag.id}`}
+                            className="flex min-w-0 flex-1 cursor-pointer items-center"
+                          >
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span
+                                    className={cn(
+                                      "inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2 py-0.5",
+                                      compact ? "text-xs" : "text-sm",
+                                    )}
+                                    style={tag.color ? { borderColor: tag.color } : undefined}
+                                  >
+                                    {tag.color ? (
+                                      <span
+                                        aria-hidden
+                                        className="size-2 shrink-0 rounded-full"
+                                        style={{ backgroundColor: tag.color }}
+                                      />
+                                    ) : null}
+                                    <span className="truncate">
+                                      {tag.name.length > 35 ? `${tag.name.slice(0, 35)}...` : tag.name}
+                                    </span>
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side="top" className="max-w-[300px]">
+                                  <div className="space-y-1">
+                                    <p className="font-medium wrap-break-word">{tag.name}</p>
+                                    {tag.description && (
+                                      <p className={cn(widgetType.caption, "wrap-break-word whitespace-pre-wrap")}>{tag.description}</p>
+                                    )}
+                                  </div>
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          </label>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className={actionButtonClass}
+                            onClick={() => handleEdit(tag)}
+                            disabled={isLoading}
+                            aria-label={t('widgets.tags.editTag')}
+                          >
+                            <Edit2 className={iconClass} />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className={cn("text-destructive hover:text-destructive", actionButtonClass)}
+                            onClick={() => handleDelete(tag)}
+                            disabled={isLoading}
+                            aria-label={t('widgets.tags.confirmDelete')}
+                          >
+                            <Trash2 className={iconClass} />
+                          </Button>
+                        </div>
                       </div>
-                      <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className={cn(
-                            "hover:bg-muted",
-                            size === 'small' ? "h-6 w-6" : "h-7 w-7"
-                          )}
-                          onClick={() => handleEdit(tag)}
-                          disabled={isLoading}
-                        >
-                          <Edit2 className={cn(
-                            size === 'small' ? "h-3.5 w-3.5" : "h-4 w-4"
-                          )} />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className={cn(
-                            "text-destructive hover:text-destructive hover:bg-destructive/10",
-                            size === 'small' ? "h-6 w-6" : "h-7 w-7"
-                          )}
-                          onClick={() => handleDelete(tag)}
-                          disabled={isLoading}
-                        >
-                          <Trash2 className={cn(
-                            size === 'small' ? "h-3.5 w-3.5" : "h-4 w-4"
-                          )} />
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
-                  {filteredTags.length === 0 && (
-                    <div className={cn(
-                      "flex items-center justify-center text-muted-foreground h-[200px]",
-                      size === 'small' ? "text-xs" : "text-sm"
-                    )}>
-                      {searchQuery ? t('widgets.tags.noResults') : t('widgets.tags.noTags')}
-                    </div>
-                  )}
-                </div>
+                    ))}
+                  </div>
+                )}
               </ScrollArea>
             </div>
-          </div>
-        </CardContent>
-      </Card>
+        </WidgetBody>
+      </WidgetCard>
 
       <AlertDialog open={!!tagToDelete} onOpenChange={(open) => !open && setTagToDelete(null)}>
         <AlertDialogContent>
@@ -570,7 +533,7 @@ export function TagWidget({ size = 'medium', onTagSelectionChange }: TagWidgetPr
             >
               {isLoading ? (
                 <div className="flex items-center gap-2">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-background border-t-transparent" />
+                  <div className="h-4 w-4 rounded-full border-2 border-background border-t-transparent motion-safe:animate-spin" />
                   {t('widgets.tags.deleting')}
                 </div>
               ) : (

--- a/app/[locale]/dashboard/components/mindset/day-tag-selector.tsx
+++ b/app/[locale]/dashboard/components/mindset/day-tag-selector.tsx
@@ -3,8 +3,7 @@
 import { useState, useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Plus, Check } from 'lucide-react'
-import { cn } from '@/lib/utils'
-import { useI18n } from '@/locales/client'
+import { useCurrentLocale, useI18n } from '@/locales/client'
 import { tradeMatchesDateKey } from '@/lib/trades/trade-matches-date'
 import {
   Tooltip,
@@ -25,11 +24,11 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command"
-import { Badge } from '@/components/ui/badge'
 import { Trade } from '@/prisma/generated/prisma/browser'
 import { useUserStore } from '@/store/user-store'
 import { createTagAction } from '@/server/tags'
 import { format } from 'date-fns'
+import { formatCount, widgetType } from '../widgets'
 
 interface DayTagSelectorProps {
   trades: Trade[]
@@ -37,8 +36,20 @@ interface DayTagSelectorProps {
   onApplyTagToAll: (tag: string) => Promise<void>
 }
 
+/** A tag's own color is identity, so it stays a 8px dot, never a filled pill. */
+function TagDot({ color }: { color?: string | null }) {
+  return (
+    <span
+      aria-hidden
+      className="size-2 shrink-0 rounded-full border"
+      style={color ? { backgroundColor: color } : undefined}
+    />
+  )
+}
+
 export function DayTagSelector({ trades, date, onApplyTagToAll }: DayTagSelectorProps) {
   const t = useI18n()
+  const locale = useCurrentLocale()
   const tags = useUserStore(state => state.tags)
   const setTags = useUserStore(state => state.setTags)
   const [isApplying, setIsApplying] = useState<string | null>(null)
@@ -54,14 +65,14 @@ export function DayTagSelector({ trades, date, onApplyTagToAll }: DayTagSelector
   // Calculate tag statistics
   const tagStats = useMemo(() => {
     const stats = new Map<string, { count: number, totalTrades: number }>()
-    
+
     tradesForDay.forEach(trade => {
       trade.tags.forEach(tag => {
         const current = stats.get(tag) || { count: 0, totalTrades: tradesForDay.length }
         stats.set(tag, { count: current.count + 1, totalTrades: tradesForDay.length })
       })
     })
-    
+
     return Array.from(stats.entries()).map(([tag, data]) => ({
       tag,
       count: data.count,
@@ -95,10 +106,10 @@ export function DayTagSelector({ trades, date, onApplyTagToAll }: DayTagSelector
         })
         setTags([...tags, newTag.tag])
       }
-      
+
       // Apply to all trades
       await onApplyTagToAll(trimmedTag)
-      
+
       setInputValue('')
       setIsOpen(false)
     } catch (error) {
@@ -113,141 +124,152 @@ export function DayTagSelector({ trades, date, onApplyTagToAll }: DayTagSelector
     return tags.find(t => t.name.toLowerCase() === tagName.toLowerCase())
   }
 
+  const addTagPopover = (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 w-fit px-2"
+          disabled={isApplying !== null}
+        >
+          <Plus className="mr-1 h-3.5 w-3.5" aria-hidden />
+          {t('mindset.tags.addNew')}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="p-0" side="right" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder={t('mindset.tags.search')}
+            value={inputValue}
+            onValueChange={setInputValue}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && inputValue && isApplying === null) {
+                e.preventDefault()
+                handleCreateAndApply(inputValue)
+              }
+            }}
+          />
+          <CommandList className="max-h-[200px] overflow-y-auto">
+            {inputValue.trim() && (
+              <CommandItem
+                value={inputValue.trim()}
+                onSelect={(value) => {
+                  if (isApplying === null) {
+                    handleCreateAndApply(value)
+                  }
+                }}
+              >
+                {t('mindset.tags.createAndApply', { tag: inputValue.trim() })}
+              </CommandItem>
+            )}
+            {tags.length > 0 && (
+              <CommandGroup heading={t('mindset.tags.existing')}>
+                {tags
+                  .filter(tag => {
+                    // Filter out tags that are already on all trades
+                    const tagStat = tagStats.find(ts => ts.tag.toLowerCase() === tag.name.toLowerCase())
+                    return !tagStat || !tagStat.isComplete
+                  })
+                  .filter(tag => {
+                    const input = inputValue.trim().toLowerCase()
+                    return !input || tag.name.toLowerCase().includes(input)
+                  })
+                  .map(tag => (
+                    <CommandItem
+                      key={tag.name}
+                      value={tag.name}
+                      onSelect={() => {
+                        if (isApplying === null) {
+                          handleCreateAndApply(tag.name)
+                        }
+                      }}
+                    >
+                      <div className="flex items-center gap-2">
+                        <TagDot color={tag.color} />
+                        <span>{tag.name}</span>
+                        {tag.description && (
+                          <span className={widgetType.caption}>
+                            {tag.description}
+                          </span>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+              </CommandGroup>
+            )}
+            <CommandEmpty>{t('mindset.tags.noTags')}</CommandEmpty>
+          </CommandList>
+        </Command>
+        {isApplying !== null && (
+          <div className="absolute right-2 top-2">
+            <div className="size-4 rounded-full border-2 border-primary border-t-transparent motion-safe:animate-spin" />
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+
   if (tradesForDay.length === 0) {
     return (
       <div className="flex flex-col gap-2">
-        <div className="flex items-center justify-between">
-          <label className="text-sm font-medium">{t('mindset.tags.title')}</label>
-        </div>
-        <p className="text-xs text-muted-foreground">{t('mindset.tags.noTrades')}</p>
-        
+        <h4 className={widgetType.section}>{t('mindset.tags.title')}</h4>
+        <p className={widgetType.label}>{t('mindset.tags.noTrades')}</p>
+
         {/* Add new tag button - still available even with no trades */}
-        <Popover open={isOpen} onOpenChange={setIsOpen}>
-          <PopoverTrigger asChild>
-            <Button 
-              variant="outline" 
-              size="sm" 
-              className="h-7 px-2 w-fit"
-              disabled={isApplying !== null}
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              {t('mindset.tags.addNew')}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="p-0" side="right" align="start">
-            <Command shouldFilter={false}>
-              <CommandInput 
-                placeholder={t('mindset.tags.search')}
-                value={inputValue}
-                onValueChange={setInputValue}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && inputValue && isApplying === null) {
-                    e.preventDefault()
-                    handleCreateAndApply(inputValue)
-                  }
-                }}
-              />
-              <CommandList className="max-h-[200px] overflow-y-auto">
-                {inputValue.trim() && (
-                  <CommandItem
-                    value={inputValue.trim()}
-                    onSelect={(value) => {
-                      if (isApplying === null) {
-                        handleCreateAndApply(value)
-                      }
-                    }}
-                  >
-                    {t('mindset.tags.createAndApply', { tag: inputValue.trim() })}
-                  </CommandItem>
-                )}
-                {tags.length > 0 && (
-                  <CommandGroup heading={t('mindset.tags.existing')}>
-                    {tags
-                      .filter(tag => {
-                        const input = inputValue.trim().toLowerCase()
-                        return !input || tag.name.toLowerCase().includes(input)
-                      })
-                      .map(tag => (
-                        <CommandItem
-                          key={tag.name}
-                          value={tag.name}
-                          onSelect={() => {
-                            if (isApplying === null) {
-                              handleCreateAndApply(tag.name)
-                            }
-                          }}
-                        >
-                          <div className="flex items-center gap-2">
-                            <div 
-                              className="w-3 h-3 rounded-full shrink-0"
-                              style={{ backgroundColor: tag.color || '#CBD5E1' }}
-                            />
-                            <span>{tag.name}</span>
-                            {tag.description && (
-                              <span className="text-muted-foreground text-xs">
-                                - {tag.description}
-                              </span>
-                            )}
-                          </div>
-                        </CommandItem>
-                      ))}
-                  </CommandGroup>
-                )}
-                <CommandEmpty>{t('mindset.tags.noTags')}</CommandEmpty>
-              </CommandList>
-            </Command>
-            {isApplying !== null && (
-              <div className="absolute right-2 top-2">
-                <div className="animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
-              </div>
-            )}
-          </PopoverContent>
-        </Popover>
+        {addTagPopover}
       </div>
     )
   }
 
+  /*
+   * Tags are ordinary metadata: a quiet outlined control with the tag's own
+   * color as a dot, plus the coverage count in words, rather than a filled
+   * pill whose background carries the meaning.
+   */
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between">
-        <label className="text-sm font-medium">{t('mindset.tags.title')}</label>
-        <span className="text-xs text-muted-foreground">
-          {tradesForDay.length} {tradesForDay.length === 1 ? t('mindset.tags.trade') : t('mindset.tags.trades')}
+      <div className="flex items-baseline justify-between gap-3">
+        <h4 className={widgetType.section}>{t('mindset.tags.title')}</h4>
+        <span className={widgetType.caption}>
+          {formatCount(tradesForDay.length, locale)}{' '}
+          {tradesForDay.length === 1 ? t('mindset.tags.trade') : t('mindset.tags.trades')}
         </span>
       </div>
-      
-      <div className="flex flex-wrap gap-2">
+
+      <div className="flex flex-wrap items-center gap-1.5">
         {tagStats.map(({ tag, count, totalTrades, isComplete }) => {
           const metadata = getTagMetadata(tag)
           return (
             <TooltipProvider key={tag}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Badge
-                    variant="secondary"
-                    className={cn(
-                      "cursor-pointer transition-all hover:scale-105",
-                      isComplete && "opacity-100",
-                      !isComplete && "opacity-70 hover:opacity-100"
-                    )}
-                    style={{
-                      backgroundColor: metadata?.color || '#CBD5E1',
-                      color: metadata?.color ? getContrastColor(metadata.color) : 'inherit'
-                    }}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2"
+                    aria-pressed={isComplete}
+                    aria-label={`${tag}, ${formatCount(count, locale)}/${formatCount(totalTrades, locale)}, ${isComplete ? t('mindset.tags.allTradesTagged') : t('mindset.tags.clickToApplyToAll')}`}
                     onClick={() => !isComplete && handleApplyToAll(tag)}
                   >
-                    <span className="flex items-center gap-1">
-                      {tag} ({count}/{totalTrades})
-                      {isComplete && <Check className="h-3 w-3 ml-1" />}
-                      {isApplying === tag && (
-                        <div className="animate-spin rounded-full h-3 w-3 border-2 border-current border-t-transparent ml-1" />
-                      )}
+                    <TagDot color={metadata?.color} />
+                    <span className="text-xs">{tag}</span>
+                    <span className="text-xs tabular-nums text-muted-foreground">
+                      {formatCount(count, locale)}/{formatCount(totalTrades, locale)}
                     </span>
-                  </Badge>
+                    {isComplete && <Check className="h-3 w-3" aria-hidden />}
+                    {isApplying === tag && (
+                      <span
+                        aria-hidden
+                        className="size-3 rounded-full border-2 border-current border-t-transparent motion-safe:animate-spin"
+                      />
+                    )}
+                  </Button>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>
-                    {isComplete 
+                    {isComplete
                       ? t('mindset.tags.allTradesTagged')
                       : t('mindset.tags.clickToApplyToAll')
                     }
@@ -257,118 +279,16 @@ export function DayTagSelector({ trades, date, onApplyTagToAll }: DayTagSelector
             </TooltipProvider>
           )
         })}
-        
+
         {/* Add new tag button */}
-        <Popover open={isOpen} onOpenChange={setIsOpen}>
-          <PopoverTrigger asChild>
-            <Button 
-              variant="outline" 
-              size="sm" 
-              className="h-7 px-2"
-              disabled={isApplying !== null}
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              {t('mindset.tags.addNew')}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="p-0" side="right" align="start">
-            <Command shouldFilter={false}>
-              <CommandInput 
-                placeholder={t('mindset.tags.search')}
-                value={inputValue}
-                onValueChange={setInputValue}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && inputValue && isApplying === null) {
-                    e.preventDefault()
-                    handleCreateAndApply(inputValue)
-                  }
-                }}
-              />
-              <CommandList className="max-h-[200px] overflow-y-auto">
-                {inputValue.trim() && (
-                  <CommandItem
-                    value={inputValue.trim()}
-                    onSelect={(value) => {
-                      if (isApplying === null) {
-                        handleCreateAndApply(value)
-                      }
-                    }}
-                  >
-                    {t('mindset.tags.createAndApply', { tag: inputValue.trim() })}
-                  </CommandItem>
-                )}
-                {tags.length > 0 && (
-                  <CommandGroup heading={t('mindset.tags.existing')}>
-                    {tags
-                      .filter(tag => {
-                        // Filter out tags that are already on all trades
-                        const tagStat = tagStats.find(ts => ts.tag.toLowerCase() === tag.name.toLowerCase())
-                        return !tagStat || !tagStat.isComplete
-                      })
-                      .filter(tag => {
-                        const input = inputValue.trim().toLowerCase()
-                        return !input || tag.name.toLowerCase().includes(input)
-                      })
-                      .map(tag => (
-                        <CommandItem
-                          key={tag.name}
-                          value={tag.name}
-                          onSelect={() => {
-                            if (isApplying === null) {
-                              handleCreateAndApply(tag.name)
-                            }
-                          }}
-                        >
-                          <div className="flex items-center gap-2">
-                            <div 
-                              className="w-3 h-3 rounded-full shrink-0"
-                              style={{ backgroundColor: tag.color || '#CBD5E1' }}
-                            />
-                            <span>{tag.name}</span>
-                            {tag.description && (
-                              <span className="text-muted-foreground text-xs">
-                                - {tag.description}
-                              </span>
-                            )}
-                          </div>
-                        </CommandItem>
-                      ))}
-                  </CommandGroup>
-                )}
-                <CommandEmpty>{t('mindset.tags.noTags')}</CommandEmpty>
-              </CommandList>
-            </Command>
-            {isApplying !== null && (
-              <div className="absolute right-2 top-2">
-                <div className="animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
-              </div>
-            )}
-          </PopoverContent>
-        </Popover>
+        {addTagPopover}
       </div>
-      
+
       {tagStats.length === 0 && (
-        <p className="text-xs text-muted-foreground">{t('mindset.tags.noTagsOnTrades')}</p>
+        <p className={widgetType.label}>{t('mindset.tags.noTagsOnTrades')}</p>
       )}
-      
-      <p className="text-xs text-muted-foreground">{t('mindset.tags.description')}</p>
+
+      <p className={widgetType.caption}>{t('mindset.tags.description')}</p>
     </div>
   )
-}
-
-// Helper function to determine text color based on background color
-function getContrastColor(hexColor: string): string {
-  // Remove the hash if it exists
-  const color = hexColor.replace('#', '')
-  
-  // Convert hex to RGB
-  const r = parseInt(color.substring(0, 2), 16)
-  const g = parseInt(color.substring(2, 4), 16)
-  const b = parseInt(color.substring(4, 6), 16)
-  
-  // Calculate luminance
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-  
-  // Return black or white based on luminance
-  return luminance > 0.5 ? '#000000' : '#FFFFFF'
 }

--- a/app/[locale]/dashboard/components/mindset/emotion-selector.tsx
+++ b/app/[locale]/dashboard/components/mindset/emotion-selector.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useI18n } from "@/locales/client"
-import { Frown, Smile } from "lucide-react"
+import { cn } from "@/lib/utils"
 import { Tracker } from "@/components/ui/mood-tracker"
+import { widgetType } from "../widgets"
 
 interface EmotionSelectorProps {
   value: number
@@ -17,23 +18,47 @@ export function EmotionSelector({ value, onChange }: EmotionSelectorProps) {
     key: i,
   }))
 
+  /*
+   * The scale ends are named in words rather than drawn as faces, and the
+   * current step is stated as text, so the state never rests on the ramp alone.
+   */
+  const currentLabel =
+    value < 20
+      ? t('mindset.emotion.verySad')
+      : value < 40
+        ? t('mindset.emotion.sad')
+        : value < 60
+          ? t('mindset.emotion.neutral')
+          : value < 80
+            ? t('mindset.emotion.happy')
+            : t('mindset.emotion.veryHappy')
+
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center gap-4 w-full">
-        <Frown className="h-6 w-6 text-muted-foreground" />
+    <div className="flex flex-col gap-2">
+      <div className="flex w-full items-center gap-3">
+        <span className={cn(widgetType.label, "shrink-0")}>
+          {t('mindset.emotion.verySad')}
+        </span>
         <Tracker
           data={moodData}
           hoverEffect={true}
+          defaultBackgroundColor="bg-muted"
           valueIndex={Math.max(0, Math.min(20, Math.round(value / 5)))}
           onSelectionChange={(index) => onChange(index * 5)}
           className="flex-1"
+          aria-label={t('mindset.emotion.title')}
         />
-        <Smile className="h-6 w-6 text-muted-foreground" />
+        <span className={cn(widgetType.label, "shrink-0")}>
+          {t('mindset.emotion.veryHappy')}
+        </span>
       </div>
-      
-      <p className="text-sm text-muted-foreground">
-        {t('mindset.emotion.description')}
-      </p>
+
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <span className={widgetType.value}>{currentLabel}</span>
+        <span className={widgetType.caption}>
+          {t('mindset.emotion.description')}
+        </span>
+      </div>
     </div>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/mindset/hourly-financial-timeline.tsx
+++ b/app/[locale]/dashboard/components/mindset/hourly-financial-timeline.tsx
@@ -8,41 +8,64 @@ import { useCurrentLocale, useI18n } from "@/locales/client"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
-import { Clock, ExternalLink, MoreHorizontal, DollarSign } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
+import { Clock, ExternalLink, MoreHorizontal } from "lucide-react"
 import type { FinancialEvent } from "@/prisma/generated/prisma/browser"
 import type { Locale } from "date-fns"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { useUserStore } from "@/store/user-store"
+import {
+  formatCount,
+  formatCurrency,
+  pnlTone,
+  pnlToneClass,
+  seriesColor,
+  widgetType,
+} from "../widgets"
+
+type SessionKey = "ASIA" | "LONDON" | "US"
 
 interface Session {
-  name: string
+  key: SessionKey
   startHour: number
   endHour: number
-  color: string
+  /** Index into the categorical series scale. Sessions are categories, not states. */
+  colorIndex: number
 }
 
 const SESSIONS: Session[] = [
-  {
-    name: "Tokyo Session",
-    startHour: 0,
-    endHour: 8,
-    color: "bg-red-500/20 border-red-500"
-  },
-  {
-    name: "London Session",
-    startHour: 8,
-    endHour: 16,
-    color: "bg-blue-500/20 border-blue-500"
-  },
-  {
-    name: "New York Session",
-    startHour: 13,
-    endHour: 21,
-    color: "bg-green-500/20 border-green-500"
-  }
+  { key: "ASIA", startHour: 0, endHour: 8, colorIndex: 0 },
+  { key: "LONDON", startHour: 8, endHour: 16, colorIndex: 1 },
+  { key: "US", startHour: 13, endHour: 21, colorIndex: 2 },
 ]
+
+function useSessionLabel() {
+  const t = useI18n()
+  return (key: SessionKey) => {
+    switch (key) {
+      case "LONDON":
+        return t("mindset.newsImpact.session.LONDON")
+      case "US":
+        return t("mindset.newsImpact.session.US")
+      default:
+        return t("mindset.newsImpact.session.ASIA")
+    }
+  }
+}
+
+function useImportanceLabel() {
+  const t = useI18n()
+  return (importance: string) => {
+    switch (importance.toUpperCase()) {
+      case "HIGH":
+        return t("mindset.newsImpact.importanceFilter.high")
+      case "MEDIUM":
+        return t("mindset.newsImpact.importanceFilter.medium")
+      default:
+        return t("mindset.newsImpact.importanceFilter.low")
+    }
+  }
+}
 
 interface HourlyFinancialTimelineProps {
   date: Date
@@ -62,8 +85,9 @@ interface HourlyFinancialTimelineProps {
   selectedEventIds?: string[]
 }
 
-function SessionIndicator({ session, hourElements, containerRef }: { 
-  session: Session; 
+function SessionIndicator({ session, label, hourElements, containerRef }: {
+  session: Session;
+  label: string;
   hourElements: HTMLDivElement[];
   containerRef: React.RefObject<HTMLDivElement | null>;
 }) {
@@ -88,52 +112,67 @@ function SessionIndicator({ session, hourElements, containerRef }: {
   }
 
   return (
-    <div 
+    <button
+      type="button"
       className={cn(
-        "absolute left-0 w-1 border-l cursor-pointer transition-all hover:w-2 hover:opacity-100",
-        session.color,
-        "opacity-60"
+        "absolute left-0 w-1 cursor-pointer rounded-sm outline-none",
+        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+        "motion-safe:transition-opacity motion-safe:duration-150 motion-safe:ease-out",
+        "opacity-70 hover:opacity-100",
       )}
       style={{
         top: `${startPosition}px`,
-        height: `${height}px`
+        height: `${height}px`,
+        backgroundColor: seriesColor(session.colorIndex),
       }}
       onClick={handleClick}
-      role="button"
-      aria-label={`Scroll to ${session.name}`}
+      aria-label={label}
     />
   )
 }
 
 function SessionLegend({ containerRef }: { containerRef: React.RefObject<HTMLDivElement | null> }) {
+  const sessionLabel = useSessionLabel()
+
   return (
-    <div className="p-2 bg-background/95 backdrop-blur-sm supports-backdrop-filter:bg-background/60 border-t shadow-lg">
-      <div className="flex items-center justify-center gap-4 text-xs">
+    <div className="shrink-0 border-t bg-background p-2">
+      <ul className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
         {SESSIONS.map((session) => (
-          <div 
-            key={session.name} 
-            className="flex items-center gap-1.5 cursor-pointer hover:opacity-80 transition-opacity"
-            onClick={() => {
-              if (!containerRef.current) return
-              const hourElement = containerRef.current.querySelector(`[data-hour="${session.startHour}"]`)
-              if (!hourElement) return
-              containerRef.current.scrollTo({
-                top: hourElement.getBoundingClientRect().top - containerRef.current.getBoundingClientRect().top + containerRef.current.scrollTop,
-                behavior: 'smooth'
-              })
-            }}
-          >
-            <div className={cn("w-2 h-2 rounded-full", session.color.replace("border", "bg"))} />
-            <span className="text-muted-foreground">{session.name}</span>
-          </div>
+          <li key={session.key}>
+            <button
+              type="button"
+              className={cn(
+                "flex items-center gap-1.5 rounded-sm outline-none",
+                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                "motion-safe:transition-opacity motion-safe:duration-150 motion-safe:ease-out",
+                "hover:opacity-80",
+              )}
+              onClick={() => {
+                if (!containerRef.current) return
+                const hourElement = containerRef.current.querySelector(`[data-hour="${session.startHour}"]`)
+                if (!hourElement) return
+                containerRef.current.scrollTo({
+                  top: hourElement.getBoundingClientRect().top - containerRef.current.getBoundingClientRect().top + containerRef.current.scrollTop,
+                  behavior: 'smooth'
+                })
+              }}
+            >
+              <span
+                aria-hidden
+                className="size-2 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: seriesColor(session.colorIndex) }}
+              />
+              <span className={widgetType.label}>{sessionLabel(session.key)}</span>
+            </button>
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   )
 }
 
-export function HourlyFinancialTimeline({ 
-  date, 
+export function HourlyFinancialTimeline({
+  date,
   events,
   trades = [],
   onEventClick,
@@ -147,6 +186,7 @@ export function HourlyFinancialTimeline({
   const locale = useCurrentLocale()
   const dateLocale = locale === "fr" ? fr : enUS
   const t = useI18n()
+  const sessionLabel = useSessionLabel()
   const containerRef = useRef<HTMLDivElement>(null)
   const [hourElements, setHourElements] = useState<HTMLDivElement[]>([])
 
@@ -163,7 +203,7 @@ export function HourlyFinancialTimeline({
     if (!preventScrollPropagation || !events.length) return
 
     // Sort events by date to find the earliest one
-    const sortedEvents = [...events].sort((a, b) => 
+    const sortedEvents = [...events].sort((a, b) =>
       new Date(a.date).getTime() - new Date(b.date).getTime()
     )
     const firstEvent = sortedEvents[0]
@@ -269,7 +309,7 @@ export function HourlyFinancialTimeline({
       if (hourTrades.length > 0) {
         const totalPnL = hourTrades.reduce((sum, trade) => sum + (trade.pnl - trade.commission), 0)
         const uniqueSymbols = new Set(hourTrades.map(trade => trade.instrument))
-        
+
         hourMap.get(hour)?.push({
           type: 'trade',
           id: `trade-${hour}`,
@@ -302,51 +342,58 @@ export function HourlyFinancialTimeline({
     return formatInTimeZone(date, timezone, "EEE d MMM yyyy", { locale: dateLocale })
   }, [date, timezone, dateLocale])
 
+  /*
+   * A sub-panel, not a second card: the surface it sits on already owns the
+   * border, so this only keeps the rules that separate header, scroll area and
+   * legend.
+   */
   return (
-    <div className={cn("flex flex-col h-full border rounded-lg overflow-hidden relative", className)}>
+    <div className={cn("relative flex h-full flex-col overflow-hidden", className)}>
       {/* Header with date */}
-      <div className="p-2 text-center font-medium border-b bg-muted/20">{formattedDate}</div>
+      <div className={cn(widgetType.section, "shrink-0 border-b p-2 text-center")}>
+        {formattedDate}
+      </div>
 
       {/* Timeline content */}
-      <div 
+      <div
         ref={containerRef}
-        className="flex-1 overflow-y-auto relative "
-        style={{ 
+        className="relative flex-1 overflow-y-auto"
+        style={{
           overscrollBehavior: preventScrollPropagation ? 'contain' : 'auto'
         }}
       >
         {/* Session indicators */}
-        <div className="absolute left-0 top-0 bottom-0 w-1">
+        <div className="absolute bottom-0 left-0 top-0 w-1">
           {SESSIONS.map((session) => (
-            <SessionIndicator 
-              key={session.name} 
-              session={session} 
+            <SessionIndicator
+              key={session.key}
+              session={session}
+              label={sessionLabel(session.key)}
               hourElements={hourElements}
               containerRef={containerRef}
             />
           ))}
         </div>
 
-        <div className="flex flex-col divide-y pl-2 pb-16">
+        <div className="flex flex-col divide-y pb-16 pl-2">
           {hours.map((hour) => {
             const hourEvents = eventsByHour.get(hour.getHours()) || []
-            const hasEvents = hourEvents.length > 0
             const hasMultipleEvents = hourEvents.length > 2
             const displayEvents = hasMultipleEvents ? hourEvents.slice(0, 2) : hourEvents
 
             return (
-              <div 
-                key={hour.getTime()} 
-                className={cn("relative min-h-[60px]", hasEvents ? "bg-muted/5" : "")}
+              <div
+                key={hour.getTime()}
+                className="relative min-h-[60px]"
                 data-hour={hour.getHours()}
               >
-                {/* Time indicator */}
-                <div className="absolute left-0 top-0 text-xs text-muted-foreground p-1">
+                {/* Time indicator: a timestamp, the one place mono belongs */}
+                <div className={cn(widgetType.mono, "absolute left-0 top-0 p-1 text-muted-foreground")}>
                   {formatInTimeZone(hour, timezone, "HH:mm", { locale: dateLocale })}
                 </div>
 
                 {/* Events for this hour */}
-                <div className="pt-6 px-1 space-y-1">
+                <div className="flex flex-col gap-1 px-1 pt-6">
                   {displayEvents.map((item) => (
                     item.type === 'trade' ? (
                       <TradeCard
@@ -380,16 +427,16 @@ export function HourlyFinancialTimeline({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="w-full h-auto py-1 text-xs text-muted-foreground flex items-center justify-center"
+                          className="flex h-auto w-full items-center justify-center py-1 text-xs text-muted-foreground"
                         >
-                          <MoreHorizontal className="h-3 w-3 mr-1" />
+                          <MoreHorizontal className="mr-1 h-3 w-3" aria-hidden />
                           {t('mindset.newsImpact.moreEvents', { count: hourEvents.length - 2 })}
                         </Button>
                       </PopoverTrigger>
-                      <PopoverContent className="w-72 p-2 max-h-96 overflow-y-auto">
-                        <div className="space-y-2">
-                          <h4 className="text-sm font-medium">{format(hour, "HH:mm")}</h4>
-                          <div className="space-y-2">
+                      <PopoverContent className="max-h-96 w-72 overflow-y-auto p-2">
+                        <div className="flex flex-col gap-2">
+                          <h4 className={cn(widgetType.mono, "text-foreground")}>{format(hour, "HH:mm")}</h4>
+                          <div className="flex flex-col gap-2">
                             {hourEvents.slice(2).map((item) => (
                               item.type === 'trade' ? (
                                 <TradeCard
@@ -442,61 +489,63 @@ interface FinancialEventCardProps {
 
 function FinancialEventCard({ event, onClick, timezone, dateLocale, expanded = false, isSelected = false }: FinancialEventCardProps) {
   const t = useI18n()
+  const importanceLabel = useImportanceLabel()
 
-  // Get color class based on event importance
-  const getImportanceColorClass = (importance: string) => {
-    switch (importance) {
-      case "HIGH":
-        return "bg-red-100 border-red-300 text-red-800 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400"
-      case "MEDIUM":
-        return "bg-yellow-100 border-yellow-300 text-yellow-800 dark:bg-yellow-900/30 dark:border-yellow-800 dark:text-yellow-400"
-      case "LOW":
-        return "bg-blue-100 border-blue-300 text-blue-800 dark:bg-blue-900/30 dark:border-blue-800 dark:text-blue-400"
-      default:
-        return "bg-gray-100 border-gray-300 text-gray-800 dark:bg-gray-800/30 dark:border-gray-700 dark:text-gray-300"
-    }
-  }
-
+  /*
+   * Importance is ordinary metadata: it reads as a word, not a colored tile.
+   * The only state that earns a token here is selection, and it is announced
+   * with `aria-pressed` as well as the ring.
+   */
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
       className={cn(
-        "rounded-md p-2 cursor-pointer transition-colors hover:opacity-90",
-        getImportanceColorClass(event.importance),
-        !isSelected && "border-l-4",
-        isSelected && "border-2 border-current"
+        "w-full cursor-pointer rounded-md border px-2 py-1.5 text-left outline-none",
+        "hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+        "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
+        isSelected && "border-primary",
       )}
       onClick={(e) => {
         // Ensure clicks within child elements don't bubble to outside popovers
         e.stopPropagation()
         onClick?.()
       }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          e.stopPropagation()
+          onClick?.()
+        }
+      }}
     >
-      <div className="font-medium text-sm truncate">{event.title}</div>
+      <div className="truncate text-sm font-medium">{event.title}</div>
 
-      <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1 text-xs">
-        {event.country && (
-          <Badge variant="outline" className="text-xs h-5 px-1.5 rounded-sm font-normal">
-            {event.country}
-          </Badge>
-        )}
-
-        <div className="flex items-center">
-          <Clock className="h-3 w-3 mr-1 shrink-0" />
-          <span>{formatInTimeZone(new Date(event.date), timezone, "HH:mm", { locale: dateLocale })}</span>
-        </div>
+      <div className={cn(widgetType.caption, "mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5")}>
+        <span>{importanceLabel(event.importance)}</span>
+        {event.country && <span className="truncate">{event.country}</span>}
+        <span className="flex items-center gap-1">
+          <Clock className="h-3 w-3 shrink-0" aria-hidden />
+          <span className="tabular-nums">
+            {formatInTimeZone(new Date(event.date), timezone, "HH:mm", { locale: dateLocale })}
+          </span>
+        </span>
       </div>
 
-      {expanded && event.description && <p className="text-xs mt-2">{event.description}</p>}
+      {expanded && event.description && (
+        <p className={cn(widgetType.caption, "mt-2")}>{event.description}</p>
+      )}
 
       {expanded && event.sourceUrl && (
         <a
           href={event.sourceUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-xs mt-2 text-primary hover:text-primary/80"
+          className="mt-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
           onClick={(e) => e.stopPropagation()}
         >
-          <ExternalLink className="h-3 w-3" />
+          <ExternalLink className="h-3 w-3" aria-hidden />
           {t("calendar.events.viewSource")}
         </a>
       )}
@@ -528,6 +577,7 @@ interface TradeCardProps {
 
 function TradeCard({ trade, onClick, timezone, dateLocale, expanded = false, date }: TradeCardProps) {
   const t = useI18n()
+  const locale = useCurrentLocale()
   const hourDate = new Date(date)
   hourDate.setHours(trade.hour)
 
@@ -545,52 +595,49 @@ function TradeCard({ trade, onClick, timezone, dateLocale, expanded = false, dat
     return dateA.getTime() - dateB.getTime()
   })
 
+  const totalTone = pnlTone(trade.totalPnL)
+  const earliestTime = formatInTimeZone(new Date(earliestTrade.entryDate), timezone, "HH:mm", { locale: dateLocale })
+
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <div
+        <button
+          type="button"
           className={cn(
-            "border-l-4 rounded-r-md p-2 cursor-pointer transition-colors hover:opacity-90",
-            trade.totalPnL > 0 
-              ? "bg-green-100 border-green-300 text-green-800 dark:bg-green-900/30 dark:border-green-800 dark:text-green-400"
-              : "bg-red-100 border-red-300 text-red-800 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400"
+            "w-full cursor-pointer rounded-md border px-2 py-1.5 text-left outline-none",
+            "hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+            "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
           )}
+          onClick={() => onClick?.()}
         >
-          <div className="font-medium text-sm">
+          <span className="block text-sm font-medium">
             {t('mindset.newsImpact.tradedHour')}
-          </div>
+          </span>
 
-          <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1 text-xs">
-            <div className="flex items-center">
-              <Clock className="h-3 w-3 mr-1 shrink-0" />
-              <span>{formatInTimeZone(new Date(earliestTrade.entryDate), timezone, "HH:mm", { locale: dateLocale })}</span>
-            </div>
+          <span className={cn(widgetType.caption, "mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5")}>
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3 shrink-0" aria-hidden />
+              <span className="tabular-nums">{earliestTime}</span>
+            </span>
+            <span className={cn(widgetType.value, pnlToneClass(totalTone))}>
+              {formatCurrency(trade.totalPnL, locale)}
+            </span>
+          </span>
 
-            <div className="flex items-center">
-              <DollarSign className="h-3 w-3 mr-1 shrink-0" />
-              <span>{trade.totalPnL.toFixed(2)}</span>
-            </div>
-          </div>
-
-          <div className="mt-1 text-xs text-muted-foreground underline">
+          <span className={cn(widgetType.caption, "mt-1 block")}>
             {t('mindset.newsImpact.clickToSeeMore')}
-          </div>
-        </div>
+          </span>
+        </button>
       </PopoverTrigger>
       <PopoverContent className="w-[500px] p-0" align="start">
-        <div className="p-4 border-b">
-          <h4 className="font-medium">
-            {formatInTimeZone(new Date(earliestTrade.entryDate), timezone, "HH:mm", { locale: dateLocale })} - {trade.tradeCount} {trade.tradeCount === 1 ? 'Trade' : 'Trades'}
+        <div className="flex items-baseline justify-between gap-3 border-b p-4">
+          <h4 className={widgetType.title}>
+            {earliestTime} · {formatCount(trade.tradeCount, locale)}{' '}
+            {trade.tradeCount === 1 ? t('mindset.tags.trade') : t('mindset.tags.trades')}
           </h4>
-          <div className="flex items-center gap-2 mt-1">
-            <DollarSign className="h-4 w-4" />
-            <span className={cn(
-              "font-medium",
-              trade.totalPnL > 0 ? "text-green-500" : "text-red-500"
-            )}>
-              {trade.totalPnL.toFixed(2)}
-            </span>
-          </div>
+          <span className={cn(widgetType.value, "shrink-0", pnlToneClass(totalTone))}>
+            {formatCurrency(trade.totalPnL, locale)}
+          </span>
         </div>
         <ScrollArea className="h-[300px]">
           <Table>
@@ -604,33 +651,30 @@ function TradeCard({ trade, onClick, timezone, dateLocale, expanded = false, dat
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedTrades.map((t) => (
-                <TableRow key={t.id}>
-                  <TableCell className="font-medium">{t.instrument}</TableCell>
-                  <TableCell>
-                    {formatInTimeZone(new Date(t.entryDate), timezone, "HH:mm:ss", { locale: dateLocale })}
-                  </TableCell>
-                  <TableCell className={cn(
-                    "text-right",
-                    t.pnl > 0 ? "text-green-500" : "text-red-500"
-                  )}>
-                    {t.pnl.toFixed(2)}
-                  </TableCell>
-                  <TableCell className="text-right text-muted-foreground">
-                    {t.commission.toFixed(2)}
-                  </TableCell>
-                  <TableCell className={cn(
-                    "text-right font-medium",
-                    (t.pnl - t.commission) > 0 ? "text-green-500" : "text-red-500"
-                  )}>
-                    {(t.pnl - t.commission).toFixed(2)}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {sortedTrades.map((row) => {
+                const net = row.pnl - row.commission
+                return (
+                  <TableRow key={row.id}>
+                    <TableCell className="font-medium">{row.instrument}</TableCell>
+                    <TableCell className={widgetType.mono}>
+                      {formatInTimeZone(new Date(row.entryDate), timezone, "HH:mm:ss", { locale: dateLocale })}
+                    </TableCell>
+                    <TableCell className={cn("text-right tabular-nums", pnlToneClass(pnlTone(row.pnl)))}>
+                      {formatCurrency(row.pnl, locale)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      {formatCurrency(row.commission, locale)}
+                    </TableCell>
+                    <TableCell className={cn("text-right font-medium tabular-nums", pnlToneClass(pnlTone(net)))}>
+                      {formatCurrency(net, locale)}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
             </TableBody>
           </Table>
         </ScrollArea>
       </PopoverContent>
     </Popover>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/mindset/journaling.tsx
+++ b/app/[locale]/dashboard/components/mindset/journaling.tsx
@@ -6,6 +6,7 @@ import { EmotionSelector } from "./emotion-selector"
 import { DayTagSelector } from "./day-tag-selector"
 import { FinancialEvent, Trade } from "@/prisma/generated/prisma/browser"
 import { TiptapEditor } from "@/components/tiptap-editor"
+import { widgetType } from "../widgets"
 
 interface JournalingProps {
   content: string
@@ -36,18 +37,19 @@ export function Journaling({
 }: JournalingProps) {
   const t = useI18n()
 
+  /* Groups are separated by spacing, not by a box each. */
   return (
-    <div className="h-full flex flex-col">
-      <div className="flex-none">
-        <h3 className="text-sm font-medium mb-2">{t("mindset.emotion.title")}</h3>
+    <div className="flex h-full flex-col gap-6">
+      <section className="flex flex-none flex-col gap-2">
+        <h3 className={widgetType.section}>{t("mindset.emotion.title")}</h3>
         <EmotionSelector value={emotionValue} onChange={onEmotionChange} />
-      </div>
+      </section>
 
-      <div className="flex-none mt-6">
+      <div className="flex-none">
         <DayTagSelector trades={trades} date={date} onApplyTagToAll={onApplyTagToAll} />
       </div>
 
-      <div className="flex-1 min-h-0 mt-6 flex flex-col">
+      <div className="flex min-h-0 flex-1 flex-col">
         <TiptapEditor
           content={content}
           onChange={onChange}
@@ -61,7 +63,7 @@ export function Journaling({
         />
       </div>
 
-      <div className="flex-none flex gap-4 mt-6">
+      <div className="flex flex-none gap-4">
         <Button onClick={onSave} className="w-full">
           {t("mindset.journaling.save")}
         </Button>

--- a/app/[locale]/dashboard/components/mindset/mindset-summary.tsx
+++ b/app/[locale]/dashboard/components/mindset/mindset-summary.tsx
@@ -16,8 +16,7 @@ import { Label } from "@/components/ui/label"
 import { useUserStore } from "@/store/user-store"
 import { useTradesStore } from "@/store/trades-store"
 import { useFinancialEventsStore } from "@/store/widgets/financial-events-store"
-
-type ImpactLevel = "low" | "medium" | "high"
+import { widgetType } from "../widgets"
 
 interface MindsetSummaryProps {
   date: Date
@@ -27,12 +26,38 @@ interface MindsetSummaryProps {
   onEdit: (section?: 'emotion' | 'journal' | 'news') => void
 }
 
-export function MindsetSummary({ 
-  date, 
-  emotionValue, 
-  selectedNews, 
+/** Section name plus the one control that acts on it. No pill, no icon tile. */
+function SummarySectionHeader({
+  title,
+  editLabel,
+  onEdit,
+}: {
+  title: string
+  editLabel: string
+  onEdit: () => void
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <h4 className={widgetType.section}>{title}</h4>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        aria-label={editLabel}
+        onClick={onEdit}
+      >
+        <Pencil className="h-3 w-3" aria-hidden />
+      </Button>
+    </div>
+  )
+}
+
+export function MindsetSummary({
+  date,
+  emotionValue,
+  selectedNews,
   journalContent,
-  onEdit 
+  onEdit
 }: MindsetSummaryProps) {
   const t = useI18n()
   const { locale } = useParams()
@@ -50,18 +75,22 @@ export function MindsetSummary({
       const matchesDate = eventDate.toDateString() === date.toDateString()
       const matchesLocale = event.lang === locale
       const matchesSelectedNews = !showOnlySelectedNews || selectedNews.includes(event.id)
-      
+
       return matchesDate && matchesLocale && matchesSelectedNews
     })
     setEvents(dateEvents)
   }, [date, financialEvents, locale, selectedNews, showOnlySelectedNews])
 
+  /*
+   * Emotional state is ordinary metadata: it reads as a word, not as a colored
+   * band, so nothing here competes with the P&L evidence elsewhere.
+   */
   const getEmotionLabel = (value: number) => {
-    if (value < 20) return { label: t('mindset.emotion.verySad'), color: "text-red-500" }
-    if (value < 40) return { label: t('mindset.emotion.sad'), color: "text-orange-500" }
-    if (value < 60) return { label: t('mindset.emotion.neutral'), color: "text-yellow-500" }
-    if (value < 80) return { label: t('mindset.emotion.happy'), color: "text-green-500" }
-    return { label: t('mindset.emotion.veryHappy'), color: "text-emerald-500" }
+    if (value < 20) return t('mindset.emotion.verySad')
+    if (value < 40) return t('mindset.emotion.sad')
+    if (value < 60) return t('mindset.emotion.neutral')
+    if (value < 80) return t('mindset.emotion.happy')
+    return t('mindset.emotion.veryHappy')
   }
 
   // Filter trades for the selected date
@@ -72,89 +101,63 @@ export function MindsetSummary({
     return tradeDateString === selectedDateString
   })
 
-  const [emotion, setEmotion] = useState<{ label: string; color: string }>(getEmotionLabel(emotionValue))
-
-  useEffect(() => {
-   setEmotion(getEmotionLabel(emotionValue))
-  }, [emotionValue])
+  const emotionLabel = getEmotionLabel(emotionValue)
 
   return (
-    <div className="h-full flex flex-col gap-4 p-4 overflow-y-auto">
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">
-          {format(date, 'MMMM d, yyyy', { locale: dateLocale })}
-        </h2>
-      </div>
+    <div className="flex h-full flex-col gap-4 overflow-y-auto p-4">
+      <h3 className={cn(widgetType.title, "capitalize")}>
+        {format(date, 'MMMM d, yyyy', { locale: dateLocale })}
+      </h3>
 
-      <div className="grid gap-4">
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="space-y-1">
-              <div className="flex items-center gap-2">
-                <p className="text-sm text-muted-foreground">
-                  {t('mindset.emotion.title')}
-                </p>
-                <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onEdit('emotion')}>
-                  <Pencil className="h-3 w-3" />
-                </Button>
-              </div>
-              <p className={cn("text-sm", emotion.color)}>
-                {emotion.label}
-              </p>
-            </div>
-          </div>
-        </div>
+      <section className="flex flex-col gap-1">
+        <SummarySectionHeader
+          title={t('mindset.emotion.title')}
+          editLabel={`${t('mindset.edit')}: ${t('mindset.emotion.title')}`}
+          onEdit={() => onEdit('emotion')}
+        />
+        <p className="text-sm">{emotionLabel}</p>
+      </section>
 
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <p className="text-sm text-muted-foreground">
-              {t('mindset.journaling.title')}
-            </p>
-            <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onEdit('journal')}>
-              <Pencil className="h-3 w-3" />
-            </Button>
-          </div>
-          {!journalContent ? (
-            <p className="text-sm text-muted-foreground">{t('mindset.noData')}</p>
-          ) : (
-            <div 
-              key={journalContent}
-              className="prose prose-sm dark:prose-invert max-w-none [&_.ProseMirror]:outline-hidden [&_.ProseMirror]:relative [&_.ProseMirror]:h-full"
-              dangerouslySetInnerHTML={{ __html: journalContent }}
-            />
-          )}
-        </div>
-        <div className="space-y-2">
-          <div className="flex justify-between flex-col gap-2">
-            <div className="flex items-center gap-2">
-              <p className="text-sm text-muted-foreground">
-                {t('mindset.newsImpact.title')}
-              </p>
-              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onEdit('news')}>
-                <Pencil className="h-3 w-3" />
-              </Button>
-            </div>
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="show-only-selected"
-                  checked={showOnlySelectedNews}
-                  onCheckedChange={(checked) => setShowOnlySelectedNews(checked === true)}
-                />
-                <Label htmlFor="show-only-selected" className="text-xs text-muted-foreground">
-                  {t('mindset.newsImpact.showOnlySelectedNews')}
-                </Label>
-              </div>
-            </div>
-          </div>
-          <HourlyFinancialTimeline
-            date={date}
-            events={events}
-            trades={dayTrades}
-            selectedEventIds={selectedNews}
+      <section className="flex flex-col gap-2">
+        <SummarySectionHeader
+          title={t('mindset.journaling.title')}
+          editLabel={`${t('mindset.edit')}: ${t('mindset.journaling.title')}`}
+          onEdit={() => onEdit('journal')}
+        />
+        {!journalContent ? (
+          <p className={widgetType.label}>{t('mindset.noData')}</p>
+        ) : (
+          <div
+            key={journalContent}
+            className="prose prose-sm dark:prose-invert max-w-none [&_.ProseMirror]:outline-hidden [&_.ProseMirror]:relative [&_.ProseMirror]:h-full"
+            dangerouslySetInnerHTML={{ __html: journalContent }}
           />
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <SummarySectionHeader
+          title={t('mindset.newsImpact.title')}
+          editLabel={`${t('mindset.edit')}: ${t('mindset.newsImpact.title')}`}
+          onEdit={() => onEdit('news')}
+        />
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="show-only-selected"
+            checked={showOnlySelectedNews}
+            onCheckedChange={(checked) => setShowOnlySelectedNews(checked === true)}
+          />
+          <Label htmlFor="show-only-selected" className={widgetType.label}>
+            {t('mindset.newsImpact.showOnlySelectedNews')}
+          </Label>
         </div>
-      </div>
+        <HourlyFinancialTimeline
+          date={date}
+          events={events}
+          trades={dayTrades}
+          selectedEventIds={selectedNews}
+        />
+      </section>
     </div>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/mindset/mindset-widget.tsx
+++ b/app/[locale]/dashboard/components/mindset/mindset-widget.tsx
@@ -1,15 +1,13 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carousel"
 import { Journaling } from "./journaling"
 import { Timeline } from "./timeline"
 import { MindsetSummary } from "./mindset-summary"
 import { useI18n } from "@/locales/client"
-import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown, Download } from "lucide-react"
+import { ChevronLeft, ChevronRight, Download } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { InfoBubble } from "@/components/ui/info-bubble"
 import {
   Tooltip as UITooltip,
   TooltipContent,
@@ -18,6 +16,13 @@ import {
 } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetHeader,
+  formatCount,
+  widgetType,
+} from "../widgets"
 import type { EmblaCarouselType as CarouselApi } from "embla-carousel"
 import { toast } from "sonner"
 import { saveMindset, deleteMindset } from "@/server/journal"
@@ -366,31 +371,13 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
   ]
 
   return (
-    <Card className="flex flex-col p-0 h-full w-full">
-      <CardHeader 
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle 
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
-            >
-              {t('mindset.title')}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={size === 'small' ? 'size-3.5' : 'size-4'}
-            >
-              <p>{t('mindset.description')}</p>
-            </InfoBubble>
-          </div>
-          <div className="flex items-center gap-2">
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('mindset.title')}
+        description={t('mindset.description')}
+        actions={
+          <>
             <TooltipProvider>
               <UITooltip>
                 <TooltipTrigger asChild>
@@ -399,9 +386,10 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
                     size="icon"
                     onClick={handleExportAllPdf}
                     disabled={isExporting}
-                    className="h-6 w-6"
+                    aria-label={t("mindset.exportAllPdf")}
+                    className="h-7 w-7"
                   >
-                    <Download className="h-3 w-3" />
+                    <Download className="h-3.5 w-3.5" aria-hidden />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
@@ -413,47 +401,40 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
                 </TooltipContent>
               </UITooltip>
             </TooltipProvider>
-            <div className="flex items-center gap-1.5">
-              {steps.map((_, index) => (
-                <div
-                  key={index}
-                  className={cn(
-                    "h-1.5 w-1.5 rounded-full transition-colors",
-                    current === index
-                      ? "bg-primary"
-                      : "bg-muted"
-                  )}
-                />
-              ))}
-            </div>
-            <div className="flex items-center gap-1">
+            {/* Step position as a figure, not a color-only dot row */}
+            <span className={cn(widgetType.caption, "tabular-nums")}>
+              {formatCount(current + 1, locale)}/{formatCount(steps.length, locale)}
+            </span>
+            <div className="flex items-center gap-0.5">
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={() => api?.scrollPrev()}
                 disabled={current === 0}
-                className="h-6 w-6"
+                aria-label={t('mindset.back')}
+                className="h-7 w-7"
               >
-                <ChevronLeft className="h-3 w-3" />
+                <ChevronLeft className="h-3.5 w-3.5" aria-hidden />
               </Button>
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={() => api?.scrollNext()}
                 disabled={current === steps.length - 1}
-                className="h-6 w-6"
+                aria-label={t('mindset.next')}
+                className="h-7 w-7"
               >
-                <ChevronRight className="h-3 w-3" />
+                <ChevronRight className="h-3.5 w-3.5" aria-hidden />
               </Button>
             </div>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="flex-1 overflow-hidden p-0 flex flex-row relative">
-        {/* Timeline with animation */}
-        <div 
+          </>
+        }
+      />
+      <WidgetBody size={size} flush className="relative flex flex-row overflow-hidden">
+        {/* Timeline, which collapses to give the editor the frame */}
+        <div
           className={cn(
-            "relative transition-[width] duration-300 ease-out-quart motion-reduce:transition-none",
+            "relative motion-safe:transition-[width] motion-safe:duration-150 motion-safe:ease-out",
             isTimelineVisible ? "w-auto" : "w-0 overflow-hidden"
           )}
         >
@@ -474,12 +455,14 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
                     variant="secondary"
                     size="icon"
                     onClick={toggleTimeline}
-                    className="h-8 w-4 rounded-r-none rounded-l-md border-r-0"
+                    aria-label={isTimelineVisible ? t('mindset.hideTimeline') : t('mindset.showTimeline')}
+                    aria-pressed={isTimelineVisible}
+                    className="h-8 w-4 rounded-l-md rounded-r-none border-r-0"
                   >
                     {isTimelineVisible ? (
-                      <ChevronLeft className="h-3 w-3" />
+                      <ChevronLeft className="h-3 w-3" aria-hidden />
                     ) : (
-                      <ChevronRight className="h-3 w-3" />
+                      <ChevronRight className="h-3 w-3" aria-hidden />
                     )}
                   </Button>
                 </TooltipTrigger>
@@ -501,9 +484,11 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
                     variant="secondary"
                     size="icon"
                     onClick={toggleTimeline}
+                    aria-label={t('mindset.showTimeline')}
+                    aria-pressed={false}
                     className="h-8 w-4 rounded-l-none rounded-r-md border-l-0"
                   >
-                    <ChevronRight className="h-3 w-3" />
+                    <ChevronRight className="h-3 w-3" aria-hidden />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="right">
@@ -527,7 +512,7 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
             }
           }}
           setApi={setApi}
-          className="flex-1 min-w-0 h-full flex flex-col"
+          className="flex h-full min-w-0 flex-1 flex-col"
         >
           <CarouselContent className="h-full flex-1 pl-4">
             {steps.map((step, index) => (
@@ -537,7 +522,7 @@ export function MindsetWidget({ size }: MindsetWidgetProps) {
             ))}
           </CarouselContent>
         </Carousel>
-      </CardContent>
-    </Card>
+      </WidgetBody>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/mindset/news-impact.tsx
+++ b/app/[locale]/dashboard/components/mindset/news-impact.tsx
@@ -5,14 +5,12 @@ import { Button } from "@/components/ui/button"
 import { useI18n } from "@/locales/client"
 import { FinancialEvent } from "@/prisma/generated/prisma/browser"
 import { useCurrentLocale } from "@/locales/client"
-import { X } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
 import { HourlyFinancialTimeline } from "@/app/[locale]/dashboard/components/mindset/hourly-financial-timeline"
-import { Skeleton } from "@/components/ui/skeleton"
 import { ImportanceFilter } from "@/app/[locale]/dashboard/components/importance-filter"
 import { useNewsFilterStore } from "@/store/filters/news-filter-store"
 import { CountryFilter } from "@/components/country-filter"
 import { useFinancialEventsStore } from "../../../../../store/widgets/financial-events-store"
+import { WidgetSkeleton, formatCount, widgetType } from "../widgets"
 
 interface NewsImpactProps {
   onNext: () => void
@@ -55,12 +53,12 @@ export function NewsImpact({ onNext, onBack, selectedNews, onNewsSelection, date
 
   // Filter events based on selected countries and impact levels
   const filteredEvents = events.filter(event => {
-    const matchesCountry = selectedCountries.length === 0 || 
+    const matchesCountry = selectedCountries.length === 0 ||
       (event.country && selectedCountries.includes(event.country))
-    
-    const matchesImpact = impactLevels.length === 0 || 
+
+    const matchesImpact = impactLevels.length === 0 ||
       impactLevels.includes(event.importance.toLowerCase() as "low" | "medium" | "high")
-    
+
     return matchesCountry && matchesImpact
   })
 
@@ -68,20 +66,31 @@ export function NewsImpact({ onNext, onBack, selectedNews, onNewsSelection, date
     toggleNews(event.id)
   }
 
+  /*
+   * The selection count is a figure with a named action next to it, not a
+   * clickable pill whose only affordance is a dismiss glyph.
+   */
   return (
-    <div className="flex h-full flex-col space-y-4 overflow-hidden">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">{t('mindset.newsImpact.selectImportantNews')}</h2>
-        <div className="flex items-center gap-2">
+    <div className="flex h-full flex-col gap-4 overflow-hidden">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className={widgetType.title}>{t('mindset.newsImpact.selectImportantNews')}</h3>
+        <div className="flex flex-wrap items-center gap-2">
           {selectedNews.length > 0 && (
-            <Badge 
-              variant="secondary" 
-              className="text-xs cursor-pointer flex items-center gap-1"
-              onClick={() => onNewsSelection([])}
-            >
-              {selectedNews.length} selected
-              <X className="h-3 w-3 opacity-50 hover:opacity-100 transition-opacity" />
-            </Badge>
+            <>
+              <span className={widgetType.caption}>
+                {t('mindset.editor.news.selectedCount', {
+                  count: formatCount(selectedNews.length, locale),
+                })}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2"
+                onClick={() => onNewsSelection([])}
+              >
+                {t('mindset.editor.news.clearSelection')}
+              </Button>
+            </>
           )}
           <ImportanceFilter
             value={impactLevels}
@@ -92,17 +101,13 @@ export function NewsImpact({ onNext, onBack, selectedNews, onNewsSelection, date
         </div>
       </div>
 
-      <div className="flex-1 min-h-0">
+      <div className="min-h-0 flex-1">
         {isLoading ? (
-          <div className="border rounded-lg h-full">
-            <div className="p-2 border-b">
-              <Skeleton className="h-6 w-full" />
-            </div>
-            <div className="p-4 space-y-4">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <Skeleton key={i} className="h-16 w-full" />
-              ))}
-            </div>
+          <div className="flex h-full flex-col gap-4">
+            <WidgetSkeleton className="h-6 w-full" />
+            {Array.from({ length: 8 }).map((_, i) => (
+              <WidgetSkeleton key={i} className="h-16 w-full" />
+            ))}
           </div>
         ) : (
           <HourlyFinancialTimeline
@@ -132,4 +137,4 @@ export function NewsImpact({ onNext, onBack, selectedNews, onNewsSelection, date
       </div>
     </div>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/mindset/timeline.tsx
+++ b/app/[locale]/dashboard/components/mindset/timeline.tsx
@@ -6,7 +6,7 @@ import { format, isToday, compareDesc } from "date-fns"
 import { fr, enUS } from "date-fns/locale"
 import { useParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { Calendar, Trash2, Plus } from "lucide-react"
+import { Trash2, Plus } from "lucide-react"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -25,6 +25,7 @@ import {
 import { Calendar as CalendarComponent } from "@/components/ui/calendar"
 import { useState } from "react"
 import { toast } from "sonner"
+import { WidgetEmpty, widgetType } from "../widgets"
 
 interface TimelineProps {
   onSelectDate: (date: Date) => void
@@ -42,12 +43,16 @@ export function Timeline({ onSelectDate, selectedDate, moodHistory, className, o
   const [entryToDelete, setEntryToDelete] = useState<Date | null>(null)
   const [datePickerOpen, setDatePickerOpen] = useState(false)
 
-  const getEmotionColor = (value: number) => {
-    if (value < 20) return 'bg-red-500'
-    if (value < 40) return 'bg-orange-500'
-    if (value < 60) return 'bg-yellow-500'
-    if (value < 80) return 'bg-green-500'
-    return 'bg-emerald-500'
+  /*
+   * Emotional state is ordinary metadata, so it reads as a word rather than a
+   * colored dot: one encoding per state, and that encoding is the label itself.
+   */
+  const getEmotionLabel = (value: number) => {
+    if (value < 20) return t('mindset.emotion.verySad')
+    if (value < 40) return t('mindset.emotion.sad')
+    if (value < 60) return t('mindset.emotion.neutral')
+    if (value < 80) return t('mindset.emotion.happy')
+    return t('mindset.emotion.veryHappy')
   }
 
   const handleDeleteClick = (e: React.MouseEvent, date: Date) => {
@@ -96,51 +101,43 @@ export function Timeline({ onSelectDate, selectedDate, moodHistory, className, o
   return (
     <>
       <div className={cn(
-        "h-full border-r overflow-hidden flex flex-col",
+        "flex h-full flex-col overflow-hidden border-r",
         "w-[180px] sm:w-[200px] md:w-[220px]",
         className
       )}>
         <div className="flex-1 overflow-y-auto">
-          <div className="space-y-1 p-2">
+          <div className="flex flex-col gap-0.5 p-2">
             {/* Always show Today entry if no entry exists for today */}
             {!todayEntry && (
-              <div className="group relative">
-                <Button
-                  variant="ghost"
-                  className={cn(
-                    "w-full justify-start gap-2 h-auto p-2",
-                    "hover:bg-accent/50 transition-colors border-l-2 border-dashed border-muted-foreground/30",
-                    isToday(selectedDate) && "bg-accent"
-                  )}
-                  onClick={handleTodayClick}
-                >
-                  <div className="flex flex-col items-center justify-center gap-1 min-w-10">
-                    <div className="w-2 h-2 rounded-full bg-muted-foreground/50" />
-                  </div>
-                  <div className="flex-1 text-left min-w-0 flex items-center">
-                    <p className="text-sm font-medium text-muted-foreground">
-                      {t('mindset.today')}
-                    </p>
-                  </div>
-                </Button>
-              </div>
+              <Button
+                variant="ghost"
+                className={cn(
+                  "h-auto w-full justify-start p-2 text-left",
+                  "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
+                  isToday(selectedDate) && "bg-accent"
+                )}
+                aria-current={isToday(selectedDate) ? "date" : undefined}
+                onClick={handleTodayClick}
+              >
+                <span className="truncate text-sm font-medium text-muted-foreground">
+                  {t('mindset.today')}
+                </span>
+              </Button>
             )}
 
             {/* Show existing entries or empty state */}
             {!sortedMoodHistory?.length && todayEntry === undefined ? (
-              <div className="flex flex-col items-center justify-center p-4 text-center">
-                <Calendar className="h-6 w-6 text-muted-foreground mb-2" />
-                <p className="text-xs text-muted-foreground">
-                  {t('mindset.noEntries')}
-                </p>
-              </div>
+              <WidgetEmpty size="small" message={t('mindset.noEntries')} />
             ) : (
               sortedMoodHistory.map((mood) => {
                 if (!mood?.day) return null
                 const moodDate = mood.day instanceof Date ? mood.day : new Date(mood.day)
                 const isSelected = moodDate.toDateString() === selectedDate.toDateString()
                 const isCurrentDay = isToday(moodDate)
-                
+                const dateLabel = isCurrentDay
+                  ? t('mindset.today')
+                  : `${format(moodDate, 'EEE', { locale: dateLocale }).slice(0, 3)} ${format(moodDate, 'd', { locale: dateLocale })} ${format(moodDate, 'MMM', { locale: dateLocale }).slice(0, 3)}`
+
                 return (
                   <div
                     key={moodDate.toISOString()}
@@ -149,36 +146,33 @@ export function Timeline({ onSelectDate, selectedDate, moodHistory, className, o
                     <Button
                       variant="ghost"
                       className={cn(
-                        "w-full justify-start gap-2 h-auto p-2",
-                        "hover:bg-accent/50 transition-colors",
-                        isSelected && "bg-accent",
-                        isCurrentDay && "border-l-2 border-primary"
+                        "h-auto w-full justify-start p-2 pr-8 text-left",
+                        "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
+                        isSelected && "bg-accent"
                       )}
+                      aria-current={isSelected ? "date" : undefined}
                       onClick={() => onSelectDate(moodDate)}
                     >
-                      <div className="flex flex-col items-center justify-center gap-1 min-w-10">
-                        <div className={cn(
-                          "w-2 h-2 rounded-full transition-colors",
-                          getEmotionColor(mood.emotionValue)
-                        )} />
-                      </div>
-                      <div className="flex-1 text-left min-w-0 flex items-center">
-                        <p className="text-sm font-medium truncate">
-                          {isCurrentDay ? t('mindset.today') : `${format(moodDate, 'EEE', { locale: dateLocale }).slice(0, 3)} ${format(moodDate, 'd', { locale: dateLocale })} ${format(moodDate, 'MMM', { locale: dateLocale }).slice(0, 3)}`}
-                        </p>
-                      </div>
+                      <span className="flex min-w-0 flex-col items-start gap-0.5">
+                        <span className="truncate text-sm font-medium">{dateLabel}</span>
+                        <span className={cn(widgetType.caption, "truncate")}>
+                          {getEmotionLabel(mood.emotionValue)}
+                        </span>
+                      </span>
                     </Button>
                     <Button
                       variant="ghost"
                       size="icon"
+                      aria-label={`${t('mindset.delete')}: ${dateLabel}`}
                       className={cn(
-                        "absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6",
-                        "opacity-0 group-hover:opacity-100 transition-opacity",
-                        "text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                        "absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2",
+                        "opacity-0 focus-visible:opacity-100 group-hover:opacity-100",
+                        "motion-safe:transition-opacity motion-safe:duration-150 motion-safe:ease-out",
+                        "text-muted-foreground hover:text-destructive"
                       )}
                       onClick={(e) => handleDeleteClick(e, moodDate)}
                     >
-                      <Trash2 className="h-3 w-3" />
+                      <Trash2 className="h-3 w-3" aria-hidden />
                     </Button>
                   </div>
                 )
@@ -186,8 +180,8 @@ export function Timeline({ onSelectDate, selectedDate, moodHistory, className, o
             )}
           </div>
         </div>
-        
-        <div className="p-2 border-t">
+
+        <div className="border-t p-2">
           <Popover open={datePickerOpen} onOpenChange={setDatePickerOpen}>
             <PopoverTrigger asChild>
               <Button
@@ -195,7 +189,7 @@ export function Timeline({ onSelectDate, selectedDate, moodHistory, className, o
                 className="w-full justify-start gap-2 text-xs"
                 size="sm"
               >
-                <Plus className="h-4 w-4 shrink-0" />
+                <Plus className="h-4 w-4 shrink-0" aria-hidden />
                 {t('mindset.addEntry')}
               </Button>
             </PopoverTrigger>
@@ -238,4 +232,4 @@ export function Timeline({ onSelectDate, selectedDate, moodHistory, className, o
       </AlertDialog>
     </>
   )
-} 
+}

--- a/app/[locale]/dashboard/components/statistics/average-position-time-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/average-position-time-card.tsx
@@ -1,34 +1,58 @@
+'use client'
+
 import { useData } from "@/context/data-provider"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import { Clock } from "lucide-react"
-import { cn } from "@/lib/utils"
 import { WidgetSize } from '../../types/dashboard'
 import { useI18n } from '@/locales/client'
-import { InfoBubble } from "@/components/ui/info-bubble"
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetMetric,
+  formatDuration,
+  isCompactSize,
+  widgetMetricClass,
+} from "../widgets"
 
 interface AveragePositionTimeCardProps {
   size?: WidgetSize
 }
 
 export default function AveragePositionTimeCard({ size = 'medium' }: AveragePositionTimeCardProps) {
-  const { statistics: { averagePositionTime } } = useData()
-  const  t  = useI18n()
+  const { statistics: { totalPositionTime, nbTrades } } = useData()
+  const t = useI18n()
 
-    return (
-      <Card className="h-full">
-        <div className="flex items-center justify-center h-full gap-1.5">
-          <Clock className="h-3 w-3 text-muted-foreground" />
-          <div className="font-medium text-sm tabular-nums">{averagePositionTime}</div>
-          <InfoBubble
-            icon="help"
-            side="bottom"
-            sideOffset={5}
-            iconClassName="size-3"
-            contentClassName="max-w-[300px]"
-          >
-            {t('widgets.averagePositionTime.tooltip')}
-          </InfoBubble>
-        </div>
-      </Card>
-    )
+  // Same quantity the statistics layer derives, rendered through the shared
+  // duration formatter so precision matches every other duration on the board.
+  const averageSeconds = nbTrades > 0 ? totalPositionTime / nbTrades : 0
+  const value = formatDuration(averageSeconds)
+
+  return (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.types.averagePositionTime')}
+        description={t('widgets.averagePositionTime.tooltip')}
+      />
+      {nbTrades === 0 ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      ) : isCompactSize(size) ? (
+        <WidgetBody size={size} className="flex items-center justify-center">
+          <span className={widgetMetricClass(size)}>{value}</span>
+        </WidgetBody>
+      ) : (
+        <WidgetBody size={size} className="flex items-center">
+          <WidgetMetric
+            size={size}
+            label={t('statistics.activity.avgDuration')}
+            value={value}
+          />
+        </WidgetBody>
+      )}
+    </WidgetCard>
+  )
 }

--- a/app/[locale]/dashboard/components/statistics/cumulative-pnl-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/cumulative-pnl-card.tsx
@@ -1,41 +1,63 @@
+'use client'
+
 import { useData } from "@/context/data-provider"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import { PiggyBank } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { WidgetSize } from '../../types/dashboard'
-import { useI18n } from '@/locales/client'
-import { InfoBubble } from "@/components/ui/info-bubble"
+import { useCurrentLocale, useI18n } from '@/locales/client'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetMetric,
+  formatCurrency,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  widgetMetricClass,
+} from "../widgets"
 
 interface CumulativePnlCardProps {
   size?: WidgetSize
 }
 
 export default function CumulativePnlCard({ size = 'medium' }: CumulativePnlCardProps) {
-  const { statistics: { cumulativePnl, cumulativeFees } } = useData()
-  const totalPnl = cumulativePnl - cumulativeFees
-  const isPositive = totalPnl > 0
+  const { statistics: { cumulativePnl, cumulativeFees, nbTrades } } = useData()
   const t = useI18n()
+  const locale = useCurrentLocale()
 
-    return (
-      <Card className="flex items-center justify-center h-full p-2">
-        <div className="flex items-center gap-1.5">
-          <PiggyBank className="h-4 w-4 text-muted-foreground" />
-          <span className={cn(
-            "font-semibold text-base tabular-nums",
-            isPositive ? "text-green-500" : "text-red-500"
-          )}>
-            ${Math.abs(totalPnl).toFixed(2)}
-          </span>
-          <InfoBubble
-            icon="help"
-            side="bottom"
-            sideOffset={5}
-            iconClassName="size-3"
-            contentClassName="max-w-[300px]"
-          >
-            {t('widgets.cumulativePnl.tooltip')}
-          </InfoBubble>
-        </div>
-      </Card>
-    )
-  }
+  const totalPnl = cumulativePnl - cumulativeFees
+  const toneClassName = pnlToneClass(pnlTone(totalPnl))
+  // The sign stays on the number, so the tone color is never the only signal.
+  const value = formatCurrency(totalPnl, locale)
+
+  return (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.types.cumulativePnl')}
+        description={t('widgets.cumulativePnl.tooltip')}
+      />
+      {nbTrades === 0 ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      ) : isCompactSize(size) ? (
+        <WidgetBody size={size} className="flex items-center justify-center">
+          <span className={cn(widgetMetricClass(size), toneClassName)}>{value}</span>
+        </WidgetBody>
+      ) : (
+        <WidgetBody size={size} className="flex items-center">
+          <WidgetMetric
+            size={size}
+            label={t('statistics.profitLoss.net')}
+            value={value}
+            toneClassName={toneClassName}
+          />
+        </WidgetBody>
+      )}
+    </WidgetCard>
+  )
+}

--- a/app/[locale]/dashboard/components/statistics/long-short-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/long-short-card.tsx
@@ -1,12 +1,20 @@
 'use client'
 
 import { useData } from '@/context/data-provider'
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import { ArrowLeftRight, ArrowUpFromLine, ArrowDownFromLine } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { WidgetSize } from '../../types/dashboard'
-import { useI18n } from '@/locales/client'
-import { InfoBubble } from "@/components/ui/info-bubble"
+import { useCurrentLocale, useI18n } from '@/locales/client'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetStat,
+  WidgetStatList,
+  formatPercent,
+  isCompactSize,
+  widgetType,
+} from "../widgets"
 
 interface LongShortPerformanceCardProps {
   size?: WidgetSize
@@ -14,7 +22,8 @@ interface LongShortPerformanceCardProps {
 
 export default function LongShortPerformanceCard({ size = 'medium' }: LongShortPerformanceCardProps) {
   const { calendarData } = useData()
-  const  t  = useI18n()
+  const t = useI18n()
+  const locale = useCurrentLocale()
 
   // Calculate long/short data
   const chartData = Object.entries(calendarData).map(([date, values]) => ({
@@ -27,31 +36,49 @@ export default function LongShortPerformanceCard({ size = 'medium' }: LongShortP
   const longNumber = chartData.reduce((acc, curr) => acc + curr.longNumber, 0)
   const shortNumber = chartData.reduce((acc, curr) => acc + curr.shortNumber, 0)
   const totalTrades = longNumber + shortNumber
-  const longRate = Number((longNumber / totalTrades * 100).toFixed(2))
-  const shortRate = Number((shortNumber / totalTrades * 100).toFixed(2))
+  // Guarded: an empty dataset used to divide by zero and render "NaN%".
+  const longRate = totalTrades > 0 ? (longNumber / totalTrades) * 100 : 0
+  const shortRate = totalTrades > 0 ? (shortNumber / totalTrades) * 100 : 0
 
-    return (
-      <Card className="h-full">
-        <div className="flex items-center justify-center h-full gap-1.5">
-          <div className="flex items-center gap-1">
-            <ArrowUpFromLine className="h-3 w-3 text-green-500" />
-            <span className="font-medium text-sm tabular-nums">{longRate}%</span>
-          </div>
-          <span className="text-muted-foreground">/</span>
-          <div className="flex items-center gap-1">
-            <ArrowDownFromLine className="h-3 w-3 text-red-500" />
-            <span className="font-medium text-sm tabular-nums">{shortRate}%</span>
-          </div>
-          <InfoBubble
-            icon="help"
-            side="bottom"
-            sideOffset={5}
-            iconClassName="size-3"
-            contentClassName="max-w-[300px]"
-          >
-            {t('widgets.longShortPerformance.tooltip')}
-          </InfoBubble>
-        </div>
-      </Card>
-    )
-  }
+  const rows = [
+    { label: t('statistics.distribution.long'), value: formatPercent(longRate, locale) },
+    { label: t('statistics.distribution.short'), value: formatPercent(shortRate, locale) },
+  ]
+
+  return (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.types.longShortPerformance')}
+        description={t('widgets.longShortPerformance.tooltip')}
+      />
+      {totalTrades === 0 ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      ) : isCompactSize(size) ? (
+        <WidgetBody
+          size={size}
+          className="flex items-baseline justify-center gap-x-4 overflow-hidden"
+        >
+          {rows.map((row) => (
+            <div key={row.label} className="flex min-w-0 items-baseline gap-1.5">
+              <span className={cn(widgetType.label, "truncate")}>{row.label}</span>
+              <span className={cn(widgetType.value, "shrink-0")}>{row.value}</span>
+            </div>
+          ))}
+        </WidgetBody>
+      ) : (
+        <WidgetBody size={size}>
+          <WidgetStatList>
+            {rows.map((row) => (
+              <WidgetStat key={row.label} label={row.label} value={row.value} />
+            ))}
+          </WidgetStatList>
+        </WidgetBody>
+      )}
+    </WidgetCard>
+  )
+}

--- a/app/[locale]/dashboard/components/statistics/profit-factor-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/profit-factor-card.tsx
@@ -1,34 +1,58 @@
+'use client'
+
 import { useData } from "@/context/data-provider"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import { Scale } from "lucide-react"
-import { cn } from "@/lib/utils"
 import { WidgetSize } from '../../types/dashboard'
-import { useI18n } from '@/locales/client'
-import { InfoBubble } from "@/components/ui/info-bubble"
+import { useCurrentLocale, useI18n } from '@/locales/client'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetMetric,
+  formatRatio,
+  isCompactSize,
+  widgetMetricClass,
+} from "../widgets"
 
 interface ProfitFactorCardProps {
   size?: WidgetSize
 }
 
 export default function ProfitFactorCard({ size = 'medium' }: ProfitFactorCardProps) {
-  const { statistics: { profitFactor } } = useData()
-  const  t  = useI18n()
+  const { statistics: { profitFactor, nbTrades } } = useData()
+  const t = useI18n()
+  const locale = useCurrentLocale()
 
-    return (
-      <Card className="h-full">
-        <div className="flex items-center justify-center h-full gap-1.5">
-          <Scale className="h-3 w-3 text-blue-500" />
-          <div className="font-medium text-sm tabular-nums">{profitFactor.toFixed(2)}</div>
-          <InfoBubble
-            icon="help"
-            side="bottom"
-            sideOffset={5}
-            iconClassName="size-3"
-            contentClassName="max-w-[300px]"
-          >
-            {t('widgets.profitFactor.tooltip')}
-          </InfoBubble>
-        </div>
-      </Card>
-    )
-  }
+  // formatRatio renders a non-finite factor (no losses yet) as ∞ rather than
+  // "Infinity" or a fabricated number.
+  const value = formatRatio(profitFactor, locale)
+
+  return (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.types.profitFactor')}
+        description={t('widgets.profitFactor.tooltip')}
+      />
+      {nbTrades === 0 ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      ) : isCompactSize(size) ? (
+        <WidgetBody size={size} className="flex items-center justify-center">
+          <span className={widgetMetricClass(size)}>{value}</span>
+        </WidgetBody>
+      ) : (
+        <WidgetBody size={size} className="flex items-center">
+          <WidgetMetric
+            size={size}
+            label={t('statistics.performance.profitFactor')}
+            value={value}
+          />
+        </WidgetBody>
+      )}
+    </WidgetCard>
+  )
+}

--- a/app/[locale]/dashboard/components/statistics/risk-reward-ratio-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/risk-reward-ratio-card.tsx
@@ -1,19 +1,24 @@
 'use client'
 
 import { useData } from "@/context/data-provider"
-import { Card } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { WidgetSize } from '../../types/dashboard'
-import { Scale } from "lucide-react"
-import { useI18n } from '@/locales/client'
+import { useCurrentLocale, useI18n } from '@/locales/client'
 import { useMemo } from "react"
-import { InfoBubble } from "@/components/ui/info-bubble"
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetMetric,
+  WidgetStat,
+  WidgetStatList,
+  formatCurrency,
+  formatRatio,
+  isCompactSize,
+  pnlTone,
+  pnlToneClass,
+  widgetMetricClass,
+} from "../widgets"
 
 interface RiskRewardRatioCardProps {
   size?: WidgetSize
@@ -22,8 +27,9 @@ interface RiskRewardRatioCardProps {
 export default function RiskRewardRatioCard({ size = 'tiny' }: RiskRewardRatioCardProps) {
   const { formattedTrades } = useData()
   const t = useI18n()
-  
-  const { avgWin, avgLoss, riskRewardRatio, profitPercentage } = useMemo(() => {
+  const locale = useCurrentLocale()
+
+  const { avgWin, avgLoss, riskRewardRatio } = useMemo(() => {
     // Filter winning and losing trades
     const winningTrades = formattedTrades.filter(trade => trade.pnl > 0)
     const losingTrades = formattedTrades.filter(trade => trade.pnl < 0)
@@ -38,51 +44,55 @@ export default function RiskRewardRatioCard({ size = 'tiny' }: RiskRewardRatioCa
       : 0
 
     // Calculate Risk-Reward ratio
-    const riskRewardRatio = Math.abs(avgLoss) > 0 
-      ? Number((avgWin / Math.abs(avgLoss)).toFixed(2)) 
+    const riskRewardRatio = Math.abs(avgLoss) > 0
+      ? avgWin / Math.abs(avgLoss)
       : 0
-    
-    // Calculate progress percentage for visualization
-    const totalValue = Math.abs(avgLoss) + Math.abs(avgWin)
-    const profitPercentage = totalValue > 0 
-      ? (Math.abs(avgWin) / totalValue) * 100 
-      : 50
 
-    return { avgWin, avgLoss, riskRewardRatio, profitPercentage }
+    return { avgWin, avgLoss, riskRewardRatio }
   }, [formattedTrades])
 
+  const ratio = formatRatio(riskRewardRatio, locale)
+
   return (
-    <Card className="h-full">
-      <div className="flex flex-col items-center justify-center h-full gap-2 p-2">
-        <div className="flex items-center gap-1.5">
-          <Scale className="h-3 w-3 text-primary" />
-          <span className="font-medium text-sm tabular-nums">RR {riskRewardRatio}</span>
-          <InfoBubble
-            icon="help"
-            side="bottom"
-            sideOffset={5}
-            iconClassName="size-3"
-            contentClassName="max-w-[300px]"
-          >
-            {t('widgets.riskRewardRatio.tooltip')}
-          </InfoBubble>
-        </div>
-        <TooltipProvider delayDuration={100}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="w-full px-1 py-1.5 cursor-pointer">
-                <Progress value={profitPercentage} className="h-1.5" />
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={5}>
-              <div className="text-xs space-y-0.5 tabular-nums">
-                <div className="text-green-500">Avg. Win: ${avgWin.toFixed(2)}</div>
-                <div className="text-red-500">Avg. Loss: ${avgLoss.toFixed(2)}</div>
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-    </Card>
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.types.riskRewardRatio')}
+        description={t('widgets.riskRewardRatio.tooltip')}
+      />
+      {formattedTrades.length === 0 ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      ) : isCompactSize(size) ? (
+        <WidgetBody size={size} className="flex items-center justify-center">
+          <span className={widgetMetricClass(size)}>{ratio}</span>
+        </WidgetBody>
+      ) : (
+        <WidgetBody size={size} className="flex flex-col gap-4">
+          <WidgetMetric
+            size={size}
+            label={t('widgets.types.riskRewardRatio')}
+            value={ratio}
+          />
+          {/* Averages the ratio is built from: evidence beside the claim, not
+              hidden behind a hover tooltip. */}
+          <WidgetStatList>
+            <WidgetStat
+              label={t('statistics.performance.avgWin')}
+              value={formatCurrency(avgWin, locale)}
+              toneClassName={pnlToneClass(pnlTone(avgWin))}
+            />
+            <WidgetStat
+              label={t('statistics.performance.avgLoss')}
+              value={formatCurrency(avgLoss, locale)}
+              toneClassName={pnlToneClass(pnlTone(avgLoss))}
+            />
+          </WidgetStatList>
+        </WidgetBody>
+      )}
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/statistics/statistics-widget.tsx
+++ b/app/[locale]/dashboard/components/statistics/statistics-widget.tsx
@@ -1,54 +1,38 @@
 "use client"
 
 import * as React from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useData } from "@/context/data-provider"
-import { Clock, PiggyBank, Award, BarChart } from "lucide-react"
-import { InfoBubble } from "@/components/ui/info-bubble"
 import { cn, calculateStatistics } from "@/lib/utils"
 import { useI18n, useCurrentLocale } from "@/locales/client"
 import { useBreakevenStore } from "@/store/widgets/breakeven-store"
-import { Progress } from "@/components/ui/progress"
 import { CalendarEntry } from "@/app/[locale]/dashboard/types/calendar"
 import { Trade } from "@/prisma/generated/prisma/browser"
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetSection,
+  WidgetStat,
+  WidgetStatList,
+  formatCount,
+  formatCurrency,
+  formatDuration,
+  formatPercent,
+  pnlTone,
+  pnlToneClass,
+} from "../widgets"
 
 interface StatisticsWidgetProps {
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'small-long' | 'extra-large'
   dayData?: CalendarEntry // Optional: if provided, show statistics for this specific day only
 }
 
-function debounce<T extends (...args: any[]) => void>(func: T, wait: number): (...args: Parameters<T>) => void {
-  let timeout: NodeJS.Timeout | null = null
-  return (...args: Parameters<T>) => {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(() => func(...args), wait)
-  }
-}
-
 export default function StatisticsWidget({ size = 'medium', dayData }: StatisticsWidgetProps) {
   const dataContext = useData()
   const breakevenRange = useBreakevenStore((state) => state.range)
-  const [activeTooltip, setActiveTooltip] = React.useState<string | null>(null)
-  const [isTouch, setIsTouch] = React.useState(false)
-  const cardRef = React.useRef<HTMLDivElement>(null)
-  const lastTouchTime = React.useRef(0)
   const t = useI18n()
   const locale = useCurrentLocale()
-
-  // Number formatter for currency with thousands separators based on locale
-  const formatCurrency = (value: number) => {
-    const formatted = new Intl.NumberFormat(locale === 'fr' ? 'fr-FR' : 'en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(value)
-    
-    // Always use $ symbol with proper spacing for French
-    if (locale === 'fr') {
-      return `${formatted} $`
-    } else {
-      return `$${formatted}`
-    }
-  }
 
   // Calculate statistics - either for a specific day or for all data
   const statistics = React.useMemo(() => {
@@ -73,9 +57,9 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
     return dataContext.calendarData
   }, [dayData, dataContext.calendarData])
 
-  const { 
-    nbWin, nbLoss, nbBe, nbTrades, 
-    averagePositionTime, 
+  const {
+    nbWin, nbLoss, nbBe, nbTrades,
+    totalPositionTime,
     cumulativePnl, cumulativeFees,
     winningStreak,
     grossLosses,
@@ -87,24 +71,28 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
   // Calculate Net P&L including payouts
   const netPnlWithPayouts = cumulativePnl - cumulativeFees - totalPayouts
 
-  // Calculate rates
-  const winRate = Number((nbWin / nbTrades * 100).toFixed(2))
-  const lossRate = Number((nbLoss / nbTrades * 100).toFixed(2))
-  const beRate = Number((nbBe / nbTrades * 100).toFixed(2))
+  // Calculate rates. Guarded: dividing by an empty dataset used to render "NaN%".
+  const winRate = nbTrades > 0 ? (nbWin / nbTrades) * 100 : 0
+  const lossRate = nbTrades > 0 ? (nbLoss / nbTrades) * 100 : 0
+  const beRate = nbTrades > 0 ? (nbBe / nbTrades) * 100 : 0
+  const averagePositionSeconds = nbTrades > 0 ? totalPositionTime / nbTrades : 0
 
   // Calculate long/short data
-  const chartData = Object.entries(calendarData).map(([date, values]) => ({
-    date,
-    pnl: values.pnl,
-    shortNumber: values.shortNumber,
-    longNumber: values.longNumber,
-  }))
+  const chartData = React.useMemo(
+    () => Object.entries(calendarData).map(([date, values]) => ({
+      date,
+      pnl: values.pnl,
+      shortNumber: values.shortNumber,
+      longNumber: values.longNumber,
+    })),
+    [calendarData],
+  )
 
   const longNumber = chartData.reduce((acc, curr) => acc + curr.longNumber, 0)
   const shortNumber = chartData.reduce((acc, curr) => acc + curr.shortNumber, 0)
   const totalTrades = longNumber + shortNumber
-  const longRate = Number((longNumber / totalTrades * 100).toFixed(2))
-  const shortRate = Number((shortNumber / totalTrades * 100).toFixed(2))
+  const longRate = totalTrades > 0 ? (longNumber / totalTrades) * 100 : 0
+  const shortRate = totalTrades > 0 ? (shortNumber / totalTrades) * 100 : 0
 
   // Calculate average win/loss based on daily P&L
   // For single day mode, use the day's P&L directly; for multi-day, calculate average
@@ -114,8 +102,8 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
       return dayData.pnl > 0 ? dayData.pnl : 0
     }
     const winningDays = chartData.filter(day => day.pnl > 0)
-    return winningDays.length > 0 
-      ? winningDays.reduce((sum, day) => sum + day.pnl, 0) / winningDays.length 
+    return winningDays.length > 0
+      ? winningDays.reduce((sum, day) => sum + day.pnl, 0) / winningDays.length
       : 0
   }, [dayData, chartData])
 
@@ -125,230 +113,141 @@ export default function StatisticsWidget({ size = 'medium', dayData }: Statistic
       return dayData.pnl < 0 ? Math.abs(dayData.pnl) : 0
     }
     const losingDays = chartData.filter(day => day.pnl < 0)
-    return losingDays.length > 0 
+    return losingDays.length > 0
       ? Math.abs(losingDays.reduce((sum, day) => sum + day.pnl, 0) / losingDays.length)
       : 0
   }, [dayData, chartData])
 
-  // Colors
-  const positiveColor = "hsl(var(--chart-win))"
-  const negativeColor = "hsl(var(--chart-loss))"
-  const neutralColor = "hsl(var(--muted))"
+  const isTiny = size === 'tiny'
 
-  // Performance data
-  const performanceData = [
-    { name: 'Win', value: winRate, color: positiveColor },
-    { name: 'BE', value: beRate, color: neutralColor },
-    { name: 'Loss', value: lossRate, color: negativeColor },
-  ]
+  // Deductions carry their own minus sign, so the tone color is never the only
+  // thing telling the reader the figure works against them.
+  const losses = -grossLosses
+  const fees = -cumulativeFees
+  const payouts = -totalPayouts
+  const avgLoss = -avgLossPerDay
 
-  // Long/Short data
-  const sideData = [
-    { name: 'Long', value: longRate, color: positiveColor, number: longNumber },
-    { name: 'Short', value: shortRate, color: negativeColor, number: shortNumber },
-  ]
-
-  // Touch event handlers
-  React.useEffect(() => {
-    const handleOutsideClick = (event: MouseEvent | TouchEvent) => {
-      if (cardRef.current && !cardRef.current.contains(event.target as Node)) {
-        setActiveTooltip(null)
-      }
-    }
-
-    const handleTouchStart = () => {
-      setIsTouch(true)
-    }
-
-    document.addEventListener('mousedown', handleOutsideClick)
-    document.addEventListener('touchstart', handleOutsideClick)
-    window.addEventListener('touchstart', handleTouchStart, { once: true })
-
-    return () => {
-      document.removeEventListener('mousedown', handleOutsideClick)
-      document.removeEventListener('touchstart', handleOutsideClick)
-      window.removeEventListener('touchstart', handleTouchStart)
-    }
-  }, [])
+  if (nbTrades === 0) {
+    return (
+      <WidgetCard>
+        <WidgetHeader
+          size={size}
+          title={t('statistics.title')}
+          description={t('statistics.tooltip')}
+        />
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      </WidgetCard>
+    )
+  }
 
   return (
-    <Card className="h-full flex flex-col" ref={cardRef}>
-      <CardHeader 
-        className={cn(
-          "flex-none border-b",
-          size === 'tiny' 
-            ? "py-1 px-2"
-            : (size === 'small' || size === 'small-long')
-              ? "py-2 px-3" 
-              : "py-3 px-4"
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <CardTitle 
-              className={cn(
-                "line-clamp-1",
-                size === 'tiny'
-                  ? "text-xs"
-                  : (size === 'small' || size === 'small-long') 
-                    ? "text-sm" 
-                    : "text-base"
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('statistics.title')}
+        description={t('statistics.tooltip')}
+      />
+      <WidgetBody size={size} className="overflow-y-auto">
+        {/* Four groups, read as groups through spacing and alignment. The card
+            border is the only border; no quadrant boxes inside it. */}
+        <div className={cn("grid grid-cols-2", isTiny ? "gap-x-3 gap-y-3" : "gap-x-6 gap-y-4")}>
+          <WidgetSection title={t('statistics.profitLoss.title')} className="gap-1.5">
+            <WidgetStatList>
+              <WidgetStat
+                label={t('statistics.profitLoss.profits')}
+                value={formatCurrency(grossWin, locale)}
+                toneClassName={pnlToneClass(pnlTone(grossWin))}
+              />
+              <WidgetStat
+                label={t('statistics.profitLoss.losses')}
+                value={formatCurrency(losses, locale)}
+                toneClassName={pnlToneClass(pnlTone(losses))}
+              />
+              <WidgetStat
+                label={t('statistics.profitLoss.fees')}
+                value={formatCurrency(fees, locale)}
+                toneClassName={pnlToneClass(pnlTone(fees))}
+              />
+              <WidgetStat
+                label={`${t('statistics.profitLoss.payouts')} (${formatCount(nbPayouts, locale)})`}
+                value={formatCurrency(payouts, locale)}
+                toneClassName={pnlToneClass(pnlTone(payouts))}
+              />
+            </WidgetStatList>
+            {/* The conclusion of the group. Separated by space, not by a rule. */}
+            <WidgetStat
+              label={t('statistics.profitLoss.net')}
+              value={formatCurrency(netPnlWithPayouts, locale)}
+              toneClassName={cn(pnlToneClass(pnlTone(netPnlWithPayouts)), "font-semibold")}
+            />
+          </WidgetSection>
+
+          <WidgetSection title={t('statistics.performance.title')} className="gap-1.5">
+            <WidgetStatList>
+              <WidgetStat
+                label={t('statistics.performance.winRate')}
+                value={formatPercent(winRate, locale)}
+              />
+              <WidgetStat
+                label={t('statistics.performance.avgWin')}
+                description={t('statistics.performance.avgWinTooltip')}
+                value={formatCurrency(avgWinPerDay, locale)}
+                toneClassName={pnlToneClass(pnlTone(avgWinPerDay))}
+              />
+              {!isTiny && (
+                <WidgetStat
+                  label={t('statistics.performance.avgLoss')}
+                  description={t('statistics.performance.avgLossTooltip')}
+                  value={formatCurrency(avgLoss, locale)}
+                  toneClassName={pnlToneClass(pnlTone(avgLoss))}
+                />
               )}
-            >
-              {t('statistics.title')}
-            </CardTitle>
-            <InfoBubble iconClassName="size-3.5">
-              <p>{t('statistics.tooltip')}</p>
-            </InfoBubble>
-          </div>
-          <BarChart className="h-3.5 w-3.5 text-muted-foreground" />
+            </WidgetStatList>
+          </WidgetSection>
+
+          <WidgetSection title={t('statistics.activity.title')} className="gap-1.5">
+            <WidgetStatList>
+              <WidgetStat
+                label={t('statistics.activity.totalTrades')}
+                value={formatCount(nbTrades, locale)}
+              />
+              <WidgetStat
+                label={t('statistics.activity.winningTrades')}
+                value={formatCount(nbWin, locale)}
+              />
+              {!isTiny && (
+                <WidgetStat
+                  label={t('statistics.activity.avgDuration')}
+                  value={formatDuration(averagePositionSeconds)}
+                />
+              )}
+            </WidgetStatList>
+          </WidgetSection>
+
+          <WidgetSection title={t('statistics.distribution.title')} className="gap-1.5">
+            <WidgetStatList>
+              <WidgetStat
+                label={t('statistics.distribution.long')}
+                value={formatPercent(longRate, locale)}
+              />
+              {!isTiny && (
+                <WidgetStat
+                  label={t('statistics.distribution.short')}
+                  value={formatPercent(shortRate, locale)}
+                />
+              )}
+              <WidgetStat
+                label={t('statistics.distribution.winningStreak')}
+                value={formatCount(winningStreak, locale)}
+              />
+            </WidgetStatList>
+          </WidgetSection>
         </div>
-      </CardHeader>
-      <CardContent className="flex-1 p-0">
-        <div className="grid h-full grid-cols-2">
-          {/* Profit/Loss Section */}
-          <div className={cn(
-            "flex flex-col border-r border-b",
-            size === 'tiny' ? "p-1.5" : "p-3"
-          )}>
-            <h3 className="text-xs font-medium mb-1.5">{t('statistics.profitLoss.title')}</h3>
-            <div className="flex-1 flex flex-col justify-center gap-0.5">
-              {/* Profits */}
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs">{t('statistics.profitLoss.profits')}</span>
-                <span className="text-xs font-medium text font-mono tabular-nums">{formatCurrency(grossWin)}</span>
-              </div>
-              
-              {/* Losses */}
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs">- {t('statistics.profitLoss.losses')}</span>
-                <span className="text-xs font-medium text-red-500 font-mono tabular-nums">{formatCurrency(grossLosses)}</span>
-              </div>
-              
-              {/* Fees */}
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs">- {t('statistics.profitLoss.fees')}</span>
-                <span className="text-xs font-medium text-red-500 font-mono tabular-nums">{formatCurrency(cumulativeFees)}</span>
-              </div>
-              
-              {/* Payouts */}
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs">- {t('statistics.profitLoss.payouts')} ({nbPayouts})</span>
-                <span className="text-xs font-medium text-red-500 font-mono tabular-nums">{formatCurrency(totalPayouts)}</span>
-              </div>
-              
-              {/* Divider */}
-              <div className="border-t border-dashed my-1"></div>
-              
-              {/* Net Result */}
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs font-medium">{t('statistics.profitLoss.net')}</span>
-                <span className={cn(
-                  "text-sm font-bold font-mono tabular-nums",
-                  netPnlWithPayouts > 0 ? "text-green-500" : "text-red-500"
-                )}>
-                  {formatCurrency(netPnlWithPayouts)}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* Performance Section */}
-          <div className={cn(
-            "flex flex-col border-b",
-            size === 'tiny' ? "p-1.5" : "p-3"
-          )}>
-            <h3 className="text-xs font-medium mb-1.5">{t('statistics.performance.title')}</h3>
-            <div className="flex-1 flex flex-col justify-center gap-1.5">
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs">{t('statistics.performance.winRate')}</span>
-                <span className="text-sm font-medium tabular-nums">{winRate}%</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <div className="flex items-center gap-1">
-                  <span className="text-muted-foreground text-xs">{t('statistics.performance.avgWin')}</span>
-                  <InfoBubble iconClassName="size-3">
-                    <p>{t('statistics.performance.avgWinTooltip')}</p>
-                  </InfoBubble>
-                </div>
-                <span className="text-sm font-medium text-green-500 font-mono tabular-nums">{formatCurrency(avgWinPerDay)}</span>
-              </div>
-              {size !== 'tiny' && (
-                <div className="flex justify-between items-center">
-                  <div className="flex items-center gap-1">
-                    <span className="text-muted-foreground text-xs">{t('statistics.performance.avgLoss')}</span>
-                    <InfoBubble iconClassName="size-3">
-                      <p>{t('statistics.performance.avgLossTooltip')}</p>
-                    </InfoBubble>
-                  </div>
-                  <span className="text-sm font-medium text-red-500 font-mono tabular-nums">-{formatCurrency(avgLossPerDay)}</span>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Activity Section */}
-          <div className={cn(
-            "flex flex-col border-r",
-            size === 'tiny' ? "p-1.5" : "p-3"
-          )}>
-            <h3 className="text-xs font-medium mb-1.5">{t('statistics.activity.title')}</h3>
-            <div className="flex-1 flex flex-col justify-center gap-1.5">
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs">{t('statistics.activity.totalTrades')}</span>
-                <span className="text-sm font-medium tabular-nums">{nbTrades}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground text-xs">{t('statistics.activity.winningTrades')}</span>
-                <span className="text-sm font-medium text-green-500 tabular-nums">{nbWin}</span>
-              </div>
-              {size !== 'tiny' && (
-                <div className="flex justify-between items-center">
-                  <span className="text-muted-foreground text-xs">{t('statistics.activity.avgDuration')}</span>
-                  <span className="text-sm font-medium tabular-nums">{averagePositionTime}</span>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Distribution Section */}
-          <div className={cn(
-            "flex flex-col",
-            size === 'tiny' ? "p-1.5" : "p-3"
-          )}>
-            <h3 className="text-xs font-medium mb-1.5">{t('statistics.distribution.title')}</h3>
-            <div className="flex-1 flex flex-col justify-center gap-1.5">
-              <div className="space-y-1">
-                <div className="flex justify-between items-center">
-                  <span className="text-muted-foreground text-xs">{t('statistics.distribution.long')}</span>
-                  <span className="text-sm font-medium tabular-nums">{longRate}%</span>
-                </div>
-                <Progress value={longRate} className="h-1" />
-              </div>
-              {size !== 'tiny' ? (
-                <>
-                  <div className="space-y-1">
-                    <div className="flex justify-between items-center">
-                      <span className="text-muted-foreground text-xs">{t('statistics.distribution.short')}</span>
-                      <span className="text-sm font-medium tabular-nums">{shortRate}%</span>
-                    </div>
-                    <Progress value={shortRate} className="h-1" />
-                  </div>
-                  <div className="flex justify-between items-center">
-                    <span className="text-muted-foreground text-xs">{t('statistics.distribution.winningStreak')}</span>
-                    <span className="text-sm font-medium tabular-nums">{winningStreak}</span>
-                  </div>
-                </>
-              ) : (
-                <div className="flex justify-between items-center">
-                  <span className="text-muted-foreground text-xs">{t('statistics.distribution.winningStreak')}</span>
-                  <span className="text-sm font-medium tabular-nums">{winningStreak}</span>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+      </WidgetBody>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/statistics/trade-performance-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/trade-performance-card.tsx
@@ -1,12 +1,20 @@
 'use client'
 
 import { useData } from "@/context/data-provider"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import { BarChart, TrendingUp, TrendingDown, Minus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { WidgetSize } from '../../types/dashboard'
-import { useI18n } from '@/locales/client'
-import { InfoBubble } from "@/components/ui/info-bubble"
+import { useCurrentLocale, useI18n } from '@/locales/client'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetStat,
+  WidgetStatList,
+  formatPercent,
+  isCompactSize,
+  widgetType,
+} from "../widgets"
 
 interface TradePerformanceCardProps {
   size?: WidgetSize
@@ -15,39 +23,55 @@ interface TradePerformanceCardProps {
 export default function TradePerformanceCard({ size = 'medium' }: TradePerformanceCardProps) {
   const { statistics: { nbWin, nbLoss, nbBe, nbTrades } } = useData()
   const t = useI18n()
+  const locale = useCurrentLocale()
 
-  // Calculate rates
-  const winRate = Number((nbWin / nbTrades * 100).toFixed(2))
-  const lossRate = Number((nbLoss / nbTrades * 100).toFixed(2))
-  const beRate = Number((nbBe / nbTrades * 100).toFixed(2))
+  // Guarded: an empty dataset used to divide by zero and render "NaN%".
+  const winRate = nbTrades > 0 ? (nbWin / nbTrades) * 100 : 0
+  const lossRate = nbTrades > 0 ? (nbLoss / nbTrades) * 100 : 0
+  const beRate = nbTrades > 0 ? (nbBe / nbTrades) * 100 : 0
 
-    return (
-      <Card className="h-full">
-        <div className="flex items-center justify-center h-full gap-1.5">
-          <div className="flex items-center gap-1">
-            <TrendingUp className="h-3 w-3 text-green-500" />
-            <span className="font-medium text-sm tabular-nums">{winRate}%</span>
-          </div>
-          <span className="text-muted-foreground">/</span>
-          <div className="flex items-center gap-1">
-            <Minus className="h-3 w-3 text-yellow-500" />
-            <span className="font-medium text-sm tabular-nums">{beRate}%</span>
-          </div>
-          <span className="text-muted-foreground">/</span>
-          <div className="flex items-center gap-1">
-            <TrendingDown className="h-3 w-3 text-red-500" />
-            <span className="font-medium text-sm tabular-nums">{lossRate}%</span>
-          </div>
-          <InfoBubble
-            icon="help"
-            side="bottom"
-            sideOffset={5}
-            iconClassName="size-3"
-            contentClassName="max-w-[300px]"
-          >
-            {t('widgets.tradePerformance.tooltip')}
-          </InfoBubble>
-        </div>
-      </Card>
-    )
-  }
+  // Win/breakeven/loss is a distribution, not a signed P&L, so it stays
+  // monochrome: the labels carry the meaning, not the color.
+  const rows = [
+    { label: t('statistics.performance.win'), value: formatPercent(winRate, locale) },
+    { label: t('statistics.activity.breakeven'), value: formatPercent(beRate, locale) },
+    { label: t('statistics.performance.loss'), value: formatPercent(lossRate, locale) },
+  ]
+
+  return (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.types.tradePerformance')}
+        description={t('widgets.tradePerformance.tooltip')}
+      />
+      {nbTrades === 0 ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      ) : isCompactSize(size) ? (
+        <WidgetBody
+          size={size}
+          className="flex items-baseline justify-center gap-x-3 overflow-hidden"
+        >
+          {rows.map((row) => (
+            <div key={row.label} className="flex min-w-0 items-baseline gap-1">
+              <span className={cn(widgetType.label, "truncate")}>{row.label}</span>
+              <span className={cn(widgetType.value, "shrink-0")}>{row.value}</span>
+            </div>
+          ))}
+        </WidgetBody>
+      ) : (
+        <WidgetBody size={size}>
+          <WidgetStatList>
+            {rows.map((row) => (
+              <WidgetStat key={row.label} label={row.label} value={row.value} />
+            ))}
+          </WidgetStatList>
+        </WidgetBody>
+      )}
+    </WidgetCard>
+  )
+}

--- a/app/[locale]/dashboard/components/statistics/winning-streak-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/winning-streak-card.tsx
@@ -1,34 +1,56 @@
+'use client'
+
 import { useData } from "@/context/data-provider"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import { Award } from "lucide-react"
-import { cn } from "@/lib/utils"
 import { WidgetSize } from '../../types/dashboard'
-import { useI18n } from '@/locales/client'
-import { InfoBubble } from "@/components/ui/info-bubble"
+import { useCurrentLocale, useI18n } from '@/locales/client'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetEmpty,
+  WidgetHeader,
+  WidgetMetric,
+  formatCount,
+  isCompactSize,
+  widgetMetricClass,
+} from "../widgets"
 
 interface WinningStreakCardProps {
   size?: WidgetSize
 }
 
 export default function WinningStreakCard({ size = 'medium' }: WinningStreakCardProps) {
-  const { statistics: { winningStreak } } = useData()
-  const  t  = useI18n()
+  const { statistics: { winningStreak, nbTrades } } = useData()
+  const t = useI18n()
+  const locale = useCurrentLocale()
 
-    return (
-      <Card className="h-full">
-        <div className="flex items-center justify-center h-full gap-1.5">
-          <Award className="h-3 w-3 text-yellow-500" />
-          <div className="font-medium text-sm tabular-nums">{winningStreak}</div>
-          <InfoBubble
-            icon="help"
-            side="bottom"
-            sideOffset={5}
-            iconClassName="size-3"
-            contentClassName="max-w-[300px]"
-          >
-            {t('widgets.winningStreak.tooltip')}
-          </InfoBubble>
-        </div>
-      </Card>
-    )
-  }
+  const value = formatCount(winningStreak, locale)
+
+  return (
+    <WidgetCard>
+      <WidgetHeader
+        size={size}
+        title={t('widgets.types.winningStreak')}
+        description={t('widgets.winningStreak.tooltip')}
+      />
+      {nbTrades === 0 ? (
+        <WidgetEmpty
+          size={size}
+          className="flex-1"
+          message={t('widgets.empty.noTrades')}
+        />
+      ) : isCompactSize(size) ? (
+        <WidgetBody size={size} className="flex items-center justify-center">
+          <span className={widgetMetricClass(size)}>{value}</span>
+        </WidgetBody>
+      ) : (
+        <WidgetBody size={size} className="flex items-center">
+          <WidgetMetric
+            size={size}
+            label={t('statistics.distribution.winningStreak')}
+            value={value}
+          />
+        </WidgetBody>
+      )}
+    </WidgetCard>
+  )
+}

--- a/app/[locale]/dashboard/components/tables/bulk-edit-panel.tsx
+++ b/app/[locale]/dashboard/components/tables/bulk-edit-panel.tsx
@@ -4,9 +4,8 @@ import React, { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { WidgetBody, WidgetCard, WidgetHeader, widgetType } from '../widgets'
 import { Separator } from '@/components/ui/separator'
-import { Badge } from '@/components/ui/badge'
 import { Clock, Edit3, Plus, Minus, X } from 'lucide-react'
 import { useI18n } from '@/locales/client'
 import { cn } from '@/lib/utils'
@@ -122,31 +121,35 @@ export function BulkEditPanel({
   if (!isVisible) return null
 
   return (
-    <Card className={cn(
-      "fixed bottom-4 right-4 w-96 z-50 shadow-2xl border-2 transition-all duration-150 ease-out",
+    // A floating panel earns its elevation, but one border is enough to say it
+    // sits above the table.
+    <WidgetCard className={cn(
+      "fixed bottom-4 right-4 z-50 h-auto w-96 shadow-lg motion-safe:transition-all motion-safe:duration-150 motion-safe:ease-out",
       isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
       className
     )}>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg flex items-center gap-2">
-            {t('trade-table.bulkEdit.title')}
-            <Badge variant="secondary" className="text-xs">
-              {selectedTrades.length} {t('trade-table.bulkEdit.trades')}
-            </Badge>
-          </CardTitle>
+      <WidgetHeader
+        title={t('trade-table.bulkEdit.title')}
+        actions={
           <Button
             variant="ghost"
             size="sm"
             onClick={handleClose}
             className="h-6 w-6 p-0"
+            aria-label={t('common.close')}
           >
             <X className="h-4 w-4" />
           </Button>
-        </div>
-      </CardHeader>
-      
-      <CardContent className="space-y-4">
+        }
+      >
+        {/* The selection count is ordinary metadata, so it reads as text
+            rather than as a badge. */}
+        <span className={cn(widgetType.caption, "shrink-0 tabular-nums")}>
+          {selectedTrades.length} {t('trade-table.bulkEdit.trades')}
+        </span>
+      </WidgetHeader>
+
+      <WidgetBody className="space-y-4">
         {/* Time Adjustments */}
         <div className="space-y-3">
           <div className="flex items-center gap-2">
@@ -346,7 +349,7 @@ export function BulkEditPanel({
             )}
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </WidgetBody>
+    </WidgetCard>
   )
 }

--- a/app/[locale]/dashboard/components/tables/column-header.tsx
+++ b/app/[locale]/dashboard/components/tables/column-header.tsx
@@ -30,6 +30,11 @@ interface DataTableColumnHeaderProps<TData, TValue>
   toggleLabel?: string
   onToggleChange?: (value: boolean) => void
   toggleValue?: boolean
+  /**
+   * Header alignment. It must match the alignment of the cells underneath:
+   * text reads from the left, numbers line up on the right.
+   */
+  align?: "left" | "right"
 }
 
 export function DataTableColumnHeader<TData, TValue>({
@@ -42,6 +47,7 @@ export function DataTableColumnHeader<TData, TValue>({
   toggleLabel,
   onToggleChange,
   toggleValue = false,
+  align = "left",
 }: DataTableColumnHeaderProps<TData, TValue>) {
   const { updateColumnVisibility } = useTableConfigStore()
   const t = useI18n()
@@ -88,18 +94,29 @@ export function DataTableColumnHeader<TData, TValue>({
   const isFiltered = column.getFilterValue() !== undefined
 
   if (!column.getCanSort()) {
-    return <div className={cn(className)}>{title}</div>
+    return (
+      <div className={cn(align === "right" && "text-right", className)}>
+        {title}
+      </div>
+    )
   }
 
   return (
-    <div className={cn("flex items-center space-x-2", className)}>
+    <div
+      className={cn(
+        "flex items-center space-x-2",
+        align === "right" && "justify-end",
+        className,
+      )}
+    >
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
             className={cn(
-              "-ml-3 h-8 data-[state=open]:bg-accent",
+              "h-8 data-[state=open]:bg-accent",
+              align === "right" ? "-mr-3" : "-ml-3",
               isFiltered && "bg-accent"
             )}
           >

--- a/app/[locale]/dashboard/components/tables/editable-instrument-cell.tsx
+++ b/app/[locale]/dashboard/components/tables/editable-instrument-cell.tsx
@@ -90,26 +90,30 @@ export function EditableInstrumentCell({
           onKeyDown={handleKeyDown}
           onBlur={handleSave}
           placeholder="Instrument"
-          className="h-7 text-base sm:text-xs font-medium border-blue-500 focus-visible:ring-1"
+          className="h-7 text-base sm:text-xs font-medium border-ring focus-visible:ring-1"
           disabled={isSaving}
         />
+        {/* Save and cancel are disambiguated by their icons and accessible
+            names; a green tick and a red cross add no further meaning. */}
         <Button
           size="sm"
           variant="ghost"
-          className="h-7 w-7 p-0 hover:bg-green-100"
+          className="h-7 w-7 p-0"
           onClick={handleSave}
           disabled={isSaving}
+          aria-label={t('common.save')}
         >
-          <Check className="h-3 w-3 text-green-600" />
+          <Check className="h-3 w-3" />
         </Button>
         <Button
           size="sm"
           variant="ghost"
-          className="h-7 w-7 p-0 hover:bg-red-100"
+          className="h-7 w-7 p-0"
           onClick={handleCancel}
           disabled={isSaving}
+          aria-label={t('common.cancel')}
         >
-          <X className="h-3 w-3 text-red-600" />
+          <X className="h-3 w-3" />
         </Button>
       </div>
     )
@@ -118,13 +122,13 @@ export function EditableInstrumentCell({
   return (
     <div
       className={cn(
-        "group cursor-pointer hover:bg-accent/50 rounded px-2 py-1 transition-colors border border-transparent hover:border-accent-foreground/20 flex items-center gap-2",
+        "group cursor-pointer hover:bg-accent/50 rounded px-2 py-1 motion-safe:transition-colors border border-transparent hover:border-accent-foreground/20 flex items-center gap-2",
         className
       )}
       onClick={handleStartEdit}
     >
       <span className="text-sm font-medium">{value}</span>
-      <Edit3 className="h-3 w-3 opacity-0 group-hover:opacity-60 transition-opacity" />
+      <Edit3 className="h-3 w-3 opacity-0 group-hover:opacity-60 motion-safe:transition-opacity" />
     </div>
   )
 }

--- a/app/[locale]/dashboard/components/tables/editable-time-cell.tsx
+++ b/app/[locale]/dashboard/components/tables/editable-time-cell.tsx
@@ -116,26 +116,30 @@ export function EditableTimeCell({
           onChange={(e) => setTempValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="HH:mm:ss"
-          className="h-7 text-base sm:text-xs font-mono border-blue-500 focus-visible:ring-1"
+          className="h-7 text-base sm:text-xs font-mono border-ring focus-visible:ring-1"
           disabled={isSaving}
         />
+        {/* Save and cancel are disambiguated by their icons and accessible
+            names; a green tick and a red cross add no further meaning. */}
         <Button
           size="sm"
           variant="ghost"
-          className="h-7 w-7 p-0 hover:bg-green-100"
+          className="h-7 w-7 p-0"
           onClick={handleSave}
           disabled={isSaving}
+          aria-label={t('common.save')}
         >
-          <Check className="h-3 w-3 text-green-600" />
+          <Check className="h-3 w-3" />
         </Button>
         <Button
           size="sm"
           variant="ghost"
-          className="h-7 w-7 p-0 hover:bg-red-100"
+          className="h-7 w-7 p-0"
           onClick={handleCancel}
           disabled={isSaving}
+          aria-label={t('common.cancel')}
         >
-          <X className="h-3 w-3 text-red-600" />
+          <X className="h-3 w-3" />
         </Button>
       </div>
     )
@@ -146,14 +150,14 @@ export function EditableTimeCell({
       <PopoverTrigger asChild>
         <div
           className={cn(
-            "group cursor-pointer hover:bg-accent/50 rounded px-2 py-1 transition-colors border border-transparent hover:border-accent-foreground/20",
+            "group cursor-pointer hover:bg-accent/50 rounded px-2 py-1 motion-safe:transition-colors border border-transparent hover:border-accent-foreground/20",
             className
           )}
           onClick={() => setIsPopoverOpen(true)}
         >
           <div className="flex items-center gap-2">
             <span className="text-sm font-mono">{formattedTime}</span>
-            <Clock className="h-3 w-3 opacity-0 group-hover:opacity-60 transition-opacity" />
+            <Clock className="h-3 w-3 opacity-0 group-hover:opacity-60 motion-safe:transition-opacity" />
           </div>
         </div>
       </PopoverTrigger>

--- a/app/[locale]/dashboard/components/tables/trade-comment.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-comment.tsx
@@ -114,18 +114,18 @@ export function TradeComment({ tradeIds, comment: initialComment, onCommentChang
                   onChange={(e) => setLocalComment(e.target.value)}
                   className={cn(
                     "w-full px-3 py-2 text-base sm:text-sm bg-transparent border rounded min-h-[100px]",
-                    "focus:outline-hidden focus:ring-2 focus:ring-primary resize-none transition-all duration-200",
-                    showSuccess && "border-green-500 ring-2 ring-green-500/20",
+                    "focus:outline-hidden focus:ring-2 focus:ring-primary resize-none motion-safe:transition-colors motion-safe:duration-150",
+                    showSuccess && "border-success ring-2 ring-success/20",
                     isUpdating && "border-primary/50"
                   )}
                 />
                 {isUpdating && (
                   <div className="absolute right-2 top-2">
-                    <div className="animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
+                    <div className="motion-safe:animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
                   </div>
                 )}
                 {showSuccess && !isUpdating && (
-                  <div className="absolute right-2 top-2 text-green-500 animate-in fade-in zoom-in duration-300">
+                  <div className="absolute right-2 top-2 text-success motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150">
                     <svg
                       className="h-4 w-4"
                       fill="none"

--- a/app/[locale]/dashboard/components/tables/trade-table-review.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-review.tsx
@@ -40,7 +40,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn, parsePositionTime } from "@/lib/utils";
 import { Checkbox } from "@/components/ui/checkbox";
-import { useI18n } from "@/locales/client";
+import { useCurrentLocale, useI18n } from "@/locales/client";
 import { TradeComment } from "./trade-comment";
 import { TradeVideoUrl } from "./trade-video-url";
 import { TradeTag } from "./trade-tag";
@@ -53,13 +53,6 @@ import {
 } from "@/components/ui/tooltip";
 import { DataTableColumnHeader } from "./column-header";
 import { createClient } from "@/lib/supabase";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardFooter,
-} from "@/components/ui/card";
 import {
   Select,
   SelectContent,
@@ -109,6 +102,22 @@ import {
   DEFAULT_TRADE_TABLE_PAGE_SIZE,
   sanitizeTablePageSize,
 } from "@/store/widgets/table-config-store";
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetFooter,
+  WidgetHeader,
+  formatCount,
+  formatCurrency,
+  formatDuration,
+  formatTicks,
+  pnlTone,
+  pnlToneClass,
+  widgetType,
+} from "../widgets";
+
+/** Numeric cells and their headers share one right edge and tabular figures. */
+const numericCell = "text-right tabular-nums";
 
 // Custom Tags Header Component
 function TagsColumnHeader() {
@@ -167,14 +176,17 @@ function TagsColumnHeader() {
                 </p>
               </div>
 
-              {/* Search input */}
-              <div className="flex items-center gap-2 bg-muted/30 rounded-md px-2">
-                <Search className="h-4 w-4 text-muted-foreground" />
+              {/* Search input: a form control, not a nested panel. */}
+              <div className="relative">
+                <Search
+                  aria-hidden
+                  className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                />
                 <Input
                   placeholder={t("widgets.tags.searchPlaceholder")}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="flex-1 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 h-8 text-base sm:text-sm"
+                  className="h-8 pl-8 text-base sm:text-sm"
                 />
               </div>
 
@@ -185,9 +197,9 @@ function TagsColumnHeader() {
                     {filteredTags.map((tag) => (
                       <div
                         key={tag.id}
-                        className="flex items-center justify-between rounded-md hover:bg-muted/50 transition-colors p-1.5"
+                        className="flex items-center justify-between rounded-md p-1.5 motion-safe:transition-colors hover:bg-muted/50"
                       >
-                        <div className="flex items-center gap-2 min-w-0 flex-1">
+                        <div className="flex min-w-0 flex-1 items-center gap-2">
                           <Checkbox
                             checked={tagFilter.tags.includes(tag.name)}
                             onCheckedChange={(checked) => {
@@ -200,13 +212,17 @@ function TagsColumnHeader() {
                             id={`tag-filter-${tag.id}`}
                             className="h-4 w-4"
                           />
-                          <div
-                            className="w-3 h-3 rounded-full shrink-0"
-                            style={{ backgroundColor: tag.color || "#CBD5E1" }}
-                          />
+                          {/* Only a user-chosen tag color earns a swatch. */}
+                          {tag.color ? (
+                            <span
+                              aria-hidden
+                              className="size-2.5 shrink-0 rounded-full"
+                              style={{ backgroundColor: tag.color }}
+                            />
+                          ) : null}
                           <label
                             htmlFor={`tag-filter-${tag.id}`}
-                            className="font-medium cursor-pointer truncate flex-1 text-sm"
+                            className="flex-1 cursor-pointer truncate text-sm"
                           >
                             {tag.name}
                           </label>
@@ -300,6 +316,7 @@ function getColumnDefId(columnDef: ColumnDef<ExtendedTrade>): string | undefined
 
 export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps) {
   const t = useI18n();
+  const locale = useCurrentLocale();
   const { formattedTrades, updateTrades, deleteTrades } = useData();
   const tags = useUserStore((state) => state.tags);
   const timezone = useUserStore((state) => state.timezone);
@@ -750,11 +767,19 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
               <div className="flex items-center gap-1">
                 <Popover>
                   <PopoverTrigger asChild>
-                    <div className="flex items-center justify-center w-fit min-w-5 px-1.5 h-5 rounded-full bg-muted text-[10px] font-medium cursor-pointer hover:bg-muted/80 transition-colors sm:min-w-6 sm:px-2 sm:h-6 sm:text-xs">
+                    {/* An account id is an identifier, so mono is right here.
+                        It is not state, so it gets no pill. */}
+                    <button
+                      type="button"
+                      className={cn(
+                        widgetType.mono,
+                        "cursor-pointer rounded-sm underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      )}
+                    >
                       {accounts.length === 1
                         ? `${accounts[0].slice(0, 2)}${accounts[0].slice(-2)}`
                         : `+${accounts.length}`}
-                    </div>
+                    </button>
                   </PopoverTrigger>
                   <PopoverContent
                     className="w-fit p-0"
@@ -775,8 +800,8 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 </Popover>
               </div>
               {trade.trades.length > 0 && (
-                <span className="text-xs text-muted-foreground">
-                  ({trade.trades.length})
+                <span className={cn(widgetType.caption, "tabular-nums")}>
+                  ({formatCount(trade.trades.length, locale)})
                 </span>
               )}
             </div>
@@ -793,12 +818,15 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             tableId="trade-table"
           />
         ),
-        cell: ({ row }) =>
-          formatInTimeZone(
-            new Date(row.original.entryDate),
-            timezone,
-            "yyyy-MM-dd",
-          ),
+        cell: ({ row }) => (
+          <span className={widgetType.mono}>
+            {formatInTimeZone(
+              new Date(row.original.entryDate),
+              timezone,
+              "yyyy-MM-dd",
+            )}
+          </span>
+        ),
         sortingFn: (rowA, rowB, columnId) => {
           const a = new Date(rowA.getValue(columnId)).getTime();
           const b = new Date(rowB.getValue(columnId)).getTime();
@@ -824,7 +852,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
               : [trade.id];
 
           return (
-            <div className="text-right">
+            <div className="text-left">
               <EditableInstrumentCell
                 value={trade.instrument}
                 tradeIds={tradeIds}
@@ -845,9 +873,12 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
         ),
         size: 100,
         cell: ({ row }) => {
+          // Ordinary metadata: plain text, sentence case, no pill and no
+          // all-caps eyebrow.
+          const side = row.original.side ?? "";
           return (
-            <div className="text-right font-medium">
-              {row.original.side?.toUpperCase()}
+            <div className="text-left">
+              {side ? side.charAt(0).toUpperCase() + side.slice(1).toLowerCase() : ""}
             </div>
           );
         },
@@ -870,13 +901,14 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             column={column}
             title={t("trade-table.entryPrice")}
             tableId="trade-table"
+            align="right"
           />
         ),
         cell: ({ row }) => {
           const entryPrice = parseFloat(row.original.entryPrice);
           return (
-            <div className="text-right font-medium">
-              ${entryPrice.toFixed(2)}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCurrency(entryPrice, locale)}
             </div>
           );
         },
@@ -889,13 +921,14 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             column={column}
             title={t("trade-table.exitPrice")}
             tableId="trade-table"
+            align="right"
           />
         ),
         cell: ({ row }) => {
           const exitPrice = parseFloat(row.original.closePrice);
           return (
-            <div className="text-right font-medium">
-              ${exitPrice.toFixed(2)}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCurrency(exitPrice, locale)}
             </div>
           );
         },
@@ -908,11 +941,12 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             column={column}
             title={t("trade-table.positionTime")}
             tableId="trade-table"
+            align="right"
           />
         ),
         cell: ({ row }) => {
           const timeInPosition = row.original.timeInPosition || 0;
-          return <div>{parsePositionTime(timeInPosition)}</div>;
+          return <div className={numericCell}>{formatDuration(timeInPosition)}</div>;
         },
         sortingFn: (rowA, rowB, columnId) => {
           const a = rowA.original.timeInPosition || 0;
@@ -983,17 +1017,16 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             column={column}
             title={t("trade-table.pnl")}
             tableId="trade-table"
+            align="right"
           />
         ),
         cell: ({ row }) => {
           const pnl = row.original.pnl;
+          // The number keeps its own sign, so the tone is a reinforcement and
+          // never the only carrier of meaning.
           return (
-            <div className="text-right font-medium">
-              <span
-                className={cn(pnl >= 0 ? "text-green-600" : "text-red-600")}
-              >
-                {pnl.toFixed(2)}
-              </span>
+            <div className={cn(numericCell, "font-medium", pnlToneClass(pnlTone(pnl)))}>
+              {formatCurrency(pnl, locale)}
             </div>
           );
         },
@@ -1012,8 +1045,8 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
         cell: ({ row }) => {
           const commission = row.original.commission;
           return (
-            <div className="text-right font-medium">
-              ${commission.toFixed(2)}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCurrency(commission, locale)}
             </div>
           );
         },
@@ -1026,13 +1059,14 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             column={column}
             title={t("trade-table.quantity")}
             tableId="trade-table"
+            align="right"
           />
         ),
         cell: ({ row }) => {
           const quantity = row.original.quantity;
           return (
-            <div className="text-right font-medium">
-              {quantity.toLocaleString()}
+            <div className={cn(numericCell, "font-medium")}>
+              {formatCount(quantity, locale)}
             </div>
           );
         },
@@ -1048,6 +1082,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
               showPoints ? t("trade-table.points") : t("trade-table.ticks")
             }
             tableId="trade-table"
+            align="right"
             showFilter={true}
             showToggle={true}
             toggleLabel={t("table.showPoints")}
@@ -1069,12 +1104,10 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           );
           const value = showPoints ? calculation.points : calculation.ticks;
           return (
-            <div className="text-right font-medium">
-              <span
-                className={cn(value >= 0 ? "text-green-600" : "text-red-600")}
-              >
-                {showPoints ? value.toFixed(2) : value}
-              </span>
+            <div className={cn(numericCell, "font-medium", pnlToneClass(pnlTone(value)))}>
+              {formatTicks(value, locale, {
+                maximumFractionDigits: showPoints ? 2 : 0,
+              })}
             </div>
           );
         },
@@ -1293,30 +1326,17 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
   const visibleColumns = table.getVisibleLeafColumns();
 
   return (
-    <Card
-      className="h-full flex min-w-0 flex-col w-full"
+    <WidgetCard
+      className="w-full"
       style={cardStyle}
     >
       {showHeader && (
-        <CardHeader className="border-b shrink-0 p-2 sm:p-4">
-        <div className="flex w-full min-w-0 flex-col gap-2 sm:gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div className="flex min-w-0 items-center justify-between gap-1.5">
-            <div className="flex min-w-0 items-center gap-1.5">
-              <CardTitle className="line-clamp-1 text-sm sm:text-base">
-                {t("trade-table.title")}
-              </CardTitle>
-              <InfoBubble
-                side="top"
-                iconClassName="size-3.5 sm:size-4"
-              >
-                <p>{t("trade-table.description")}</p>
-              </InfoBubble>
-            </div>
-            {isMobile && !config?.disableColumnConfig && (
-              <ColumnConfigDialog tableId="trade-table" trigger={columnConfigTrigger} />
-            )}
-          </div>
-          <div className="grid w-full min-w-0 grid-cols-2 gap-1.5 sm:grid-cols-2 sm:gap-2 xl:flex xl:w-auto xl:flex-wrap xl:items-center xl:justify-end">
+        <WidgetHeader
+          className="flex-wrap items-start"
+          title={t("trade-table.title")}
+          description={t("trade-table.description")}
+          actions={
+            <div className="grid w-full min-w-0 grid-cols-2 gap-1.5 sm:grid-cols-2 sm:gap-2 xl:flex xl:w-auto xl:flex-wrap xl:items-center xl:justify-end">
             {selectedTrades.length > 0 && (
               <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
                 <AlertDialogTrigger asChild>
@@ -1448,29 +1468,37 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                 </SelectContent>
               </Select>
             )}
-            {!config?.disableColumnConfig && !isMobile && (
+            {!config?.disableColumnConfig && (
               <ColumnConfigDialog tableId="trade-table" trigger={columnConfigTrigger} />
             )}
-          </div>
-        </div>
-      </CardHeader>
+            </div>
+          }
+        />
       )}
-      <CardContent ref={setTableScrollElement} className="flex-1 min-h-0 overflow-auto p-0">
+      <WidgetBody flush ref={setTableScrollElement} className="overflow-auto">
         <div className="relative w-full min-w-max">
           <table
             className="w-full border-separate border-spacing-0 caption-bottom text-sm"
             style={{ minWidth: table.getTotalSize() }}
           >
-            <thead className="sticky top-0 z-10 bg-muted/90 backdrop-blur-xs shadow-xs border-b [&_tr]:border-b">
+            <caption className="sr-only">{t("trade-table.description")}</caption>
+            <thead className="sticky top-0 z-10 border-b bg-card [&_tr]:border-b">
                 {table.getHeaderGroups().map((headerGroup) => (
-                  <tr
-                    key={headerGroup.id}
-                    className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
-                  >
+                  <tr key={headerGroup.id} className="border-b">
                     {headerGroup.headers.map((header) => (
                       <th
                         key={header.id}
-                        className="whitespace-nowrap px-2 py-1 text-left text-xs font-semibold bg-muted/90 border-r border-border last:border-r-0 first:border-l h-8 sm:h-12 sm:px-3 sm:py-2 sm:text-sm align-middle text-muted-foreground [&:has([role=checkbox])]:pr-0"
+                        scope="col"
+                        aria-sort={
+                          header.column.getIsSorted() === "asc"
+                            ? "ascending"
+                            : header.column.getIsSorted() === "desc"
+                              ? "descending"
+                              : header.column.getCanSort()
+                                ? "none"
+                                : undefined
+                        }
+                        className="h-8 whitespace-nowrap border-b bg-card px-2 py-1 text-left align-middle text-xs font-medium text-muted-foreground sm:h-12 sm:px-3 sm:py-2 [&:has([role=checkbox])]:pr-0"
                         style={{ width: header.getSize() }}
                       >
                         {header.isPlaceholder
@@ -1491,8 +1519,8 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
               columnCount={visibleColumns.length}
               compact={isMobile}
             />
-            <tfoot className="sticky bottom-0 z-10 bg-muted/90 backdrop-blur-xs border-t-2 border-border">
-              <tr className="border-b transition-colors">
+            <tfoot className="sticky bottom-0 z-10 border-t bg-card">
+              <tr>
                 {visibleColumns.map((column, index) => {
                   const columnId = column.id;
                   
@@ -1510,9 +1538,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                     return (
                       <td
                         key={columnId || index}
-                        className={cn(
-                          "px-2 py-1.5 align-middle whitespace-nowrap text-xs font-semibold border-r border-border/50 last:border-r-0 first:border-l sm:px-3 sm:py-2 sm:text-sm",
-                        )}
+                        className="whitespace-nowrap px-2 py-1.5 align-middle text-xs font-medium sm:px-3 sm:py-2 sm:text-sm"
                         style={{ width: column.getSize() }}
                       >
                         {t("trade-table.subtotal")}
@@ -1525,9 +1551,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                     return (
                       <td
                         key={columnId || index}
-                        className={cn(
-                          "px-2 py-1.5 align-middle whitespace-nowrap text-xs border-r border-border/50 last:border-r-0 sm:px-3 sm:py-2 sm:text-sm",
-                        )}
+                        className="whitespace-nowrap px-2 py-1.5 align-middle text-xs sm:px-3 sm:py-2 sm:text-sm"
                       style={{ width: column.getSize() }}
                       />
                     );
@@ -1539,17 +1563,13 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                       <td
                         key={columnId}
                         className={cn(
-                          "px-2 py-1.5 align-middle whitespace-nowrap text-xs font-semibold text-right border-r border-border/50 last:border-r-0 sm:px-3 sm:py-2 sm:text-sm",
+                          "whitespace-nowrap px-2 py-1.5 align-middle text-xs font-medium sm:px-3 sm:py-2 sm:text-sm",
+                          numericCell,
+                          pnlToneClass(pnlTone(currentPageTotals.totalPnl)),
                         )}
                       style={{ width: column.getSize() }}
                       >
-                        <span
-                          className={cn(
-                            currentPageTotals.totalPnl >= 0 ? "text-green-600" : "text-red-600"
-                          )}
-                        >
-                          {currentPageTotals.totalPnl.toFixed(2)}
-                        </span>
+                        {formatCurrency(currentPageTotals.totalPnl, locale)}
                       </td>
                     );
                   }
@@ -1559,11 +1579,12 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                       <td
                         key={columnId}
                         className={cn(
-                          "px-2 py-1.5 align-middle whitespace-nowrap text-xs font-semibold text-right border-r border-border/50 last:border-r-0 sm:px-3 sm:py-2 sm:text-sm",
+                          "whitespace-nowrap px-2 py-1.5 align-middle text-xs font-medium sm:px-3 sm:py-2 sm:text-sm",
+                          numericCell,
                         )}
                       style={{ width: column.getSize() }}
                       >
-                        ${currentPageTotals.totalCommission.toFixed(2)}
+                        {formatCurrency(currentPageTotals.totalCommission, locale)}
                       </td>
                     );
                   }
@@ -1573,11 +1594,12 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                       <td
                         key={columnId}
                         className={cn(
-                          "px-2 py-1.5 align-middle whitespace-nowrap text-xs font-semibold text-right border-r border-border/50 last:border-r-0 sm:px-3 sm:py-2 sm:text-sm",
+                          "whitespace-nowrap px-2 py-1.5 align-middle text-xs font-medium sm:px-3 sm:py-2 sm:text-sm",
+                          numericCell,
                         )}
                       style={{ width: column.getSize() }}
                       >
-                        {currentPageTotals.totalQuantity.toLocaleString()}
+                        {formatCount(currentPageTotals.totalQuantity, locale)}
                       </td>
                     );
                   }
@@ -1586,9 +1608,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
                   return (
                     <td
                       key={columnId || index}
-                      className={cn(
-                        "px-2 py-1.5 align-middle whitespace-nowrap text-xs border-r border-border/50 last:border-r-0 sm:px-3 sm:py-2 sm:text-sm",
-                      )}
+                      className="whitespace-nowrap px-2 py-1.5 align-middle text-xs sm:px-3 sm:py-2 sm:text-sm"
                       style={{ width: column.getSize() }}
                     />
                   );
@@ -1597,9 +1617,9 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             </tfoot>
           </table>
         </div>
-      </CardContent>
-      <CardFooter className="flex shrink-0 items-center justify-between gap-2 border-t bg-background px-2 py-1.5 sm:px-4 sm:py-3">
-        <div className="text-xs text-muted-foreground sm:text-sm">
+      </WidgetBody>
+      <WidgetFooter>
+        <div className={widgetType.caption}>
           {t("trade-table.totalTrades", { count: groupedTrades.length })}
         </div>
         <div className="flex items-center gap-1 sm:gap-2">
@@ -1613,7 +1633,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <span className="min-w-[4.5rem] text-center text-xs whitespace-nowrap sm:text-sm">
+          <span className="min-w-[4.5rem] whitespace-nowrap text-center text-xs tabular-nums">
             {isMobile
               ? `${table.getState().pagination.pageIndex + 1}/${table.getPageCount()}`
               : t("trade-table.pageInfo", {
@@ -1724,7 +1744,7 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
             </>
           )}
         </div>
-      </CardFooter>
+      </WidgetFooter>
 
       {showBulkEdit && (
         <BulkEditPanel
@@ -1734,6 +1754,6 @@ export function TradeTableReview({ tradesParam, config }: TradeTableReviewProps)
           onClose={() => setShowBulkEdit(false)}
         />
       )}
-    </Card>
+    </WidgetCard>
   );
 }

--- a/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-table-virtual-body.tsx
@@ -31,7 +31,7 @@ function TradeTableBodyRow<TData>({
     <tr
       data-state={row.getIsSelected() && "selected"}
       className={cn(
-        "border-b border-border transition-colors duration-75 hover:bg-muted/40 group",
+        "border-b border-border motion-safe:transition-colors duration-75 hover:bg-muted/40 group",
         row.getIsSelected() &&
           "bg-accent/50 hover:bg-accent data-[state=selected]:bg-muted",
         row.getIsExpanded()

--- a/app/[locale]/dashboard/components/tables/trade-tag.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-tag.tsx
@@ -199,7 +199,7 @@ export function TradeTag({ trade, tradeIds }: TradeTagProps) {
           </Command>
           {isUpdating && (
             <div className="absolute right-2 top-2">
-              <div className="animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
+              <div className="motion-safe:animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
             </div>
           )}
         </PopoverContent>

--- a/app/[locale]/dashboard/components/tables/trade-video-url.tsx
+++ b/app/[locale]/dashboard/components/tables/trade-video-url.tsx
@@ -154,19 +154,19 @@ export function TradeVideoUrl({ tradeIds, videoUrl: initialVideoUrl, onVideoUrlC
                     className={cn(
                       "pr-8",
                       !isValid && draftUrl && "border-destructive focus-visible:ring-destructive",
-                      showSuccess && "border-green-500 focus-visible:ring-green-500",
+                      showSuccess && "border-success focus-visible:ring-success",
                       isUpdating && "border-primary/50"
                     )}
                   />
                   <div className="absolute right-3 top-1/2 -translate-y-1/2">
                     {isUpdating && (
                       <div className="h-4 w-4">
-                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-r-transparent" />
+                        <div className="h-4 w-4 motion-safe:animate-spin rounded-full border-2 border-primary border-r-transparent" />
                       </div>
                     )}
                     {showSuccess && !isUpdating && (
                       <svg
-                        className="h-4 w-4 text-green-500"
+                        className="h-4 w-4 text-success"
                         xmlns="http://www.w3.org/2000/svg"
                         fill="none"
                         stroke="currentColor"

--- a/app/[locale]/dashboard/components/widgets/DESIGN.md
+++ b/app/[locale]/dashboard/components/widgets/DESIGN.md
@@ -13,11 +13,17 @@ In a trading dashboard "significant meaning" is a short list:
 
 | Meaning                     | Token                                    |
 | --------------------------- | ---------------------------------------- |
-| Positive / winning P&L      | `hsl(var(--chart-win))` / `text-success`  |
-| Negative / losing P&L       | `hsl(var(--chart-loss))` / `text-destructive` |
+| Positive / winning P&L      | `pnlToneClass('positive')` → `--chart-win` |
+| Negative / losing P&L       | `pnlToneClass('negative')` → `--chart-loss` |
 | Breakeven / neutral         | `hsl(var(--muted-foreground))`            |
+| Action succeeded (transient)| `text-success` / `border-success`         |
+| Action failed / destructive | `text-destructive`                        |
 | Active selection / filter   | `hsl(var(--primary))`                     |
 | Categorical series (3+)     | `--chart-1` … `--chart-8`, in order       |
+
+`success` is distinct from `--chart-win`: the former marks a completed action
+(a save confirmed), the latter marks a positive financial result. Do not
+substitute one for the other.
 
 Everything else — magnitude bars, distributions, timelines, axis furniture — is
 `foreground` / `muted-foreground` / `border`. Never hardcode `text-green-500`,

--- a/app/[locale]/dashboard/components/widgets/DESIGN.md
+++ b/app/[locale]/dashboard/components/widgets/DESIGN.md
@@ -1,0 +1,145 @@
+# Dashboard widget design system
+
+Derived from the Vercel/Geist brand design guidance (`https://vercel.com/design.md`),
+translated into the primitives that exist in this repository (Tailwind + shadcn +
+Recharts). Read this before touching any widget.
+
+## The one rule
+
+> Design in monochrome. Use color only when it adds significant meaning to state,
+> action, or data.
+
+In a trading dashboard "significant meaning" is a short list:
+
+| Meaning                     | Token                                    |
+| --------------------------- | ---------------------------------------- |
+| Positive / winning P&L      | `hsl(var(--chart-win))` / `text-success`  |
+| Negative / losing P&L       | `hsl(var(--chart-loss))` / `text-destructive` |
+| Breakeven / neutral         | `hsl(var(--muted-foreground))`            |
+| Active selection / filter   | `hsl(var(--primary))`                     |
+| Categorical series (3+)     | `--chart-1` … `--chart-8`, in order       |
+
+Everything else — magnitude bars, distributions, timelines, axis furniture — is
+`foreground` / `muted-foreground` / `border`. Never hardcode `text-green-500`,
+`text-red-500`, `#22c55e`, or any raw hex. Use the tokens.
+
+## Typography roles
+
+Do not invent sizes. Every widget uses exactly these roles, exposed as helpers in
+`widget-shell.tsx` and `widget-type.ts`:
+
+| Role       | Class                                              | Use                                     |
+| ---------- | -------------------------------------------------- | --------------------------------------- |
+| `title`    | `text-sm font-medium leading-none tracking-tight`   | Widget title in the header              |
+| `metric`   | `text-2xl font-semibold tabular-nums tracking-tight`| The one focal number of a KPI widget    |
+| `value`    | `text-sm font-medium tabular-nums`                  | Values in label/value rows              |
+| `label`    | `text-xs text-muted-foreground`                     | Names in label/value rows, axis titles  |
+| `caption`  | `text-xs text-muted-foreground`                     | Units, periods, qualifiers under a value|
+| `mono`     | `font-mono text-xs`                                 | **Only** ids, symbols, paths, timestamps|
+
+**Financial figures are Sans + `tabular-nums`, never `font-mono`.** Mono is for
+operational identifiers (account ids, instrument tickers when used as codes,
+timestamps), not for money. This is the single most common violation in the old
+widgets.
+
+Hard rejects, verbatim from the guidance:
+
+- All-caps eyebrows and tracked labels (`uppercase tracking-wider` on a label).
+- Em dashes in interface copy.
+- Badges/pills for ordinary metadata.
+- Nested cards, or borders used to repair weak hierarchy.
+- Colored tiles around icons; oversized decorative icons.
+- Decorative gradients, glows, blobs, glass effects.
+- Repeated metric boxes with identical silhouettes across unrelated questions.
+
+## Structure and spacing
+
+A widget is **one** card. Inside it there are no more cards.
+
+```
+WidgetCard            border, radius, bg-card — the only border you get for free
+  WidgetHeader        title + info + actions, separated by a single border-b
+  WidgetBody          the evidence
+  WidgetFooter        optional: units, period, source qualifier
+```
+
+Spacing expresses relationship, not a universal stack rule:
+
+- label → its value: no gap (they sit on one row, value right-aligned)
+- row → sibling row: `gap-1.5`
+- group → next group: `gap-4`
+- header → body: the `border-b`, plus body padding
+
+Padding scales with `WidgetSize` via `widgetPadding(size)`. Do not hand-roll
+`size === 'small' ? 'p-2' : 'p-4'` ternaries in each widget again.
+
+## Numbers and alignment
+
+- Numeric cells and values are **right-aligned**; their labels are left-aligned.
+- Every number that can change width gets `tabular-nums`.
+- Peer values across a widget share precision. Pick it once, in the formatter.
+- State the unit and the period near the evidence, in `caption`, not in a tooltip
+  only.
+
+Use `formatCurrency`, `formatPercent`, `formatCount`, `formatDuration` and
+`formatCompactCurrency` from `widget-format.ts`. They are locale-aware and give
+consistent precision. Do not call `toFixed(2)` inline.
+
+## Charts
+
+- Zero baseline on every length encoding (bars, areas). If a range or delta
+  answers the question better, chart the delta explicitly, on a stated basis.
+- Direct labels beat legends. Drop the legend when there are ≤ 2 series.
+- Axis furniture is quiet: no axis line, no tick line, `border` colored grid,
+  `muted-foreground` ticks at `11px` (`10px` at small sizes).
+- Grid: horizontal only for magnitude charts. Vertical grid lines are noise.
+- Tooltips use `WidgetTooltip` from `chart-primitives.tsx`. Sentence-case labels,
+  right-aligned values, tabular numbers. No uppercase eyebrows.
+- Do not exaggerate small differences with a cropped baseline, and do not bury
+  them in near-identical totals. Show the delta.
+- A chart must stay legible in both themes. Read colors from CSS variables so the
+  theme swap is automatic; never branch on a `darkMode` boolean read from a
+  `MutationObserver`.
+
+## Motion
+
+Default to stillness.
+
+- Motion only communicates a state change, maintains continuity, or confirms an
+  action. Duration `150ms`, `ease-out`.
+- No entry animations on data that was already there, no pulsing, no simulated
+  typing, no auto-scrolling.
+- Everything animated must be inert under `prefers-reduced-motion: reduce`. Use
+  the `motion-safe:` variant rather than a bare `transition-*`.
+
+## Accessibility
+
+- The widget title is a real heading (`WidgetTitle` renders `<h3>`).
+- Interactive widgets (click-to-filter charts) need a real `<button>` or
+  `role="button"` + `tabIndex={0}` + key handlers, a visible `focus-visible` ring,
+  and an accessible name that states the effect.
+- Never encode meaning with color alone: pair win/loss color with a sign, an
+  arrow, or a label.
+- Chart data that is material gets a semantic table alternative or, at minimum,
+  an `aria-label` summarizing the takeaway.
+- Contrast meets WCAG AA in both themes.
+
+## Empty, loading, error
+
+Three states, one shape each, from `widget-states.tsx`:
+
+- `WidgetEmpty` — one line saying what would appear here and what to do. No
+  illustration, no card inside the card.
+- `WidgetSkeleton` — matches the final layout's geometry so nothing jumps.
+- `WidgetError` — states what failed in one sentence, offers retry if it exists.
+
+## Checklist before you call a widget done
+
+1. Squint at it: is the dominant claim obvious, and is the reading path stable?
+2. Would removing any border, tile, or color change what the reader understands?
+   If no, remove it.
+3. Are all peer values aligned on the same right edge with the same precision?
+4. Does it work at every `allowedSizes` entry in the widget registry?
+5. Light and dark, without a visible theme switcher?
+6. Keyboard reachable, focus visible, no color-only meaning?
+7. `bun run typecheck` and `bun run lint` clean.

--- a/app/[locale]/dashboard/components/widgets/chart-primitives.tsx
+++ b/app/[locale]/dashboard/components/widgets/chart-primitives.tsx
@@ -1,0 +1,227 @@
+"use client"
+
+import * as React from "react"
+import { CartesianGrid, ReferenceLine } from "recharts"
+
+import { cn } from "@/lib/utils"
+import { WidgetSize } from "../../types/dashboard"
+import { chartTickFontSize, isCompactSize, widgetType } from "./widget-type"
+
+/**
+ * Shared Recharts furniture, so every chart in the dashboard reads as one
+ * system: quiet axes, horizontal-only grid, honest zero baselines, direct
+ * labels over legends, and colors read from CSS variables so the theme swap is
+ * automatic in both directions.
+ */
+
+/** Grid, ticks, and axis lines all resolve from theme tokens. */
+export const chartColors = {
+  grid: "hsl(var(--border))",
+  tick: "hsl(var(--muted-foreground))",
+  axis: "hsl(var(--border))",
+  baseline: "hsl(var(--muted-foreground))",
+  foreground: "hsl(var(--foreground))",
+  /** Neutral magnitude fill. The default for any bar that is not signed. */
+  neutral: "hsl(var(--muted-foreground))",
+  win: "hsl(var(--chart-win))",
+  loss: "hsl(var(--chart-loss))",
+  primary: "hsl(var(--primary))",
+} as const
+
+/** Categorical series colors, in the order they must be used. */
+export const categoricalSeries = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+  "hsl(var(--chart-6))",
+  "hsl(var(--chart-7))",
+  "hsl(var(--chart-8))",
+] as const
+
+export function seriesColor(index: number): string {
+  return categoricalSeries[index % categoricalSeries.length]
+}
+
+/**
+ * Axis props every chart spreads. No axis line, no tick line — the grid already
+ * carries the scale, and a second rule is noise.
+ */
+export function axisProps(size: WidgetSize) {
+  return {
+    tickLine: false as const,
+    axisLine: false as const,
+    tick: { fontSize: chartTickFontSize(size), fill: chartColors.tick },
+    tickMargin: isCompactSize(size) ? 4 : 8,
+  }
+}
+
+/** Plot margins matched to the widget's padding scale. */
+export function chartMargin(size: WidgetSize) {
+  return isCompactSize(size)
+    ? { top: 4, right: 4, bottom: 4, left: 0 }
+    : { top: 8, right: 8, bottom: 8, left: 0 }
+}
+
+/**
+ * Horizontal-only grid. Vertical grid lines add no information to a categorical
+ * or time axis and compete with the marks.
+ */
+export function WidgetChartGrid({ vertical = false }: { vertical?: boolean }) {
+  return (
+    <CartesianGrid
+      strokeDasharray="3 3"
+      stroke={chartColors.grid}
+      vertical={vertical}
+      horizontal
+    />
+  )
+}
+
+/**
+ * The zero baseline. Any chart that plots signed values must draw it, so a
+ * small loss is never read as a small gain.
+ */
+export function WidgetZeroLine({ y = 0 }: { y?: number }) {
+  return (
+    <ReferenceLine
+      y={y}
+      stroke={chartColors.baseline}
+      strokeOpacity={0.4}
+      strokeWidth={1}
+    />
+  )
+}
+
+export interface WidgetTooltipRow {
+  label: React.ReactNode
+  value: React.ReactNode
+  /** Optional swatch color, for multi-series charts only. */
+  color?: string
+  /** Optional tone class applied to the value. */
+  toneClassName?: string
+}
+
+/**
+ * The one tooltip shape for the dashboard: sentence-case labels on the left,
+ * right-aligned tabular values, no uppercase eyebrows, no nested panels.
+ */
+export function WidgetTooltip({
+  title,
+  rows,
+  caption,
+  className,
+}: {
+  title?: React.ReactNode
+  rows: WidgetTooltipRow[]
+  caption?: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-[9rem] rounded-md border bg-popover px-2.5 py-2 text-popover-foreground shadow-md",
+        className,
+      )}
+    >
+      {title ? (
+        <div className={cn(widgetType.section, "mb-1.5")}>{title}</div>
+      ) : null}
+      <div className="flex flex-col gap-1">
+        {rows.map((row, index) => (
+          <div key={index} className="flex items-center justify-between gap-4">
+            <div className="flex min-w-0 items-center gap-1.5">
+              {row.color ? (
+                <span
+                  aria-hidden
+                  className="size-2 shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: row.color }}
+                />
+              ) : null}
+              <span className={cn(widgetType.label, "truncate")}>{row.label}</span>
+            </div>
+            <span
+              className={cn(
+                widgetType.value,
+                "shrink-0 text-right",
+                row.toneClassName,
+              )}
+            >
+              {row.value}
+            </span>
+          </div>
+        ))}
+      </div>
+      {caption ? (
+        <div className={cn(widgetType.caption, "mt-1.5")}>{caption}</div>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * Direct labels beat legends. Use this only when a chart carries three or more
+ * series and direct labelling genuinely does not fit.
+ */
+export function WidgetChartLegend({
+  items,
+  className,
+}: {
+  items: { label: React.ReactNode; color: string }[]
+  className?: string
+}) {
+  return (
+    <ul className={cn("flex flex-wrap items-center gap-x-4 gap-y-1", className)}>
+      {items.map((item, index) => (
+        <li key={index} className="flex items-center gap-1.5">
+          <span
+            aria-hidden
+            className="size-2 shrink-0 rounded-[2px]"
+            style={{ backgroundColor: item.color }}
+          />
+          <span className={widgetType.label}>{item.label}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/**
+ * Wraps a chart whose marks are clickable (click-to-filter). Gives the region a
+ * real accessible name, keyboard operation, and a visible focus ring, so the
+ * interaction is not mouse-only.
+ */
+export function WidgetChartInteractive({
+  onActivate,
+  label,
+  className,
+  children,
+}: {
+  onActivate: () => void
+  /** States the effect, e.g. "Filter trades by the hovered weekday". */
+  label: string
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      onClick={onActivate}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault()
+          onActivate()
+        }
+      }}
+      className={cn(
+        "h-full w-full cursor-pointer rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/widgets/index.ts
+++ b/app/[locale]/dashboard/components/widgets/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Dashboard widget design system.
+ *
+ * Read `./DESIGN.md` before using these. Every dashboard widget composes from
+ * this module; widgets do not hand-roll cards, type scales, number formatting,
+ * or chart furniture.
+ */
+
+export {
+  WidgetCard,
+  WidgetHeader,
+  WidgetBody,
+  WidgetFooter,
+  WidgetMetric,
+  WidgetStat,
+  WidgetStatList,
+  WidgetSection,
+} from "./widget-shell"
+
+export {
+  WidgetEmpty,
+  WidgetError,
+  WidgetSkeleton,
+  WidgetStatListSkeleton,
+  WidgetChartSkeleton,
+} from "./widget-states"
+
+export {
+  chartColors,
+  categoricalSeries,
+  seriesColor,
+  axisProps,
+  chartMargin,
+  WidgetChartGrid,
+  WidgetZeroLine,
+  WidgetTooltip,
+  WidgetChartLegend,
+  WidgetChartInteractive,
+} from "./chart-primitives"
+export type { WidgetTooltipRow } from "./chart-primitives"
+
+export {
+  widgetType,
+  isCompactSize,
+  widgetPadding,
+  widgetHeaderPadding,
+  widgetMetricClass,
+  chartTickFontSize,
+} from "./widget-type"
+export type { WidgetTypeRole } from "./widget-type"
+
+export {
+  formatCurrency,
+  formatCompactCurrency,
+  formatPercent,
+  formatCount,
+  formatRatio,
+  formatTicks,
+  formatDuration,
+  pnlTone,
+  pnlToneClass,
+  pnlToneFill,
+} from "./widget-format"
+export type { PnlTone } from "./widget-format"

--- a/app/[locale]/dashboard/components/widgets/widget-format.ts
+++ b/app/[locale]/dashboard/components/widgets/widget-format.ts
@@ -1,0 +1,142 @@
+/**
+ * Locale-aware formatters shared by every dashboard widget.
+ *
+ * One canonical precision per kind of quantity, decided here rather than in each
+ * widget, so peer values across the dashboard always agree. Do not call
+ * `toFixed` inline in a widget.
+ */
+
+type Locale = "en" | "fr" | string
+
+function intlLocale(locale: Locale): string {
+  return locale === "fr" ? "fr-FR" : "en-US"
+}
+
+/**
+ * Money, always in USD, always two decimals, always with the sign carried by the
+ * caller's presentation (color plus an explicit `-`) rather than parentheses.
+ *
+ * `signDisplay: 'auto'` keeps the minus sign on the number itself so meaning is
+ * never carried by color alone.
+ */
+export function formatCurrency(
+  value: number,
+  locale: Locale = "en",
+  options: { maximumFractionDigits?: number; signDisplay?: "auto" | "always" | "never" } = {},
+): string {
+  const { maximumFractionDigits = 2, signDisplay = "auto" } = options
+  return new Intl.NumberFormat(intlLocale(locale), {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: maximumFractionDigits,
+    maximumFractionDigits,
+    signDisplay,
+  }).format(value)
+}
+
+/**
+ * Money for axis ticks and dense tables, where the full figure would not fit.
+ * Never use this for a focal metric: the reader must be able to audit the exact
+ * value somewhere on the widget.
+ */
+export function formatCompactCurrency(value: number, locale: Locale = "en"): string {
+  return new Intl.NumberFormat(intlLocale(locale), {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value)
+}
+
+/** Percentages. One decimal by default; whole numbers when the value is exact. */
+export function formatPercent(
+  value: number,
+  locale: Locale = "en",
+  options: { maximumFractionDigits?: number } = {},
+): string {
+  const { maximumFractionDigits = 1 } = options
+  return new Intl.NumberFormat(intlLocale(locale), {
+    style: "percent",
+    minimumFractionDigits: 0,
+    maximumFractionDigits,
+  }).format(value / 100)
+}
+
+/** Plain counts: trades, days, streaks. Grouped, never decimal. */
+export function formatCount(value: number, locale: Locale = "en"): string {
+  return new Intl.NumberFormat(intlLocale(locale), {
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+/** A ratio such as risk/reward or profit factor. Two decimals, no unit. */
+export function formatRatio(value: number, locale: Locale = "en"): string {
+  if (!Number.isFinite(value)) return "∞"
+  return new Intl.NumberFormat(intlLocale(locale), {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+/** Ticks and points. Grouped, no decimals unless the caller asks. */
+export function formatTicks(
+  value: number,
+  locale: Locale = "en",
+  options: { maximumFractionDigits?: number } = {},
+): string {
+  return new Intl.NumberFormat(intlLocale(locale), {
+    maximumFractionDigits: options.maximumFractionDigits ?? 0,
+  }).format(value)
+}
+
+/**
+ * A duration in seconds, rendered at the coarsest unit that stays honest.
+ * `0` renders as `0s`, not an em dash or a blank.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "0s"
+  const total = Math.round(seconds)
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  if (minutes > 0) return secs > 0 ? `${minutes}m ${secs}s` : `${minutes}m`
+  return `${secs}s`
+}
+
+/**
+ * The sign of a P&L figure, as a discrete state rather than a color.
+ * Pair with `pnlToneClass` so meaning never rests on color alone.
+ */
+export type PnlTone = "positive" | "negative" | "neutral"
+
+export function pnlTone(value: number, epsilon = 0): PnlTone {
+  if (value > epsilon) return "positive"
+  if (value < -epsilon) return "negative"
+  return "neutral"
+}
+
+/** Text color for a P&L tone, from theme tokens. Never raw Tailwind palette. */
+export function pnlToneClass(tone: PnlTone): string {
+  switch (tone) {
+    case "positive":
+      return "text-[hsl(var(--chart-win))]"
+    case "negative":
+      return "text-[hsl(var(--chart-loss))]"
+    default:
+      return "text-muted-foreground"
+  }
+}
+
+/** Chart fill for a P&L tone, from theme tokens. */
+export function pnlToneFill(tone: PnlTone): string {
+  switch (tone) {
+    case "positive":
+      return "hsl(var(--chart-win))"
+    case "negative":
+      return "hsl(var(--chart-loss))"
+    default:
+      return "hsl(var(--muted-foreground))"
+  }
+}

--- a/app/[locale]/dashboard/components/widgets/widget-shell.tsx
+++ b/app/[locale]/dashboard/components/widgets/widget-shell.tsx
@@ -93,15 +93,16 @@ interface WidgetBodyProps extends React.HTMLAttributes<HTMLDivElement> {
   flush?: boolean
 }
 
-/** The evidence. Fills the remaining height and may shrink below its content. */
-export function WidgetBody({
-  size = "medium",
-  flush = false,
-  className,
-  ...props
-}: WidgetBodyProps) {
-  return (
+/**
+ * The evidence. Fills the remaining height and may shrink below its content.
+ *
+ * Forwards its ref: scrolling and virtualized bodies need to measure this
+ * element, and a table should not have to wrap it in another div to do so.
+ */
+export const WidgetBody = React.forwardRef<HTMLDivElement, WidgetBodyProps>(
+  ({ size = "medium", flush = false, className, ...props }, ref) => (
     <div
+      ref={ref}
       className={cn(
         "min-h-0 min-w-0 flex-1",
         flush ? "p-0" : widgetPadding(size),
@@ -109,8 +110,9 @@ export function WidgetBody({
       )}
       {...props}
     />
-  )
-}
+  ),
+)
+WidgetBody.displayName = "WidgetBody"
 
 /** Units, period, population — the qualifiers that make a figure auditable. */
 export function WidgetFooter({

--- a/app/[locale]/dashboard/components/widgets/widget-shell.tsx
+++ b/app/[locale]/dashboard/components/widgets/widget-shell.tsx
@@ -1,0 +1,227 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { InfoBubble } from "@/components/ui/info-bubble"
+import { WidgetSize } from "../../types/dashboard"
+import {
+  isCompactSize,
+  widgetHeaderPadding,
+  widgetMetricClass,
+  widgetPadding,
+  widgetType,
+} from "./widget-type"
+
+/**
+ * A widget is one card. Inside it there are no more cards.
+ *
+ * `WidgetCard` owns the only border a widget gets for free. Any further border
+ * has to be earned by selection, interaction, warning, or real grouping —
+ * prefer spacing and alignment first.
+ */
+export const WidgetCard = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "flex h-full min-w-0 flex-col overflow-hidden rounded-lg border bg-card text-card-foreground",
+      className,
+    )}
+    {...props}
+  />
+))
+WidgetCard.displayName = "WidgetCard"
+
+interface WidgetHeaderProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+  size?: WidgetSize
+  /** The widget name. Rendered as a heading. */
+  title: React.ReactNode
+  /** One sentence explaining what the widget measures. */
+  description?: React.ReactNode
+  /** Controls that act on this widget. Kept to the right, quiet by default. */
+  actions?: React.ReactNode
+}
+
+/**
+ * Title, optional explanation, optional actions, separated from the body by a
+ * single rule. The rule is structural grouping, so it is earned.
+ */
+export function WidgetHeader({
+  size = "medium",
+  title,
+  description,
+  actions,
+  className,
+  children,
+  ...props
+}: WidgetHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-between gap-2 border-b",
+        widgetHeaderPadding(size),
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex min-w-0 items-center gap-1.5">
+        <h3 className={cn(widgetType.title, "min-w-0 truncate")}>{title}</h3>
+        {description ? (
+          <InfoBubble
+            side="top"
+            iconClassName={isCompactSize(size) ? "size-3.5" : "size-4"}
+          >
+            <p>{description}</p>
+          </InfoBubble>
+        ) : null}
+        {children}
+      </div>
+      {actions ? (
+        <div className="flex shrink-0 items-center gap-1">{actions}</div>
+      ) : null}
+    </div>
+  )
+}
+
+interface WidgetBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: WidgetSize
+  /** Charts fill the frame edge to edge; drop the padding for them. */
+  flush?: boolean
+}
+
+/** The evidence. Fills the remaining height and may shrink below its content. */
+export function WidgetBody({
+  size = "medium",
+  flush = false,
+  className,
+  ...props
+}: WidgetBodyProps) {
+  return (
+    <div
+      className={cn(
+        "min-h-0 min-w-0 flex-1",
+        flush ? "p-0" : widgetPadding(size),
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+/** Units, period, population — the qualifiers that make a figure auditable. */
+export function WidgetFooter({
+  size = "medium",
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { size?: WidgetSize }) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-between gap-2 border-t",
+        widgetType.caption,
+        widgetHeaderPadding(size),
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+interface WidgetMetricProps {
+  /** What the number is. Sentence case, no all-caps eyebrow. */
+  label: React.ReactNode
+  /** The formatted figure. Format it with `widget-format.ts`, not `toFixed`. */
+  value: React.ReactNode
+  /** Unit, period, or population. Sits directly under the value. */
+  caption?: React.ReactNode
+  /** Color the value by P&L tone. Always pair with a sign in the value itself. */
+  toneClassName?: string
+  size?: WidgetSize
+  className?: string
+}
+
+/**
+ * The single focal figure of a KPI widget: label above, number below, qualifier
+ * under that. No icon tile, no badge, no border.
+ */
+export function WidgetMetric({
+  label,
+  value,
+  caption,
+  toneClassName,
+  size = "medium",
+  className,
+}: WidgetMetricProps) {
+  return (
+    <div className={cn("flex min-w-0 flex-col gap-1.5", className)}>
+      <span className={widgetType.label}>{label}</span>
+      <span className={cn(widgetMetricClass(size), toneClassName)}>{value}</span>
+      {caption ? <span className={widgetType.caption}>{caption}</span> : null}
+    </div>
+  )
+}
+
+interface WidgetStatProps {
+  label: React.ReactNode
+  value: React.ReactNode
+  /** Optional one-sentence explanation, shown as an info affordance. */
+  description?: React.ReactNode
+  /** Color the value by P&L tone. */
+  toneClassName?: string
+  className?: string
+}
+
+/**
+ * A label/value row. The label sits left, the value right, so peers across a
+ * widget share one right edge and one precision.
+ */
+export function WidgetStat({
+  label,
+  value,
+  description,
+  toneClassName,
+  className,
+}: WidgetStatProps) {
+  return (
+    <div className={cn("flex items-center justify-between gap-3", className)}>
+      <div className="flex min-w-0 items-center gap-1">
+        <span className={cn(widgetType.label, "truncate")}>{label}</span>
+        {description ? (
+          <InfoBubble iconClassName="size-3">
+            <p>{description}</p>
+          </InfoBubble>
+        ) : null}
+      </div>
+      <span className={cn(widgetType.value, "shrink-0 text-right", toneClassName)}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+/** A group of `WidgetStat` rows. Rows sit close; groups sit apart. */
+export function WidgetStatList({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col gap-1.5", className)} {...props} />
+}
+
+/** A named group inside the body, when a group genuinely needs naming. */
+export function WidgetSection({
+  title,
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { title?: React.ReactNode }) {
+  return (
+    <section className={cn("flex min-w-0 flex-col gap-2", className)} {...props}>
+      {title ? <h4 className={widgetType.section}>{title}</h4> : null}
+      {children}
+    </section>
+  )
+}

--- a/app/[locale]/dashboard/components/widgets/widget-states.tsx
+++ b/app/[locale]/dashboard/components/widgets/widget-states.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { WidgetSize } from "../../types/dashboard"
+import { widgetPadding, widgetType } from "./widget-type"
+
+/**
+ * Nothing to show yet. One line saying what would appear here and what to do
+ * about it. No illustration, no card inside the card, no oversized icon.
+ */
+export function WidgetEmpty({
+  message,
+  action,
+  size = "medium",
+  className,
+}: {
+  message: React.ReactNode
+  action?: React.ReactNode
+  size?: WidgetSize
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 flex-col items-center justify-center gap-2 text-center",
+        widgetPadding(size),
+        className,
+      )}
+    >
+      <p className={cn(widgetType.label, "max-w-[36ch] text-balance")}>{message}</p>
+      {action}
+    </div>
+  )
+}
+
+/**
+ * Something failed. State what, in one sentence, and offer the retry if one
+ * exists. Uses the destructive token for the state, plus words — never color
+ * alone.
+ */
+export function WidgetError({
+  message,
+  onRetry,
+  retryLabel = "Retry",
+  size = "medium",
+  className,
+}: {
+  message: React.ReactNode
+  onRetry?: () => void
+  retryLabel?: string
+  size?: WidgetSize
+  className?: string
+}) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex h-full min-h-0 flex-col items-center justify-center gap-2 text-center",
+        widgetPadding(size),
+        className,
+      )}
+    >
+      <p className={cn("text-xs text-destructive", "max-w-[36ch] text-balance")}>
+        {message}
+      </p>
+      {onRetry ? (
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          {retryLabel}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * A skeleton that matches the geometry of the thing it replaces, so nothing
+ * jumps when data arrives. Static under `prefers-reduced-motion`.
+ */
+export function WidgetSkeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "rounded-md bg-muted motion-safe:animate-pulse",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+/** Skeleton shaped like a label/value list. */
+export function WidgetStatListSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {Array.from({ length: rows }).map((_, index) => (
+        <div key={index} className="flex items-center justify-between gap-3">
+          <WidgetSkeleton className="h-3 w-24" />
+          <WidgetSkeleton className="h-3 w-16" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Skeleton shaped like a plotted frame: axis gutter plus plot area. */
+export function WidgetChartSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex h-full min-h-0 w-full gap-2", className)}>
+      <div className="flex w-10 shrink-0 flex-col justify-between py-1">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <WidgetSkeleton key={index} className="h-2 w-full" />
+        ))}
+      </div>
+      <div className="flex min-w-0 flex-1 items-end gap-2 pb-5">
+        {[0.45, 0.7, 0.35, 0.85, 0.6, 0.5, 0.75].map((height, index) => (
+          <WidgetSkeleton
+            key={index}
+            className="min-w-0 flex-1"
+            style={{ height: `${height * 100}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/widgets/widget-type.ts
+++ b/app/[locale]/dashboard/components/widgets/widget-type.ts
@@ -1,0 +1,81 @@
+import { WidgetSize } from "../../types/dashboard"
+
+/**
+ * The complete set of type roles a dashboard widget may use.
+ *
+ * Widgets never invent sizes. If a piece of text does not map to one of these
+ * roles, the composition is wrong, not the scale.
+ *
+ * Financial figures use `metric` / `value` (Sans + tabular-nums). `mono` is
+ * reserved for operational identifiers: account ids, order ids, paths,
+ * timestamps. Money is never mono.
+ */
+export const widgetType = {
+  /** Widget title in the header. Rendered as a heading. */
+  title: "text-sm font-medium leading-none tracking-tight",
+  /** The single focal number of a KPI widget. */
+  metric: "text-2xl font-semibold tabular-nums tracking-tight leading-none",
+  /** A secondary focal number, when two share the frame. */
+  metricSecondary: "text-lg font-semibold tabular-nums tracking-tight leading-none",
+  /** Values in label/value rows. Always right-aligned against their label. */
+  value: "text-sm font-medium tabular-nums",
+  /** Names in label/value rows, axis titles, section names. */
+  label: "text-xs text-muted-foreground",
+  /** A section name inside the body, when a group genuinely needs naming. */
+  section: "text-xs font-medium text-foreground",
+  /** Units, periods, populations, qualifiers sitting under a value. */
+  caption: "text-xs text-muted-foreground",
+  /** Operational identifiers only. Never money. */
+  mono: "font-mono text-xs tabular-nums",
+} as const
+
+export type WidgetTypeRole = keyof typeof widgetType
+
+/** Widget sizes that need a denser type scale and tighter padding. */
+export function isCompactSize(size: WidgetSize): boolean {
+  return size === "tiny" || size === "small" || size === "small-long"
+}
+
+/**
+ * Body padding for a widget at a given size. Use this instead of hand-rolling
+ * `size === 'small' ? 'p-2' : 'p-4'` in every widget.
+ */
+export function widgetPadding(size: WidgetSize): string {
+  switch (size) {
+    case "tiny":
+      return "p-2"
+    case "small":
+    case "small-long":
+      return "p-3"
+    default:
+      return "p-4"
+  }
+}
+
+/** Header padding for a widget at a given size. */
+export function widgetHeaderPadding(size: WidgetSize): string {
+  switch (size) {
+    case "tiny":
+      return "px-2 py-1.5"
+    case "small":
+    case "small-long":
+      return "px-3 py-2"
+    default:
+      return "px-4 py-3"
+  }
+}
+
+/**
+ * Focal metric size at a given widget size. A `tiny` widget still has one
+ * number that matters; it just cannot afford `text-2xl`.
+ */
+export function widgetMetricClass(size: WidgetSize): string {
+  if (size === "tiny") return widgetType.value
+  if (size === "small" || size === "small-long") return widgetType.metricSecondary
+  return widgetType.metric
+}
+
+/** Recharts tick font size, matched to the type scale. */
+export function chartTickFontSize(size: WidgetSize): number {
+  return isCompactSize(size) ? 10 : 11
+}

--- a/app/[locale]/dashboard/config/widget-registry.tsx
+++ b/app/[locale]/dashboard/config/widget-registry.tsx
@@ -22,15 +22,22 @@ import StatisticsWidget from '../components/statistics/statistics-widget'
 import { TradeTableReview } from '../components/tables/trade-table-review'
 import { MoodSelector } from '../components/calendar/mood-selector'
 import TradeDistributionChart from '../components/charts/trade-distribution'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ArrowUp, ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import {
+  WidgetBody,
+  WidgetCard,
+  WidgetChartSkeleton,
+  WidgetHeader,
+  WidgetSkeleton,
+  WidgetStatListSkeleton,
+  widgetType,
+} from '../components/widgets'
 import { AccountsOverview } from '../components/accounts/accounts-overview'
 import { TagWidget } from '../components/filters/tag-widget'
 import ProfitFactorCard from '../components/statistics/profit-factor-card'
 import DailyTickTargetChart from '../components/charts/daily-tick-target'
-import { LineChart, Line, XAxis, YAxis, ResponsiveContainer } from 'recharts'
 import { MindsetWidget } from '../components/mindset/mindset-widget'
 import ChatWidget from '../components/chat/chat'
 import { useI18n } from '@/locales/client'
@@ -50,160 +57,139 @@ export interface WidgetConfig {
   getPreview: () => React.JSX.Element
 }
 
+/**
+ * A preview is a sample of a widget, not a loading state. `WidgetSkeleton`
+ * carries `motion-safe:animate-pulse` for the real loading case; inside a
+ * preview every placeholder is frozen so nothing on the picker shimmers.
+ */
+const previewStatic = '[&_*]:motion-safe:animate-none!'
+
+/**
+ * Every preview is the same shell the real widget renders — one `WidgetCard`,
+ * one `WidgetHeader`, one `WidgetBody` — so what a user previews is the frame
+ * they get on the canvas.
+ */
+function PreviewShell({
+  title,
+  actions,
+  flush = false,
+  bodyClassName,
+  children,
+}: {
+  title: React.ReactNode
+  actions?: React.ReactNode
+  flush?: boolean
+  bodyClassName?: string
+  children: React.ReactNode
+}) {
+  return (
+    <WidgetCard className={previewStatic}>
+      <WidgetHeader title={title} actions={actions} />
+      <WidgetBody
+        flush={flush}
+        className={cn('overflow-hidden', bodyClassName)}
+      >
+        {children}
+      </WidgetBody>
+    </WidgetCard>
+  )
+}
+
 // Helper function to create table preview
 function createTablePreview(type: 'tradeTableReview' | 'consistencyTable') {
+  // Column widths mirror the real table: an id column, a wide label column,
+  // then right-aligned numeric columns.
+  const columns =
+    type === 'tradeTableReview'
+      ? ['w-14', 'w-20', 'w-10', 'w-12', 'w-12']
+      : ['w-20', 'w-20', 'w-10', 'w-10', 'w-10']
+
   return (
-    <Card className="h-[300px]">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-sm font-medium">
-          {type === 'tradeTableReview' ? 'Trade Review' : 'Consistency Analysis'}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pb-2">
-        <div className="w-full flex flex-col gap-2">
-          <div className="flex items-center gap-2 sm:gap-4 px-2 sm:px-3 py-2 bg-muted rounded-md border">
-            {Array(type === 'tradeTableReview' ? 4 : 5).fill(0).map((_, i) => (
-              <div key={i} className={cn(
-                "h-4 bg-muted-foreground/20 rounded",
-                type === 'tradeTableReview' 
-                  ? i === 1 ? "flex-3" : "flex-2"
-                  : i < 2 ? "flex-2" : "flex-1"
-              )} />
+    <PreviewShell
+      title={type === 'tradeTableReview' ? 'Trade review' : 'Consistency analysis'}
+      flush
+      bodyClassName="flex flex-col"
+    >
+      <div className="flex shrink-0 items-center gap-4 border-b bg-muted/50 px-4 py-2">
+        {columns.map((width, index) => (
+          <WidgetSkeleton key={index} className={cn('h-2.5', width)} />
+        ))}
+      </div>
+      <div className="flex min-h-0 flex-col">
+        {Array.from({ length: 5 }).map((_, rowIndex) => (
+          <div
+            key={rowIndex}
+            className="flex items-center gap-4 border-b px-4 py-2.5 last:border-b-0"
+          >
+            {columns.map((width, index) => (
+              <WidgetSkeleton key={index} className={cn('h-2', width)} />
             ))}
           </div>
-          {[...Array(4)].map((_, rowIndex) => (
-            <div key={rowIndex} className="flex items-center gap-2 sm:gap-4 px-2 sm:px-3 py-2 border border-border/50 rounded-md">
-              {Array(type === 'tradeTableReview' ? 4 : 5).fill(0).map((_, i) => (
-                <div key={i} className={cn(
-                  "h-3 bg-muted-foreground/10 rounded",
-                  type === 'tradeTableReview' 
-                    ? i === 1 ? "flex-3" : "flex-2"
-                    : i < 2 ? "flex-2" : "flex-1"
-                )} />
-              ))}
-            </div>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+        ))}
+      </div>
+    </PreviewShell>
   )
 }
 
 function createPropfirmPreview() {
-  // Sample data for the preview
-  const data = [
-    { name: '1', equity: 100, drawdown: 95 },
-    { name: '2', equity: 120, drawdown: 110 },
-    { name: '3', equity: 115, drawdown: 105 },
-    { name: '4', equity: 130, drawdown: 120 },
-    { name: '5', equity: 140, drawdown: 130 },
-    { name: '6', equity: 150, drawdown: 140 },
-  ]
-
   return (
-    <Card className="h-[300px]">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-sm font-medium">Propfirm</CardTitle>
-      </CardHeader>
-      <CardContent className="pb-2">
-        <div className="w-full flex flex-col gap-3">
-          {[...Array(2)].map((_, index) => (
-            <div key={index} className="flex flex-col gap-2 p-3 bg-muted rounded-md border">
-              <div className="flex justify-between items-center">
-                <div className="h-4 w-24 bg-muted-foreground/20 rounded" />
-                <div className="h-4 w-16 bg-muted-foreground/20 rounded" />
-              </div>
-              <div className="h-20 w-full">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={data} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
-                    <XAxis dataKey="name" hide />
-                    <YAxis hide />
-                    <Line
-                      type="monotone"
-                      dataKey="equity"
-                      stroke="hsl(var(--primary))"
-                      strokeWidth={2}
-                      dot={false}
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="drawdown"
-                      stroke="hsl(var(--destructive))"
-                      strokeWidth={2}
-                      strokeDasharray="4 2"
-                      dot={false}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-            </div>
-          ))}
+    <PreviewShell title="Prop firm" bodyClassName="flex flex-col gap-4">
+      {[0, 1].map((index) => (
+        <div key={index} className="flex min-w-0 flex-col gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <WidgetSkeleton className="h-2.5 w-24" />
+            <WidgetSkeleton className="h-2.5 w-16" />
+          </div>
+          <div className="h-16">
+            <WidgetChartSkeleton />
+          </div>
+          <WidgetStatListSkeleton rows={2} />
         </div>
-      </CardContent>
-    </Card>
+      ))}
+    </PreviewShell>
   )
 }
 
-function createMindsetPreview() {
+function CreateMindsetPreview() {
   const t = useI18n()
   return (
-    <Card className="h-[300px] flex flex-col">
-      <CardHeader className="pb-3 border-b">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium">{t('mindset.title')}</CardTitle>
-          <div className="flex items-center gap-2">
-            <div className="flex items-center gap-1.5">
-              <div className="h-1.5 w-1.5 rounded-full bg-primary" />
-              <div className="h-1.5 w-1.5 rounded-full bg-muted" />
-              <div className="h-1.5 w-1.5 rounded-full bg-muted" />
-            </div>
+    <PreviewShell title={t('mindset.title')} flush bodyClassName="flex flex-row">
+      {/* Day rail: the current day is the one selection worth a color. */}
+      <div className="flex w-14 shrink-0 flex-col items-center gap-1 border-r py-3">
+        {Array.from({ length: 7 }).map((_, index) => (
+          <div key={index} className="flex flex-col items-center gap-1">
+            <div
+              aria-hidden
+              className={cn(
+                'size-2 rounded-full',
+                index === 2 ? 'bg-primary' : 'bg-muted-foreground/30',
+              )}
+            />
+            {index < 6 ? (
+              <div aria-hidden className="h-4 w-px bg-border" />
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-4 p-4">
+        <div className="flex flex-col gap-2">
+          <WidgetSkeleton className="h-2.5 w-28" />
+          <div className="flex gap-2">
+            <WidgetSkeleton className="h-5 w-14 rounded-full" />
+            <WidgetSkeleton className="h-5 w-16 rounded-full" />
+            <WidgetSkeleton className="h-5 w-12 rounded-full" />
           </div>
         </div>
-      </CardHeader>
-      <CardContent className="flex-1 p-0 flex flex-row">
-        {/* Timeline mock */}
-        <div className="w-16 border-r p-2 flex flex-col gap-1">
-          {[...Array(7)].map((_, index) => (
-            <div key={index} className="flex flex-col items-center gap-1">
-              <div className={cn(
-                "h-6 w-6 rounded-full border-2 flex items-center justify-center",
-                index === 2 ? "bg-primary border-primary" : "border-muted-foreground/20"
-              )}>
-                <div className="h-1 w-1 rounded-full bg-white" />
-              </div>
-              {index < 6 && <div className="h-4 w-px bg-muted-foreground/20" />}
-            </div>
-          ))}
+
+        <div className="flex flex-col gap-2">
+          <WidgetSkeleton className="h-2.5 w-20" />
+          <WidgetSkeleton className="h-14 w-full" />
         </div>
-        
-        {/* Content area mock */}
-        <div className="flex-1 p-4 flex flex-col gap-3">
-          <div className="flex flex-col gap-2">
-            <div className="h-4 w-32 bg-muted-foreground/20 rounded" />
-            <div className="flex gap-2">
-              <div className="h-6 w-16 bg-muted rounded-full" />
-              <div className="h-6 w-20 bg-muted rounded-full" />
-              <div className="h-6 w-18 bg-muted rounded-full" />
-            </div>
-          </div>
-          
-          <div className="flex flex-col gap-2">
-            <div className="h-4 w-24 bg-muted-foreground/20 rounded" />
-            <div className="h-16 w-full bg-muted rounded border" />
-          </div>
-          
-          <div className="flex flex-col gap-2">
-            <div className="h-4 w-28 bg-muted-foreground/20 rounded" />
-            <div className="flex items-center gap-2">
-              <div className="h-8 w-8 bg-muted rounded-full" />
-              <div className="h-2 flex-1 bg-muted-foreground/10 rounded-full">
-                <div className="h-2 w-1/2 bg-primary rounded-full" />
-              </div>
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+
+        <WidgetStatListSkeleton rows={2} />
+      </div>
+    </PreviewShell>
   )
 }
 
@@ -220,57 +206,52 @@ function CreateCalendarPreview() {
   ] as const
 
   return (
-    <Card className="h-[500px] flex flex-col">
-      <CardHeader className="pb-3 border-b">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <CardTitle className="text-sm font-medium">Calendar</CardTitle>
+    <PreviewShell
+      title="Calendar"
+      bodyClassName="flex flex-col gap-2"
+      actions={
+        <>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label="Previous month"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label="Next month"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </>
+      }
+    >
+      {/* Weekday headers */}
+      <div className="grid shrink-0 grid-cols-7 gap-1">
+        {weekdays.map((day) => (
+          <div key={day} className={cn(widgetType.label, 'text-center')}>
+            {translateWeekday(t, day)}
           </div>
-          <div className="flex items-center gap-1.5">
-            <Button 
-              variant="outline" 
-              size="icon" 
-              className="h-7 w-7 sm:h-8 sm:w-8"
-              aria-label="Previous month"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <Button 
-              variant="outline" 
-              size="icon" 
-              className="h-7 w-7 sm:h-8 sm:w-8"
-              aria-label="Next month"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
+        ))}
+      </div>
+
+      {/* Calendar grid: the cell borders are the real structure of a month grid */}
+      <div className="grid min-h-0 flex-1 grid-cols-7 gap-1">
+        {Array.from({ length: 35 }, (_, i) => (
+          <div
+            key={i}
+            className="flex min-h-0 flex-col justify-between rounded-sm border p-1"
+          >
+            <WidgetSkeleton className="h-1.5 w-4" />
+            <WidgetSkeleton className="h-2 w-full" />
           </div>
-        </div>
-      </CardHeader>
-      <CardContent className="flex-1 p-4">
-        {/* Weekday headers */}
-        <div className="grid grid-cols-7 gap-1 mb-2">
-          {weekdays.map((day) => (
-            <div key={day} className="text-center text-xs font-medium text-muted-foreground p-1">
-              {translateWeekday(t, day)}
-            </div>
-          ))}
-        </div>
-        
-        {/* Calendar grid */}
-        <div className="grid grid-cols-7 gap-1 h-[calc(100%-40px)]">
-          {/* Calendar days - just empty boxes showing the structure */}
-          {Array.from({ length: 35 }, (_, i) => (
-            <div 
-              key={i} 
-              className="flex flex-col items-center justify-center p-1 rounded border border-border hover:bg-accent transition-colors cursor-pointer"
-            >
-              <div className="h-4 w-full bg-muted-foreground/10 rounded mb-0.5" />
-              <div className="h-2 w-3/4 bg-muted-foreground/5 rounded" />
-            </div>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+        ))}
+      </div>
+    </PreviewShell>
   )
 }
 
@@ -278,69 +259,52 @@ function CreateChatPreview() {
   const t = useI18n()
 
   return (
-    <Card className="h-[300px] flex flex-col bg-background relative">
-      {/* Header */}
-      <CardHeader className="pb-3 border-b">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium">AI Assistant</CardTitle>
-          <Button variant="ghost" size="sm" className="h-6 px-2 text-xs">
-            Reset
-          </Button>
+    <PreviewShell
+      title={t('chat.title')}
+      flush
+      bodyClassName="flex flex-col"
+      actions={
+        <Button variant="ghost" size="sm" className="h-7 px-2 text-xs">
+          {t('chat.resetConversation')}
+        </Button>
+      }
+    >
+      <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+        {/* Assistant turn */}
+        <div className="flex flex-col gap-1.5 self-start">
+          <WidgetSkeleton className="h-2.5 w-40" />
+          <WidgetSkeleton className="h-2.5 w-28" />
         </div>
-      </CardHeader>
-      
-      {/* Chat area */}
-      <CardContent className="flex-1 flex flex-col min-h-0 p-0 relative">
-        <div className="flex-1 min-h-0 w-full overflow-y-auto">
-          <div className="p-4 space-y-3">
-            {/* Bot message */}
-            <div className="flex items-start gap-2">
-              <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                <div className="w-3 h-3 rounded-full bg-primary" />
-              </div>
-              <div className="bg-muted rounded-lg p-2 max-w-[80%]">
-                <div className="h-3 w-32 bg-muted-foreground/20 rounded mb-1" />
-                <div className="h-3 w-24 bg-muted-foreground/20 rounded" />
-              </div>
-            </div>
-            
-            {/* User message */}
-            <div className="flex items-start gap-2 justify-end">
-              <div className="bg-primary rounded-lg p-2 max-w-[80%]">
-                <div className="h-3 w-20 bg-primary-foreground/40 rounded" />
-              </div>
-              <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center shrink-0">
-                <div className="w-3 h-3 rounded-full bg-muted-foreground" />
-              </div>
-            </div>
-            
-            {/* Bot message */}
-            <div className="flex items-start gap-2">
-              <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                <div className="w-3 h-3 rounded-full bg-primary" />
-              </div>
-              <div className="bg-muted rounded-lg p-2 max-w-[80%]">
-                <div className="h-3 w-40 bg-muted-foreground/20 rounded mb-1" />
-                <div className="h-3 w-28 bg-muted-foreground/20 rounded mb-1" />
-                <div className="h-3 w-16 bg-muted-foreground/20 rounded" />
-              </div>
-            </div>
-          </div>
+
+        {/* The reader's own turn, right aligned like the real transcript */}
+        <div className="flex flex-col items-end gap-1.5 self-end rounded-md bg-muted px-3 py-2">
+          <WidgetSkeleton className="h-2.5 w-24" />
         </div>
-        
-        {/* Input area */}
-        <div className="border-t p-3">
-          <div className="flex items-center gap-2">
-            <div className="flex-1 h-9 bg-muted rounded-md border flex items-center px-3">
-              <div className="h-3 w-24 bg-muted-foreground/20 rounded" />
-            </div>
-            <Button size="sm" className="h-9 px-3">
-              Send
-            </Button>
-          </div>
+
+        {/* Assistant turn */}
+        <div className="flex flex-col gap-1.5 self-start">
+          <WidgetSkeleton className="h-2.5 w-44" />
+          <WidgetSkeleton className="h-2.5 w-32" />
+          <WidgetSkeleton className="h-2.5 w-20" />
         </div>
-      </CardContent>
-    </Card>
+      </div>
+
+      {/* Composer. The preview is a static sample, so the send affordance is
+          inert and hidden from assistive tech rather than given invented copy. */}
+      <div className="flex shrink-0 items-center gap-2 border-t p-3">
+        <div className="flex h-9 flex-1 items-center rounded-md border px-3">
+          <span className="text-xs text-muted-foreground">
+            {t('chat.writeMessage')}
+          </span>
+        </div>
+        <div
+          aria-hidden
+          className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground"
+        >
+          <ArrowUp className="size-4" />
+        </div>
+      </div>
+    </PreviewShell>
   )
 }
 
@@ -569,7 +533,7 @@ export const WIDGET_REGISTRY: Record<WidgetType, WidgetConfig> = {
     category: 'other',
     previewHeight: 300,
     getComponent: ({ size }) => <MindsetWidget size={size} />,
-    getPreview: () => createMindsetPreview()
+    getPreview: () => <CreateMindsetPreview />
   },
   tagWidget: {
     type: 'tagWidget',

--- a/components/ui/mood-tracker.tsx
+++ b/components/ui/mood-tracker.tsx
@@ -1,202 +1,146 @@
 "use client"
 
 import React from "react"
-import * as HoverCardPrimitives from "@radix-ui/react-hover-card"
 import { cn } from "@/lib/utils"
 
 interface TrackerBlockProps {
   key?: string | number
+  /** Optional explicit fill for a single block. Rarely needed. */
   color?: string
   hoverEffect?: boolean
   defaultBackgroundColor?: string
 }
 
-interface BlockInternalProps extends TrackerBlockProps {
-  index: number
-  selectedIndex: number | null
-  hoveredIndex: number | null
-  onHover: (index: number | null) => void
-  onClick: (index: number) => void
-  blockColor: string
-  isHighlighted: boolean
-  animationDelay: number
-}
-
-const Block = ({
-  color,
-  defaultBackgroundColor,
-  hoverEffect,
-  index,
-  selectedIndex,
-  hoveredIndex,
-  onHover,
-  onClick,
-  blockColor,
-  isHighlighted,
-  animationDelay,
-}: BlockInternalProps) => {
-  const [open, setOpen] = React.useState(false)
-
-  const shouldAnimate = selectedIndex !== null && index <= selectedIndex
-
-  return (
-    <HoverCardPrimitives.Root open={open} onOpenChange={setOpen} openDelay={0} closeDelay={0}>
-      <HoverCardPrimitives.Trigger onClick={() => setOpen(true)} asChild>
-        <div
-          className="size-full overflow-hidden px-[0.5px] transition first:rounded-l-[4px] first:pl-0 last:rounded-r-[4px] last:pr-0 sm:px-px cursor-pointer"
-          onMouseEnter={() => onHover(index)}
-          onMouseLeave={() => onHover(null)}
-          onClick={() => onClick(index)}
-        >
-          <div
-            className={cn(
-              "size-full rounded-[1px] transition-all duration-300",
-              blockColor,
-              hoverEffect ? "hover:opacity-80" : "",
-              shouldAnimate && "animate-pulse",
-            )}
-            style={{
-              animationDelay: shouldAnimate ? `${animationDelay}ms` : undefined,
-              animationDuration: shouldAnimate ? "600ms" : undefined,
-              animationIterationCount: shouldAnimate ? "1" : undefined,
-            }}
-          />
-        </div>
-      </HoverCardPrimitives.Trigger>
-    </HoverCardPrimitives.Root>
-  )
-}
-
-Block.displayName = "Block"
-
-interface TrackerProps extends React.HTMLAttributes<HTMLDivElement> {
+interface TrackerProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect"> {
   data: TrackerBlockProps[]
   defaultBackgroundColor?: string
   hoverEffect?: boolean
   onSelectionChange?: (index: number) => void
-  // Optional externally-controlled selected index for initial/controlled state
+  /** Externally controlled selected index. */
   valueIndex?: number | null
 }
 
-// Pre-computed color arrays for performance
-const COLOR_MAPS = {
-  red: ["bg-red-100", "bg-red-200", "bg-red-300", "bg-red-400", "bg-red-500", "bg-red-600", "bg-red-700"],
-  orange: [
-    "bg-orange-100",
-    "bg-orange-200",
-    "bg-orange-300",
-    "bg-orange-400",
-    "bg-orange-500",
-    "bg-orange-600",
-    "bg-orange-700",
-  ],
-  yellow: [
-    "bg-yellow-100",
-    "bg-yellow-200",
-    "bg-yellow-300",
-    "bg-yellow-400",
-    "bg-yellow-500",
-    "bg-yellow-600",
-    "bg-yellow-700",
-  ],
-  lime: ["bg-lime-100", "bg-lime-200", "bg-lime-300", "bg-lime-400", "bg-lime-500", "bg-lime-600", "bg-lime-700"],
-  green: [
-    "bg-green-100",
-    "bg-green-200",
-    "bg-green-300",
-    "bg-green-400",
-    "bg-green-500",
-    "bg-green-600",
-    "bg-green-700",
-  ],
-} as const
-
+/**
+ * A discrete scale: the reader picks one step out of `data.length`.
+ *
+ * Position on the scale is the encoding, so the fill is monochrome — the value
+ * is read from how far the fill extends, not from a hue. Callers are expected
+ * to name the scale ends and state the current step in words, so the meaning
+ * never rests on the bar alone.
+ *
+ * Exposed as a single `role="slider"` rather than N click targets, so the whole
+ * scale is one stop in the tab order and is operable with the arrow keys,
+ * Home/End, and PageUp/PageDown.
+ */
 const Tracker = React.forwardRef<HTMLDivElement, TrackerProps>(
   (
-    { data = [], defaultBackgroundColor = "bg-gray-300", className, hoverEffect, onSelectionChange, valueIndex, ...props },
+    {
+      data = [],
+      defaultBackgroundColor = "bg-muted",
+      className,
+      hoverEffect,
+      onSelectionChange,
+      valueIndex,
+      "aria-label": ariaLabel,
+      ...props
+    },
     forwardedRef,
   ) => {
-    const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null)
+    const [internalIndex, setInternalIndex] = React.useState<number | null>(null)
     const [hoveredIndex, setHoveredIndex] = React.useState<number | null>(null)
-    const [animationKey, setAnimationKey] = React.useState(0)
 
-    // Sync internal selection with external valueIndex when provided
-    React.useEffect(() => {
-      if (typeof valueIndex === 'number') {
-        setSelectedIndex(valueIndex)
-      } else if (valueIndex === null) {
-        setSelectedIndex(null)
-      }
-    }, [valueIndex])
+    const lastIndex = Math.max(0, data.length - 1)
 
-    // Fast color computation using pre-computed maps
-    const getColorForIndex = React.useCallback((index: number, totalBlocks: number) => {
-      const ratio = index / (totalBlocks - 1)
+    // The external value wins whenever it is supplied, so the component stays
+    // controlled without an effect mirroring props into state.
+    const selectedIndex =
+      valueIndex === undefined ? internalIndex : valueIndex
 
-      if (ratio <= 0.2) return "red"
-      if (ratio <= 0.4) return "orange"
-      if (ratio <= 0.6) return "yellow"
-      if (ratio <= 0.8) return "lime"
-      return "green"
-    }, [])
-
-    const getBlockColor = React.useCallback(
-      (blockIndex: number, activeIndex: number | null, totalBlocks: number) => {
-        if (activeIndex === null) {
-          return defaultBackgroundColor
-        }
-
-        if (blockIndex > activeIndex) {
-          return "bg-blue-300" // Highlighted blocks
-        }
-
-        // Get base color for the active index
-        const baseColor = getColorForIndex(activeIndex, totalBlocks)
-        const colorMap = COLOR_MAPS[baseColor]
-
-        // Calculate intensity based on position (0 to 6 for array index)
-        const intensity = Math.floor((blockIndex / activeIndex) * 6)
-        return colorMap[Math.min(intensity, 6)]
+    const select = React.useCallback(
+      (index: number) => {
+        const clamped = Math.max(0, Math.min(lastIndex, index))
+        setInternalIndex(clamped)
+        onSelectionChange?.(clamped)
       },
-      [defaultBackgroundColor, getColorForIndex],
+      [lastIndex, onSelectionChange],
     )
 
-    const handleClick = (index: number) => {
-      setSelectedIndex(index)
-      setAnimationKey((prev) => prev + 1)
-      onSelectionChange?.(index)
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const current = selectedIndex ?? 0
+      const step = Math.max(1, Math.round(data.length / 10))
+
+      switch (event.key) {
+        case "ArrowRight":
+        case "ArrowUp":
+          event.preventDefault()
+          select(current + 1)
+          break
+        case "ArrowLeft":
+        case "ArrowDown":
+          event.preventDefault()
+          select(current - 1)
+          break
+        case "PageUp":
+          event.preventDefault()
+          select(current + step)
+          break
+        case "PageDown":
+          event.preventDefault()
+          select(current - step)
+          break
+        case "Home":
+          event.preventDefault()
+          select(0)
+          break
+        case "End":
+          event.preventDefault()
+          select(lastIndex)
+          break
+      }
     }
 
-    const handleHover = (index: number | null) => {
-      setHoveredIndex(index)
-    }
-
-    const activeIndex = hoveredIndex !== null ? hoveredIndex : selectedIndex
-    const totalBlocks = data.length
+    // Hover previews the step the pointer is over; it never commits a value.
+    const activeIndex = hoveredIndex ?? selectedIndex
 
     return (
-      <div ref={forwardedRef} className={cn("group flex h-8 w-full items-center", className)} {...props}>
+      <div
+        ref={forwardedRef}
+        role="slider"
+        tabIndex={0}
+        aria-label={ariaLabel}
+        aria-valuemin={0}
+        aria-valuemax={lastIndex}
+        aria-valuenow={selectedIndex ?? undefined}
+        onKeyDown={handleKeyDown}
+        onMouseLeave={() => setHoveredIndex(null)}
+        className={cn(
+          "group flex h-8 w-full items-center rounded-sm outline-none",
+          "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+          className,
+        )}
+        {...props}
+      >
         {data.map((blockProps, index) => {
-          const { key: blockKey, ...restBlockProps } = blockProps
-          const blockColor = getBlockColor(index, activeIndex, totalBlocks)
-          const isHighlighted = activeIndex !== null && index > activeIndex
-          const animationDelay = index * 20 // Faster animation
+          const { key: blockKey, color } = blockProps
+          const isFilled = activeIndex !== null && index <= activeIndex
 
           return (
-            <Block
-              key={`${blockKey ?? index}-${animationKey}`}
-              index={index}
-              selectedIndex={selectedIndex}
-              hoveredIndex={hoveredIndex}
-              onHover={handleHover}
-              onClick={handleClick}
-              blockColor={blockColor}
-              isHighlighted={isHighlighted}
-              animationDelay={animationDelay}
-              defaultBackgroundColor={defaultBackgroundColor}
-              hoverEffect={hoverEffect}
-              {...restBlockProps}
-            />
+            <div
+              key={blockKey ?? index}
+              aria-hidden
+              onMouseEnter={() => setHoveredIndex(index)}
+              onClick={() => select(index)}
+              className="size-full cursor-pointer overflow-hidden px-[0.5px] first:pl-0 last:pr-0 sm:px-px"
+            >
+              <div
+                className={cn(
+                  "size-full rounded-[1px] motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
+                  color ?? (isFilled ? "bg-primary" : defaultBackgroundColor),
+                  hoverEffect && "group-hover:opacity-90",
+                )}
+              />
+            </div>
           )
         })}
       </div>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1512,6 +1512,8 @@ export default {
       profitFactor: "Profit Factor",
       bestTrade: "Best Trade",
       worstTrade: "Worst Trade",
+      win: "Win",
+      loss: "Loss",
     },
     activity: {
       title: "Activity",
@@ -1917,6 +1919,8 @@ export default {
   "disclaimer.hypothetical.title": "Hypothetical Performance Warning",
   "disclaimer.hypothetical.content":
     "Hypothetical performance results have many inherent limitations, some of which are described below. No representation is being made that any account will or is likely to achieve profits or losses similar to those shown; in fact, there are frequently sharp differences between hypothetical performance results and the actual results subsequently achieved by any particular trading program. One of the limitations of hypothetical performance results is that they are generally prepared with the benefit of hindsight. In addition, hypothetical trading does not involve financial risk, and no hypothetical trading record can completely account for the impact of financial risk in actual trading. For example, the ability to withstand losses or to adhere to a particular trading program in spite of trading losses are material points which can also adversely affect actual trading results. There are numerous other factors related to the markets in general or to the implementation of any specific trading program which cannot be fully accounted for in the preparation of hypothetical performance results and all of which can adversely affect actual trading results.",
+  "widgets.empty.noTrades":
+    "No trades in the selected period. Adjust your filters or import trades to see this metric.",
   "widgets.cumulativePnl.tooltip":
     "Your total profit or loss across all trades, including fees. This metric shows your overall trading performance and helps you track your long-term profitability.",
   "widgets.averagePositionTime.tooltip":

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1081,6 +1081,8 @@ export default {
       profitFactor: "Facteur de Profit",
       bestTrade: "Meilleur Trade",
       worstTrade: "Pire Trade",
+      win: "Gain",
+      loss: "Perte",
     },
     activity: {
       title: "Activité",
@@ -2037,6 +2039,8 @@ export default {
     "Les résultats des performances hypothétiques ont de nombreuses limitations inhérentes, dont certaines sont décrites ci-dessous. Aucune déclaration n'est faite selon laquelle un compte réalisera ou est susceptible de réaliser des profits ou des pertes similaires à ceux indiqués ; en fait, il existe souvent des différences marquées entre les résultats de performance hypothétiques et les résultats réels obtenus par la suite par un programme de trading particulier. L'une des limites des résultats de performance hypothétiques est qu'ils sont généralement préparés avec le bénéfice du recul. De plus, la négociation hypothétique n'implique pas de risque financier, et aucun résultat de négociation hypothétique ne peut complètement rendre compte de l'impact du risque financier de la négociation réelle. Par exemple, la capacité à supporter les pertes ou à adhérer à un programme de négociation particulier malgré les pertes de négociation sont des points importants qui peuvent également affecter négativement les résultats de négociation réels. Il existe de nombreux autres facteurs liés aux marchés en général ou à la mise en œuvre d'un programme de trading spécifique qui ne peuvent pas être entièrement pris en compte dans la préparation de résultats de performance hypothétiques et qui peuvent tous avoir un impact négatif sur les résultats de trading.",
   "widgets.averagePositionTime.tooltip":
     "Temps moyen de détention de vos positions. Cette métrique vous aide à comprendre votre période de détention typique et peut être utile pour identifier si vous tendez à garder les positions trop longtemps ou à sortir trop rapidement.",
+  "widgets.empty.noTrades":
+    "Aucun trade sur la période sélectionnée. Ajustez vos filtres ou importez des trades pour voir cette métrique.",
   "widgets.cumulativePnl.tooltip":
     "Votre profit ou perte total sur tous les trades, frais inclus. Cette métrique montre votre performance globale de trading et vous aide à suivre votre rentabilité à long terme.",
   "widgets.longShortPerformance.tooltip":

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,6 +46,10 @@ const config = {
     				DEFAULT: 'hsl(var(--info))',
     				foreground: 'hsl(var(--info-foreground))'
     			},
+    			success: {
+    				DEFAULT: 'hsl(var(--success))',
+    				foreground: 'hsl(var(--success-foreground))'
+    			},
     			border: 'hsl(var(--border))',
     			input: 'hsl(var(--input))',
     			ring: 'hsl(var(--ring))',


### PR DESCRIPTION
Redesigns the dashboard widgets against a shared design system derived from Vercel's design guidance, mapped onto this repo's Tailwind + shadcn + Recharts stack.

## The foundation

New `app/[locale]/dashboard/components/widgets/`:

| File | Purpose |
| --- | --- |
| `DESIGN.md` | The rules widgets are held to, and why |
| `widget-type.ts` | Closed set of type roles + size-scaled padding |
| `widget-format.ts` | Locale-aware formatters with one canonical precision, plus P&L tone helpers |
| `widget-shell.tsx` | `WidgetCard` / `Header` / `Body` / `Footer` / `Metric` / `Stat` |
| `widget-states.tsx` | One shape each for empty, error, skeleton |
| `chart-primitives.tsx` | Shared axes, horizontal-only grid, zero baseline, one tooltip, keyboard-operable chart wrapper |

The guidance is a brand guide for standalone report pages with its own `vbg-*` CSS API, which does not apply to a Next.js app. I took its principles — monochrome by default, fixed type roles, earned borders, honest chart encodings, stillness — and mapped them onto existing tokens rather than importing that vocabulary. `DESIGN.md` records the mapping so future widgets converge.

## What changed

Statistics (8), charts (14), calendar, mindset, accounts, tag widget, trade table and its cells, chat, and every widget-registry preview.

Recurring violations fixed across them:

- Money rendered in `font-mono`; financial figures are now Sans + `tabular-nums`, with mono reserved for identifiers and timestamps
- `text-green-500` / `text-red-500` replaced by `--chart-win` / `--chart-loss` via tone helpers, with the sign kept on the number so meaning never rests on color alone
- Uppercase tracked eyebrows in every hand-rolled chart tooltip
- Dark mode read from a `MutationObserver` on `<html>` instead of CSS variables, so themes only swapped one way
- Nested bordered boxes inside cards (the 2x2 statistics grid, the registry previews)
- Opacity ramps double-encoding what bar length already showed
- Per-widget `size === 'small' ? 'p-2' : 'p-4'` ternaries and inline `toFixed`

## Bugs found while restyling

- `useEffect` called inside Recharts tooltip render functions in two charts (the pattern had been copied between files)
- `nbWin / nbTrades` unguarded, rendering `NaN%` on an empty dataset
- `Math.max()` over an empty array yielding `-Infinity` before the length check
- Icon-only save/cancel buttons with no accessible name; click-to-filter charts as mouse-only `<div onClick>`
- `mood-tracker` defaulted to `bg-gray-300`, invisible in dark mode, with 21 `<div onClick>` blocks and no keyboard path; now one `role="slider"` with arrow keys, Home/End, PageUp/PageDown
- `text-success` silently did nothing because `--success` was never mapped in the Tailwind config; now mapped, and `DESIGN.md` records why `success` and `chart-win` are not interchangeable
- A dead `ease-out-quart` class that was never defined

## Deliberately left alone

`equity-chart.tsx` and `account-selection-popover.tsx` are **unchanged from beta**. This branch was cut from `main`, and beta reworked both afterwards — pointer-distance legend ordering, a mobile drawer, and enforcement of the displayed-account cap. Restyling them here would have reverted that work, so they are left for a follow-up written against beta's implementation. The rebase also surfaced two beta changes worth preserving explicitly, both kept: the removal of "No trades" text from empty calendar cells, and the 16px-on-mobile input sizing that stops iOS zooming on focus.

## Verification

- `bun run typecheck` — 0 errors on the beta base
- `bun run lint` — error counts down or flat on every touched file; where flat, the error sets were diffed to confirm nothing new
- Greps — no raw palette colors, `MutationObserver`, uppercase eyebrows, or `toFixed` left in any migrated widget; the shared loading skeleton's 21 exports are byte-identical
- `bun run build` — **compiles successfully, but the build does not complete on this branch or on `beta` itself.** `origin/beta` alone fails the same way: an MDX changelog route exceeds the 60-second prerender budget, on a different route each run. Pre-existing on beta, not introduced here.

## Not verified

**None of this has been looked at in a browser.** Every claim above rests on compile, lint, grep, and diff. Layout at specific widget sizes, dark-mode contrast, and whether the recomposed statistics widget actually reads better all need a running dashboard with real trade data.

A few files outside the widget tree still carry the old patterns: `suggestion-input.tsx`, `account-configurator.tsx`, `pnl-filter-simple.tsx`, `account-group.tsx`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013WbbK9t7wM6M2Xg4MUUKsw)_