### PR TITLE
chore(cron): remove Sunday weekly recap (manual send today)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -15,10 +15,6 @@
     {
       "path": "/api/cron/daily-sync",
       "schedule": "*/5 * * * *"
-    },
-    {
-      "path": "/api/cron",
-      "schedule": "0 7 * * 0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Removes `{ "path": "/api/cron", "schedule": "0 7 * * 0" }` from `vercel.json` on **beta**.
- Other crons unchanged. Restore this exact line Monday.

## Test plan
- [ ] Confirm `vercel.json` has 4 crons, no extra keys