### PR TITLE
Fix Lucid Rithmic Protocol sync returning zero fills

### DIFF
--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/actions.ts
@@ -187,6 +187,11 @@ export async function authenticateRithmicProtocol(
       gatewayId: gateway.id,
       gatewayUri: resolvedUri,
       accountIds,
+      accounts: result.accounts.map((a) => ({
+        accountId: a.accountId,
+        fcmId: a.fcmId,
+        ibId: a.ibId,
+      })),
       fcmId: result.fcmId,
       ibId: result.ibId,
       uniqueUserId: result.uniqueUserId,
@@ -413,6 +418,11 @@ export async function getRithmicProtocolTrades(
       })
       resolvedAccountIds = listed.accounts.map((a) => a.accountId)
       credentials.accountIds = resolvedAccountIds
+      credentials.accounts = listed.accounts.map((a) => ({
+        accountId: a.accountId,
+        fcmId: a.fcmId,
+        ibId: a.ibId,
+      }))
       credentials.fcmId = listed.fcmId ?? credentials.fcmId
       credentials.ibId = listed.ibId ?? credentials.ibId
       await persistRithmicProtocolCredentials(
@@ -468,6 +478,7 @@ export async function getRithmicProtocolTrades(
       fcmId: credentials.fcmId,
       ibId: credentials.ibId,
       accountIds: resolvedAccountIds,
+      accounts: credentials.accounts,
       historyStartDate: credentials.historyStartDate,
       lookbackDays: DEFAULT_LOOKBACK_DAYS,
     })

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-types.ts
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-types.ts
@@ -6,6 +6,15 @@ export interface RithmicProtocolStoredCredentials {
   gatewayId?: string
   gatewayUri: string
   accountIds?: string[]
+  /**
+   * Per-account FCM/IB from ResponseAccountList. Prop-firm plants (LucidTrading,
+   * etc.) often differ from the login-level fcmId/ibId — prefer these on sync.
+   */
+  accounts?: Array<{
+    accountId: string
+    fcmId?: string
+    ibId?: string
+  }>
   fcmId?: string
   ibId?: string
   /** From ResponseLogin.unique_user_id — useful for Rithmic support/conformance. */

--- a/lib/rithmic-protocol/README.md
+++ b/lib/rithmic-protocol/README.md
@@ -64,7 +64,11 @@ that predate the start-date field.
 
 Same-day fills are also pulled via `ReplayExecutions` (ssboe), because on Test the
 fill/order history date index often lags UTC “today”.
-Order-history fallback also requests dates one at a time.
+Order-history fallback also requests dates one at a time. When `ShowFillHistory`
+returns empty (rp_code `7 no data`) — common on prop-firm plants such as
+**LucidTrading** — sync still tries order-history dates before giving up. Fill
+requests use each account’s own FCM/IB from `ResponseAccountList`, not only the
+login-level ids.
 
 Protocol API has a **separate conformance** process from R | API+. Conformance is
 approved, so production connect points are live; Rithmic Test remains available for

--- a/lib/rithmic-protocol/client-fill-map.test.ts
+++ b/lib/rithmic-protocol/client-fill-map.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { mapShowFillHistoryRow } from './client'
+
+describe('mapShowFillHistoryRow', () => {
+  it('accepts fill_price when present', () => {
+    const fill = mapShowFillHistoryRow(
+      {
+        symbol: 'ESH6',
+        fillPrice: 5000.25,
+        fillSize: 2,
+        transactionType: 'BUY',
+      },
+      'acct-1',
+    )
+    expect(fill).toMatchObject({
+      accountId: 'acct-1',
+      symbol: 'ESH6',
+      fillPrice: 5000.25,
+      fillSize: 2,
+    })
+  })
+
+  it('falls back to avg_fill_price then price (prop-firm plants)', () => {
+    expect(
+      mapShowFillHistoryRow(
+        { symbol: 'NQH6', avgFillPrice: 21000, fillSize: 1 },
+        'acct-2',
+      )?.fillPrice,
+    ).toBe(21000)
+
+    expect(
+      mapShowFillHistoryRow(
+        { symbol: 'NQH6', price: 21001.5, fillSize: 1 },
+        'acct-2',
+      )?.fillPrice,
+    ).toBe(21001.5)
+  })
+
+  it('skips rows without a usable symbol, price, or size', () => {
+    expect(
+      mapShowFillHistoryRow({ fillPrice: 1, fillSize: 1 }, 'acct'),
+    ).toBeNull()
+    expect(
+      mapShowFillHistoryRow({ symbol: 'ESH6', fillSize: 1 }, 'acct'),
+    ).toBeNull()
+    expect(
+      mapShowFillHistoryRow({ symbol: 'ESH6', fillPrice: 1, fillSize: 0 }, 'acct'),
+    ).toBeNull()
+  })
+})

--- a/lib/rithmic-protocol/client.ts
+++ b/lib/rithmic-protocol/client.ts
@@ -112,6 +112,61 @@ function rpMessage(rpCode: unknown): string {
   return rpCode.map(String).join(' ')
 }
 
+/**
+ * Map a ResponseShowFillHistory row. Some plants populate `price` /
+ * `avg_fill_price` without `fill_price` — accept any of the three.
+ */
+export function mapShowFillHistoryRow(
+  decoded: {
+    accountId?: string
+    fcmId?: string
+    ibId?: string
+    symbol?: string
+    exchange?: string
+    transactionType?: string | number
+    price?: number
+    fillPrice?: number
+    fillSize?: number | string
+    fillId?: string
+    fillDate?: string
+    fillTime?: string
+    basketId?: string
+    sequenceNumber?: string
+    ssboe?: number
+    usecs?: number
+    avgFillPrice?: number
+  },
+  fallbackAccountId: string,
+): RithmicProtocolFill | null {
+  if (!decoded.symbol) return null
+  const fillPrice = Number(
+    decoded.fillPrice ?? decoded.avgFillPrice ?? decoded.price ?? NaN,
+  )
+  if (!Number.isFinite(fillPrice)) return null
+  const fillSize = Number(decoded.fillSize ?? 0)
+  if (!Number.isFinite(fillSize) || fillSize <= 0) return null
+
+  return {
+    accountId: decoded.accountId || fallbackAccountId,
+    fcmId: decoded.fcmId,
+    ibId: decoded.ibId,
+    symbol: decoded.symbol,
+    exchange: decoded.exchange,
+    transactionType: String(decoded.transactionType ?? ''),
+    fillPrice,
+    fillSize,
+    fillId: decoded.fillId,
+    fillDate: decoded.fillDate,
+    fillTime: decoded.fillTime,
+    basketId: decoded.basketId,
+    sequenceNumber: decoded.sequenceNumber,
+    ssboe: decoded.ssboe,
+    usecs: decoded.usecs,
+    avgFillPrice:
+      decoded.avgFillPrice != null ? Number(decoded.avgFillPrice) : undefined,
+  }
+}
+
 type InboundMessage = {
   templateId: number
   raw: Buffer
@@ -384,6 +439,7 @@ export class RithmicProtocolClient {
           symbol?: string
           exchange?: string
           transactionType?: string
+          price?: number
           fillPrice?: number
           fillSize?: number | string
           fillId?: string
@@ -396,29 +452,8 @@ export class RithmicProtocolClient {
           avgFillPrice?: number
         }>(this.root!, 'rti.ResponseShowFillHistory', msg.raw)
 
-        if (decoded.symbol && decoded.fillPrice != null) {
-          fills.push({
-            accountId: decoded.accountId || params.accountId,
-            fcmId: decoded.fcmId,
-            ibId: decoded.ibId,
-            symbol: decoded.symbol,
-            exchange: decoded.exchange,
-            transactionType: String(decoded.transactionType ?? ''),
-            fillPrice: Number(decoded.fillPrice),
-            fillSize: Number(decoded.fillSize ?? 0),
-            fillId: decoded.fillId,
-            fillDate: decoded.fillDate,
-            fillTime: decoded.fillTime,
-            basketId: decoded.basketId,
-            sequenceNumber: decoded.sequenceNumber,
-            ssboe: decoded.ssboe,
-            usecs: decoded.usecs,
-            avgFillPrice:
-              decoded.avgFillPrice != null
-                ? Number(decoded.avgFillPrice)
-                : undefined,
-          })
-        }
+        const mapped = mapShowFillHistoryRow(decoded, params.accountId)
+        if (mapped) fills.push(mapped)
 
         if (Array.isArray(decoded.rpCode) && decoded.rpCode.length > 0) {
           if (rpOk(decoded.rpCode) || rpIsNoData(decoded.rpCode)) {
@@ -795,6 +830,8 @@ export async function fetchFillsForAccounts(params: {
   fcmId?: string
   ibId?: string
   accountIds: string[]
+  /** Optional cached per-account FCM/IB from connect time. */
+  accounts?: Array<{ accountId: string; fcmId?: string; ibId?: string }>
   /**
    * Preferred: UTC YYYY-MM-DD when the account started trading.
    * Sync walks from this date through today in serial ≤30-day windows.
@@ -815,13 +852,39 @@ export async function fetchFillsForAccounts(params: {
       password: params.password,
     })
     const info = await client.loginInfo()
-    const fcmId = params.fcmId || info.fcmId || login.fcmId
-    const ibId = params.ibId || info.ibId || login.ibId
+    const loginFcmId = params.fcmId || info.fcmId || login.fcmId
+    const loginIbId = params.ibId || info.ibId || login.ibId
     const uniqueUserId = login.uniqueUserId
 
     console.log(
       `[RITHMIC-PROTOCOL] Sync session unique_user_id=${uniqueUserId ?? '(none)'} at ${new Date().toISOString()} (UTC)`,
     )
+
+    // Prop-firm systems (e.g. LucidTrading) often stamp a different FCM/IB on
+    // each trading account than ResponseLogin. Prefer a fresh list from this
+    // session; fall back to cached connect-time metadata.
+    const accountMeta = new Map<
+      string,
+      { accountId: string; fcmId?: string; ibId?: string }
+    >()
+    for (const account of params.accounts ?? []) {
+      accountMeta.set(account.accountId, account)
+    }
+    try {
+      const listedAccounts = await client.listAccounts({
+        fcmId: loginFcmId,
+        ibId: loginIbId,
+        userType: info.userType,
+      })
+      for (const account of listedAccounts) {
+        accountMeta.set(account.accountId, account)
+      }
+    } catch (error) {
+      console.warn(
+        '[RITHMIC-PROTOCOL] Re-list accounts during sync failed; using cached FCM/IB',
+        error instanceof Error ? error.message : error,
+      )
+    }
 
     const end = utcCalendarDay(new Date())
     const start = resolveHistoryStartUtc(params.historyStartDate, params.lookbackDays, end)
@@ -838,7 +901,15 @@ export async function fetchFillsForAccounts(params: {
 
     // Accounts and ≤30-day windows are requested serially (await each response fully).
     for (const accountId of params.accountIds) {
-      let usedFallback = false
+      const meta = accountMeta.get(accountId)
+      const fcmId = meta?.fcmId || loginFcmId
+      const ibId = meta?.ibId || loginIbId
+      console.log(
+        `[RITHMIC-PROTOCOL] Account ${accountId} using fcm=${fcmId ?? '(none)'} ib=${ibId ?? '(none)'}`,
+      )
+
+      let historyFills = 0
+      let usedOrderHistoryFallback = false
       for (const window of windows) {
         try {
           const accountFills = await client.getFillHistory({
@@ -848,24 +919,54 @@ export async function fetchFillsForAccounts(params: {
             startDateYyyymmdd: toYyyymmddNumber(window.start),
             endDateYyyymmdd: toYyyymmddNumber(window.end),
           })
+          historyFills += accountFills.length
           fills.push(...accountFills)
         } catch (error) {
           console.warn(
             `[RITHMIC-PROTOCOL] Fill history failed for ${accountId} (${toYyyymmddString(window.start)}–${toYyyymmddString(window.end)}), falling back to order history`,
             error instanceof Error ? error.message : error,
           )
-          if (!usedFallback) {
-            usedFallback = true
+          if (!usedOrderHistoryFallback) {
+            usedOrderHistoryFallback = true
             const fallback = await client.getFillsViaOrderHistory({
               fcmId,
               ibId,
               accountId,
               startDateYyyymmdd: startYmdStr,
             })
+            console.log(
+              `[RITHMIC-PROTOCOL] Order-history fallback for ${accountId}: ${fallback.length} fill(s)`,
+            )
             fills.push(...fallback)
           }
           break
         }
+      }
+
+      // ShowFillHistory can return rp_code 7 (no data) with no exception — common
+      // on some prop-firm plants. Still try order-history dates before giving up.
+      if (historyFills === 0 && !usedOrderHistoryFallback) {
+        try {
+          const fallback = await client.getFillsViaOrderHistory({
+            fcmId,
+            ibId,
+            accountId,
+            startDateYyyymmdd: startYmdStr,
+          })
+          console.log(
+            `[RITHMIC-PROTOCOL] Empty ShowFillHistory for ${accountId}; order-history fallback: ${fallback.length} fill(s)`,
+          )
+          fills.push(...fallback)
+        } catch (error) {
+          console.warn(
+            `[RITHMIC-PROTOCOL] Order-history fallback failed for ${accountId}`,
+            error instanceof Error ? error.message : error,
+          )
+        }
+      } else {
+        console.log(
+          `[RITHMIC-PROTOCOL] ShowFillHistory for ${accountId}: ${historyFills} fill(s)`,
+        )
       }
 
       // Same-day fills on Test often land in ReplayExecutions before ShowFillHistory

--- a/lib/rithmic-protocol/types.ts
+++ b/lib/rithmic-protocol/types.ts
@@ -36,6 +36,8 @@ export interface RithmicProtocolCredentials {
   gatewayUri: string
   /** Trading account ids selected for sync; empty = all */
   accountIds?: string[]
+  /** Per-account FCM/IB from ResponseAccountList when available. */
+  accounts?: Array<{ accountId: string; fcmId?: string; ibId?: string }>
   fcmId?: string
   ibId?: string
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Beta Rithmic Protocol logs for a LucidTrading sync showed login succeeding with multiple trading accounts, then repeated `POST /api/rithmic-protocol/sync` completing with HTTP 200 and `fills=0`, with no fill-history failure / fallback log lines.

### What the logs prove
- Auth + account listing worked.
- Fill fetch completed “successfully” with zero fills.
- The order-history fallback path did not run (that path only logs on throw).

### What was inferred from code (not proven by payload logs)
We did **not** capture raw `ShowFillHistory` responses, so these are hypotheses that motivate the defensive fixes:
1. Sync keyed history requests with login-level FCM/IB and discarded per-account FCM/IB from `ResponseAccountList` — a common prop-firm footgun, but not verified against this session’s account rows.
2. Empty `ShowFillHistory` (`rp_code 7` / no rows) was treated as success, so order-history never ran — this matches the code + the missing fallback logs.
3. `ResponseShowFillHistory` mapping required `fill_price`; the proto also has `price` / `avg_fill_price`. Whether Lucid omitted `fill_price` is unknown without payload logs.

### Changes
1. Re-list accounts during sync and use each account’s FCM/IB when present; persist account metadata at connect.
2. If `ShowFillHistory` returns empty without throwing, still try order-history dates.
3. Accept `avg_fill_price` / `price` when mapping fill rows.

## Test plan
- [ ] Re-sync a LucidTrading Protocol connection on beta; confirm either non-zero `fills=` or an explicit order-history fallback count in logs
- [ ] `bunx vitest run lib/rithmic-protocol/client-fill-map.test.ts lib/rithmic-protocol/systems.test.ts`
- [ ] Spot-check a non-Lucid Protocol connection still syncs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-442e6e13-f5b7-447e-9663-fde155841f05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-442e6e13-f5b7-447e-9663-fde155841f05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

