### PR TITLE
feat(newsletter): Mon–Sun UTC week window + green-week send gate

### DIFF
--- a/app/api/email/weekly-summary/[userid]/actions/user-data.ts
+++ b/app/api/email/weekly-summary/[userid]/actions/user-data.ts
@@ -2,6 +2,10 @@
 
 import { PrismaClient } from "@/prisma/generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
+import {
+  getLastCompleteWeekUtc,
+  isEntryInWeek,
+} from "@/lib/weekly-newsletter-window"
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
@@ -38,6 +42,7 @@ interface ComputedStats {
     pnl: number
     weekday: number
   }[]
+  /** Net PnL for the week: sum of (pnl − commission) per day */
   thisWeekPnL: number
   profitableDays: number
   totalDays: number
@@ -66,15 +71,10 @@ export async function getUserData(userId: string): Promise<UserData> {
     },
   })
 
-  // Keep the last 14 days of trades to ensure we have two full weeks
-  const last14DaysTrades = trades.filter((trade) => {
-    const tradeDate = new Date(trade.entryDate)
-    const today = new Date()
-    const diffTime = Math.abs(today.getTime() - tradeDate.getTime())
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
-    return diffDays <= 14
-  })
-  
+  // Last complete Monday–Sunday week (UTC v1) — not a rolling lookback
+  const week = getLastCompleteWeekUtc()
+  const weekTrades = trades.filter((trade) => isEntryInWeek(trade.entryDate, week))
+
   return {
     user: {
       id: user.id,
@@ -86,13 +86,13 @@ export async function getUserData(userId: string): Promise<UserData> {
       firstName: newsletter.firstName,
       isActive: newsletter.isActive
     },
-    trades: last14DaysTrades
+    trades: weekTrades
   }
 }
 
 export async function computeTradingStats(
   trades: UserData['trades'],
-  language: string
+  _language: string
 ): Promise<ComputedStats> {
   if (trades.length === 0) {
     return {
@@ -115,23 +115,24 @@ export async function computeTradingStats(
 
   const dailyPnL = trades.reduce((acc, trade) => {
     const tradeDate = new Date(trade.entryDate)
-    // Set time to 00:00:00 to ensure proper date comparison
-    tradeDate.setHours(0, 0, 0, 0)
-    
-    // Convert from Sunday-based (0-6) to Monday-based (0-6) weekday
-    const weekday = tradeDate.getDay() === 0 ? 6 : tradeDate.getDay() - 1
-    
-    const existingEntry = acc.find(entry => {
-      const entryDate = new Date(entry.date)
-      entryDate.setHours(0, 0, 0, 0)
-      return entryDate.getTime() === tradeDate.getTime()
-    })
+    // UTC midnight for date bucketing (UTC v1)
+    const dayUtc = new Date(Date.UTC(
+      tradeDate.getUTCFullYear(),
+      tradeDate.getUTCMonth(),
+      tradeDate.getUTCDate(),
+    ))
+
+    // Convert from Sunday-based (0-6) to Monday-based (0-6) weekday (UTC)
+    const utcDay = dayUtc.getUTCDay()
+    const weekday = utcDay === 0 ? 6 : utcDay - 1
+
+    const existingEntry = acc.find(entry => entry.date.getTime() === dayUtc.getTime())
 
     if (existingEntry) {
       existingEntry.pnl = Number((existingEntry.pnl + trade.pnl - trade.commission).toFixed(2))
     } else {
       acc.push({
-        date: tradeDate,
+        date: dayUtc,
         pnl: Number((trade.pnl - trade.commission).toFixed(2)),
         weekday
       })
@@ -154,4 +155,4 @@ export async function computeTradingStats(
     profitableDays,
     totalDays
   }
-} 
+}

--- a/app/api/email/weekly-summary/[userid]/route.ts
+++ b/app/api/email/weekly-summary/[userid]/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server"
 import { headers } from 'next/headers'
 import TraderStatsEmail from "@/components/emails/weekly-recap"
-import MissingYouEmail from "@/components/emails/missing-data"
 import { render } from "@react-email/render"
 import { generateTradingAnalysis } from "./actions/analysis"
 import { getUserData, computeTradingStats } from "./actions/user-data"
-import { Resend } from "resend"
+import { shouldSendWeeklyRecap } from "@/lib/weekly-newsletter-window"
 
 export async function POST(req: Request, props: { params: Promise<{ userid: string }> }) {
   const params = await props.params;
@@ -21,29 +20,23 @@ export async function POST(req: Request, props: { params: Promise<{ userid: stri
       )
     }
 
-    // Get user data and compute stats
+    // Get user data and compute stats for the last complete Mon–Sun UTC week
     const { user, newsletter, trades } = await getUserData(params.userid)
     const stats = await computeTradingStats(trades, user.language)
 
-    // If no trades, return missing you email data
-    if (trades.length === 0) {
-      const missingYouEmailHtml = await render(
-        MissingYouEmail({
-          firstName: newsletter.firstName || 'trader',
-          email: newsletter.email,
-          language: user.language
-        })
-      )
-
+    // CPO gate: no trades or red week (net PnL < 0) → cron drops null emailData.
+    // Do not send missing-you / empty-week / consolation mail from this flow.
+    if (
+      !shouldSendWeeklyRecap({
+        tradeCount: trades.length,
+        netPnL: stats.thisWeekPnL,
+      })
+    ) {
       return NextResponse.json({
         success: true,
-        emailData: {
-          from: 'Deltalytix <newsletter@eu.updates.deltalytix.app>',
-          to: [newsletter.email],
-          replyTo: 'hugo.demenez@deltalytix.app',
-          subject: user.language === 'fr' ? 'Nous manquons de vous voir sur Deltalytix' : 'We miss you on Deltalytix',
-          html: missingYouEmailHtml
-        }
+        emailData: null,
+        skipped: true,
+        reason: trades.length === 0 ? "no_trades" : "negative_net_pnl",
       })
     }
 
@@ -86,7 +79,7 @@ export async function POST(req: Request, props: { params: Promise<{ userid: stri
           'List-Unsubscribe': `<${unsubscribeUrl}>`,
           'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
         },
-        replyTo: 'hugo.demenez@deltalytix.app'
+        replyTo: '[REDACTED]'
       }
     })
 

--- a/lib/weekly-newsletter-window.test.ts
+++ b/lib/weekly-newsletter-window.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import {
+  getLastCompleteWeekUtc,
+  isEntryInWeek,
+  shouldSendWeeklyRecap,
+} from "./weekly-newsletter-window"
+
+describe("getLastCompleteWeekUtc", () => {
+  it("returns the previous Mon–Sun when mid-week (Wed)", () => {
+    // Wed 2026-08-12 → last complete week Mon 2026-08-03 .. Sun 2026-08-09
+    const week = getLastCompleteWeekUtc(new Date("2026-08-12T15:30:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-08-03T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-08-10T00:00:00.000Z")
+  })
+
+  it("on Sunday still uses the previous complete week (current week unfinished)", () => {
+    // Sun 2026-08-09 08:00 UTC — current week Mon 08-03..Sun 08-09 is not complete
+    const week = getLastCompleteWeekUtc(new Date("2026-08-09T08:00:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-07-27T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-08-03T00:00:00.000Z")
+  })
+
+  it("on Monday 00:00 UTC the week that just ended becomes complete", () => {
+    const week = getLastCompleteWeekUtc(new Date("2026-08-10T00:00:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-08-03T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-08-10T00:00:00.000Z")
+  })
+
+  it("crosses month boundaries", () => {
+    // Wed 2026-09-02 → last complete Mon 2026-08-24 .. Sun 2026-08-30
+    const week = getLastCompleteWeekUtc(new Date("2026-09-02T12:00:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-08-24T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-08-31T00:00:00.000Z")
+  })
+})
+
+describe("isEntryInWeek", () => {
+  const week = getLastCompleteWeekUtc(new Date("2026-08-12T12:00:00.000Z"))
+  // week = 2026-08-03 .. 2026-08-10 exclusive
+
+  it("includes Monday 00:00 UTC of the week", () => {
+    expect(isEntryInWeek("2026-08-03T00:00:00.000Z", week)).toBe(true)
+  })
+
+  it("includes late Sunday of the week", () => {
+    expect(isEntryInWeek("2026-08-09T23:59:59.999Z", week)).toBe(true)
+  })
+
+  it("excludes the following Monday 00:00 UTC", () => {
+    expect(isEntryInWeek("2026-08-10T00:00:00.000Z", week)).toBe(false)
+  })
+
+  it("excludes the prior Sunday", () => {
+    expect(isEntryInWeek("2026-08-02T23:59:59.999Z", week)).toBe(false)
+  })
+
+  it("rejects invalid dates", () => {
+    expect(isEntryInWeek("not-a-date", week)).toBe(false)
+  })
+})
+
+describe("shouldSendWeeklyRecap", () => {
+  it("sends for a green week with trades and net PnL ≥ 0", () => {
+    expect(shouldSendWeeklyRecap({ tradeCount: 3, netPnL: 12.5 })).toBe(true)
+  })
+
+  it("sends when net PnL is exactly zero with trades", () => {
+    expect(shouldSendWeeklyRecap({ tradeCount: 1, netPnL: 0 })).toBe(true)
+  })
+
+  it("does not send when there are no trades", () => {
+    expect(shouldSendWeeklyRecap({ tradeCount: 0, netPnL: 0 })).toBe(false)
+  })
+
+  it("does not send a red week (net PnL < 0)", () => {
+    expect(shouldSendWeeklyRecap({ tradeCount: 5, netPnL: -0.01 })).toBe(false)
+  })
+})

--- a/lib/weekly-newsletter-window.ts
+++ b/lib/weekly-newsletter-window.ts
@@ -1,0 +1,56 @@
+/**
+ * Weekly performance newsletter window (UTC v1).
+ *
+ * Stats and send decisions use the last complete Monday–Sunday week in UTC,
+ * not a rolling lookback.
+ */
+
+export type UtcWeekWindow = {
+  /** Monday 00:00:00.000 UTC inclusive */
+  start: Date
+  /** Following Monday 00:00:00.000 UTC exclusive */
+  endExclusive: Date
+}
+
+/**
+ * Most recent fully finished Mon–Sun week in UTC.
+ * While the current UTC week is in progress, returns the previous Mon–Sun.
+ */
+export function getLastCompleteWeekUtc(now: Date = new Date()): UtcWeekWindow {
+  const utcDay = now.getUTCDay() // 0 Sun .. 6 Sat
+  const daysSinceMonday = utcDay === 0 ? 6 : utcDay - 1
+
+  const thisMonday = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - daysSinceMonday,
+    ),
+  )
+
+  const start = new Date(thisMonday)
+  start.setUTCDate(start.getUTCDate() - 7)
+
+  return { start, endExclusive: thisMonday }
+}
+
+/** Whether an entryDate string falls in [start, endExclusive). */
+export function isEntryInWeek(
+  entryDate: string,
+  week: UtcWeekWindow,
+): boolean {
+  const t = new Date(entryDate).getTime()
+  if (Number.isNaN(t)) return false
+  return t >= week.start.getTime() && t < week.endExclusive.getTime()
+}
+
+/**
+ * CPO send gate: recap only when the week has trades and net PnL ≥ 0.
+ * Net PnL = pnl − commission (already reflected in `netPnL`).
+ */
+export function shouldSendWeeklyRecap(params: {
+  tradeCount: number
+  netPnL: number
+}): boolean {
+  return params.tradeCount > 0 && params.netPnL >= 0
+}

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,11 @@
     {
       "path": "/api/cron/daily-sync",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron",
+      "schedule": "0 7 * * 0",
+      "_comment": "Weekly performance recap. Sunday 08:00 Lisbon. Lisbon is WEST (UTC+1) in summer → 07:00 UTC. This UTC hour shifts with DST: in winter (WET/UTC+0), Sunday 08:00 Lisbon is 08:00 UTC."
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Weekly performance recap uses the **last complete Monday–Sunday week (UTC v1)** and only produces sendable email data for **green weeks**. Cron is scheduled for Sunday 08:00 Lisbon. Merge candidate for **beta** (Hugh merges — not this agent). Separate from dashboard redesign / #442 / #448 / weekly-recap visual work.

## CPO rules (product lock)

- Recap email only if the last complete Monday–Sunday week (**UTC v1**) has trades **AND** net PnL ≥ 0.
- Net PnL = `pnl − commission`.
- Red week (net PnL < 0) = **no email**. No scoreboard, no consolation.
- Do **not** send missing-you / zero-trade / empty-week mail from this flow (`missing-data.tsx` is not used here). Missing-you is **not** this PR.
- Unsubscribe stays `Newsletter.isActive`. Dashboard “Weekly reports” toggle is **out of scope** (P1).

## Cron

- Path: `/api/cron`
- Schedule: `"0 7 * * 0"` = Sunday 08:00 Lisbon while Lisbon is WEST (UTC+1) → 07:00 UTC.
- Documented in `vercel.json` (`_comment`): this UTC hour **shifts with DST** (winter WET/UTC+0 → Sunday 08:00 Lisbon = 08:00 UTC).
- No missing-you cron. No other cron restored.

## What changed

- **Window:** last complete Mon–Sun UTC week (replaces 14-day rolling lookback).
- **Gate:** weekly-summary returns `emailData: null` when no trades or net PnL < 0; cron drops nulls. Green weeks render `weekly-recap.tsx`.
- **Helpers + tests:** `lib/weekly-newsletter-window.ts` (+ vitest).
- **Unchanged:** `Newsletter.isActive` unsubscribe; no dashboard Weekly reports wiring; no `#448` / `weekly-recap.tsx` visual edits.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ea0a93d-d7ec-4fb8-8bc3-4abd0b7aebba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ea0a93d-d7ec-4fb8-8bc3-4abd0b7aebba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

