### PR TITLE
Dashboard v6 QA nits + hide placed widgets from add sheet

### DIFF
--- a/app/[locale]/dashboard/components/add-widget-catalog.test.ts
+++ b/app/[locale]/dashboard/components/add-widget-catalog.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it } from 'vitest'
 import type { Layouts, Widget, WidgetType } from '../types/dashboard'
 import {
   omitPlacedWidgets,
@@ -6,7 +6,7 @@ import {
   placedWidgetTypes,
 } from './add-widget-catalog'
 
-function widget(type: WidgetType, i = type): Widget {
+function widget(type: WidgetType, i: string = type): Widget {
   return { i, type, size: 'tiny', x: 0, y: 0, w: 3, h: 1 }
 }
 

--- a/app/[locale]/dashboard/components/add-widget-catalog.test.ts
+++ b/app/[locale]/dashboard/components/add-widget-catalog.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test'
+import type { Layouts, Widget, WidgetType } from '../types/dashboard'
+import {
+  omitPlacedWidgets,
+  placedTypesForViewport,
+  placedWidgetTypes,
+} from './add-widget-catalog'
+
+function widget(type: WidgetType, i = type): Widget {
+  return { i, type, size: 'tiny', x: 0, y: 0, w: 3, h: 1 }
+}
+
+const catalog: { type: WidgetType }[] = [
+  { type: 'calendarWidget' },
+  { type: 'equityChart' },
+  { type: 'tradeTableReview' },
+  { type: 'cumulativePnl' },
+]
+
+describe('placedWidgetTypes', () => {
+  it('collects unique types from the current layout', () => {
+    expect(
+      placedWidgetTypes([
+        widget('calendarWidget'),
+        widget('equityChart'),
+        widget('calendarWidget', 'dup'),
+      ])
+    ).toEqual(new Set<WidgetType>(['calendarWidget', 'equityChart']))
+  })
+
+  it('is empty when the layout is missing', () => {
+    expect(placedWidgetTypes(undefined).size).toBe(0)
+  })
+})
+
+describe('placedTypesForViewport', () => {
+  const layouts: Layouts = {
+    desktop: [widget('calendarWidget'), widget('equityChart')],
+    mobile: [widget('cumulativePnl')],
+  }
+
+  it('reads desktop types off the mobile breakpoint', () => {
+    expect(placedTypesForViewport(layouts, false)).toEqual(
+      new Set<WidgetType>(['calendarWidget', 'equityChart'])
+    )
+  })
+
+  it('reads mobile types on the mobile breakpoint', () => {
+    expect(placedTypesForViewport(layouts, true)).toEqual(
+      new Set<WidgetType>(['cumulativePnl'])
+    )
+  })
+})
+
+describe('omitPlacedWidgets', () => {
+  it('drops types already on the board and keeps the rest', () => {
+    expect(
+      omitPlacedWidgets(catalog, ['calendarWidget', 'equityChart']).map(
+        (item) => item.type
+      )
+    ).toEqual(['tradeTableReview', 'cumulativePnl'])
+  })
+
+  it('returns the full catalog when nothing is placed', () => {
+    expect(omitPlacedWidgets(catalog, []).map((item) => item.type)).toEqual(
+      catalog.map((item) => item.type)
+    )
+  })
+
+  it('returns an empty list when every type is already placed', () => {
+    expect(
+      omitPlacedWidgets(catalog, catalog.map((item) => item.type))
+    ).toEqual([])
+  })
+})

--- a/app/[locale]/dashboard/components/add-widget-catalog.ts
+++ b/app/[locale]/dashboard/components/add-widget-catalog.ts
@@ -1,0 +1,33 @@
+import type { Layouts, WidgetType } from '../types/dashboard'
+
+export const ADD_WIDGET_CATEGORIES = [
+  'other',
+  'charts',
+  'tables',
+  'statistics',
+] as const
+
+export type AddWidgetCategory = (typeof ADD_WIDGET_CATEGORIES)[number]
+
+export function placedWidgetTypes(
+  widgets: { type: WidgetType }[] | undefined
+): Set<WidgetType> {
+  return new Set((widgets ?? []).map((widget) => widget.type))
+}
+
+/** Same viewport split WidgetCanvas uses for `activeLayout`. */
+export function placedTypesForViewport(
+  layouts: Layouts,
+  isMobile: boolean
+): Set<WidgetType> {
+  return placedWidgetTypes(isMobile ? layouts.mobile : layouts.desktop)
+}
+
+export function omitPlacedWidgets<T extends { type: WidgetType }>(
+  widgets: T[],
+  placedTypes: Iterable<WidgetType>
+): T[] {
+  const placed =
+    placedTypes instanceof Set ? placedTypes : new Set(placedTypes)
+  return widgets.filter((widget) => !placed.has(widget.type))
+}

--- a/app/[locale]/dashboard/components/add-widget-sheet.tsx
+++ b/app/[locale]/dashboard/components/add-widget-sheet.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { forwardRef, useState, useEffect, useRef, useCallback } from 'react'
+import React, { forwardRef, useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -8,13 +8,28 @@ import { Plus, Loader2 } from 'lucide-react'
 import { useI18n } from "@/locales/client"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from '@/lib/utils'
-import { WidgetType, WidgetSize } from '../types/dashboard'
+import { WidgetType, WidgetSize, Layouts } from '../types/dashboard'
 import { getWidgetsByCategory, WIDGET_REGISTRY, getWidgetPreview } from '../config/widget-registry'
 import { useData } from '@/context/data-provider'
+import { useIsMobileLayout } from '@/hooks/use-mobile'
+import {
+  ADD_WIDGET_CATEGORIES,
+  omitPlacedWidgets,
+  placedTypesForViewport,
+  type AddWidgetCategory,
+} from './add-widget-catalog'
+
+const CATEGORY_LABEL_KEY = {
+  other: 'widgets.categories.other',
+  charts: 'widgets.categories.charts',
+  tables: 'widgets.categories.tables',
+  statistics: 'widgets.categories.statistics',
+} as const satisfies Record<AddWidgetCategory, `widgets.categories.${AddWidgetCategory}`>
 
 interface AddWidgetSheetProps {
   onAddWidget: (type: WidgetType, size?: WidgetSize) => void
   isCustomizing: boolean
+  currentLayout: Layouts
   compact?: boolean
   appearance?: 'default' | 'pill'
 }
@@ -123,11 +138,26 @@ const PreviewCard = forwardRef<HTMLDivElement, PreviewCardProps>(
 PreviewCard.displayName = "PreviewCard"
 
 export const AddWidgetSheet = forwardRef<HTMLButtonElement, AddWidgetSheetProps>(
-  ({ onAddWidget, compact = false, appearance = 'default' }, ref) => {
+  ({ onAddWidget, currentLayout, compact = false, appearance = 'default' }, ref) => {
     const t = useI18n()
+    const isMobileLayout = useIsMobileLayout()
     const [isOpen, setIsOpen] = React.useState(false)
     const [loadedItems, setLoadedItems] = useState<Set<number>>(new Set())
     const [loadingStarted, setLoadingStarted] = useState(false)
+    const placedTypes = useMemo(
+      () => placedTypesForViewport(currentLayout, isMobileLayout === true),
+      [currentLayout, isMobileLayout]
+    )
+    const visibleCategories = useMemo(
+      () =>
+        ADD_WIDGET_CATEGORIES.filter(
+          (category) =>
+            omitPlacedWidgets(getWidgetsByCategory(category), placedTypes)
+              .length > 0
+        ),
+      [placedTypes]
+    )
+    const defaultCategory = visibleCategories[0] ?? 'other'
 
     const handleAddWidget = (type: WidgetType) => {
       const config = WIDGET_REGISTRY[type]
@@ -166,8 +196,11 @@ export const AddWidgetSheet = forwardRef<HTMLButtonElement, AddWidgetSheetProps>
       }
     }, [isOpen])
 
-    const renderWidgetsByCategory = (category: 'charts' | 'statistics' | 'tables' | 'other') => {
-      const widgets = getWidgetsByCategory(category)
+    const renderWidgetsByCategory = (category: AddWidgetCategory) => {
+      const widgets = omitPlacedWidgets(
+        getWidgetsByCategory(category),
+        placedTypes
+      )
       return (
         <div className="grid gap-4">
           {widgets.map((config, index) => (
@@ -231,30 +264,38 @@ export const AddWidgetSheet = forwardRef<HTMLButtonElement, AddWidgetSheetProps>
           <SheetHeader>
             <SheetTitle>{t('widgets.addWidget')}</SheetTitle>
           </SheetHeader>
-          <Tabs defaultValue="other" className="flex-1 flex flex-col mt-6 min-h-0">
-            <TabsList className="w-full">
-              <TabsTrigger value="other" className="flex-1">{t('widgets.categories.other')}</TabsTrigger>
-              <TabsTrigger value="charts" className="flex-1">{t('widgets.categories.charts')}</TabsTrigger>
-              <TabsTrigger value="tables" className="flex-1">{t('widgets.categories.tables')}</TabsTrigger>
-              <TabsTrigger value="statistics" className="flex-1">{t('widgets.categories.statistics')}</TabsTrigger>
-            </TabsList>
-            <ScrollArea className="flex-1 mt-2">
-              <div className="pr-4 pb-8">
-                <TabsContent value="other" className="mt-0">
-                  {renderWidgetsByCategory('other')}
-                </TabsContent>
-                <TabsContent value="charts" className="mt-0">
-                  {renderWidgetsByCategory('charts')}
-                </TabsContent>
-                <TabsContent value="tables" className="mt-0">
-                  {renderWidgetsByCategory('tables')}
-                </TabsContent>
-                <TabsContent value="statistics" className="mt-0">
-                  {renderWidgetsByCategory('statistics')}
-                </TabsContent>
-              </div>
-            </ScrollArea>
-          </Tabs>
+          {visibleCategories.length === 0 ? (
+            <p className="mt-6 text-sm text-muted-foreground">
+              {t('widgets.addSheet.empty')}
+            </p>
+          ) : (
+            <Tabs
+              key={visibleCategories.join('|')}
+              defaultValue={defaultCategory}
+              className="flex-1 flex flex-col mt-6 min-h-0"
+            >
+              <TabsList className="w-full">
+                {visibleCategories.map((category) => (
+                  <TabsTrigger
+                    key={category}
+                    value={category}
+                    className="flex-1"
+                  >
+                    {t(CATEGORY_LABEL_KEY[category])}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              <ScrollArea className="flex-1 mt-2">
+                <div className="pr-4 pb-8">
+                  {visibleCategories.map((category) => (
+                    <TabsContent key={category} value={category} className="mt-0">
+                      {renderWidgetsByCategory(category)}
+                    </TabsContent>
+                  ))}
+                </div>
+              </ScrollArea>
+            </Tabs>
+          )}
         </SheetContent>
       </Sheet>
     )

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -49,6 +49,7 @@ export function Toolbar({
   onAddWidget,
   isCustomizing,
   onEditToggle,
+  currentLayout,
   onRemoveAll,
   onRestoreDefaults,
   mobileActiveWidget = null,
@@ -132,13 +133,14 @@ export function Toolbar({
         isConsentVisible ? "bottom-36 sm:bottom-20" : "bottom-4"
       )}
     >
-      <div className="relative flex max-w-full items-center rounded-full border border-[#E5E5E5] bg-white px-2 py-[6px]">
+      <div className="relative flex max-w-full items-center rounded-full border border-[#E5E5E5] bg-white px-2 py-[6px] shadow-none">
         {isCustomizing ? (
           <>
             <Button
               onClick={onEditToggle}
               aria-label={t('widgets.done')}
               className={cn(
+                "shadow-none",
                 iconOnly
                   ? "size-8 rounded-full bg-[#171717] p-0 text-white hover:bg-[#171717]/90"
                   : "h-8 rounded-full bg-[#171717] px-3.5 text-sm font-medium text-white hover:bg-[#171717]/90"
@@ -150,6 +152,7 @@ export function Toolbar({
             <AddWidgetSheet
               onAddWidget={onAddWidget}
               isCustomizing={isCustomizing}
+              currentLayout={currentLayout}
               compact={iconOnly}
               appearance="pill"
             />
@@ -222,6 +225,7 @@ export function Toolbar({
             <AddWidgetSheet
               onAddWidget={onAddWidget}
               isCustomizing={isCustomizing}
+              currentLayout={currentLayout}
               compact={iconOnly}
               appearance="pill"
             />

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -890,6 +890,7 @@ export default {
   "import.error.noTradesAddedDescription":
     "No trades were added. Please check your data and try again.",
   "widgets.addWidget": "Add",
+  "widgets.addSheet.empty": "Every widget type is already on this dashboard.",
   "widgets.removeWidget": "Remove",
   "widgets.removeWidgetConfirm": "Are you sure?",
   "widgets.removeWidgetDescription":

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -900,6 +900,7 @@ export default {
   "import.error.noTradesAddedDescription":
     "Aucun trade n'a été ajouté. Veuillez vérifier vos données et réessayer.",
   "widgets.addWidget": "Ajouter",
+  "widgets.addSheet.empty": "Tous les types de widgets sont déjà sur ce tableau de bord.",
   "widgets.removeWidget": "Supprimer",
   "widgets.removeWidgetConfirm": "Êtes-vous sûr ?",
   "widgets.removeWidgetDescription":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#442 is already on `beta`. This is a follow-up PR (not a merge of the old #442 branch).

## A. A2Z / AD0 chrome

Most of the visual lock already landed with #442. This PR keeps that contract and drops the leftover default `shadow` on the toolbar pill / desktop Done control.

Already on `beta` and left as-is:

- Pill: white, 1px `#E5E5E5`, pad 6/8, hairline dividers, icon-only at 390
- Desktop Done is the black nested pill, word only (no Check)
- Restore / delete are ghost icons; delete is red stroke
- Auto-hide defaults off and is not wired to this chrome
- Add connection is icon-only `+` (36×36 / 32×32)
- 390 connection chips: no chevron, numeric count only, hidden when N=1
- 390 active filters: 26px / 4px / `#E5E5E5` / `#FAFAFA`, no color dots
- Navbar share glyph is lucide `Share2`
- Account → Theme is Theme › only (no intensity slider)
- Connections strip ground is white
- Desktop This week / + Filter is 12px `#737373`
- Account initials tile is 20×20, 4px

Left unchanged: standalone offline dot, `use-mobile` 768, plan-chip / billing-sheet navbar mount.

## B. Add sheet: hide widgets already on the board

The add-widget sheet now omits types already present on the current desktop/mobile layout. It filters `getWidgetsByCategory` — no second catalog. Empty categories are hidden; if every type is placed, the sheet shows an empty state.

Verified on the seeded dashboard:

- Desktop Other: AI Assistant, Trading Journal, Tags (Calendar omitted)
- Desktop Charts: Tick Target only
- Desktop Tables: Trade Review, Propfirm
- Desktop Statistics: Long/Short, Trade Performance, Winning Streak
- 390 omits Calendar, Equity, Cumulative P/L, and Trade Performance (the mobile layout)

![Add sheet Other tab omits Calendar](https://cursor.com/artifacts/c/art-8b54b57d-5525-4414-84c9-d61dbfad2648)
![Account Theme menu without intensity slider](https://cursor.com/artifacts/c/art-2b165d78-d05d-476d-8373-e27ceddc9754)
![390 dashboard chrome](https://cursor.com/artifacts/c/art-70fd0cb9-be4d-4cef-8efe-be1e12ea57d6)
<a href="https://cursor.com/agents/bc-54f1f3c0-dfe5-400e-9d4f-e1086ff1bc95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_sheet_hides_placed_widgets.mp4"><img src="https://cursor.com/artifacts/c/art-3dbcc20f-f206-4df0-9ce8-f2291212f5ca" alt="add_sheet_hides_placed_widgets.mp4" /></a>

## Test plan

- `bun test app/[locale]/dashboard/components/add-widget-catalog.test.ts` — 7 pass
- Typecheck / lint of new catalog code is clean. Pre-existing lint in `add-widget-sheet.tsx` (`any`, unused `onAdd`, setState-in-effect) was not introduced here.
- Manual: add sheet omits placed types; toolbar Done is word-only on desktop; Theme menu has no intensity slider.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54f1f3c0-dfe5-400e-9d4f-e1086ff1bc95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54f1f3c0-dfe5-400e-9d4f-e1086ff1bc95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

