### PR TITLE
Add UTMs to weekly recap CTAs

### DIFF
--- a/components/emails/weekly-recap.test.tsx
+++ b/components/emails/weekly-recap.test.tsx
@@ -43,6 +43,18 @@ describe("TraderStatsEmail weekly recap visual lock", () => {
     expect(html).not.toContain("72.0%");
     expect(html).toContain("Visit dashboard");
     expect(html).toContain("Book a call*");
+    expect(html).toContain("utm_source=resend");
+    expect(html).toContain("utm_medium=email");
+    expect(html).toContain("utm_campaign=weekly_recap");
+    expect(html).toContain("utm_content=2026-08-03");
+    expect(html).toContain(
+      "https://cal.com/hugo-demenez/deltalytix-discussion?utm_source=resend&amp;utm_medium=email&amp;utm_campaign=weekly_recap&amp;utm_content=2026-08-03",
+    );
+    expect(html).toContain(
+      "/dashboard?utm_source=resend&amp;utm_medium=email&amp;utm_campaign=weekly_recap&amp;utm_content=2026-08-03",
+    );
+    expect(html).toContain("/api/email/unsubscribe?email=");
+    expect(html).not.toMatch(/unsubscribe[^"]*utm_source/);
     expect(html).toContain("Hugo Demenez");
     expect(html).toContain("Founder of Deltalytix");
     expect(html).toContain("border-radius:4px");

--- a/components/emails/weekly-recap.tsx
+++ b/components/emails/weekly-recap.tsx
@@ -187,6 +187,17 @@ function formatSignedEuro(pnl: number): string {
   return `${amount}€`;
 }
 
+function withWeeklyRecapUtms(url: string, weekStartIso: string): string {
+  const separator = url.includes("?") ? "&" : "?";
+  const params = new URLSearchParams({
+    utm_source: "resend",
+    utm_medium: "email",
+    utm_campaign: "weekly_recap",
+    utm_content: weekStartIso,
+  });
+  return `${url}${separator}${params.toString()}`;
+}
+
 function pnlColor(pnl: number): string {
   if (pnl > 0) return colors.positive;
   if (pnl < 0) return colors.negative;
@@ -227,13 +238,20 @@ export default function TraderStatsEmail({
     /\/$/,
     "",
   );
-  const dashboardUrl = `${baseUrl}/dashboard`;
+  const weekStart = resolveWeekStart(dailyPnL);
+  const weekStartIso = dateKey(weekStart);
+  const dashboardUrl = withWeeklyRecapUtms(
+    `${baseUrl}/dashboard`,
+    weekStartIso,
+  );
   const unsubscribeUrl = email
     ? `${baseUrl}/api/email/unsubscribe?email=${encodeURIComponent(email)}`
     : "#";
-  const bookCallUrl = "https://cal.com/hugo-demenez/deltalytix-discussion";
+  const bookCallUrl = withWeeklyRecapUtms(
+    "https://cal.com/hugo-demenez/deltalytix-discussion",
+    weekStartIso,
+  );
 
-  const weekStart = resolveWeekStart(dailyPnL);
   const weekDays = buildWeekDays(weekStart, dailyPnL);
   const weekPnL = weekDays.reduce(
     (sum, day) => sum + (day.pnl ?? 0),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-pick of `94fc1926` onto post-#448 beta.

Adds UTMs on weekly recap CTAs only (Book a call / Visit dashboard):
- `utm_source=resend`
- `utm_medium=email`
- `utm_campaign=weekly_recap`
- `utm_content=YYYY-MM-DD` (Mon UTC week start)

Unsubscribe is left untagged. Beta’s 9OS-0 visual from #448 is preserved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f485e1d8-5104-42c4-bdba-8165506be103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f485e1d8-5104-42c4-bdba-8165506be103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

