### PR TITLE
Support Trade Date in Rithmic performance imports

### DIFF
--- a/app/[locale]/dashboard/components/import/config/platforms.tsx
+++ b/app/[locale]/dashboard/components/import/config/platforms.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { Trade } from '@/prisma/generated/prisma/browser'
+import { processRithmicPerformance } from '@/lib/rithmic-performance-import'
 import { ThorSync } from '../thor/thor-sync'
 import { TradovateSync } from '../tradovate/sync/tradovate-sync'
 import { DxFeedSync } from '../dxfeed/sync/dxfeed-sync'
@@ -183,42 +184,6 @@ export interface PlatformConfig {
 }
 
 // Platform-specific processing functions
-const processRithmicPerformance = (data: string[][]): ProcessedData => {
-  const processedData: string[][] = [];
-  let currentAccountNumber = '';
-  let currentInstrument = '';
-  let headers: string[] = [];
-
-  const isAccountNumber = (value: string) => {
-    return value.length > 8 &&
-      !/^[A-Z]{3}\d$/.test(value) &&
-      !/^\d+$/.test(value) &&
-      value !== 'Account' &&
-      value !== 'Entry Order Number';
-  };
-
-  const isInstrument = (value: string) => {
-    // Match common futures instrument patterns:
-    // - 2-4 uppercase letters followed by 1-2 digits (e.g. ESZ4, MESZ4, ZNH3)
-    // - Optionally prefixed with 'M' for micro contracts
-    return /^[A-Z]{2,4}\d{1,2}$/.test(value);
-  };
-
-  data.forEach((row) => {
-    if (row[0] && isAccountNumber(row[0])) {
-      currentAccountNumber = row[0];
-    } else if (row[0] && isInstrument(row[0])) {
-      currentInstrument = row[0];
-    } else if (row[0] === 'Entry Order Number') {
-      headers = ['AccountNumber', 'Instrument', ...row];
-    } else if (headers.length > 0 && row[0] && row[0] !== 'Entry Order Number' && row[0] !== 'Account') {
-      processedData.push([currentAccountNumber, currentInstrument, ...row]);
-    }
-  });
-
-  return { headers, processedData };
-};
-
 const processRithmicOrders = (data: string[][]): ProcessedData => {
   const headerRowIndex = data.findIndex(row => row[0] === 'Completed Orders') + 1
   const headers = data[headerRowIndex].filter(header => header && header.trim() !== '')

--- a/lib/rithmic-performance-import.test.ts
+++ b/lib/rithmic-performance-import.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { processRithmicPerformance } from './rithmic-performance-import'
+
+describe('processRithmicPerformance', () => {
+  it('keeps supporting exports where Entry Order Number is the first trade column', () => {
+    const result = processRithmicPerformance([
+      ['BX-M407010817610'],
+      ['MESZ4'],
+      ['Entry Order Number', 'Entry Buy/Sell', 'Entry Time'],
+      ['1001', 'B', '2025-03-10 09:35:12'],
+    ])
+
+    expect(result).toEqual({
+      headers: [
+        'AccountNumber',
+        'Instrument',
+        'Entry Order Number',
+        'Entry Buy/Sell',
+        'Entry Time',
+      ],
+      processedData: [[
+        'BX-M407010817610',
+        'MESZ4',
+        '1001',
+        'B',
+        '2025-03-10 09:35:12',
+      ]],
+    })
+  })
+
+  it('recognizes newer exports with Trade Date before Entry Order Number', () => {
+    const result = processRithmicPerformance([
+      ['Account', 'Trade P&L', 'Commission & Fees'],
+      ['BX-M407010817610', '47.50', '2.44'],
+      ['MESU6', '47.50', '2.44'],
+      [
+        'Trade Date',
+        'Entry Order Number',
+        'Entry Buy/Sell',
+        'Entry Time',
+      ],
+      ['20260811', '2605467589', 'S', '2026-08-11 13:07:41'],
+    ])
+
+    expect(result).toEqual({
+      headers: [
+        'AccountNumber',
+        'Instrument',
+        'Trade Date',
+        'Entry Order Number',
+        'Entry Buy/Sell',
+        'Entry Time',
+      ],
+      processedData: [[
+        'BX-M407010817610',
+        'MESU6',
+        '20260811',
+        '2605467589',
+        'S',
+        '2026-08-11 13:07:41',
+      ]],
+    })
+  })
+})

--- a/lib/rithmic-performance-import.ts
+++ b/lib/rithmic-performance-import.ts
@@ -1,0 +1,49 @@
+export interface RithmicPerformanceImportData {
+  headers: string[]
+  processedData: string[][]
+}
+
+const ENTRY_ORDER_HEADER = 'Entry Order Number'
+
+const isAccountNumber = (value: string) => {
+  return value.length > 8 &&
+    !/^[A-Z]{3}\d$/.test(value) &&
+    !/^\d+$/.test(value) &&
+    value !== 'Account' &&
+    value !== ENTRY_ORDER_HEADER
+}
+
+const isInstrument = (value: string) => {
+  // Match common futures instrument patterns such as ESZ4, MESZ4, and ZNH3.
+  return /^[A-Z]{2,4}\d{1,2}$/.test(value)
+}
+
+export const processRithmicPerformance = (
+  data: string[][],
+): RithmicPerformanceImportData => {
+  const processedData: string[][] = []
+  let currentAccountNumber = ''
+  let currentInstrument = ''
+  let headers: string[] = []
+
+  data.forEach((row) => {
+    const firstCell = row[0]?.trim() ?? ''
+    const isTradeHeader = row.some(
+      (value) => value.trim() === ENTRY_ORDER_HEADER,
+    )
+
+    // Newer Rithmic exports prefix the trade fields with "Trade Date". Detect
+    // the identifying order column anywhere in the row so both layouts work.
+    if (isTradeHeader) {
+      headers = ['AccountNumber', 'Instrument', ...row]
+    } else if (firstCell && isAccountNumber(firstCell)) {
+      currentAccountNumber = firstCell
+    } else if (firstCell && isInstrument(firstCell)) {
+      currentInstrument = firstCell
+    } else if (headers.length > 0 && firstCell && firstCell !== 'Account') {
+      processedData.push([currentAccountNumber, currentInstrument, ...row])
+    }
+  })
+
+  return { headers, processedData }
+}


### PR DESCRIPTION
## Summary

- detect the Rithmic `Entry Order Number` marker anywhere in a performance-report header
- preserve the new leading `Trade Date` column and keep every trade field aligned
- retain compatibility with legacy exports where `Entry Order Number` is the first column
- extract the parser into a focused helper and add regression coverage for both layouts

## Root cause

The importer only recognized a trade header when `Entry Order Number` was the first cell. Newer Rithmic Performance exports prepend `Trade Date`, so the header was classified as an account row and no trades were produced.

## User impact

Users can import the current Rithmic Performance CSV directly without manually deleting the `Trade Date` column. The date remains available alongside the full entry and exit timestamps.

## Validation

- parsed the reported `Performance 110826.csv` fixture: 2 trades, 2 correct accounts, `MESU6` instrument, and `20260811` retained for both rows
- verified the legacy header layout still produces a trade
- bundled the parser and regression test successfully with Bun
- `git diff --check` passes

The full Vitest suite was not run because this clean checkout does not have repository dependencies installed.