### PR TITLE
fix(cron): remove invalid vercel.json _comment

### DIFF
--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -29,7 +29,9 @@ async function fetchWithRetry(url: string, options: RequestInit, retries = MAX_R
   }
 }
 
-// Vercel cron job handler - runs every Sunday at 8 AM UTC+1
+// Weekly performance recap. Vercel cron: path `/api/cron`, schedule `0 7 * * 0`.
+// Sunday 08:00 Lisbon. Summer WEST UTC+1 → 07:00 UTC (`0 7 * * 0`).
+// Winter WET UTC+0 → would need 08:00 UTC. Vercel cron objects only allow path + schedule.
 export async function GET(req: Request) {
   try {
     // Verify that this is a legitimate Vercel cron job request

--- a/vercel.json
+++ b/vercel.json
@@ -18,8 +18,7 @@
     },
     {
       "path": "/api/cron",
-      "schedule": "0 7 * * 0",
-      "_comment": "Weekly performance recap. Sunday 08:00 Lisbon. Lisbon is WEST (UTC+1) in summer → 07:00 UTC. This UTC hour shifts with DST: in winter (WET/UTC+0), Sunday 08:00 Lisbon is 08:00 UTC."
+      "schedule": "0 7 * * 0"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vercel build on `beta` fails because `crons[4]` included `_comment`. Vercel’s cron schema only allows `path` and `schedule`.

This PR:

1. Removes `_comment` from the `/api/cron` entry in `vercel.json`. Path `/api/cron` and schedule `0 7 * * 0` are unchanged. No other crons added or restored.
2. Moves the DST note onto the weekly recap handler in `app/api/cron/route.ts`: Sunday 08:00 Lisbon; summer WEST UTC+1 → 07:00 UTC (`0 7 * * 0`); winter WET UTC+0 → would need 08:00 UTC. Cron behavior is unchanged.

## Out of scope

- Dashboard redesign / #442
- Weekly recap email visuals / UTMs
- Cron schedule or path changes

## Test plan

- [x] `vercel.json` parses as JSON
- [x] Every cron object has only `path` and `schedule`
- [x] `crons[4]` remains `/api/cron` at `0 7 * * 0`
- [ ] Confirm Vercel build is green on this PR (Hugh merges after that)

Do **not** merge until the Vercel build is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08dc712b-9b52-4577-ad05-da8ee1607f30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08dc712b-9b52-4577-ad05-da8ee1607f30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

