### PR TITLE
Fix optimistic updates for account deletion across stores

### DIFF
--- a/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
+++ b/app/[locale]/dashboard/components/accounts/accounts-overview.tsx
@@ -715,10 +715,13 @@ function PayoutDialog({
 
 export function AccountsOverview({ size }: { size: WidgetSize }) {
   const trades = useTradesStore(state => state.trades)
+  const setTradesStore = useTradesStore(state => state.setTrades)
   const user = useUserStore(state => state.user)
   const isLoading = useUserStore(state => state.isLoading)
   const groups = useUserStore(state => state.groups)
+  const setGroups = useUserStore(state => state.setGroups)
   const accounts = useUserStore(state => state.accounts)
+  const setAccounts = useUserStore(state => state.setAccounts)
   const { accountNumbers, deletePayout, saveAccount, savePayout, isMobile } = useData()
   const { getOrderedAccounts, reorderAccounts } = useAccountOrderStore()
   const t = useI18n()
@@ -1147,11 +1150,22 @@ export function AccountsOverview({ size }: { size: WidgetSize }) {
   const handleDelete = async () => {
     if (!user || !selectedAccountForTable || !canDeleteAccount) return
 
+    const accountToDelete = selectedAccountForTable
+
     try {
       setIsDeleting(true)
       // Delete both account configuration and all associated trades
-      await removeAccountsFromTradesAction([selectedAccountForTable.number])
-      // DataProvider updates accounts/trades optimistically; no full refresh
+      await removeAccountsFromTradesAction([accountToDelete.number])
+      // Drop the account and its trades locally so the UI reflects the
+      // deletion immediately instead of waiting for a page refresh
+      setTradesStore(trades.filter(trade => trade.accountNumber !== accountToDelete.number))
+      setAccounts(accounts.filter(acc => acc.number !== accountToDelete.number))
+      setGroups(
+        groups.map(group => ({
+          ...group,
+          accounts: group.accounts.filter(acc => acc.number !== accountToDelete.number),
+        }))
+      )
       setSelectedAccountForTable(null)
 
       toast.success(t('propFirm.toast.deleteSuccess'), {

--- a/app/[locale]/dashboard/components/filters/account-group-board.tsx
+++ b/app/[locale]/dashboard/components/filters/account-group-board.tsx
@@ -63,6 +63,7 @@ export function AccountGroupBoard() {
   const setTradesStore = useTradesStore(state => state.setTrades)
   const existingAccounts = useUserStore(state => state.accounts)
   const setAccounts = useUserStore(state => state.setAccounts)
+  const setGroups = useUserStore(state => state.setGroups)
   const {
     saveGroup,
     renameGroup,
@@ -326,6 +327,14 @@ export function AccountGroupBoard() {
       if (setAccounts) {
         setAccounts(existingAccounts.filter((acc) => acc.id !== account.id))
       }
+      // Grouped accounts are rendered from `groups[].accounts`, so the board
+      // keeps showing the deleted account until the group membership is pruned
+      setGroups(
+        groups.map(group => ({
+          ...group,
+          accounts: group.accounts.filter(acc => acc.id !== account.id),
+        })),
+      )
       await refreshTradesOnly({ force: false })
       setSelectedAccountIds(prev => prev.filter(id => id !== account.id))
       toast.success(t("common.success"), {
@@ -338,7 +347,7 @@ export function AccountGroupBoard() {
       })
     }
     setDeletingAccountId(null)
-  }, [existingAccounts, refreshTradesOnly, setAccounts, setTradesStore, t, trades])
+  }, [existingAccounts, groups, refreshTradesOnly, setAccounts, setGroups, setTradesStore, t, trades])
 
   const confirmDeleteAccount = useCallback(async () => {
     if (!accountToDelete) return

--- a/app/[locale]/dashboard/data/components/data-management/data-management-card.tsx
+++ b/app/[locale]/dashboard/data/components/data-management/data-management-card.tsx
@@ -36,6 +36,8 @@ export function DataManagementCard() {
   const user = useUserStore((state) => state.user)
   const accounts = useUserStore((state) => state.accounts)
   const setAccounts = useUserStore((state) => state.setAccounts)
+  const groups = useUserStore((state) => state.groups)
+  const setGroups = useUserStore((state) => state.setGroups)
   const trades = useTradesStore((state) => state.trades)
   const setTradesStore = useTradesStore((state) => state.setTrades)
 
@@ -95,6 +97,12 @@ export function DataManagementCard() {
       if (accounts && setAccounts) {
         setAccounts(accounts.filter((acc) => !accountsToDelete.includes(acc.number)))
       }
+      setGroups(
+        groups.map((group) => ({
+          ...group,
+          accounts: group.accounts.filter((acc) => !accountsToDelete.includes(acc.number)),
+        }))
+      )
       // Lightweight server cache update
       await refreshTradesOnly({ force: false })
       setSelectedAccounts([])
@@ -109,7 +117,7 @@ export function DataManagementCard() {
       setDeleteLoading(false)
       setDeleteDialogOpen(false)
     }
-  }, [user, deleteMode, groupedTrades, selectedAccounts, trades, setTradesStore, accounts, setAccounts, refreshTradesOnly, t])
+  }, [user, deleteMode, groupedTrades, selectedAccounts, trades, setTradesStore, accounts, setAccounts, groups, setGroups, refreshTradesOnly, t])
 
   const handleDeleteInstrument = useCallback(async (accountNumber: string, instrumentGroup: string) => {
     try {

--- a/context/data-provider.tsx
+++ b/context/data-provider.tsx
@@ -680,8 +680,12 @@ export const DataProvider: React.FC<{
         const userId = await getUserId();
         if (!userId) return;
 
-        // Dev-only: serve trades from IndexedDB to avoid DB hits when possible
-        if (process.env.NODE_ENV === "development" && !force) {
+        // Dev-only: serve trades from IndexedDB to avoid DB hits when possible.
+        // Only on the initial load: the cache is written on a debounce, so after
+        // a mutation (e.g. deleting an account) it may still hold the pre-mutation
+        // trades and would silently undo the optimistic update.
+        const hasLoadedTrades = useTradesStore.getState().trades.length > 0;
+        if (process.env.NODE_ENV === "development" && !force && !hasLoadedTrades) {
           const cachedTrades = await getTradesCache(userId);
           if (cachedTrades && Array.isArray(cachedTrades) && cachedTrades.length > 0) {
             setTrades(cachedTrades);


### PR DESCRIPTION
## Summary
This PR fixes a bug where account deletions were not properly reflected in the UI across all data stores. When an account was deleted, the optimistic update would only remove it from the main accounts list, but grouped accounts would still appear in the UI because they're rendered from the `groups[].accounts` array.

## Key Changes
- **AccountsOverview**: Added optimistic updates to remove deleted accounts from `trades`, `accounts`, and `groups` stores when deleting an account
- **AccountGroupBoard**: Added logic to prune deleted accounts from group membership in the `groups` store during account deletion
- **DataManagementCard**: Added logic to filter deleted accounts from group membership when bulk deleting accounts
- **DataProvider**: Fixed IndexedDB cache serving logic to only use cached trades on initial load, preventing stale cache from undoing optimistic updates after mutations

## Implementation Details
- When an account is deleted, it's now removed from three places:
  1. The trades store (filter by `accountNumber`)
  2. The accounts store (filter by `number`)
  3. The groups store (filter accounts within each group by `number` or `id`)
- The IndexedDB cache in development mode now checks if trades have already been loaded before serving from cache, preventing the cache from silently reverting optimistic deletions
- Updated dependency arrays in useCallback hooks to include newly used state setters (`setGroups`)

https://claude.ai/code/session_0164tjbtuLQTF3xFbpEYpbHr