### PR TITLE
Rithmic Protocol: system-first connect + quieter mobile trademark

### DIFF
--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-connect-form.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-connect-form.tsx
@@ -1,0 +1,363 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { ChevronLeft, Eye, EyeOff, Loader2 } from 'lucide-react'
+import { useI18n } from '@/locales/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { captureConnectionCreated } from '@/lib/connection-analytics'
+import { useRithmicProtocolSyncContext } from '@/context/rithmic-protocol-sync-context'
+import { toast } from 'sonner'
+import { authenticateRithmicProtocol } from './actions'
+import { useRithmicProtocolConnectOptions } from './use-rithmic-protocol-connect-options'
+
+const fieldClassName =
+  'h-11 rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+
+const selectTriggerClassName =
+  'h-11 w-full rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10'
+
+const selectContentClassName =
+  'rounded-sm border-black/10 bg-white shadow-none dark:border-white/10 dark:bg-black'
+
+const primaryButtonClassName =
+  'inline-flex h-11 w-full items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-6 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]'
+
+type ConnectStep = 'system' | 'credentials'
+
+export function RithmicProtocolConnectForm({
+  onConnected,
+  initialUsername,
+  enabled = true,
+}: {
+  onConnected?: () => void
+  initialUsername?: string
+  /** When false, skip loading gateways/systems (e.g. closed dialog). */
+  enabled?: boolean
+}) {
+  const t = useI18n()
+  const { loadAccounts, performSyncForAccount } = useRithmicProtocolSyncContext()
+  const [step, setStep] = useState<ConnectStep>('system')
+  const [username, setUsername] = useState(initialUsername ?? '')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [historyStartDate, setHistoryStartDate] = useState('')
+  const {
+    gateways,
+    gatewayId,
+    setGatewayId,
+    systems,
+    systemName,
+    setSystemName,
+    loadingGateways,
+    loadingSystems,
+  } = useRithmicProtocolConnectOptions(enabled)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const todayUtc = new Date().toISOString().slice(0, 10)
+  const selectedGateway = gateways.find((gateway) => gateway.id === gatewayId)
+  const systemReady =
+    !loadingGateways &&
+    !loadingSystems &&
+    gateways.length > 0 &&
+    systems.length > 0 &&
+    Boolean(systemName)
+
+  const handleConnect = useCallback(async () => {
+    if (!username || !password || !systemName || !historyStartDate) {
+      toast.error(t('rithmicProtocolSync.error.credentialsRequired'))
+      return
+    }
+
+    const connectedUsername = username
+    try {
+      setIsLoading(true)
+      const result = await authenticateRithmicProtocol(
+        username,
+        password,
+        systemName,
+        historyStartDate,
+        gatewayId,
+      )
+
+      if ('error' in result && result.error) {
+        const translate = t as (
+          key: string,
+          params?: Record<string, string | number>,
+        ) => string
+        toast.error(
+          translate(`rithmicProtocolSync.errors.${result.error}`, {
+            reason: String(result.errorParams?.reason ?? ''),
+          }),
+        )
+        return
+      }
+
+      toast.success(t('rithmicProtocolSync.connected'))
+      captureConnectionCreated('rithmic-protocol')
+      setUsername('')
+      setPassword('')
+      setShowPassword(false)
+      setHistoryStartDate('')
+      setStep('system')
+      await loadAccounts()
+      onConnected?.()
+      // One sync pulls every trading account stored on this connection.
+      void performSyncForAccount(connectedUsername)
+    } catch (error) {
+      console.error('Rithmic Protocol connect error:', error)
+      toast.error(t('rithmicProtocolSync.error.authFailed'))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [
+    username,
+    password,
+    systemName,
+    historyStartDate,
+    gatewayId,
+    t,
+    loadAccounts,
+    performSyncForAccount,
+    onConnected,
+  ])
+
+  if (step === 'system') {
+    return (
+      <div className="flex flex-col space-y-5">
+        <p className="text-sm leading-relaxed text-black/55 dark:text-white/55">
+          {t('rithmicProtocolSync.addAccount.systemStepDescription')}
+        </p>
+
+        <div className="space-y-2">
+          <Label
+            htmlFor="rithmic-protocol-gateway"
+            className="text-sm text-black/55 dark:text-white/55"
+          >
+            {t('rithmicProtocolSync.addAccount.gatewayLabel')}
+          </Label>
+          <Select
+            value={gatewayId}
+            onValueChange={setGatewayId}
+            disabled={loadingGateways || gateways.length === 0}
+          >
+            <SelectTrigger
+              id="rithmic-protocol-gateway"
+              className={selectTriggerClassName}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className={selectContentClassName}>
+              {gateways.map((gateway) => (
+                <SelectItem
+                  key={gateway.id}
+                  value={gateway.id}
+                  className="rounded-sm"
+                >
+                  {gateway.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs leading-relaxed text-black/45 dark:text-white/45">
+            {t('rithmicProtocolSync.addAccount.gatewayHelp')}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label
+            htmlFor="rithmic-protocol-system"
+            className="text-sm text-black/55 dark:text-white/55"
+          >
+            {t('rithmicProtocolSync.addAccount.systemLabel')}
+          </Label>
+          <div className="relative">
+            <Select
+              value={systemName}
+              onValueChange={setSystemName}
+              disabled={loadingSystems || systems.length === 0}
+            >
+              <SelectTrigger
+                id="rithmic-protocol-system"
+                className={selectTriggerClassName}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className={selectContentClassName}>
+                {systems.map((system) => (
+                  <SelectItem
+                    key={system}
+                    value={system}
+                    className="rounded-sm"
+                  >
+                    {system}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {loadingSystems ? (
+              <Loader2 className="pointer-events-none absolute right-10 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-black/35 dark:text-white/35" />
+            ) : null}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          disabled={!systemReady}
+          onClick={() => setStep('credentials')}
+          className={primaryButtonClassName}
+        >
+          {t('rithmicProtocolSync.addAccount.continueToCredentials')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <form
+      className="flex flex-col space-y-5"
+      onSubmit={(e) => {
+        e.preventDefault()
+        void handleConnect()
+      }}
+      autoComplete="on"
+    >
+      <div className="flex flex-col gap-2 rounded-sm border border-black/10 px-3 py-2.5 dark:border-white/10">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs text-black/45 dark:text-white/45">
+              {t('rithmicProtocolSync.addAccount.systemLabel')}
+            </p>
+            <p className="truncate text-sm font-medium">{systemName}</p>
+            {selectedGateway ? (
+              <p className="truncate text-xs text-black/45 dark:text-white/45">
+                {selectedGateway.label}
+              </p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setShowPassword(false)
+              setStep('system')
+            }}
+            className="inline-flex shrink-0 items-center gap-1 text-xs text-black/55 transition-colors hover:text-black dark:text-white/55 dark:hover:text-white"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" strokeWidth={1.75} />
+            {t('common.back')}
+          </button>
+        </div>
+      </div>
+
+      <p className="text-sm leading-relaxed text-black/55 dark:text-white/55">
+        {t('rithmicProtocolSync.addAccount.credentialsStepDescription')}
+      </p>
+
+      <div className="space-y-2">
+        <Label
+          htmlFor="rithmic-protocol-username"
+          className="text-sm text-black/55 dark:text-white/55"
+        >
+          {t('rithmicProtocolSync.addAccount.usernameLabel')}
+        </Label>
+        <Input
+          id="rithmic-protocol-username"
+          name="username"
+          autoComplete="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          spellCheck={false}
+          required
+          className={fieldClassName}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label
+          htmlFor="rithmic-protocol-password"
+          className="text-sm text-black/55 dark:text-white/55"
+        >
+          {t('rithmicProtocolSync.addAccount.passwordLabel')}
+        </Label>
+        <div className="relative">
+          <Input
+            id="rithmic-protocol-password"
+            name="password"
+            type={showPassword ? 'text' : 'password'}
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className={`${fieldClassName} pr-10`}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-1 top-1/2 h-9 w-9 -translate-y-1/2 text-black/45 hover:bg-transparent hover:text-black dark:text-white/45 dark:hover:text-white"
+            onClick={() => setShowPassword((v) => !v)}
+            aria-label={
+              showPassword
+                ? t('rithmicProtocolSync.addAccount.hidePassword')
+                : t('rithmicProtocolSync.addAccount.showPassword')
+            }
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" strokeWidth={1.75} />
+            ) : (
+              <Eye className="h-4 w-4" strokeWidth={1.75} />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label
+          htmlFor="rithmic-protocol-history-start"
+          className="text-sm text-black/55 dark:text-white/55"
+        >
+          {t('rithmicProtocolSync.addAccount.historyStartLabel')}
+        </Label>
+        <Input
+          id="rithmic-protocol-history-start"
+          name="historyStartDate"
+          type="date"
+          value={historyStartDate}
+          onChange={(e) => setHistoryStartDate(e.target.value)}
+          min="2013-01-01"
+          max={todayUtc}
+          required
+          className={fieldClassName}
+        />
+        <p className="text-xs leading-relaxed text-black/45 dark:text-white/45">
+          {t('rithmicProtocolSync.addAccount.historyStartHelp')}
+        </p>
+      </div>
+
+      <button
+        type="submit"
+        disabled={
+          isLoading || !username || !password || !systemName || !historyStartDate
+        }
+        className={primaryButtonClassName}
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            {t('rithmicProtocolSync.addAccount.connecting')}
+          </>
+        ) : (
+          t('rithmicProtocolSync.addAccount.connect')
+        )}
+      </button>
+    </form>
+  )
+}

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-connect-form.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-connect-form.tsx
@@ -1,8 +1,16 @@
 'use client'
 
-import { useCallback, useState } from 'react'
-import { ChevronLeft, Eye, EyeOff, Loader2 } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import {
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  Eye,
+  EyeOff,
+  Loader2,
+} from 'lucide-react'
 import { useI18n } from '@/locales/client'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -13,6 +21,27 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { captureConnectionCreated } from '@/lib/connection-analytics'
 import { useRithmicProtocolSyncContext } from '@/context/rithmic-protocol-sync-context'
 import { toast } from 'sonner'
@@ -20,18 +49,165 @@ import { authenticateRithmicProtocol } from './actions'
 import { useRithmicProtocolConnectOptions } from './use-rithmic-protocol-connect-options'
 
 const fieldClassName =
-  'h-11 rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
+  'h-11 w-full min-w-0 max-w-full rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
 
 const selectTriggerClassName =
-  'h-11 w-full rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10'
+  'h-11 w-full min-w-0 max-w-full rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10 [&>span]:truncate'
 
 const selectContentClassName =
   'rounded-sm border-black/10 bg-white shadow-none dark:border-white/10 dark:bg-black'
+
+const pickerTriggerClassName =
+  'inline-flex h-11 w-full min-w-0 max-w-full items-center justify-between gap-2 rounded-sm border border-black/10 bg-transparent px-3 text-left text-base shadow-none transition-colors duration-150 hover:bg-black/5 disabled:pointer-events-none disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5 sm:text-sm'
 
 const primaryButtonClassName =
   'inline-flex h-11 w-full items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-6 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]'
 
 type ConnectStep = 'system' | 'credentials'
+
+function SystemPicker({
+  systems,
+  systemName,
+  onSelect,
+  disabled,
+  loading,
+}: {
+  systems: string[]
+  systemName: string
+  onSelect: (system: string) => void
+  disabled?: boolean
+  loading?: boolean
+}) {
+  const t = useI18n()
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+
+  const filteredSystems = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) return systems
+    return systems.filter((system) => system.toLowerCase().includes(query))
+  }, [systems, search])
+
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next)
+    if (!next) setSearch('')
+  }, [])
+
+  const handleSelect = useCallback(
+    (system: string) => {
+      onSelect(system)
+      handleOpenChange(false)
+    },
+    [onSelect, handleOpenChange],
+  )
+
+  const triggerButton = (
+    <button
+      id="rithmic-protocol-system"
+      type="button"
+      role="combobox"
+      aria-expanded={open}
+      disabled={disabled || loading || systems.length === 0}
+      className={pickerTriggerClassName}
+    >
+      <span className="min-w-0 truncate">
+        {systemName || t('rithmicProtocolSync.addAccount.systemPlaceholder')}
+      </span>
+      {loading ? (
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-black/35 dark:text-white/35" />
+      ) : (
+        <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+      )}
+    </button>
+  )
+
+  const commandList = (
+    <Command shouldFilter={false} className="min-w-0">
+      <CommandInput
+        placeholder={t('rithmicProtocolSync.addAccount.systemSearchPlaceholder')}
+        value={search}
+        onValueChange={setSearch}
+        className="text-base sm:text-sm"
+      />
+      <CommandList className="max-h-[min(320px,50vh)] overflow-y-auto overflow-x-hidden">
+        <CommandEmpty>
+          {t('rithmicProtocolSync.addAccount.noSystemFound')}
+        </CommandEmpty>
+        <CommandGroup>
+          {filteredSystems.map((system) => (
+            <CommandItem
+              key={system}
+              value={system}
+              className="rounded-sm"
+              onSelect={() => handleSelect(system)}
+            >
+              <Check
+                className={cn(
+                  'mr-2 h-4 w-4 shrink-0',
+                  systemName === system ? 'opacity-100' : 'opacity-0',
+                )}
+              />
+              <span className="min-w-0 truncate">{system}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+
+  if (isMobile) {
+    return (
+      <>
+        <button
+          id="rithmic-protocol-system"
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled || loading || systems.length === 0}
+          className={pickerTriggerClassName}
+          onClick={() => handleOpenChange(true)}
+        >
+          <span className="min-w-0 truncate">
+            {systemName || t('rithmicProtocolSync.addAccount.systemPlaceholder')}
+          </span>
+          {loading ? (
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin text-black/35 dark:text-white/35" />
+          ) : (
+            <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+          )}
+        </button>
+        <Drawer open={open} onOpenChange={handleOpenChange}>
+          <DrawerContent className="rounded-t-sm border-black/10 dark:border-white/10">
+            <DrawerHeader className="text-left">
+              <DrawerTitle className="font-normal tracking-tight">
+                {t('rithmicProtocolSync.addAccount.systemLabel')}
+              </DrawerTitle>
+              <DrawerDescription className="text-black/55 dark:text-white/55">
+                {t('rithmicProtocolSync.addAccount.systemSearchHelp')}
+              </DrawerDescription>
+            </DrawerHeader>
+            <div className="min-w-0 overflow-x-hidden px-2 pb-4">
+              {commandList}
+            </div>
+          </DrawerContent>
+        </Drawer>
+      </>
+    )
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] max-w-[calc(100vw-2rem)] rounded-sm border-black/10 bg-white p-0 shadow-none dark:border-white/10 dark:bg-black"
+        align="start"
+      >
+        {commandList}
+      </PopoverContent>
+    </Popover>
+  )
+}
 
 export function RithmicProtocolConnectForm({
   onConnected,
@@ -132,12 +308,12 @@ export function RithmicProtocolConnectForm({
 
   if (step === 'system') {
     return (
-      <div className="flex flex-col space-y-5">
+      <div className="flex w-full min-w-0 flex-col space-y-5 overflow-x-hidden">
         <p className="text-sm leading-relaxed text-black/55 dark:text-white/55">
           {t('rithmicProtocolSync.addAccount.systemStepDescription')}
         </p>
 
-        <div className="space-y-2">
+        <div className="min-w-0 space-y-2">
           <Label
             htmlFor="rithmic-protocol-gateway"
             className="text-sm text-black/55 dark:text-white/55"
@@ -172,41 +348,20 @@ export function RithmicProtocolConnectForm({
           </p>
         </div>
 
-        <div className="space-y-2">
+        <div className="min-w-0 space-y-2">
           <Label
             htmlFor="rithmic-protocol-system"
             className="text-sm text-black/55 dark:text-white/55"
           >
             {t('rithmicProtocolSync.addAccount.systemLabel')}
           </Label>
-          <div className="relative">
-            <Select
-              value={systemName}
-              onValueChange={setSystemName}
-              disabled={loadingSystems || systems.length === 0}
-            >
-              <SelectTrigger
-                id="rithmic-protocol-system"
-                className={selectTriggerClassName}
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent className={selectContentClassName}>
-                {systems.map((system) => (
-                  <SelectItem
-                    key={system}
-                    value={system}
-                    className="rounded-sm"
-                  >
-                    {system}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {loadingSystems ? (
-              <Loader2 className="pointer-events-none absolute right-10 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-black/35 dark:text-white/35" />
-            ) : null}
-          </div>
+          <SystemPicker
+            systems={systems}
+            systemName={systemName}
+            onSelect={setSystemName}
+            disabled={loadingGateways}
+            loading={loadingSystems}
+          />
         </div>
 
         <button
@@ -223,16 +378,16 @@ export function RithmicProtocolConnectForm({
 
   return (
     <form
-      className="flex flex-col space-y-5"
+      className="flex w-full min-w-0 flex-col space-y-5 overflow-x-hidden"
       onSubmit={(e) => {
         e.preventDefault()
         void handleConnect()
       }}
       autoComplete="on"
     >
-      <div className="flex flex-col gap-2 rounded-sm border border-black/10 px-3 py-2.5 dark:border-white/10">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
+      <div className="flex min-w-0 flex-col gap-2 rounded-sm border border-black/10 px-3 py-2.5 dark:border-white/10">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-black/45 dark:text-white/45">
               {t('rithmicProtocolSync.addAccount.systemLabel')}
             </p>
@@ -261,7 +416,7 @@ export function RithmicProtocolConnectForm({
         {t('rithmicProtocolSync.addAccount.credentialsStepDescription')}
       </p>
 
-      <div className="space-y-2">
+      <div className="min-w-0 space-y-2">
         <Label
           htmlFor="rithmic-protocol-username"
           className="text-sm text-black/55 dark:text-white/55"
@@ -280,14 +435,14 @@ export function RithmicProtocolConnectForm({
         />
       </div>
 
-      <div className="space-y-2">
+      <div className="min-w-0 space-y-2">
         <Label
           htmlFor="rithmic-protocol-password"
           className="text-sm text-black/55 dark:text-white/55"
         >
           {t('rithmicProtocolSync.addAccount.passwordLabel')}
         </Label>
-        <div className="relative">
+        <div className="relative min-w-0">
           <Input
             id="rithmic-protocol-password"
             name="password"
@@ -319,7 +474,7 @@ export function RithmicProtocolConnectForm({
         </div>
       </div>
 
-      <div className="space-y-2">
+      <div className="min-w-0 space-y-2">
         <Label
           htmlFor="rithmic-protocol-history-start"
           className="text-sm text-black/55 dark:text-white/55"

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-credentials-manager.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-credentials-manager.tsx
@@ -3,8 +3,6 @@
 import { useState, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
 import {
-  Eye,
-  EyeOff,
   Loader2,
   Trash2,
   Plus,
@@ -29,21 +27,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { useI18n } from '@/locales/client'
 import { toast } from 'sonner'
-import { authenticateRithmicProtocol } from './actions'
 import { useRithmicProtocolSyncContext } from '@/context/rithmic-protocol-sync-context'
-import { captureConnectionCreated } from '@/lib/connection-analytics'
-import { useRithmicProtocolConnectOptions } from './use-rithmic-protocol-connect-options'
+import { RithmicProtocolConnectForm } from './rithmic-protocol-connect-form'
 
 export function RithmicProtocolCredentialsManager() {
   const {
@@ -59,27 +46,11 @@ export function RithmicProtocolCredentialsManager() {
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
   const [isReloading, setIsReloading] = useState(false)
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [showPassword, setShowPassword] = useState(false)
-  const [historyStartDate, setHistoryStartDate] = useState('')
-  const {
-    gateways,
-    gatewayId,
-    setGatewayId,
-    systems,
-    systemName,
-    setSystemName,
-    loadingGateways,
-    loadingSystems,
-  } = useRithmicProtocolConnectOptions(isAddDialogOpen)
   const [actionsMenuAccountId, setActionsMenuAccountId] = useState<string | null>(
     null,
   )
   const t = useI18n()
-  const todayUtc = new Date().toISOString().slice(0, 10)
 
   const handleRemoveConnection = useCallback(
     async (accountId: string) => {
@@ -98,63 +69,6 @@ export function RithmicProtocolCredentialsManager() {
     },
     [t, deleteAccount],
   )
-
-  const handleAddAccount = useCallback(async () => {
-    if (!username || !password || !systemName || !historyStartDate) {
-      toast.error(t('rithmicProtocolSync.error.credentialsRequired'))
-      return
-    }
-
-    const connectedUsername = username
-    try {
-      setIsLoading(true)
-      const result = await authenticateRithmicProtocol(
-        username,
-        password,
-        systemName,
-        historyStartDate,
-        gatewayId,
-      )
-
-      if ('error' in result && result.error) {
-        const translate = t as (
-          key: string,
-          params?: Record<string, string | number>,
-        ) => string
-        toast.error(
-          translate(`rithmicProtocolSync.errors.${result.error}`, {
-            reason: String(result.errorParams?.reason ?? ''),
-          }),
-        )
-        return
-      }
-
-      toast.success(t('rithmicProtocolSync.connected'))
-      captureConnectionCreated('rithmic-protocol')
-      setIsAddDialogOpen(false)
-      setUsername('')
-      setPassword('')
-      setShowPassword(false)
-      setHistoryStartDate('')
-      await loadAccounts()
-      // One sync pulls every trading account stored on this connection.
-      void performSyncForAccount(connectedUsername)
-    } catch (error) {
-      console.error('Rithmic Protocol connect error:', error)
-      toast.error(t('rithmicProtocolSync.error.authFailed'))
-    } finally {
-      setIsLoading(false)
-    }
-  }, [
-    username,
-    password,
-    systemName,
-    historyStartDate,
-    gatewayId,
-    t,
-    loadAccounts,
-    performSyncForAccount,
-  ])
 
   const handleReloadAccounts = useCallback(async () => {
     try {
@@ -292,13 +206,7 @@ export function RithmicProtocolCredentialsManager() {
         </Accordion>
       )}
 
-      <Dialog
-        open={isAddDialogOpen}
-        onOpenChange={(open) => {
-          setIsAddDialogOpen(open)
-          if (!open) setShowPassword(false)
-        }}
-      >
+      <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t('rithmicProtocolSync.addAccount.title')}</DialogTitle>
@@ -306,124 +214,11 @@ export function RithmicProtocolCredentialsManager() {
               {t('rithmicProtocolSync.addAccount.description')}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-1.5">
-              <Label>{t('rithmicProtocolSync.addAccount.gatewayLabel')}</Label>
-              <Select
-                value={gatewayId}
-                onValueChange={setGatewayId}
-                disabled={loadingGateways || gateways.length === 0}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {gateways.map((gateway) => (
-                    <SelectItem key={gateway.id} value={gateway.id}>
-                      {gateway.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                {t('rithmicProtocolSync.addAccount.gatewayHelp')}
-              </p>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>{t('rithmicProtocolSync.addAccount.systemLabel')}</Label>
-              <Select
-                value={systemName}
-                onValueChange={setSystemName}
-                disabled={loadingSystems || systems.length === 0}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {systems.map((system) => (
-                    <SelectItem key={system} value={system}>
-                      {system}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>{t('rithmicProtocolSync.addAccount.usernameLabel')}</Label>
-              <Input
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                autoComplete="username"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>{t('rithmicProtocolSync.addAccount.passwordLabel')}</Label>
-              <div className="relative">
-                <Input
-                  type={showPassword ? 'text' : 'password'}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  autoComplete="current-password"
-                  className="pr-10"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:bg-transparent hover:text-foreground"
-                  onClick={() => setShowPassword((v) => !v)}
-                  aria-label={
-                    showPassword
-                      ? t('rithmicProtocolSync.addAccount.hidePassword')
-                      : t('rithmicProtocolSync.addAccount.showPassword')
-                  }
-                >
-                  {showPassword ? (
-                    <EyeOff className="h-4 w-4" />
-                  ) : (
-                    <Eye className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>
-                {t('rithmicProtocolSync.addAccount.historyStartLabel')}
-              </Label>
-              <Input
-                type="date"
-                value={historyStartDate}
-                onChange={(e) => setHistoryStartDate(e.target.value)}
-                min="2013-01-01"
-                max={todayUtc}
-                required
-              />
-              <p className="text-xs text-muted-foreground">
-                {t('rithmicProtocolSync.addAccount.historyStartHelp')}
-              </p>
-            </div>
-            <Button
-              onClick={() => void handleAddAccount()}
-              disabled={
-                isLoading ||
-                loadingGateways ||
-                loadingSystems ||
-                !systemName ||
-                !username ||
-                !password ||
-                !historyStartDate
-              }
-            >
-              {isLoading ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                  {t('rithmicProtocolSync.addAccount.connecting')}
-                </>
-              ) : (
-                t('rithmicProtocolSync.addAccount.connect')
-              )}
-            </Button>
-          </div>
+          {isAddDialogOpen ? (
+            <RithmicProtocolConnectForm
+              onConnected={() => setIsAddDialogOpen(false)}
+            />
+          ) : null}
         </DialogContent>
       </Dialog>
 

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
@@ -1,313 +1,59 @@
 'use client'
 
 import {
-  useCallback,
-  useState,
   type Dispatch,
   type SetStateAction,
 } from 'react'
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useI18n } from '@/locales/client'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { ThemeAwareLogo } from '@/components/monochrome-logo'
-import { captureConnectionCreated } from '@/lib/connection-analytics'
-import { useRithmicProtocolSyncContext } from '@/context/rithmic-protocol-sync-context'
-import { toast } from 'sonner'
-import { authenticateRithmicProtocol } from './actions'
 import { RithmicProtocolCredentialsManager } from './rithmic-protocol-credentials-manager'
-import { useRithmicProtocolConnectOptions } from './use-rithmic-protocol-connect-options'
+import { RithmicProtocolConnectForm } from './rithmic-protocol-connect-form'
 
-const fieldClassName =
-  'h-11 rounded-sm border-black/10 bg-transparent text-base sm:text-sm shadow-none focus-visible:border-black/30 focus-visible:ring-0 focus-visible:ring-offset-0 dark:border-white/10 dark:focus-visible:border-white/30'
-
-const configSelectClassName =
-  'h-8 w-auto min-w-0 max-w-full gap-1 rounded-sm border-black/10 bg-transparent px-2 text-xs shadow-none focus:ring-0 focus:ring-offset-0 dark:border-white/10 [&>span]:truncate'
-
-const selectContentClassName =
-  'rounded-sm border-black/10 bg-white shadow-none dark:border-white/10 dark:bg-black'
-
-const primaryButtonClassName =
-  'inline-flex h-11 w-full items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-6 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]'
-
-function RithmicProtocolConnectView({
-  onConnected,
-  initialUsername,
-}: {
-  onConnected?: () => void
-  initialUsername?: string
-}) {
+function RithmicTrademarkFooter() {
   const t = useI18n()
-  const { loadAccounts, performSyncForAccount } = useRithmicProtocolSyncContext()
-  const [username, setUsername] = useState(initialUsername ?? '')
-  const [password, setPassword] = useState('')
-  const [showPassword, setShowPassword] = useState(false)
-  const [historyStartDate, setHistoryStartDate] = useState('')
-  const {
-    gateways,
-    gatewayId,
-    setGatewayId,
-    systems,
-    systemName,
-    setSystemName,
-    loadingGateways,
-    loadingSystems,
-  } = useRithmicProtocolConnectOptions()
-  const [isLoading, setIsLoading] = useState(false)
 
-  const todayUtc = new Date().toISOString().slice(0, 10)
-
-  const handleConnect = useCallback(async () => {
-    if (!username || !password || !systemName || !historyStartDate) {
-      toast.error(t('rithmicProtocolSync.error.credentialsRequired'))
-      return
-    }
-
-    const connectedUsername = username
-    try {
-      setIsLoading(true)
-      const result = await authenticateRithmicProtocol(
-        username,
-        password,
-        systemName,
-        historyStartDate,
-        gatewayId,
-      )
-
-      if ('error' in result && result.error) {
-        const translate = t as (
-          key: string,
-          params?: Record<string, string | number>,
-        ) => string
-        toast.error(
-          translate(`rithmicProtocolSync.errors.${result.error}`, {
-            reason: String(result.errorParams?.reason ?? ''),
-          }),
-        )
-        return
-      }
-
-      toast.success(t('rithmicProtocolSync.connected'))
-      captureConnectionCreated('rithmic-protocol')
-      setUsername('')
-      setPassword('')
-      setShowPassword(false)
-      setHistoryStartDate('')
-      await loadAccounts()
-      onConnected?.()
-      // One sync pulls every trading account stored on this connection.
-      void performSyncForAccount(connectedUsername)
-    } catch (error) {
-      console.error('Rithmic Protocol connect error:', error)
-      toast.error(t('rithmicProtocolSync.error.authFailed'))
-    } finally {
-      setIsLoading(false)
-    }
-  }, [
-    username,
-    password,
-    systemName,
-    historyStartDate,
-    gatewayId,
-    t,
-    loadAccounts,
-    performSyncForAccount,
-    onConnected,
-  ])
+  const notices = (
+    <>
+      <p>{t('import.type.copyright.rithmic')}</p>
+      <p>{t('import.type.copyright.protocol')}</p>
+      <p>{t('import.type.copyright.platform')}</p>
+      <p>{t('import.type.copyright.omne')}</p>
+      <p>{t('import.type.copyright.omneSoftware')}</p>
+    </>
+  )
 
   return (
-    <form
-      className="flex flex-col space-y-5"
-      onSubmit={(e) => {
-        e.preventDefault()
-        void handleConnect()
-      }}
-      autoComplete="on"
-    >
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-black/10 pb-3 dark:border-white/10">
-        <div className="flex min-w-0 items-center gap-2">
-          <Label
-            htmlFor="rithmic-protocol-gateway"
-            className="shrink-0 text-xs text-black/45 dark:text-white/45"
-          >
-            {t('rithmicProtocolSync.addAccount.gatewayLabel')}
-          </Label>
-          <Select
-            value={gatewayId}
-            onValueChange={setGatewayId}
-            disabled={loadingGateways || gateways.length === 0}
-          >
-            <SelectTrigger
-              id="rithmic-protocol-gateway"
-              className={configSelectClassName}
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className={selectContentClassName}>
-              {gateways.map((gateway) => (
-                <SelectItem
-                  key={gateway.id}
-                  value={gateway.id}
-                  className="rounded-sm text-xs"
-                >
-                  {gateway.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex min-w-0 items-center gap-2">
-          <Label
-            htmlFor="rithmic-protocol-system"
-            className="shrink-0 text-xs text-black/45 dark:text-white/45"
-          >
-            {t('rithmicProtocolSync.addAccount.systemLabel')}
-          </Label>
-          <Select
-            value={systemName}
-            onValueChange={setSystemName}
-            disabled={loadingSystems || systems.length === 0}
-          >
-            <SelectTrigger
-              id="rithmic-protocol-system"
-              className={configSelectClassName}
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className={selectContentClassName}>
-              {systems.map((system) => (
-                <SelectItem
-                  key={system}
-                  value={system}
-                  className="rounded-sm text-xs"
-                >
-                  {system}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {loadingSystems ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin text-black/35 dark:text-white/35" />
-          ) : null}
-        </div>
-      </div>
-
-      <p className="text-sm leading-relaxed text-black/55 dark:text-white/55">
-        {t('rithmicProtocolSync.addAccount.description')}
-      </p>
-
-      <div className="space-y-2">
-        <Label
-          htmlFor="rithmic-protocol-username"
-          className="text-sm text-black/55 dark:text-white/55"
-        >
-          {t('rithmicProtocolSync.addAccount.usernameLabel')}
-        </Label>
-        <Input
-          id="rithmic-protocol-username"
-          name="username"
-          autoComplete="username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          spellCheck={false}
-          required
-          className={fieldClassName}
+    <div className="shrink-0 border-t border-black/10 pt-3 dark:border-white/10">
+      <div className="mb-1.5 flex items-center gap-2.5 opacity-50 sm:mb-2 sm:gap-4 sm:opacity-70">
+        <ThemeAwareLogo
+          path="/logos/monochrome/trading-platform-by-rithmic-black.png"
+          darkPath="/logos/monochrome/trading-platform-by-rithmic-white.png"
+          alt="Trading Platform by Rithmic"
+          width={164}
+          height={35}
+          className="h-3.5 w-auto sm:h-6"
+        />
+        <ThemeAwareLogo
+          path="/logos/monochrome/powered-by-omne-black.png"
+          darkPath="/logos/monochrome/powered-by-omne-white.png"
+          alt="Powered by OMNE"
+          width={141}
+          height={15}
+          className="h-2 w-auto sm:h-3"
         />
       </div>
-
-      <div className="space-y-2">
-        <Label
-          htmlFor="rithmic-protocol-password"
-          className="text-sm text-black/55 dark:text-white/55"
-        >
-          {t('rithmicProtocolSync.addAccount.passwordLabel')}
-        </Label>
-        <div className="relative">
-          <Input
-            id="rithmic-protocol-password"
-            name="password"
-            type={showPassword ? 'text' : 'password'}
-            autoComplete="current-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className={`${fieldClassName} pr-10`}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="absolute right-1 top-1/2 h-9 w-9 -translate-y-1/2 text-black/45 hover:bg-transparent hover:text-black dark:text-white/45 dark:hover:text-white"
-            onClick={() => setShowPassword((v) => !v)}
-            aria-label={
-              showPassword
-                ? t('rithmicProtocolSync.addAccount.hidePassword')
-                : t('rithmicProtocolSync.addAccount.showPassword')
-            }
-          >
-            {showPassword ? (
-              <EyeOff className="h-4 w-4" strokeWidth={1.75} />
-            ) : (
-              <Eye className="h-4 w-4" strokeWidth={1.75} />
-            )}
-          </Button>
+      <details className="sm:hidden">
+        <summary className="cursor-pointer list-none text-[10px] leading-relaxed text-black/40 marker:content-none dark:text-white/40 [&::-webkit-details-marker]:hidden">
+          {t('rithmicProtocolSync.trademark.summary')}
+        </summary>
+        <div className="mt-1.5 space-y-1 text-[10px] leading-snug text-black/35 dark:text-white/35">
+          {notices}
         </div>
+      </details>
+      <div className="hidden space-y-1.5 text-xs leading-relaxed text-black/45 dark:text-white/45 sm:block">
+        {notices}
       </div>
-
-      <div className="space-y-2">
-        <Label
-          htmlFor="rithmic-protocol-history-start"
-          className="text-sm text-black/55 dark:text-white/55"
-        >
-          {t('rithmicProtocolSync.addAccount.historyStartLabel')}
-        </Label>
-        <Input
-          id="rithmic-protocol-history-start"
-          name="historyStartDate"
-          type="date"
-          value={historyStartDate}
-          onChange={(e) => setHistoryStartDate(e.target.value)}
-          min="2013-01-01"
-          max={todayUtc}
-          required
-          className={fieldClassName}
-        />
-        <p className="text-xs leading-relaxed text-black/45 dark:text-white/45">
-          {t('rithmicProtocolSync.addAccount.historyStartHelp')}
-        </p>
-      </div>
-
-      <button
-        type="submit"
-        disabled={
-          isLoading ||
-          loadingGateways ||
-          loadingSystems ||
-          !username ||
-          !password ||
-          !systemName ||
-          !historyStartDate
-        }
-        className={primaryButtonClassName}
-      >
-        {isLoading ? (
-          <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            {t('rithmicProtocolSync.addAccount.connecting')}
-          </>
-        ) : (
-          t('rithmicProtocolSync.addAccount.connect')
-        )}
-      </button>
-    </form>
+    </div>
   )
 }
 
@@ -333,7 +79,7 @@ export function RithmicProtocolSync({
     <div className="flex h-full min-h-0 flex-col">
       <div className="min-h-0 flex-1 space-y-5 overflow-y-auto">
         {!initialShowAccountsManager ? (
-          <RithmicProtocolConnectView
+          <RithmicProtocolConnectForm
             onConnected={onConnected}
             initialUsername={initialUsername}
           />
@@ -351,31 +97,7 @@ export function RithmicProtocolSync({
           </>
         )}
       </div>
-      <div className="shrink-0 space-y-2 border-t border-black/10 pt-4 text-xs leading-relaxed text-black/45 dark:border-white/10 dark:text-white/45">
-        <div className="mb-2 flex items-center gap-4">
-          <ThemeAwareLogo
-            path="/logos/monochrome/trading-platform-by-rithmic-black.png"
-            darkPath="/logos/monochrome/trading-platform-by-rithmic-white.png"
-            alt="Trading Platform by Rithmic"
-            width={164}
-            height={35}
-            className="h-7 w-auto"
-          />
-          <ThemeAwareLogo
-            path="/logos/monochrome/powered-by-omne-black.png"
-            darkPath="/logos/monochrome/powered-by-omne-white.png"
-            alt="Powered by OMNE"
-            width={141}
-            height={15}
-            className="h-3.5 w-auto"
-          />
-        </div>
-        <p>{t('import.type.copyright.rithmic')}</p>
-        <p>{t('import.type.copyright.protocol')}</p>
-        <p>{t('import.type.copyright.platform')}</p>
-        <p>{t('import.type.copyright.omne')}</p>
-        <p>{t('import.type.copyright.omneSoftware')}</p>
-      </div>
+      <RithmicTrademarkFooter />
     </div>
   )
 }

--- a/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
+++ b/app/[locale]/dashboard/components/import/rithmic-protocol/sync/rithmic-protocol-sync.tsx
@@ -76,8 +76,8 @@ export function RithmicProtocolSync({
   const t = useI18n()
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto">
+    <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-x-hidden">
+      <div className="min-h-0 min-w-0 flex-1 space-y-5 overflow-x-hidden overflow-y-auto">
         {!initialShowAccountsManager ? (
           <RithmicProtocolConnectForm
             onConnected={onConnected}

--- a/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
+++ b/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
@@ -75,7 +75,7 @@ export function ConnectServiceModal({
             {title}
           </SheetTitle>
         </SheetHeader>
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-2 sm:p-4">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-hidden p-2 sm:p-4">
           {service === 'rithmic' && (
             <RithmicSyncWrapper
               initialShowCredentialsManager={false}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2560,7 +2560,11 @@ export default {
     addAccount: {
       title: "Connect Rithmic Protocol",
       description:
-        "Sign in with your Rithmic username/password, then pick the system your account lives on (for example Rithmic 01 or Rithmic Paper Trading).",
+        "Pick the Rithmic system your account lives on, then sign in with your username and password.",
+      systemStepDescription:
+        "Choose your connect point and Rithmic system first (for example Rithmic 01 or Rithmic Paper Trading).",
+      credentialsStepDescription:
+        "Sign in with the credentials for the system you selected.",
       gatewayLabel: "Connect point",
       gatewayHelp:
         "Choose the Rithmic connect point closest to you. Core (Chicago) works everywhere; a regional one only lowers latency.",
@@ -2572,8 +2576,12 @@ export default {
       historyStartLabel: "Account start date",
       historyStartHelp:
         "Pick the day you started trading this account. We import fills from then until today in serial 30-day batches (Rithmic guidance).",
+      continueToCredentials: "Continue",
       connecting: "Connecting…",
       connect: "Connect",
+    },
+    trademark: {
+      summary: "Trademarks & copyright",
     },
     sync: {
       inProgress: "Syncing Rithmic fills for {accountId}…",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2569,6 +2569,10 @@ export default {
       gatewayHelp:
         "Choose the Rithmic connect point closest to you. Core (Chicago) works everywhere; a regional one only lowers latency.",
       systemLabel: "Rithmic system",
+      systemPlaceholder: "Select a system",
+      systemSearchPlaceholder: "Search systems…",
+      systemSearchHelp: "Search and pick the Rithmic system your account uses.",
+      noSystemFound: "No system found",
       usernameLabel: "Username",
       passwordLabel: "Password",
       showPassword: "Show password",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2710,6 +2710,11 @@ export default {
       gatewayHelp:
         "Choisissez le point de connexion Rithmic le plus proche. Core (Chicago) fonctionne partout ; un point régional réduit seulement la latence.",
       systemLabel: "Système Rithmic",
+      systemPlaceholder: "Sélectionner un système",
+      systemSearchPlaceholder: "Rechercher un système…",
+      systemSearchHelp:
+        "Recherchez et choisissez le système Rithmic de votre compte.",
+      noSystemFound: "Aucun système trouvé",
       usernameLabel: "Nom d'utilisateur",
       passwordLabel: "Mot de passe",
       showPassword: "Afficher le mot de passe",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2701,7 +2701,11 @@ export default {
     addAccount: {
       title: "Connecter Rithmic Protocol",
       description:
-        "Connectez-vous avec votre identifiant Rithmic, puis choisissez le système de votre compte (par exemple Rithmic 01 ou Rithmic Paper Trading).",
+        "Choisissez d'abord le système Rithmic de votre compte, puis connectez-vous avec vos identifiants.",
+      systemStepDescription:
+        "Choisissez d'abord votre point de connexion et le système Rithmic (par exemple Rithmic 01 ou Rithmic Paper Trading).",
+      credentialsStepDescription:
+        "Connectez-vous avec les identifiants du système sélectionné.",
       gatewayLabel: "Point de connexion",
       gatewayHelp:
         "Choisissez le point de connexion Rithmic le plus proche. Core (Chicago) fonctionne partout ; un point régional réduit seulement la latence.",
@@ -2713,8 +2717,12 @@ export default {
       historyStartLabel: "Date de début du compte",
       historyStartHelp:
         "Indiquez le jour où vous avez commencé à trader sur ce compte. Nous importons les fills depuis cette date jusqu'à aujourd'hui par lots de 30 jours (recommandation Rithmic).",
+      continueToCredentials: "Continuer",
       connecting: "Connexion…",
       connect: "Connecter",
+    },
+    trademark: {
+      summary: "Marques et copyright",
     },
     sync: {
       inProgress: "Synchronisation des fills Rithmic pour {accountId}…",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Stacked on #436.

- Split Rithmic Protocol connect into two steps: pick connect point + system first, then enter credentials.
- System picker is a searchable Command list — **drawer on mobile**, popover on desktop.
- Fixed mobile horizontal scroll (`min-w-0` / `overflow-x-hidden` on the form, sheet, and fields).
- On mobile, trademark logos are smaller/quieter and legal notices collapse behind a disclosure.

## Test plan
- [ ] Open Connections → Add → Rithmic Protocol on a phone: no horizontal scroll on either step.
- [ ] System field opens a bottom drawer with search; picking a system closes it.
- [ ] Desktop: system field opens a searchable popover.
- [ ] Continue → credentials → connect still works.
- [ ] Trademark footer stays compact on mobile until expanded.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff189-91c2-76be-87b3-524b4d7296a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff189-91c2-76be-87b3-524b4d7296a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

