### PR TITLE
Paid relaunch: attribution persistence + Ads conversion wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=your_posthog_project_token_here
 NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
+# Google Ads / GA4 (optional overrides — defaults match production tags in components/google-tag.tsx)
+# NEXT_PUBLIC_GOOGLE_ADS_ID=AW-16864609071
+# NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=G-PYK62LTZRQ
+# Conversion send_to from Google Ads → Conversions → Tag setup (AW-XXXX/LABEL).
+# Required for event-snippet Sign-up / Subscribe; leave unset until labels are pasted.
+# NEXT_PUBLIC_GOOGLE_ADS_SIGNUP_SEND_TO=AW-16864609071/YOUR_SIGNUP_LABEL
+# NEXT_PUBLIC_GOOGLE_ADS_PURCHASE_SEND_TO=AW-16864609071/YOUR_PURCHASE_LABEL
+
 # Local dashboard auth bypass (development/self-host only — never enable in production)
 # LOCAL_DASHBOARD_AUTH_BYPASS=true
 # NEXT_PUBLIC_LOCAL_DASHBOARD_AUTH_BYPASS=true

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -224,6 +224,7 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
             pendingPurchaseSetCookieHeader({
                 revenue: revenueMajor,
                 currency: (session.currency || price.currency || 'eur').toLowerCase(),
+                transaction_id: session.id,
                 plan,
                 billing_interval: billingInterval,
             }),

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -269,7 +269,7 @@ export async function GET(req: Request) {
     const promo_code = searchParams.get('promo_code');
 
     if (!lookup_key) {
-        return NextResponse.json({ message: "Lookup key is required" }, { status: 404 });
+        return NextResponse.json({ message: "Lookup key is required" }, { status: 400 });
     }
 
     const supabase = await createClient();

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -7,6 +7,16 @@ import { getSubscriptionDetails } from "@/server/subscription";
 import { getReferralBySlug } from "@/server/referral";
 import { capturePostHogEvent, hasAnalyticsConsent } from "@/lib/posthog-server";
 import { applySignupSuccess, hasSignupSuccess } from "@/lib/signup-redirect";
+import {
+  attributionToPersonSetOnce,
+  attributionToPostHogProperties,
+  attributionToStripeMetadata,
+  minorUnitsToMajor,
+} from "@/lib/attribution";
+import {
+  pendingPurchaseSetCookieHeader,
+  readAttributionFromCookies,
+} from "@/lib/attribution-server";
 
 // This endpoint renders no page of ours — it redirects straight to Stripe — so
 // a signup marker arriving here would never reach the Google tag. Forward it to
@@ -24,6 +34,17 @@ function buildReturnUrl(
     }
     applySignupSuccess(url, signupSuccess);
     return url.toString();
+}
+
+function billingIntervalFromPrice(price: {
+    type?: string | null;
+    recurring?: { interval?: string | null; interval_count?: number | null } | null;
+}, lookup_key: string): string {
+    if (price.type === 'one_time' || lookup_key.includes('lifetime')) {
+        return 'lifetime';
+    }
+    if (price.recurring?.interval_count === 3) return 'quarter';
+    return price.recurring?.interval || 'month';
 }
 
 async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: string, referral?: string | null, promo_code?: string | null, signupSuccess = false) {
@@ -95,6 +116,12 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
 
     const price = prices.data[0];
     const isLifetimePlan = price.type === 'one_time' || lookup_key.includes('lifetime');
+    const billingInterval = billingIntervalFromPrice(price, lookup_key);
+    const productName =
+        typeof price.product === 'object' && price.product && 'name' in price.product
+            ? String((price.product as { name?: string }).name || lookup_key)
+            : lookup_key;
+    const plan = productName.toUpperCase();
 
     // Calculate remaining trial days if there was a previous trial (only for recurring plans)
     let trialDays = 0;
@@ -115,12 +142,15 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
 
     // Create session with appropriate mode based on price type
     const analyticsConsent = await hasAnalyticsConsent();
+    const attribution = await readAttributionFromCookies();
+    const attributionMeta = attributionToStripeMetadata(attribution);
     const sessionConfig: any = {
         customer: customerId,
         metadata: {
             plan: lookup_key,
             ...(referral && { referral_code: referral }),
             ...(promo_code && { promo_code: promo_code }),
+            ...attributionMeta,
             ...(analyticsConsent && {
                 analytics_consent: 'granted',
                 posthog_distinct_id: user.id,
@@ -162,19 +192,45 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
 
     const session = await stripe.checkout.sessions.create(sessionConfig);
 
+    const attributionProps = attributionToPostHogProperties(attribution);
+    const setOnce = attributionToPersonSetOnce(attribution);
+
     await capturePostHogEvent({
         distinctId: user.id,
         event: 'checkout_started',
         properties: {
             lookup_key,
+            plan,
+            billing_interval: billingInterval,
             is_lifetime: isLifetimePlan,
             has_referral: Boolean(referral),
             has_promo_code: Boolean(promo_code),
             stripe_checkout_session_id: session.id,
+            ...attributionProps,
+            ...(setOnce ? { $set_once: setOnce } : {}),
         },
     });
 
-    return NextResponse.redirect(session.url as string, 303);
+    const response = NextResponse.redirect(session.url as string, 303);
+
+    // Stash expected purchase value for the Google Ads conversion tag on return.
+    // Prefer Stripe session amount_total; fall back to the catalog unit_amount.
+    const revenueMajor =
+        minorUnitsToMajor(session.amount_total) ??
+        minorUnitsToMajor(price.unit_amount);
+    if (revenueMajor && revenueMajor > 0) {
+        response.headers.append(
+            'Set-Cookie',
+            pendingPurchaseSetCookieHeader({
+                revenue: revenueMajor,
+                currency: (session.currency || price.currency || 'eur').toLowerCase(),
+                plan,
+                billing_interval: billingInterval,
+            }),
+        );
+    }
+
+    return response;
 }
 
 export async function POST(req: Request) {
@@ -212,7 +268,7 @@ export async function GET(req: Request) {
     const promo_code = searchParams.get('promo_code');
 
     if (!lookup_key) {
-        return NextResponse.json({ message: "Lookup key is required" }, { status: 400 });
+        return NextResponse.json({ message: "Lookup key is required" }, { status: 404 });
     }
 
     const supabase = await createClient();

--- a/app/api/stripe/webhooks/route.ts
+++ b/app/api/stripe/webhooks/route.ts
@@ -7,6 +7,12 @@ import { PrismaClient } from "@/prisma/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { sendSubscriptionErrorEmail } from "@/app/[locale]/(landing)/actions/send-support-email";
 import { capturePostHogEvent } from "@/lib/posthog-server";
+import {
+  attributionFromStripeMetadata,
+  attributionToPersonSetOnce,
+  attributionToPostHogProperties,
+  resolveCheckoutRevenueMajor,
+} from "@/lib/attribution";
 
 // Helper function to get current period end from subscription items
 function getCurrentPeriodEnd(subscription: Stripe.Subscription): number {
@@ -138,6 +144,14 @@ export async function POST(req: Request) {
             console.log('subscription created/updated', subscription)
 
             if (data.metadata?.analytics_consent === 'granted' && user?.id) {
+              const attribution = attributionFromStripeMetadata(data.metadata);
+              const attributionProps = attributionToPostHogProperties(attribution);
+              const setOnce = attributionToPersonSetOnce(attribution);
+              const revenue = resolveCheckoutRevenueMajor({
+                amountTotal: data.amount_total,
+                priceUnitAmount: price.unit_amount,
+              });
+
               await capturePostHogEvent({
                 consentGranted: true,
                 distinctId: data.metadata.posthog_distinct_id || user.id,
@@ -147,8 +161,12 @@ export async function POST(req: Request) {
                   plan: subscriptionPlan,
                   billing_interval: interval,
                   currency: data.currency,
-                  revenue: data.amount_total ? data.amount_total / 100 : 0,
+                  // Prefer Stripe amount_total; fall back to catalog price so we
+                  // never invent 0 when Stripe has a real amount.
+                  ...(revenue !== null ? { revenue } : {}),
                   stripe_checkout_session_id: data.id,
+                  ...attributionProps,
+                  ...(setOnce ? { $set_once: setOnce } : {}),
                 },
               })
             }
@@ -228,6 +246,16 @@ export async function POST(req: Request) {
                 console.log('lifetime subscription created/updated')
 
                 if (data.metadata?.analytics_consent === 'granted' && user?.id) {
+                  const attribution = attributionFromStripeMetadata(data.metadata);
+                  const attributionProps = attributionToPostHogProperties(attribution);
+                  const setOnce = attributionToPersonSetOnce(attribution);
+                  const lineItemAmountTotal = lineItems[0]?.amount_total;
+                  const revenue = resolveCheckoutRevenueMajor({
+                    amountTotal: data.amount_total,
+                    lineItemAmountTotal,
+                    priceUnitAmount: price.unit_amount,
+                  });
+
                   await capturePostHogEvent({
                     consentGranted: true,
                     distinctId: data.metadata.posthog_distinct_id || user.id,
@@ -237,8 +265,10 @@ export async function POST(req: Request) {
                       plan: subscriptionPlan,
                       billing_interval: 'lifetime',
                       currency: data.currency,
-                      revenue: data.amount_total ? data.amount_total / 100 : 0,
+                      ...(revenue !== null ? { revenue } : {}),
                       stripe_checkout_session_id: data.id,
+                      ...attributionProps,
+                      ...(setOnce ? { $set_once: setOnce } : {}),
                     },
                   })
                 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,10 @@ import { ScrollLockFix } from "@/components/scroll-lock-fix";
 import { getSiteOrigin, siteUrl } from "@/lib/site-url";
 import { getSiteMetadataCopy } from "@/lib/og/site-metadata";
 import { cn } from "@/lib/utils";
+import { Suspense } from "react";
 import { GoogleTag } from "@/components/google-tag";
+import { AttributionCapture } from "@/components/attribution-capture";
+import { GoogleAdsConversions } from "@/components/google-ads-conversions";
 
 const inter = Inter({ subsets: ["latin"] });
 const metadataBase = new URL(getSiteOrigin());
@@ -350,6 +353,10 @@ export default function RootLayout({
       >
         <ScrollLockFix />
         <GoogleTag />
+        <AttributionCapture />
+        <Suspense fallback={null}>
+          <GoogleAdsConversions />
+        </Suspense>
         <SpeedInsights />
         <Analytics />
         {children}

--- a/components/attribution-capture.tsx
+++ b/components/attribution-capture.tsx
@@ -10,15 +10,35 @@ import {
   type Attribution,
   attributionToPostHogProperties,
   hasAttribution,
+  isDeltalytixHost,
   mergeAttributionFirstTouch,
   parseAttributionParams,
   readClientAttribution,
   serializeAttribution,
 } from "@/lib/attribution";
+import { isGoogleTagAllowed, readStoredConsentSettings } from "@/lib/consent-settings";
 
-function isDeltalytixHost() {
-  const host = window.location.hostname;
-  return host === "deltalytix.app" || host.endsWith(".deltalytix.app");
+const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated";
+
+/**
+ * Campaign params seen on the landing URL, held in memory only.
+ *
+ * The banner is frequently accepted a page or two after the ad click, by which
+ * point `location.search` no longer carries the params. Buffering them here
+ * keeps them recoverable without writing anything before consent — the module
+ * lives as long as the tab, and is gone with it.
+ */
+let bufferedAttribution: Attribution | null = null;
+
+/**
+ * Attribution is marketing data, not a functional requirement, so it lives
+ * behind the same gate as the Google tag: no banner decision yet, or a decision
+ * that turned both analytics and ads off, means nothing is written anywhere.
+ */
+function attributionStorageAllowed(): boolean {
+  const settings = readStoredConsentSettings();
+  if (!settings) return false;
+  return isGoogleTagAllowed(settings);
 }
 
 function writeAttributionCookie(attribution: Attribution) {
@@ -27,7 +47,7 @@ function writeAttributionCookie(attribution: Attribution) {
   const attributes = `Max-Age=${ATTRIBUTION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${secure}`;
 
   document.cookie = `${ATTRIBUTION_COOKIE}=${value}; ${attributes}`;
-  if (isDeltalytixHost()) {
+  if (isDeltalytixHost(window.location.hostname)) {
     document.cookie = `${ATTRIBUTION_COOKIE}=${value}; ${attributes}; Domain=.deltalytix.app`;
   }
 }
@@ -52,29 +72,50 @@ function registerWithPostHog(attribution: Attribution) {
   if (Object.keys(props).length === 0) return;
 
   // Super properties attach to later client events (e.g. marketing_cta_clicked).
+  // Person properties are set server-side at sign-up and purchase instead: doing
+  // it here would create a profile for every anonymous visitor on a campaign
+  // link, which `identified_only` person processing exists to avoid.
   posthog.register(props);
-  // Second arg is $set_once — keep first-touch campaign props on the person.
-  posthog.setPersonProperties({}, props);
 }
 
 /**
  * Captures utm_* / gclid from the current URL on every app origin (marketing +
  * app). Persists first-touch attribution in a SameSite=Lax cookie so Google
  * OAuth redirects do not wipe campaign context.
+ *
+ * Capture is re-attempted when the banner reports a decision, so a visitor who
+ * lands on a campaign URL and accepts on a later page is still attributed —
+ * the params are re-read from the URL that is current at that moment, and
+ * first-touch merging keeps the earliest values seen after consent.
  */
 export function AttributionCapture() {
   useEffect(() => {
-    const fromUrl = parseAttributionParams(
-      new URLSearchParams(window.location.search),
-    );
-    const existing = readClientAttribution();
-    const merged = mergeAttributionFirstTouch(existing, fromUrl);
+    const capture = () => {
+      const fromUrl = parseAttributionParams(
+        new URLSearchParams(window.location.search),
+      );
+      bufferedAttribution = mergeAttributionFirstTouch(
+        bufferedAttribution,
+        fromUrl,
+      );
 
-    if (!hasAttribution(merged)) return;
+      if (!attributionStorageAllowed()) return;
 
-    // Re-persist so cookie Max-Age refreshes when we already had storage only.
-    persistAttribution(merged);
-    registerWithPostHog(merged);
+      const existing = readClientAttribution();
+      const merged = mergeAttributionFirstTouch(existing, bufferedAttribution);
+
+      if (!hasAttribution(merged)) return;
+
+      // Re-persist so cookie Max-Age refreshes when we already had storage only.
+      persistAttribution(merged);
+      registerWithPostHog(merged);
+    };
+
+    capture();
+
+    const onConsent = () => capture();
+    window.addEventListener(CONSENT_UPDATED_EVENT, onConsent);
+    return () => window.removeEventListener(CONSENT_UPDATED_EVENT, onConsent);
   }, []);
 
   return null;

--- a/components/attribution-capture.tsx
+++ b/components/attribution-capture.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+
+import {
+  ATTRIBUTION_COOKIE,
+  ATTRIBUTION_MAX_AGE_SECONDS,
+  ATTRIBUTION_STORAGE_KEY,
+  type Attribution,
+  attributionToPostHogProperties,
+  hasAttribution,
+  mergeAttributionFirstTouch,
+  parseAttributionParams,
+  readClientAttribution,
+  serializeAttribution,
+} from "@/lib/attribution";
+
+function isDeltalytixHost() {
+  const host = window.location.hostname;
+  return host === "deltalytix.app" || host.endsWith(".deltalytix.app");
+}
+
+function writeAttributionCookie(attribution: Attribution) {
+  const value = encodeURIComponent(serializeAttribution(attribution));
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  const attributes = `Max-Age=${ATTRIBUTION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${secure}`;
+
+  document.cookie = `${ATTRIBUTION_COOKIE}=${value}; ${attributes}`;
+  if (isDeltalytixHost()) {
+    document.cookie = `${ATTRIBUTION_COOKIE}=${value}; ${attributes}; Domain=.deltalytix.app`;
+  }
+}
+
+function persistAttribution(attribution: Attribution) {
+  writeAttributionCookie(attribution);
+  try {
+    window.localStorage.setItem(
+      ATTRIBUTION_STORAGE_KEY,
+      serializeAttribution(attribution),
+    );
+  } catch {
+    // private mode / quota — cookie still carries attribution across OAuth
+  }
+}
+
+function registerWithPostHog(attribution: Attribution) {
+  if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return;
+  if (posthog.has_opted_out_capturing()) return;
+
+  const props = attributionToPostHogProperties(attribution);
+  if (Object.keys(props).length === 0) return;
+
+  // Super properties attach to later client events (e.g. marketing_cta_clicked).
+  posthog.register(props);
+  // Second arg is $set_once — keep first-touch campaign props on the person.
+  posthog.setPersonProperties({}, props);
+}
+
+/**
+ * Captures utm_* / gclid from the current URL on every app origin (marketing +
+ * app). Persists first-touch attribution in a SameSite=Lax cookie so Google
+ * OAuth redirects do not wipe campaign context.
+ */
+export function AttributionCapture() {
+  useEffect(() => {
+    const fromUrl = parseAttributionParams(
+      new URLSearchParams(window.location.search),
+    );
+    const existing = readClientAttribution();
+    const merged = mergeAttributionFirstTouch(existing, fromUrl);
+
+    if (!hasAttribution(merged)) return;
+
+    // Re-persist so cookie Max-Age refreshes when we already had storage only.
+    persistAttribution(merged);
+    registerWithPostHog(merged);
+  }, []);
+
+  return null;
+}

--- a/components/google-ads-conversions.tsx
+++ b/components/google-ads-conversions.tsx
@@ -7,12 +7,13 @@ import {
   clearPendingPurchaseCookie,
   deserializePendingPurchase,
   PENDING_PURCHASE_COOKIE,
+  readBrowserCookie,
 } from "@/lib/attribution";
 import {
   SIGNUP_SUCCESS_PARAM,
   SIGNUP_SUCCESS_VALUE,
 } from "@/lib/signup-redirect";
-import { isGoogleTagAllowed, type ConsentSettings } from "@/lib/consent-settings";
+import { isGoogleTagAllowed, readStoredConsentSettings } from "@/lib/consent-settings";
 
 /**
  * Conversion `send_to` values from Google Ads (Tools → Conversions → Tag setup).
@@ -25,42 +26,56 @@ const PURCHASE_SEND_TO =
 
 const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated";
 
-function readConsentSettings(): ConsentSettings | null {
-  const storedConsent = window.localStorage.getItem("cookieConsent");
-  if (!storedConsent) return null;
+/**
+ * Id of the signup conversion already reported, if any.
+ *
+ * The signup marker survives more than one page view — it is deliberately
+ * forwarded onto Stripe's cancel URL, and a reload replays it with a fresh
+ * component instance — so an in-memory guard is not enough. Persisting the id
+ * we sent lets Ads deduplicate on `transaction_id` and lets us skip re-firing.
+ */
+const SIGNUP_CONVERSION_ID_KEY = "deltalytix_signup_conversion_id";
+
+function adsConsentGranted(): boolean {
+  const settings = readStoredConsentSettings();
+  if (!settings) return false;
+  return isGoogleTagAllowed(settings) && settings.ad_storage === true;
+}
+
+function readStoredSignupConversionId(): string | null {
   try {
-    return JSON.parse(storedConsent) as ConsentSettings;
+    return window.localStorage.getItem(SIGNUP_CONVERSION_ID_KEY);
   } catch {
     return null;
   }
 }
 
-function adsConsentGranted(): boolean {
-  const settings = readConsentSettings();
-  if (!settings) return false;
-  return isGoogleTagAllowed(settings) && settings.ad_storage === true;
+function newConversionId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `signup-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-function readCookie(name: string): string | null {
-  const entry = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith(`${name}=`));
-  if (!entry) return null;
-  const value = entry.slice(name.length + 1);
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-}
+/** Returns false when nothing was sent, so callers can leave state to retry. */
+function fireSignupConversion(): boolean {
+  if (!SIGNUP_SEND_TO || !window.gtag) return false;
+  if (readStoredSignupConversionId()) return false;
 
-function fireSignupConversion() {
-  if (!SIGNUP_SEND_TO || !window.gtag) return;
+  const transactionId = newConversionId();
   window.gtag("event", "conversion", {
     send_to: SIGNUP_SEND_TO,
+    transaction_id: transactionId,
   });
+
+  try {
+    window.localStorage.setItem(SIGNUP_CONVERSION_ID_KEY, transactionId);
+  } catch {
+    // private mode / quota — Ads still dedupes on the id we just sent
+  }
+  return true;
 }
 
+/** Returns false when nothing was sent, so the pending cookie is kept. */
 function firePurchaseConversion({
   value,
   currency,
@@ -69,15 +84,16 @@ function firePurchaseConversion({
   value: number;
   currency: string;
   transactionId: string;
-}) {
-  if (!PURCHASE_SEND_TO || !window.gtag) return;
-  if (!(value > 0) || !transactionId) return;
+}): boolean {
+  if (!PURCHASE_SEND_TO || !window.gtag) return false;
+  if (!(value > 0) || !transactionId) return false;
   window.gtag("event", "conversion", {
     send_to: PURCHASE_SEND_TO,
     value,
     currency: currency.toUpperCase(),
     transaction_id: transactionId,
   });
+  return true;
 }
 
 /**
@@ -105,25 +121,40 @@ export function GoogleAdsConversions() {
 
       const key = `${pathname}?${searchParams.toString()}`;
       if (firedKey.current === key) return;
-      firedKey.current = key;
+
+      // Claim the URL only once something was actually sent. A no-op run — gtag
+      // still loading, label not configured yet — has to stay retryable, and
+      // the only retry we get is the consent-update replay below.
+      let fired = false;
 
       if (isSignup) {
-        fireSignupConversion();
+        fired = fireSignupConversion() || fired;
       }
 
       if (isPurchase) {
         const pending = deserializePendingPurchase(
-          readCookie(PENDING_PURCHASE_COOKIE),
+          readBrowserCookie(PENDING_PURCHASE_COOKIE),
         );
+        // Only drop the cookie once the conversion is actually on the wire:
+        // `firePurchaseConversion` no-ops while the Ads label is unconfigured
+        // or gtag has not loaded, and clearing regardless would discard the
+        // purchase value with no way to recover it.
         if (pending) {
-          firePurchaseConversion({
+          const purchaseFired = firePurchaseConversion({
             value: pending.revenue,
             currency: pending.currency,
             transactionId: pending.transaction_id,
           });
-          document.cookie = clearPendingPurchaseCookie();
+          if (purchaseFired) {
+            for (const header of clearPendingPurchaseCookie()) {
+              document.cookie = header;
+            }
+          }
+          fired = purchaseFired || fired;
         }
       }
+
+      if (fired) firedKey.current = key;
     };
 
     run();

--- a/components/google-ads-conversions.tsx
+++ b/components/google-ads-conversions.tsx
@@ -61,20 +61,30 @@ function fireSignupConversion() {
   });
 }
 
-function firePurchaseConversion(value: number, currency: string) {
+function firePurchaseConversion({
+  value,
+  currency,
+  transactionId,
+}: {
+  value: number;
+  currency: string;
+  transactionId: string;
+}) {
   if (!PURCHASE_SEND_TO || !window.gtag) return;
-  if (!(value > 0)) return;
+  if (!(value > 0) || !transactionId) return;
   window.gtag("event", "conversion", {
     send_to: PURCHASE_SEND_TO,
     value,
     currency: currency.toUpperCase(),
+    transaction_id: transactionId,
   });
 }
 
 /**
  * Fires Google Ads conversion tags when env labels are configured:
  * - Sign-up ↔ `?signup=success` (primary bidding event; URL marker still present)
- * - Subscribe ↔ `?success=true` after Stripe, value from pending-purchase cookie
+ * - Subscribe ↔ `?success=true` after Stripe; value/currency/transaction_id
+ *   from the pending-purchase cookie (Stripe Checkout session id)
  *
  * Instrumentation only — no product UX changes.
  */
@@ -106,7 +116,11 @@ export function GoogleAdsConversions() {
           readCookie(PENDING_PURCHASE_COOKIE),
         );
         if (pending) {
-          firePurchaseConversion(pending.revenue, pending.currency);
+          firePurchaseConversion({
+            value: pending.revenue,
+            currency: pending.currency,
+            transactionId: pending.transaction_id,
+          });
           document.cookie = clearPendingPurchaseCookie();
         }
       }

--- a/components/google-ads-conversions.tsx
+++ b/components/google-ads-conversions.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import {
+  clearPendingPurchaseCookie,
+  deserializePendingPurchase,
+  PENDING_PURCHASE_COOKIE,
+} from "@/lib/attribution";
+import {
+  SIGNUP_SUCCESS_PARAM,
+  SIGNUP_SUCCESS_VALUE,
+} from "@/lib/signup-redirect";
+import { isGoogleTagAllowed, type ConsentSettings } from "@/lib/consent-settings";
+
+/**
+ * Conversion `send_to` values from Google Ads (Tools → Conversions → Tag setup).
+ * Format: `AW-XXXXXXXXXX/LABEL`. Leave unset until labels are pasted from Ads.
+ */
+const SIGNUP_SEND_TO =
+  process.env.NEXT_PUBLIC_GOOGLE_ADS_SIGNUP_SEND_TO?.trim() || "";
+const PURCHASE_SEND_TO =
+  process.env.NEXT_PUBLIC_GOOGLE_ADS_PURCHASE_SEND_TO?.trim() || "";
+
+const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated";
+
+function readConsentSettings(): ConsentSettings | null {
+  const storedConsent = window.localStorage.getItem("cookieConsent");
+  if (!storedConsent) return null;
+  try {
+    return JSON.parse(storedConsent) as ConsentSettings;
+  } catch {
+    return null;
+  }
+}
+
+function adsConsentGranted(): boolean {
+  const settings = readConsentSettings();
+  if (!settings) return false;
+  return isGoogleTagAllowed(settings) && settings.ad_storage === true;
+}
+
+function readCookie(name: string): string | null {
+  const entry = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`));
+  if (!entry) return null;
+  const value = entry.slice(name.length + 1);
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function fireSignupConversion() {
+  if (!SIGNUP_SEND_TO || !window.gtag) return;
+  window.gtag("event", "conversion", {
+    send_to: SIGNUP_SEND_TO,
+  });
+}
+
+function firePurchaseConversion(value: number, currency: string) {
+  if (!PURCHASE_SEND_TO || !window.gtag) return;
+  if (!(value > 0)) return;
+  window.gtag("event", "conversion", {
+    send_to: PURCHASE_SEND_TO,
+    value,
+    currency: currency.toUpperCase(),
+  });
+}
+
+/**
+ * Fires Google Ads conversion tags when env labels are configured:
+ * - Sign-up ↔ `?signup=success` (primary bidding event; URL marker still present)
+ * - Subscribe ↔ `?success=true` after Stripe, value from pending-purchase cookie
+ *
+ * Instrumentation only — no product UX changes.
+ */
+export function GoogleAdsConversions() {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const firedKey = useRef<string | null>(null);
+
+  useEffect(() => {
+    const run = () => {
+      if (!adsConsentGranted()) return;
+
+      const isSignup =
+        searchParams.get(SIGNUP_SUCCESS_PARAM) === SIGNUP_SUCCESS_VALUE;
+      const isPurchase = searchParams.get("success") === "true";
+
+      if (!isSignup && !isPurchase) return;
+
+      const key = `${pathname}?${searchParams.toString()}`;
+      if (firedKey.current === key) return;
+      firedKey.current = key;
+
+      if (isSignup) {
+        fireSignupConversion();
+      }
+
+      if (isPurchase) {
+        const pending = deserializePendingPurchase(
+          readCookie(PENDING_PURCHASE_COOKIE),
+        );
+        if (pending) {
+          firePurchaseConversion(pending.revenue, pending.currency);
+          document.cookie = clearPendingPurchaseCookie();
+        }
+      }
+    };
+
+    run();
+
+    const onConsent = () => run();
+    window.addEventListener(CONSENT_UPDATED_EVENT, onConsent);
+    return () => window.removeEventListener(CONSENT_UPDATED_EVENT, onConsent);
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/components/google-tag.tsx
+++ b/components/google-tag.tsx
@@ -8,8 +8,11 @@ import {
   toGoogleConsent,
 } from "@/lib/consent-settings";
 
-const GOOGLE_ANALYTICS_ID = "G-PYK62LTZRQ";
-const GOOGLE_ADS_ID = "AW-16864609071";
+const GOOGLE_ANALYTICS_ID =
+  process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID?.trim() || "G-PYK62LTZRQ";
+/** Google Ads account tag. Override with NEXT_PUBLIC_GOOGLE_ADS_ID if needed. */
+const GOOGLE_ADS_ID =
+  process.env.NEXT_PUBLIC_GOOGLE_ADS_ID?.trim() || "AW-16864609071";
 const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated";
 
 function isProductionHost() {

--- a/components/google-tag.tsx
+++ b/components/google-tag.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import {
   type ConsentSettings,
   isGoogleTagAllowed,
+  readStoredConsentSettings,
   toGoogleConsent,
 } from "@/lib/consent-settings";
 
@@ -20,17 +21,6 @@ function isProductionHost() {
     window.location.hostname === "deltalytix.app" ||
     window.location.hostname === "www.deltalytix.app"
   );
-}
-
-function readConsentSettings(): ConsentSettings | null {
-  const storedConsent = window.localStorage.getItem("cookieConsent");
-  if (!storedConsent) return null;
-
-  try {
-    return JSON.parse(storedConsent) as ConsentSettings;
-  } catch {
-    return null;
-  }
 }
 
 function configureGoogleTag(settings: ConsentSettings) {
@@ -75,7 +65,7 @@ function configureGoogleTag(settings: ConsentSettings) {
 
 export function GoogleTag() {
   useEffect(() => {
-    const initialSettings = readConsentSettings();
+    const initialSettings = readStoredConsentSettings();
     if (initialSettings) configureGoogleTag(initialSettings);
 
     const handleConsentUpdate = (event: Event) => {

--- a/lib/attribution-server.ts
+++ b/lib/attribution-server.ts
@@ -4,14 +4,11 @@ import { cookies } from "next/headers";
 
 import {
   ATTRIBUTION_COOKIE,
-  ATTRIBUTION_MAX_AGE_SECONDS,
   type Attribution,
   deserializeAttribution,
-  hasAttribution,
   PENDING_PURCHASE_COOKIE,
   PENDING_PURCHASE_MAX_AGE_SECONDS,
   type PendingPurchase,
-  serializeAttribution,
   serializePendingPurchase,
 } from "@/lib/attribution";
 
@@ -44,12 +41,6 @@ export async function readAttributionFromCookies(): Promise<Attribution | null> 
   } catch {
     return null;
   }
-}
-
-export function attributionSetCookieHeader(attribution: Attribution): string | null {
-  if (!hasAttribution(attribution)) return null;
-  const value = encodeURIComponent(serializeAttribution(attribution));
-  return `${ATTRIBUTION_COOKIE}=${value}; Max-Age=${ATTRIBUTION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}${cookieDomainSuffix()}`;
 }
 
 export function pendingPurchaseSetCookieHeader(purchase: PendingPurchase): string {

--- a/lib/attribution-server.ts
+++ b/lib/attribution-server.ts
@@ -20,6 +20,15 @@ function cookieSecureSuffix(): string {
   return process.env.NODE_ENV === "production" ? "; Secure" : "";
 }
 
+function cookieDomainSuffix(): string {
+  // Mirror consent-banner sharing across apex + www + beta.
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "";
+  if (siteUrl.includes("deltalytix.app") || process.env.VERCEL_ENV === "production") {
+    return "; Domain=.deltalytix.app";
+  }
+  return "";
+}
+
 export async function readAttributionFromCookies(): Promise<Attribution | null> {
   try {
     const raw = (await cookies()).get(ATTRIBUTION_COOKIE)?.value;
@@ -40,10 +49,10 @@ export async function readAttributionFromCookies(): Promise<Attribution | null> 
 export function attributionSetCookieHeader(attribution: Attribution): string | null {
   if (!hasAttribution(attribution)) return null;
   const value = encodeURIComponent(serializeAttribution(attribution));
-  return `${ATTRIBUTION_COOKIE}=${value}; Max-Age=${ATTRIBUTION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}`;
+  return `${ATTRIBUTION_COOKIE}=${value}; Max-Age=${ATTRIBUTION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}${cookieDomainSuffix()}`;
 }
 
 export function pendingPurchaseSetCookieHeader(purchase: PendingPurchase): string {
   const value = encodeURIComponent(serializePendingPurchase(purchase));
-  return `${PENDING_PURCHASE_COOKIE}=${value}; Max-Age=${PENDING_PURCHASE_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}`;
+  return `${PENDING_PURCHASE_COOKIE}=${value}; Max-Age=${PENDING_PURCHASE_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}${cookieDomainSuffix()}`;
 }

--- a/lib/attribution-server.ts
+++ b/lib/attribution-server.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+import {
+  ATTRIBUTION_COOKIE,
+  ATTRIBUTION_MAX_AGE_SECONDS,
+  type Attribution,
+  deserializeAttribution,
+  hasAttribution,
+  PENDING_PURCHASE_COOKIE,
+  PENDING_PURCHASE_MAX_AGE_SECONDS,
+  type PendingPurchase,
+  serializeAttribution,
+  serializePendingPurchase,
+} from "@/lib/attribution";
+
+function cookieSecureSuffix(): string {
+  // Checkout and auth callbacks are HTTPS in production; local http is fine without Secure.
+  return process.env.NODE_ENV === "production" ? "; Secure" : "";
+}
+
+export async function readAttributionFromCookies(): Promise<Attribution | null> {
+  try {
+    const raw = (await cookies()).get(ATTRIBUTION_COOKIE)?.value;
+    if (!raw) return null;
+    // Cookies may be stored encoded or plain JSON depending on writer.
+    let decoded = raw;
+    try {
+      decoded = decodeURIComponent(raw);
+    } catch {
+      decoded = raw;
+    }
+    return deserializeAttribution(decoded);
+  } catch {
+    return null;
+  }
+}
+
+export function attributionSetCookieHeader(attribution: Attribution): string | null {
+  if (!hasAttribution(attribution)) return null;
+  const value = encodeURIComponent(serializeAttribution(attribution));
+  return `${ATTRIBUTION_COOKIE}=${value}; Max-Age=${ATTRIBUTION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}`;
+}
+
+export function pendingPurchaseSetCookieHeader(purchase: PendingPurchase): string {
+  const value = encodeURIComponent(serializePendingPurchase(purchase));
+  return `${PENDING_PURCHASE_COOKIE}=${value}; Max-Age=${PENDING_PURCHASE_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}`;
+}

--- a/lib/attribution.test.ts
+++ b/lib/attribution.test.ts
@@ -4,6 +4,7 @@ import {
   attributionFromStripeMetadata,
   attributionToPostHogProperties,
   attributionToStripeMetadata,
+  clearPendingPurchaseCookie,
   deserializeAttribution,
   deserializePendingPurchase,
   hasAttribution,
@@ -88,19 +89,28 @@ describe("serialize/deserialize", () => {
 });
 
 describe("posthog + stripe mappers", () => {
-  it("emits $utm_* and gclid for PostHog", () => {
+  it("namespaces PostHog properties under first_touch_", () => {
     expect(
       attributionToPostHogProperties({
         utm_source: "google",
         utm_medium: "cpc",
         gclid: "abc",
       }),
-    ).toMatchObject({
-      $utm_source: "google",
+    ).toEqual({
+      first_touch_utm_source: "google",
+      first_touch_utm_medium: "cpc",
+      first_touch_gclid: "abc",
+    });
+  });
+
+  it("never emits PostHog's own last-touch campaign keys", () => {
+    const props = attributionToPostHogProperties({
       utm_source: "google",
-      $utm_medium: "cpc",
       gclid: "abc",
     });
+    // `$utm_*` / `$gclid` belong to PostHog and are last-touch; writing
+    // first-touch values there would shadow them on every later event.
+    expect(Object.keys(props).some((key) => key.startsWith("$"))).toBe(false);
   });
 
   it("round-trips through Stripe metadata", () => {
@@ -113,6 +123,23 @@ describe("posthog + stripe mappers", () => {
   it("hasAttribution is false for empty objects", () => {
     expect(hasAttribution({})).toBe(false);
     expect(hasAttribution({ gclid: "x" })).toBe(true);
+  });
+});
+
+describe("clearPendingPurchaseCookie", () => {
+  it("mirrors the Domain the server wrote on deltalytix hosts", () => {
+    const headers = clearPendingPurchaseCookie("beta.deltalytix.app");
+    expect(headers).toHaveLength(2);
+    expect(headers.some((header) => header.includes("Domain=.deltalytix.app"))).toBe(
+      true,
+    );
+    expect(headers.every((header) => header.includes("Max-Age=0"))).toBe(true);
+  });
+
+  it("omits Domain off the production hosts", () => {
+    expect(clearPendingPurchaseCookie("localhost")).toEqual([
+      "deltalytix_pending_purchase=; Max-Age=0; Path=/; SameSite=Lax",
+    ]);
   });
 });
 
@@ -145,12 +172,31 @@ describe("resolveCheckoutRevenueMajor", () => {
     ).toBe(99);
   });
 
-  it("returns 0 only for an explicit Stripe zero total", () => {
+  it("returns 0 for an explicit Stripe zero total", () => {
     expect(
       resolveCheckoutRevenueMajor({
         amountTotal: 0,
         lineItemAmountTotal: null,
         priceUnitAmount: null,
+      }),
+    ).toBe(0);
+  });
+
+  it("does not fall through a zero total to the catalog price", () => {
+    // 100%-off coupon or fully discounted trial: Stripe settled 0, so the
+    // list price must not be reported as revenue.
+    expect(
+      resolveCheckoutRevenueMajor({
+        amountTotal: 0,
+        priceUnitAmount: 2900,
+      }),
+    ).toBe(0);
+
+    expect(
+      resolveCheckoutRevenueMajor({
+        amountTotal: null,
+        lineItemAmountTotal: 0,
+        priceUnitAmount: 2900,
       }),
     ).toBe(0);
   });

--- a/lib/attribution.test.ts
+++ b/lib/attribution.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  attributionFromStripeMetadata,
+  attributionToPostHogProperties,
+  attributionToStripeMetadata,
+  deserializeAttribution,
+  deserializePendingPurchase,
+  hasAttribution,
+  mergeAttributionFirstTouch,
+  parseAttributionParams,
+  resolveCheckoutRevenueMajor,
+  serializeAttribution,
+} from "./attribution";
+
+describe("parseAttributionParams", () => {
+  it("reads utm and google click ids from URLSearchParams", () => {
+    const params = new URLSearchParams({
+      utm_source: "google",
+      utm_medium: "cpc",
+      utm_campaign: "relaunch",
+      utm_content: "adgroup1",
+      utm_term: "trading journal",
+      gclid: "Cj0KCQ",
+      gbraid: "gbraid-1",
+      ignored: "nope",
+    });
+
+    expect(parseAttributionParams(params)).toEqual({
+      utm_source: "google",
+      utm_medium: "cpc",
+      utm_campaign: "relaunch",
+      utm_content: "adgroup1",
+      utm_term: "trading journal",
+      gclid: "Cj0KCQ",
+      gbraid: "gbraid-1",
+    });
+  });
+
+  it("ignores blank values", () => {
+    expect(
+      parseAttributionParams({ utm_source: "  ", gclid: "abc" }),
+    ).toEqual({ gclid: "abc" });
+  });
+});
+
+describe("mergeAttributionFirstTouch", () => {
+  it("keeps the first touch and fills missing keys only", () => {
+    expect(
+      mergeAttributionFirstTouch(
+        { utm_source: "google", gclid: "first" },
+        { utm_source: "bing", utm_medium: "cpc", gclid: "second" },
+      ),
+    ).toEqual({
+      utm_source: "google",
+      utm_medium: "cpc",
+      gclid: "first",
+    });
+  });
+});
+
+describe("serialize/deserialize", () => {
+  it("round-trips attribution JSON", () => {
+    const original = { utm_source: "google", gclid: "x" };
+    expect(deserializeAttribution(serializeAttribution(original))).toEqual(
+      original,
+    );
+  });
+
+  it("rejects invalid pending purchases and zero revenue", () => {
+    expect(deserializePendingPurchase('{"revenue":0,"currency":"eur"}')).toBeNull();
+    expect(
+      deserializePendingPurchase('{"revenue":29,"currency":"eur","plan":"PRO"}'),
+    ).toEqual({ revenue: 29, currency: "eur", plan: "PRO" });
+  });
+});
+
+describe("posthog + stripe mappers", () => {
+  it("emits $utm_* and gclid for PostHog", () => {
+    expect(
+      attributionToPostHogProperties({
+        utm_source: "google",
+        utm_medium: "cpc",
+        gclid: "abc",
+      }),
+    ).toMatchObject({
+      $utm_source: "google",
+      utm_source: "google",
+      $utm_medium: "cpc",
+      gclid: "abc",
+    });
+  });
+
+  it("round-trips through Stripe metadata", () => {
+    const attribution = { utm_source: "google", gclid: "abc" };
+    expect(
+      attributionFromStripeMetadata(attributionToStripeMetadata(attribution)),
+    ).toEqual(attribution);
+  });
+
+  it("hasAttribution is false for empty objects", () => {
+    expect(hasAttribution({})).toBe(false);
+    expect(hasAttribution({ gclid: "x" })).toBe(true);
+  });
+});
+
+describe("resolveCheckoutRevenueMajor", () => {
+  it("prefers amount_total when present and positive", () => {
+    expect(
+      resolveCheckoutRevenueMajor({
+        amountTotal: 2900,
+        lineItemAmountTotal: 1000,
+        priceUnitAmount: 5000,
+      }),
+    ).toBe(29);
+  });
+
+  it("falls back to line item then price when amount_total is missing", () => {
+    expect(
+      resolveCheckoutRevenueMajor({
+        amountTotal: null,
+        lineItemAmountTotal: 4500,
+        priceUnitAmount: 5000,
+      }),
+    ).toBe(45);
+
+    expect(
+      resolveCheckoutRevenueMajor({
+        amountTotal: undefined,
+        lineItemAmountTotal: null,
+        priceUnitAmount: 9900,
+      }),
+    ).toBe(99);
+  });
+
+  it("returns 0 only for an explicit Stripe zero total", () => {
+    expect(
+      resolveCheckoutRevenueMajor({
+        amountTotal: 0,
+        lineItemAmountTotal: null,
+        priceUnitAmount: null,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns null when no amount can be resolved", () => {
+    expect(
+      resolveCheckoutRevenueMajor({
+        amountTotal: null,
+        lineItemAmountTotal: null,
+        priceUnitAmount: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/lib/attribution.test.ts
+++ b/lib/attribution.test.ts
@@ -70,8 +70,20 @@ describe("serialize/deserialize", () => {
   it("rejects invalid pending purchases and zero revenue", () => {
     expect(deserializePendingPurchase('{"revenue":0,"currency":"eur"}')).toBeNull();
     expect(
-      deserializePendingPurchase('{"revenue":29,"currency":"eur","plan":"PRO"}'),
-    ).toEqual({ revenue: 29, currency: "eur", plan: "PRO" });
+      deserializePendingPurchase(
+        '{"revenue":29,"currency":"eur","plan":"PRO"}',
+      ),
+    ).toBeNull();
+    expect(
+      deserializePendingPurchase(
+        '{"revenue":29,"currency":"eur","transaction_id":"cs_test_123","plan":"PRO"}',
+      ),
+    ).toEqual({
+      revenue: 29,
+      currency: "eur",
+      transaction_id: "cs_test_123",
+      plan: "PRO",
+    });
   });
 });
 

--- a/lib/attribution.ts
+++ b/lib/attribution.ts
@@ -31,6 +31,8 @@ export type Attribution = Partial<Record<AttributionParamKey, string>>;
 export type PendingPurchase = {
   revenue: number;
   currency: string;
+  /** Stripe Checkout session id — passed to Ads gtag as `transaction_id`. */
+  transaction_id: string;
   plan?: string;
   billing_interval?: string;
 };
@@ -180,18 +182,24 @@ export function deserializePendingPurchase(
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as PendingPurchase;
+    const transactionId =
+      typeof parsed?.transaction_id === "string"
+        ? parsed.transaction_id.trim()
+        : "";
     if (
       typeof parsed?.revenue !== "number" ||
       !Number.isFinite(parsed.revenue) ||
       parsed.revenue <= 0 ||
       typeof parsed.currency !== "string" ||
-      !parsed.currency
+      !parsed.currency ||
+      !transactionId
     ) {
       return null;
     }
     return {
       revenue: parsed.revenue,
       currency: parsed.currency.toLowerCase(),
+      transaction_id: transactionId,
       ...(typeof parsed.plan === "string" ? { plan: parsed.plan } : {}),
       ...(typeof parsed.billing_interval === "string"
         ? { billing_interval: parsed.billing_interval }

--- a/lib/attribution.ts
+++ b/lib/attribution.ts
@@ -37,13 +37,14 @@ export type PendingPurchase = {
   billing_interval?: string;
 };
 
-const UTM_TO_POSTHOG: Record<string, string> = {
-  utm_source: "$utm_source",
-  utm_medium: "$utm_medium",
-  utm_campaign: "$utm_campaign",
-  utm_content: "$utm_content",
-  utm_term: "$utm_term",
-};
+/**
+ * Namespace for the stored first-touch values.
+ *
+ * Deliberately *not* PostHog's own `$utm_*` / `$gclid`: those are last-touch and
+ * PostHog maintains them itself. Registering first-touch values under the same
+ * keys would shadow last-touch campaign data on every subsequent event.
+ */
+export const FIRST_TOUCH_PROPERTY_PREFIX = "first_touch_";
 
 function sanitizeValue(value: string | null | undefined): string | undefined {
   if (!value) return undefined;
@@ -119,8 +120,8 @@ export function deserializeAttribution(raw: string | null | undefined): Attribut
 }
 
 /**
- * Event + person properties for PostHog.
- * Uses `$utm_*` plus custom click-id keys; `$set_once` keeps first-touch on the person.
+ * Event + person properties for PostHog, namespaced under `first_touch_`.
+ * `$set_once` keeps the first-touch values on the person.
  */
 export function attributionToPostHogProperties(
   attribution: Attribution | null | undefined,
@@ -130,14 +131,7 @@ export function attributionToPostHogProperties(
   const properties: Record<string, string> = {};
   for (const key of ATTRIBUTION_PARAM_KEYS) {
     const value = attribution?.[key];
-    if (!value) continue;
-    if (key.startsWith("utm_")) {
-      const posthogKey = UTM_TO_POSTHOG[key];
-      if (posthogKey) properties[posthogKey] = value;
-      properties[key] = value;
-    } else {
-      properties[key] = value;
-    }
+    if (value) properties[`${FIRST_TOUCH_PROPERTY_PREFIX}${key}`] = value;
   }
   return properties;
 }
@@ -220,8 +214,12 @@ export function minorUnitsToMajor(amount: number | null | undefined): number | n
 
 /**
  * Resolve purchase revenue for analytics.
- * Prefer session `amount_total`; fall back to line-item totals / price unit_amount
- * so we never coerce a real Stripe amount into 0 via a nullish ternary.
+ *
+ * Each source is trusted as soon as it reports a number — including 0, which is
+ * a real total for a trial or a 100%-off coupon. Falling through a zero to the
+ * catalog price would bill Ads and PostHog for revenue that never existed.
+ * The catalog `unit_amount` is only a last resort, for sessions Stripe has not
+ * priced yet (subscription mode reports a null `amount_total` at creation).
  */
 export function resolveCheckoutRevenueMajor({
   amountTotal,
@@ -234,19 +232,36 @@ export function resolveCheckoutRevenueMajor({
 }): number | null {
   for (const candidate of [amountTotal, lineItemAmountTotal, priceUnitAmount]) {
     const major = minorUnitsToMajor(candidate);
-    if (major !== null && major > 0) return major;
+    if (major !== null) return major;
   }
-
-  // Explicit zero only when Stripe reported a zero total (trial / 100% off).
-  if (amountTotal === 0) return 0;
   return null;
 }
 
-export function clearPendingPurchaseCookie(): string {
-  return `${PENDING_PURCHASE_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax`;
+/** Apex, www, and beta all share cookies via `Domain=.deltalytix.app`. */
+export function isDeltalytixHost(hostname: string): boolean {
+  return hostname === "deltalytix.app" || hostname.endsWith(".deltalytix.app");
 }
 
-function readBrowserCookie(name: string): string | null {
+/**
+ * Client-side deletion headers for the pending-purchase cookie.
+ *
+ * The server writes this cookie with `Domain=.deltalytix.app` (see
+ * `pendingPurchaseSetCookieHeader`), and a deletion that omits `Domain` targets
+ * a different cookie — leaving the original to re-fire the Subscribe conversion
+ * on every reload until it expires. Returns both variants so whichever one the
+ * browser holds is removed.
+ */
+export function clearPendingPurchaseCookie(hostname?: string): string[] {
+  const base = `${PENDING_PURCHASE_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax`;
+  const host =
+    hostname ?? (typeof window !== "undefined" ? window.location.hostname : "");
+
+  return isDeltalytixHost(host)
+    ? [base, `${base}; Domain=.deltalytix.app`]
+    : [base];
+}
+
+export function readBrowserCookie(name: string): string | null {
   if (typeof document === "undefined") return null;
   const entry = document.cookie
     .split("; ")

--- a/lib/attribution.ts
+++ b/lib/attribution.ts
@@ -1,0 +1,267 @@
+/**
+ * First-party paid attribution (UTM + Google click IDs).
+ *
+ * Captured on the landing URL and persisted for 90 days so Google OAuth and
+ * Stripe Checkout hops do not drop campaign context before PostHog events fire.
+ * First-touch wins: once stored, later landings do not overwrite.
+ */
+
+export const ATTRIBUTION_COOKIE = "deltalytix_attribution";
+export const ATTRIBUTION_STORAGE_KEY = "deltalytix_attribution";
+export const ATTRIBUTION_MAX_AGE_SECONDS = 60 * 60 * 24 * 90; // 90 days
+
+export const PENDING_PURCHASE_COOKIE = "deltalytix_pending_purchase";
+export const PENDING_PURCHASE_MAX_AGE_SECONDS = 60 * 60 * 6; // 6 hours
+
+export const ATTRIBUTION_PARAM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+  "gbraid",
+  "wbraid",
+] as const;
+
+export type AttributionParamKey = (typeof ATTRIBUTION_PARAM_KEYS)[number];
+
+export type Attribution = Partial<Record<AttributionParamKey, string>>;
+
+export type PendingPurchase = {
+  revenue: number;
+  currency: string;
+  plan?: string;
+  billing_interval?: string;
+};
+
+const UTM_TO_POSTHOG: Record<string, string> = {
+  utm_source: "$utm_source",
+  utm_medium: "$utm_medium",
+  utm_campaign: "$utm_campaign",
+  utm_content: "$utm_content",
+  utm_term: "$utm_term",
+};
+
+function sanitizeValue(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 500) return undefined;
+  return trimmed;
+}
+
+/** Pull attribution params from a URLSearchParams / query object. */
+export function parseAttributionParams(
+  params: URLSearchParams | Record<string, string | string[] | undefined | null>,
+): Attribution {
+  const attribution: Attribution = {};
+
+  for (const key of ATTRIBUTION_PARAM_KEYS) {
+    let raw: string | null | undefined;
+    if (params instanceof URLSearchParams) {
+      raw = params.get(key);
+    } else {
+      const value = params[key];
+      raw = Array.isArray(value) ? value[0] : value;
+    }
+    const sanitized = sanitizeValue(raw);
+    if (sanitized) attribution[key] = sanitized;
+  }
+
+  return attribution;
+}
+
+export function hasAttribution(attribution: Attribution | null | undefined): boolean {
+  if (!attribution) return false;
+  return ATTRIBUTION_PARAM_KEYS.some((key) => Boolean(attribution[key]));
+}
+
+/** First-touch merge: keep existing keys, fill only missing ones from incoming. */
+export function mergeAttributionFirstTouch(
+  existing: Attribution | null | undefined,
+  incoming: Attribution | null | undefined,
+): Attribution {
+  const merged: Attribution = { ...(existing ?? {}) };
+  if (!incoming) return merged;
+
+  for (const key of ATTRIBUTION_PARAM_KEYS) {
+    if (!merged[key] && incoming[key]) {
+      merged[key] = incoming[key];
+    }
+  }
+  return merged;
+}
+
+export function serializeAttribution(attribution: Attribution): string {
+  return JSON.stringify(attribution);
+}
+
+export function deserializeAttribution(raw: string | null | undefined): Attribution | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+    const attribution: Attribution = {};
+    for (const key of ATTRIBUTION_PARAM_KEYS) {
+      const value = (parsed as Record<string, unknown>)[key];
+      if (typeof value === "string") {
+        const sanitized = sanitizeValue(value);
+        if (sanitized) attribution[key] = sanitized;
+      }
+    }
+    return hasAttribution(attribution) ? attribution : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Event + person properties for PostHog.
+ * Uses `$utm_*` plus custom click-id keys; `$set_once` keeps first-touch on the person.
+ */
+export function attributionToPostHogProperties(
+  attribution: Attribution | null | undefined,
+): Record<string, string> {
+  if (!hasAttribution(attribution)) return {};
+
+  const properties: Record<string, string> = {};
+  for (const key of ATTRIBUTION_PARAM_KEYS) {
+    const value = attribution?.[key];
+    if (!value) continue;
+    if (key.startsWith("utm_")) {
+      const posthogKey = UTM_TO_POSTHOG[key];
+      if (posthogKey) properties[posthogKey] = value;
+      properties[key] = value;
+    } else {
+      properties[key] = value;
+    }
+  }
+  return properties;
+}
+
+export function attributionToPersonSetOnce(
+  attribution: Attribution | null | undefined,
+): Record<string, string> | undefined {
+  const props = attributionToPostHogProperties(attribution);
+  return Object.keys(props).length > 0 ? props : undefined;
+}
+
+/** Flatten attribution into Stripe Checkout Session metadata (string values only). */
+export function attributionToStripeMetadata(
+  attribution: Attribution | null | undefined,
+): Record<string, string> {
+  if (!hasAttribution(attribution)) return {};
+
+  const metadata: Record<string, string> = {};
+  for (const key of ATTRIBUTION_PARAM_KEYS) {
+    const value = attribution?.[key];
+    if (value) metadata[key] = value;
+  }
+  return metadata;
+}
+
+export function attributionFromStripeMetadata(
+  metadata: StripeLikeMetadata | null | undefined,
+): Attribution {
+  if (!metadata) return {};
+  return parseAttributionParams(metadata as Record<string, string | undefined>);
+}
+
+type StripeLikeMetadata = Record<string, string | undefined> | null | undefined;
+
+export function serializePendingPurchase(purchase: PendingPurchase): string {
+  return JSON.stringify(purchase);
+}
+
+export function deserializePendingPurchase(
+  raw: string | null | undefined,
+): PendingPurchase | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as PendingPurchase;
+    if (
+      typeof parsed?.revenue !== "number" ||
+      !Number.isFinite(parsed.revenue) ||
+      parsed.revenue <= 0 ||
+      typeof parsed.currency !== "string" ||
+      !parsed.currency
+    ) {
+      return null;
+    }
+    return {
+      revenue: parsed.revenue,
+      currency: parsed.currency.toLowerCase(),
+      ...(typeof parsed.plan === "string" ? { plan: parsed.plan } : {}),
+      ...(typeof parsed.billing_interval === "string"
+        ? { billing_interval: parsed.billing_interval }
+        : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Stripe amounts are minor units; PostHog/Ads expect major units. */
+export function minorUnitsToMajor(amount: number | null | undefined): number | null {
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) {
+    return null;
+  }
+  return amount / 100;
+}
+
+/**
+ * Resolve purchase revenue for analytics.
+ * Prefer session `amount_total`; fall back to line-item totals / price unit_amount
+ * so we never coerce a real Stripe amount into 0 via a nullish ternary.
+ */
+export function resolveCheckoutRevenueMajor({
+  amountTotal,
+  lineItemAmountTotal,
+  priceUnitAmount,
+}: {
+  amountTotal?: number | null;
+  lineItemAmountTotal?: number | null;
+  priceUnitAmount?: number | null;
+}): number | null {
+  for (const candidate of [amountTotal, lineItemAmountTotal, priceUnitAmount]) {
+    const major = minorUnitsToMajor(candidate);
+    if (major !== null && major > 0) return major;
+  }
+
+  // Explicit zero only when Stripe reported a zero total (trial / 100% off).
+  if (amountTotal === 0) return 0;
+  return null;
+}
+
+export function clearPendingPurchaseCookie(): string {
+  return `${PENDING_PURCHASE_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax`;
+}
+
+function readBrowserCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const entry = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`));
+  if (!entry) return null;
+  const value = entry.slice(name.length + 1);
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/** Client-only: cookie first, then localStorage (OAuth-safe first-touch store). */
+export function readClientAttribution(): Attribution | null {
+  if (typeof window === "undefined") return null;
+
+  const fromCookie = deserializeAttribution(readBrowserCookie(ATTRIBUTION_COOKIE));
+  if (fromCookie) return fromCookie;
+
+  try {
+    return deserializeAttribution(window.localStorage.getItem(ATTRIBUTION_STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}

--- a/lib/consent-settings.ts
+++ b/lib/consent-settings.ts
@@ -16,6 +16,25 @@ export interface ConsentSettings {
   security_storage: boolean;
 }
 
+/** Where the banner persists its decision; read by every consent-gated script. */
+export const CONSENT_STORAGE_KEY = "cookieConsent";
+
+/**
+ * The banner's stored decision, or null when it has not been answered yet.
+ * Browser-only — callers are consent-gated client components.
+ */
+export function readStoredConsentSettings(): ConsentSettings | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const stored = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!stored) return null;
+    return JSON.parse(stored) as ConsentSettings;
+  } catch {
+    return null;
+  }
+}
+
 export type GoogleConsentValue = "granted" | "denied";
 
 export type GoogleConsentState = Record<

--- a/lib/marketing-analytics.ts
+++ b/lib/marketing-analytics.ts
@@ -1,5 +1,10 @@
 import posthog from "posthog-js";
 
+import {
+  attributionToPostHogProperties,
+  readClientAttribution,
+} from "@/lib/attribution";
+
 function canCapture() {
   if (!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) return false;
   if (typeof window === "undefined") return false;
@@ -19,10 +24,13 @@ export function captureMarketingCtaClicked({
 }) {
   if (!canCapture()) return;
 
+  const attributionProps = attributionToPostHogProperties(readClientAttribution());
+
   posthog.capture("marketing_cta_clicked", {
     cta_id: ctaId,
     destination,
     locale,
     placement,
+    ...attributionProps,
   });
 }

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -4,7 +4,15 @@ import { cookies } from "next/headers";
 
 const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent";
 
-type PostHogProperties = Record<string, boolean | number | string | null | undefined>;
+type PostHogPropertyValue =
+  | boolean
+  | number
+  | string
+  | null
+  | undefined
+  | Record<string, boolean | number | string | null | undefined>;
+
+type PostHogProperties = Record<string, PostHogPropertyValue>;
 
 export async function hasAnalyticsConsent(): Promise<boolean> {
   try {

--- a/lib/signup-redirect.ts
+++ b/lib/signup-redirect.ts
@@ -1,14 +1,19 @@
 /**
  * Post-authentication redirect targets.
  *
- * Newly created accounts land on a URL carrying `?signup=success`. Nothing in
- * the app reads it — it exists so Google Ads can match a completed signup on a
- * URL it could not otherwise distinguish from an ordinary sign-in.
+ * Newly created accounts land on a URL carrying `?signup=success`. Google Ads
+ * URL-contains matching can use that marker; the app also fires an event-snippet
+ * conversion via `GoogleAdsConversions` when
+ * `NEXT_PUBLIC_GOOGLE_ADS_SIGNUP_SEND_TO` is configured.
  *
  * The marker is applied to any *internal* destination rather than to
  * `/dashboard` alone: `next` legitimately points at checkout and team surfaces,
  * locale-prefixed paths (`/fr/dashboard`) are equally valid landings, and a
  * signup is a signup wherever the user ends up.
+ *
+ * Paid campaign landers should be marketing `/en` or `/fr` (not `/dashboard`).
+ * Attribution (`utm_*` / `gclid`) is persisted first-party before OAuth so it
+ * still reaches `user_signed_up` after Google login.
  *
  * `next` is attacker-controlled — it arrives on the query string — so both the
  * server redirect and the client navigation resolve it against the app's own

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -516,13 +516,10 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
       const attributionProps = attributionToPostHogProperties(attribution);
       const setOnce = attributionToPersonSetOnce(attribution);
       const authProvider = user.app_metadata?.provider || 'unknown';
-      // Ads contract uses method=email|google; keep auth_provider for existing reports.
-      const method =
-        authProvider === 'google'
-          ? 'google'
-          : authProvider === 'email' || authProvider === 'unknown'
-            ? 'email'
-            : authProvider;
+      // Ads contract reads `method`; keep auth_provider for existing reports.
+      // Reported verbatim — folding 'unknown' into 'email' would silently
+      // inflate the email share of the signup-method breakdown.
+      const method = authProvider;
 
       await capturePostHogEvent({
         distinctId: user.id,

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -14,6 +14,11 @@ import {
 import { createLocalDashboardBypassAuthStub } from '@/lib/local-dashboard-bypass-client'
 import { ensureLocalDashboardUserInDatabase } from '@/server/local-dashboard-bootstrap'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import {
+  attributionToPersonSetOnce,
+  attributionToPostHogProperties,
+} from '@/lib/attribution'
+import { readAttributionFromCookies } from '@/lib/attribution-server'
 import { getRequestOrigin } from '@/lib/site-url'
 import { resolveAuthEmailLocale } from '@/lib/auth-email-locale'
 
@@ -507,12 +512,28 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
       });
       console.log('[ensureUserInDatabase] SUCCESS: New user created successfully');
 
+      const attribution = await readAttributionFromCookies();
+      const attributionProps = attributionToPostHogProperties(attribution);
+      const setOnce = attributionToPersonSetOnce(attribution);
+      const authProvider = user.app_metadata?.provider || 'unknown';
+      // Ads contract uses method=email|google; keep auth_provider for existing reports.
+      const method =
+        authProvider === 'google'
+          ? 'google'
+          : authProvider === 'email' || authProvider === 'unknown'
+            ? 'email'
+            : authProvider;
+
       await capturePostHogEvent({
         distinctId: user.id,
         event: 'user_signed_up',
         properties: {
-          auth_provider: user.app_metadata?.provider || 'unknown',
+          auth_provider: authProvider,
+          method,
           language: locale || 'en',
+          lang: locale || 'en',
+          ...attributionProps,
+          ...(setOnce ? { $set_once: setOnce } : {}),
         },
       });
       


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Instrumentation-only changes for Gaby’s Deltalytix paid relaunch. No product UX changes beyond analytics tags.

1. **First-touch attribution survives Google OAuth + Stripe** — capture `utm_*`, `gclid`, `gbraid`, `wbraid` on any lander into a 90-day first-party cookie (+ localStorage). SameSite=Lax so OAuth return trips keep campaign context. Cookie is shared across `*.deltalytix.app`.
2. **Funnel events carry attribution** — `user_signed_up`, `checkout_started`, `subscription_purchased`, `marketing_cta_clicked` now include `$utm_*` / `gclid` (and related) as event props + `$set_once` person props. Checkout also stores attrs on Stripe session metadata for the webhook.
3. **Google Ads conversion tags** — gtag event snippets fire on `?signup=success` (Sign-up) and `?success=true` (Subscribe with value) when env labels are set. Existing URL marker behavior is unchanged.
4. **Purchase revenue fix** — `subscription_purchased` no longer coerces missing `amount_total` to `0`; resolves major units from session `amount_total`, then line item / catalog `unit_amount`.
5. **Purchase `transaction_id`** — Subscribe gtag conversion now sends `transaction_id` = Stripe Checkout session id (stashed in the pending-purchase cookie with `value` + `currency`), for Ads dedupe.

### Landing URL assumption (unchanged)

Ads should land on marketing **`/en` or `/fr`**, not `/dashboard`. Hero CTA may deep-link to `/dashboard` pre-auth; that is fine. Attribution is captured on every origin via root layout.

## Event contract

| Event | Notes |
|-------|--------|
| `user_signed_up` | Adds `method` (`email` \| `google` \| …), `lang` (+ existing `language`), attribution |
| `checkout_started` | Adds `plan`, `billing_interval`, attribution (keeps `lookup_key`) |
| `subscription_purchased` | Attribution + revenue from Stripe amounts (not null→0) |
| `marketing_cta_clicked` | Existing hero CTA on `/en` & `/fr`; now includes attribution |

## Google Ads env (placeholders — do not invent labels)

Documented in `.env.example`:

```env
# NEXT_PUBLIC_GOOGLE_ADS_ID=AW-16864609071
# NEXT_PUBLIC_GOOGLE_ADS_SIGNUP_SEND_TO=AW-16864609071/YOUR_SIGNUP_LABEL
# NEXT_PUBLIC_GOOGLE_ADS_PURCHASE_SEND_TO=AW-16864609071/YOUR_PURCHASE_LABEL
```

Paste real `send_to` values from Google Ads → Conversions → Tag setup. Until set, URL-contains `signup=success` still works; event snippets stay inert.

Purchase conversion payload (when labels are set):

```js
gtag('event', 'conversion', {
  send_to: /* NEXT_PUBLIC_GOOGLE_ADS_PURCHASE_SEND_TO */,
  value: /* major units from Stripe */,
  currency: 'EUR', // uppercased session/price currency
  transaction_id: /* Stripe Checkout session id */,
})
```

## How to verify

1. **Attribution through Google OAuth**  
   Visit `/en?utm_source=google&utm_medium=cpc&utm_campaign=test&utm_content=ag&utm_term=kw&gclid=test_gclid` → accept analytics cookies → Sign up with Google → in PostHog, `user_signed_up` should show `$utm_*` / `gclid`.

2. **Purchase revenue**  
   Complete a paid Checkout (non-zero Stripe amount) → webhook `subscription_purchased` should have `revenue` matching Stripe `amount_total / 100` (not 0 when Stripe has a real amount).

3. **Ads tags**  
   With `NEXT_PUBLIC_GOOGLE_ADS_*_SEND_TO` set on production host + ad storage consent:  
   - `?signup=success` → Sign-up conversion  
   - `?success=true` after checkout → Subscribe conversion with `value`, `currency`, and `transaction_id` (Checkout session id) from pending-purchase cookie

## Files / snippets touched

- `lib/attribution.ts`, `lib/attribution-server.ts`, `lib/attribution.test.ts` — capture/persist/map helpers + revenue resolver + pending purchase `transaction_id`  
- `components/attribution-capture.tsx` — root-layout client capture  
- `components/google-ads-conversions.tsx` — gtag conversion firing (purchase includes `transaction_id`)  
- `components/google-tag.tsx` — env-overridable GA4/Ads IDs (default `AW-16864609071` / `G-PYK62LTZRQ`)  
- `app/layout.tsx` — mount attribution + conversions  
- `server/auth.ts` — `user_signed_up` props  
- `app/api/stripe/create-checkout-session/route.ts` — `checkout_started` + metadata + pending purchase cookie (value/currency/session id)  
- `app/api/stripe/webhooks/route.ts` — `subscription_purchased` revenue + attribution  
- `lib/marketing-analytics.ts`, `lib/posthog-server.ts`, `lib/signup-redirect.ts`, `.env.example`  

No GTM container. No PostHog → Google Ads destination changes in this PR (wire via gtag event snippets + existing Ads tag).

## Checks

- `bunx vitest run lib/attribution.test.ts` — pass  
- `bun run typecheck` — pass  
- `OPENAI_API_KEY=dummy bun run build` — pass (prior revision)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8237d873-f4c7-4213-8b52-5782b1efe473?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8237d873-f4c7-4213-8b52-5782b1efe473&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

