### PR TITLE
fix(cron): build weekly recap in-process so Sunday does not 401

### DIFF
--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -93,7 +93,12 @@ export async function GET(req: Request) {
             // In-process builder: avoid HTTP self-fetch via NEXT_PUBLIC_APP_URL.
             // Apex deltalytix.app 308s to www (cross-origin); fetch then strips
             // Authorization, so weekly-summary returned {"error":"Unauthorized"}.
-            const { emailData } = await buildWeeklyRecapEmail(user.id)
+            // Same User.id the cron just loaded (email unique). Builder
+            // re-loads by that id and checks the email still matches.
+            const { emailData } = await buildWeeklyRecapEmail(
+              user.id,
+              user.email,
+            )
             return emailData
           } catch (error) {
             console.warn(`Error processing user ${user.id}:`, error)

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -7,7 +7,10 @@ import {
   buildWeeklyRecapEmail,
   type WeeklyRecapEmailData,
 } from "@/lib/weekly-recap-email"
-import { weeklyRecapBatchIdempotencyKey } from "@/lib/weekly-recap-idempotency"
+import {
+  isResendIdempotentReplay,
+  weeklyRecapIdempotencyKey,
+} from "@/lib/weekly-recap-idempotency"
 import { getRecapWeekUtc } from "@/lib/weekly-newsletter-window"
 
 const adapter = new PrismaPg({
@@ -64,7 +67,8 @@ export async function GET(req: Request) {
       )
     }
 
-    // Process subscribers in batches of 100 (Resend's batch limit)
+    // Build subscribers in chunks of 100 (LLM/DB concurrency), then send
+    // one-by-one with a per-recipient idempotency key.
     const batchSize = 100
     const batches: typeof users[] = []
     for (let i = 0; i < users.length; i += batchSize) {
@@ -77,7 +81,7 @@ export async function GET(req: Request) {
     let skippedCount = 0
     let duplicateCount = 0
 
-    // Identity of the recap being sent — anchors the per-batch idempotency key.
+    // Identity of the recap being sent — anchors each per-recipient key.
     const week = getRecapWeekUtc()
 
     // Process each batch
@@ -106,54 +110,47 @@ export async function GET(req: Request) {
           }
         })
 
-        // Filter out null values and send batch
         const validEmails = (await Promise.all(emailBatch)).filter(
           (email): email is WeeklyRecapEmailData => email != null,
         )
         // Users the green-week gate dropped are skips, not failures.
         skippedCount += batch.length - validEmails.length
 
-        if (validEmails.length > 0) {
-          try {
-            // Key on the input batch, not who passed the gate / built
-            // successfully. A retry that recovers 30 more builds must 409
-            // instead of changing the key and re-mailing the original 70.
-            const inputBatchEmails = batch
-              .map((user) => user.email)
-              .filter((email): email is string => Boolean(email))
+        // One send per recipient. A set-level batch key changes when a new
+        // subscriber appears, someone unsubscribes, or a retry recovers more
+        // builds — and the original recipients get mailed twice. Per-email
+        // keys 409 those people and still deliver recoveries and newcomers.
+        for (const email of validEmails) {
+          const recipient = email.to[0]
+          if (!recipient) {
+            errorCount += 1
+            continue
+          }
 
-            const result = await resend.batch.send(validEmails, {
-              idempotencyKey: weeklyRecapBatchIdempotencyKey(
-                week.start,
-                inputBatchEmails,
-              ),
+          try {
+            const result = await resend.emails.send(email, {
+              idempotencyKey: weeklyRecapIdempotencyKey(week.start, recipient),
             })
 
             if (result.error) {
-              // The recap copy is LLM-generated, so a retry sends a different
-              // payload under the same key: Resend answers 409 rather than
-              // deduping silently. Nobody got a second email — not an outage.
-              if (
-                result.error.name === 'invalid_idempotent_request' ||
-                result.error.name === 'concurrent_idempotent_requests'
-              ) {
-                console.log(
-                  `Batch already sent for week ${week.start.toISOString().slice(0, 10)}, skipping ${validEmails.length} recipients:`,
-                  result.error.message,
-                )
-                duplicateCount += validEmails.length
+              // Recap copy is LLM-generated, so a retry has a different
+              // payload under the same key: Resend 409s instead of sending
+              // again. That person already got this week's mail.
+              if (isResendIdempotentReplay(result.error)) {
+                duplicateCount += 1
               } else {
-                console.error('Failed to send email batch:', result.error)
-                errorCount += validEmails.length
+                console.error(
+                  `Failed to send weekly recap to ${recipient}:`,
+                  result.error,
+                )
+                errorCount += 1
               }
             } else {
-              const sent = result.data?.data.length ?? 0
-              successCount += sent
-              errorCount += validEmails.length - sent
+              successCount += 1
             }
           } catch (error) {
-            console.error('Failed to send email batch:', error)
-            errorCount += validEmails.length
+            console.error(`Failed to send weekly recap to ${recipient}:`, error)
+            errorCount += 1
           }
         }
       } catch (error) {

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -11,6 +11,12 @@ import {
   isResendIdempotentReplay,
   weeklyRecapIdempotencyKey,
 } from "@/lib/weekly-recap-idempotency"
+import {
+  RESEND_RATE_LIMIT_RETRIES,
+  RESEND_RATE_LIMIT_RETRY_MS,
+  createResendRequestPacer,
+  isResendRateLimitError,
+} from "@/lib/resend-rate-limit"
 import { getRecapWeekUtc } from "@/lib/weekly-newsletter-window"
 
 const adapter = new PrismaPg({
@@ -83,6 +89,8 @@ export async function GET(req: Request) {
 
     // Identity of the recap being sent — anchors each per-recipient key.
     const week = getRecapWeekUtc()
+    // Resend default is 10 req/s per team; each emails.send is one request.
+    const paceResendSend = createResendRequestPacer()
 
     // Process each batch
     for (const batch of batches) {
@@ -128,11 +136,36 @@ export async function GET(req: Request) {
           }
 
           try {
-            const result = await resend.emails.send(email, {
-              idempotencyKey: weeklyRecapIdempotencyKey(week.start, recipient),
-            })
+            let result: Awaited<ReturnType<typeof resend.emails.send>> | null =
+              null
 
-            if (result.error) {
+            for (
+              let attempt = 0;
+              attempt <= RESEND_RATE_LIMIT_RETRIES;
+              attempt += 1
+            ) {
+              await paceResendSend()
+              result = await resend.emails.send(email, {
+                idempotencyKey: weeklyRecapIdempotencyKey(
+                  week.start,
+                  recipient,
+                ),
+              })
+
+              if (!isResendRateLimitError(result.error)) {
+                break
+              }
+
+              if (attempt === RESEND_RATE_LIMIT_RETRIES) {
+                break
+              }
+
+              await new Promise((resolve) =>
+                setTimeout(resolve, RESEND_RATE_LIMIT_RETRY_MS),
+              )
+            }
+
+            if (result?.error) {
               // Recap copy is LLM-generated, so a retry has a different
               // payload under the same key: Resend 409s instead of sending
               // again. That person already got this week's mail.

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from "@/prisma/generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
 import { Resend } from 'resend'
 import { headers } from 'next/headers'
+import { buildWeeklyRecapEmail } from "@/lib/weekly-recap-email"
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
@@ -10,24 +11,6 @@ const adapter = new PrismaPg({
 
 const prisma = new PrismaClient({ adapter })
 const resend = new Resend(process.env.RESEND_API_KEY)
-
-// Retry configuration
-const MAX_RETRIES = 3
-const RETRY_DELAY = 1000 // 1 second
-
-async function fetchWithRetry(url: string, options: RequestInit, retries = MAX_RETRIES): Promise<Response> {
-  try {
-    const response = await fetch(url, options)
-    return response
-  } catch (error) {
-    if (retries > 0 && (error instanceof Error && error.message.includes('ECONNRESET'))) {
-      console.warn(`Retrying fetch (${MAX_RETRIES - retries + 1}/${MAX_RETRIES}) for ${url}`)
-      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY))
-      return fetchWithRetry(url, options, retries - 1)
-    }
-    throw error
-  }
-}
 
 // Weekly performance recap. Vercel cron: path `/api/cron`, schedule `0 7 * * 0`.
 // Sunday 08:00 Lisbon. Summer WEST UTC+1 → 07:00 UTC (`0 7 * * 0`).
@@ -91,24 +74,10 @@ export async function GET(req: Request) {
           }
 
           try {
-            // Get email data from the weekly summary endpoint with retry logic
-            const response = await fetchWithRetry(
-              `${process.env.NEXT_PUBLIC_APP_URL}/api/email/weekly-summary/${user.id}`,
-              {
-                method: 'POST',
-                headers: {
-                  'Authorization': `Bearer ${process.env.CRON_SECRET}`
-                }
-              }
-            )
-
-            if (!response.ok) {
-              const errorText = await response.text()
-              console.warn(`Failed to get email data for user ${user.id}:`, errorText)
-              return null
-            }
-
-            const { emailData } = await response.json()
+            // In-process builder: avoid HTTP self-fetch via NEXT_PUBLIC_APP_URL.
+            // Apex deltalytix.app 308s to www (cross-origin); fetch then strips
+            // Authorization, so weekly-summary returned {"error":"Unauthorized"}.
+            const { emailData } = await buildWeeklyRecapEmail(user.id)
             return emailData
           } catch (error) {
             console.warn(`Error processing user ${user.id}:`, error)

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -3,7 +3,10 @@ import { PrismaClient } from "@/prisma/generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
 import { Resend } from 'resend'
 import { headers } from 'next/headers'
-import { buildWeeklyRecapEmail } from "@/lib/weekly-recap-email"
+import {
+  buildWeeklyRecapEmail,
+  type WeeklyRecapEmailData,
+} from "@/lib/weekly-recap-email"
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
@@ -86,7 +89,9 @@ export async function GET(req: Request) {
         })
 
         // Filter out null values and send batch
-        const validEmails = (await Promise.all(emailBatch)).filter(Boolean)
+        const validEmails = (await Promise.all(emailBatch)).filter(
+          (email): email is WeeklyRecapEmailData => email != null,
+        )
         if (validEmails.length > 0) {
           try {
             const result = await resend.batch.send(validEmails)

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -115,8 +115,18 @@ export async function GET(req: Request) {
 
         if (validEmails.length > 0) {
           try {
+            // Key on the input batch, not who passed the gate / built
+            // successfully. A retry that recovers 30 more builds must 409
+            // instead of changing the key and re-mailing the original 70.
+            const inputBatchEmails = batch
+              .map((user) => user.email)
+              .filter((email): email is string => Boolean(email))
+
             const result = await resend.batch.send(validEmails, {
-              idempotencyKey: weeklyRecapBatchIdempotencyKey(week.start, validEmails),
+              idempotencyKey: weeklyRecapBatchIdempotencyKey(
+                week.start,
+                inputBatchEmails,
+              ),
             })
 
             if (result.error) {

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -7,6 +7,8 @@ import {
   buildWeeklyRecapEmail,
   type WeeklyRecapEmailData,
 } from "@/lib/weekly-recap-email"
+import { weeklyRecapBatchIdempotencyKey } from "@/lib/weekly-recap-idempotency"
+import { getLastCompleteWeekUtc } from "@/lib/weekly-newsletter-window"
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
@@ -14,6 +16,11 @@ const adapter = new PrismaPg({
 
 const prisma = new PrismaClient({ adapter })
 const resend = new Resend(process.env.RESEND_API_KEY)
+
+// Every subscriber's recap is now built in-process: DB read + one LLM call +
+// email render each. The whole run must fit in a single invocation, so the
+// default duration is not enough once the subscriber list grows.
+export const maxDuration = 300
 
 // Weekly performance recap. Vercel cron: path `/api/cron`, schedule `0 7 * * 0`.
 // Sunday 08:00 Lisbon. Summer WEST UTC+1 → 07:00 UTC (`0 7 * * 0`).
@@ -66,6 +73,11 @@ export async function GET(req: Request) {
 
     let successCount = 0
     let errorCount = 0
+    let skippedCount = 0
+    let duplicateCount = 0
+
+    // Identity of the recap being sent — anchors the per-batch idempotency key.
+    const week = getLastCompleteWeekUtc()
 
     // Process each batch
     for (const batch of batches) {
@@ -92,11 +104,37 @@ export async function GET(req: Request) {
         const validEmails = (await Promise.all(emailBatch)).filter(
           (email): email is WeeklyRecapEmailData => email != null,
         )
+        // Users the green-week gate dropped are skips, not failures.
+        skippedCount += batch.length - validEmails.length
+
         if (validEmails.length > 0) {
           try {
-            const result = await resend.batch.send(validEmails)
-            successCount += result.data?.data.length || 0
-            errorCount += batch.length - (result.data?.data.length || 0)
+            const result = await resend.batch.send(validEmails, {
+              idempotencyKey: weeklyRecapBatchIdempotencyKey(week.start, validEmails),
+            })
+
+            if (result.error) {
+              // The recap copy is LLM-generated, so a retry sends a different
+              // payload under the same key: Resend answers 409 rather than
+              // deduping silently. Nobody got a second email — not an outage.
+              if (
+                result.error.name === 'invalid_idempotent_request' ||
+                result.error.name === 'concurrent_idempotent_requests'
+              ) {
+                console.log(
+                  `Batch already sent for week ${week.start.toISOString().slice(0, 10)}, skipping ${validEmails.length} recipients:`,
+                  result.error.message,
+                )
+                duplicateCount += validEmails.length
+              } else {
+                console.error('Failed to send email batch:', result.error)
+                errorCount += validEmails.length
+              }
+            } else {
+              const sent = result.data?.data.length ?? 0
+              successCount += sent
+              errorCount += validEmails.length - sent
+            }
           } catch (error) {
             console.error('Failed to send email batch:', error)
             errorCount += validEmails.length
@@ -108,12 +146,18 @@ export async function GET(req: Request) {
       }
     }
 
-    console.log(`Weekly emails processed: ${successCount} successful, ${errorCount} failed`)
+    const summary = `Weekly emails processed: ${successCount} successful, ${errorCount} failed, ${skippedCount} skipped (green-week gate), ${duplicateCount} already sent`
+    console.log(summary)
 
     return NextResponse.json({
       success: true,
-      message: `Weekly emails processed: ${successCount} successful, ${errorCount} failed`,
-      stats: { success: successCount, failed: errorCount }
+      message: summary,
+      stats: {
+        success: successCount,
+        failed: errorCount,
+        skipped: skippedCount,
+        duplicate: duplicateCount,
+      }
     })
 
   } catch (error) {

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -8,7 +8,7 @@ import {
   type WeeklyRecapEmailData,
 } from "@/lib/weekly-recap-email"
 import { weeklyRecapBatchIdempotencyKey } from "@/lib/weekly-recap-idempotency"
-import { getLastCompleteWeekUtc } from "@/lib/weekly-newsletter-window"
+import { getRecapWeekUtc } from "@/lib/weekly-newsletter-window"
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
@@ -25,6 +25,7 @@ export const maxDuration = 300
 // Weekly performance recap. Vercel cron: path `/api/cron`, schedule `0 7 * * 0`.
 // Sunday 08:00 Lisbon. Summer WEST UTC+1 → 07:00 UTC (`0 7 * * 0`).
 // Winter WET UTC+0 → would need 08:00 UTC. Vercel cron objects only allow path + schedule.
+// Covers the Mon–Sun week ending that same Sunday — see `getRecapWeekUtc`.
 export async function GET(req: Request) {
   try {
     // Verify that this is a legitimate Vercel cron job request
@@ -77,7 +78,7 @@ export async function GET(req: Request) {
     let duplicateCount = 0
 
     // Identity of the recap being sent — anchors the per-batch idempotency key.
-    const week = getLastCompleteWeekUtc()
+    const week = getRecapWeekUtc()
 
     // Process each batch
     for (const batch of batches) {

--- a/app/api/email/weekly-summary/[userid]/actions/user-data.ts
+++ b/app/api/email/weekly-summary/[userid]/actions/user-data.ts
@@ -65,14 +65,30 @@ export async function getUserData(userId: string): Promise<UserData> {
     throw new Error(`Newsletter subscription not found or inactive for email: ${user.email}`)
   }
 
+  // Last complete Monday–Sunday week (UTC v1) — not a rolling lookback
+  const week = getLastCompleteWeekUtc()
+
+  // Coarse pre-filter so the cron does not hold every trade a user has ever
+  // made in memory (it now builds up to 100 recaps in one invocation).
+  // `entryDate` is a String column written in several shapes across importers
+  // — trailing `Z`, `+00:00`, and non-UTC offsets — so a lexicographic range
+  // is not exactly a chronological one. Padding a day on each side absorbs any
+  // UTC offset (max ±14h); `isEntryInWeek` below is still the real cut.
+  const rangeStart = new Date(week.start)
+  rangeStart.setUTCDate(rangeStart.getUTCDate() - 1)
+  const rangeEnd = new Date(week.endExclusive)
+  rangeEnd.setUTCDate(rangeEnd.getUTCDate() + 1)
+
   const trades = await prisma.trade.findMany({
     where: {
       userId: user.id,
+      entryDate: {
+        gte: rangeStart.toISOString(),
+        lt: rangeEnd.toISOString(),
+      },
     },
   })
 
-  // Last complete Monday–Sunday week (UTC v1) — not a rolling lookback
-  const week = getLastCompleteWeekUtc()
   const weekTrades = trades.filter((trade) => isEntryInWeek(trade.entryDate, week))
 
   return {

--- a/app/api/email/weekly-summary/[userid]/actions/user-data.ts
+++ b/app/api/email/weekly-summary/[userid]/actions/user-data.ts
@@ -3,7 +3,7 @@
 import { PrismaClient } from "@/prisma/generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
 import {
-  getLastCompleteWeekUtc,
+  getRecapWeekUtc,
   isEntryInWeek,
 } from "@/lib/weekly-newsletter-window"
 
@@ -65,8 +65,9 @@ export async function getUserData(userId: string): Promise<UserData> {
     throw new Error(`Newsletter subscription not found or inactive for email: ${user.email}`)
   }
 
-  // Last complete Monday–Sunday week (UTC v1) — not a rolling lookback
-  const week = getLastCompleteWeekUtc()
+  // Monday–Sunday week the subscriber has just traded (UTC v1) — not a
+  // rolling lookback, and not the week before it
+  const week = getRecapWeekUtc()
 
   // Coarse pre-filter so the cron does not hold every trade a user has ever
   // made in memory (it now builds up to 100 recaps in one invocation).

--- a/app/api/email/weekly-summary/[userid]/route.ts
+++ b/app/api/email/weekly-summary/[userid]/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server"
 import { headers } from 'next/headers'
-import TraderStatsEmail from "@/components/emails/weekly-recap"
-import { render } from "@react-email/render"
-import { generateTradingAnalysis } from "./actions/analysis"
-import { getUserData, computeTradingStats } from "./actions/user-data"
-import { shouldSendWeeklyRecap } from "@/lib/weekly-newsletter-window"
+import { buildWeeklyRecapEmail } from "@/lib/weekly-recap-email"
 
 export async function POST(req: Request, props: { params: Promise<{ userid: string }> }) {
   const params = await props.params;
@@ -20,68 +16,8 @@ export async function POST(req: Request, props: { params: Promise<{ userid: stri
       )
     }
 
-    // Get user data and compute stats for the last complete Mon–Sun UTC week
-    const { user, newsletter, trades } = await getUserData(params.userid)
-    const stats = await computeTradingStats(trades, user.language)
-
-    // CPO gate: no trades or red week (net PnL < 0) → cron drops null emailData.
-    // Do not send missing-you / empty-week / consolation mail from this flow.
-    if (
-      !shouldSendWeeklyRecap({
-        tradeCount: trades.length,
-        netPnL: stats.thisWeekPnL,
-      })
-    ) {
-      return NextResponse.json({
-        success: true,
-        emailData: null,
-        skipped: true,
-        reason: trades.length === 0 ? "no_trades" : "negative_net_pnl",
-      })
-    }
-
-    // Generate analysis using server action
-    const analysis = await generateTradingAnalysis(
-      stats.dailyPnL,
-      user.language as 'fr' | 'en'
-    )
-
-    // Ensure URL has protocol
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
-    const apiUrl = baseUrl.startsWith('http') 
-      ? baseUrl 
-      : `http://${baseUrl}`
-
-    const unsubscribeUrl = `${apiUrl}/api/email/unsubscribe?email=${encodeURIComponent(user.email)}`
-
-    const weeklyStatsEmailHtml = await render(
-      TraderStatsEmail({
-        firstName: newsletter.firstName || 'trader',
-        dailyPnL: stats.dailyPnL,
-        winLossStats: stats.winLossStats,
-        email: newsletter.email,
-        resultAnalysisIntro: analysis.resultAnalysisIntro,
-        tipsForNextWeek: analysis.tipsForNextWeek,
-        language: user.language
-      })
-    )
-
-
-
-    return NextResponse.json({
-      success: true,
-      emailData: {
-        from: 'Deltalytix <newsletter@eu.updates.deltalytix.app>',
-        to: [user.email],
-        subject: user.language === 'fr' ? 'Vos statistiques de trading de la semaine 📈' : 'Your trading statistics for the week 📈',
-        html: weeklyStatsEmailHtml,
-        headers: {
-          'List-Unsubscribe': `<${unsubscribeUrl}>`,
-          'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
-        },
-        replyTo: '[REDACTED]'
-      }
-    })
+    const result = await buildWeeklyRecapEmail(params.userid)
+    return NextResponse.json(result)
 
   } catch (error) {
     console.error('API error:', error)

--- a/lib/resend-rate-limit.test.ts
+++ b/lib/resend-rate-limit.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import {
+  RESEND_SEND_INTERVAL_MS,
+  RESEND_TEAM_REQUESTS_PER_SECOND,
+  createResendRequestPacer,
+  isResendQuotaError,
+  isResendRateLimitError,
+} from "./resend-rate-limit"
+
+describe("Resend send limits", () => {
+  it("paces below the 10 req/s team cap", () => {
+    expect(RESEND_TEAM_REQUESTS_PER_SECOND).toBe(10)
+    expect(RESEND_SEND_INTERVAL_MS).toBeGreaterThanOrEqual(100)
+    expect(1000 / RESEND_SEND_INTERVAL_MS).toBeLessThanOrEqual(10)
+  })
+})
+
+describe("isResendRateLimitError", () => {
+  it("matches the per-second 429", () => {
+    expect(isResendRateLimitError({ name: "rate_limit_exceeded" })).toBe(true)
+  })
+
+  it("does not treat quota 429s as a retryable rate limit", () => {
+    expect(isResendRateLimitError({ name: "daily_quota_exceeded" })).toBe(false)
+    expect(isResendRateLimitError({ name: "monthly_quota_exceeded" })).toBe(
+      false,
+    )
+  })
+})
+
+describe("isResendQuotaError", () => {
+  it("matches daily and monthly quota 429s", () => {
+    expect(isResendQuotaError({ name: "daily_quota_exceeded" })).toBe(true)
+    expect(isResendQuotaError({ name: "monthly_quota_exceeded" })).toBe(true)
+    expect(isResendQuotaError({ name: "rate_limit_exceeded" })).toBe(false)
+  })
+})
+
+describe("createResendRequestPacer", () => {
+  it("does not wait before the first send", async () => {
+    const sleeps: number[] = []
+    let now = 1_000
+    const pace = createResendRequestPacer(125, {
+      now: () => now,
+      sleep: async (ms) => {
+        sleeps.push(ms)
+        now += ms
+      },
+    })
+
+    await pace()
+    expect(sleeps).toEqual([])
+  })
+
+  it("waits the remaining interval before the next send", async () => {
+    const sleeps: number[] = []
+    let now = 1_000
+    const pace = createResendRequestPacer(125, {
+      now: () => now,
+      sleep: async (ms) => {
+        sleeps.push(ms)
+        now += ms
+      },
+    })
+
+    await pace()
+    now += 40
+    await pace()
+    expect(sleeps).toEqual([85])
+  })
+
+  it("does not stack waits when the previous interval has already elapsed", async () => {
+    const sleeps: number[] = []
+    let now = 1_000
+    const pace = createResendRequestPacer(125, {
+      now: () => now,
+      sleep: async (ms) => {
+        sleeps.push(ms)
+        now += ms
+      },
+    })
+
+    await pace()
+    now += 200
+    await pace()
+    expect(sleeps).toEqual([])
+  })
+})

--- a/lib/resend-rate-limit.ts
+++ b/lib/resend-rate-limit.ts
@@ -1,0 +1,54 @@
+/** Resend default: 10 requests/sec per team, no burst above that window. */
+export const RESEND_TEAM_REQUESTS_PER_SECOND = 10
+
+/**
+ * Space individual `emails.send` calls so the weekly recap stays under the
+ * team cap and leaves headroom for other senders on the same Resend team.
+ * 125ms → 8 requests/sec.
+ */
+export const RESEND_SEND_INTERVAL_MS = 125
+
+/** Wait for the next per-second window after a 429. */
+export const RESEND_RATE_LIMIT_RETRY_MS = 1000
+
+export const RESEND_RATE_LIMIT_RETRIES = 3
+
+export function isResendRateLimitError(
+  error: { name?: string } | null,
+): boolean {
+  return error?.name === "rate_limit_exceeded"
+}
+
+export function isResendQuotaError(error: { name?: string } | null): boolean {
+  return (
+    error?.name === "daily_quota_exceeded" ||
+    error?.name === "monthly_quota_exceeded"
+  )
+}
+
+type PacerClock = {
+  now: () => number
+  sleep: (ms: number) => Promise<void>
+}
+
+/**
+ * Serial pacer: each call waits until `intervalMs` has passed since the last
+ * one, then records the new send time.
+ */
+export function createResendRequestPacer(
+  intervalMs: number = RESEND_SEND_INTERVAL_MS,
+  clock: PacerClock = {
+    now: Date.now,
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  },
+) {
+  let nextAllowedAt = 0
+
+  return async function pace() {
+    const waitMs = nextAllowedAt - clock.now()
+    if (waitMs > 0) {
+      await clock.sleep(waitMs)
+    }
+    nextAllowedAt = clock.now() + intervalMs
+  }
+}

--- a/lib/weekly-newsletter-window.test.ts
+++ b/lib/weekly-newsletter-window.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   getLastCompleteWeekUtc,
+  getWeeklyRecapSkipReason,
   isEntryInWeek,
   shouldSendWeeklyRecap,
 } from "./weekly-newsletter-window"
@@ -74,5 +75,24 @@ describe("shouldSendWeeklyRecap", () => {
 
   it("does not send a red week (net PnL < 0)", () => {
     expect(shouldSendWeeklyRecap({ tradeCount: 5, netPnL: -0.01 })).toBe(false)
+  })
+})
+
+describe("getWeeklyRecapSkipReason", () => {
+  it("is null when the green-week gate allows a send", () => {
+    expect(getWeeklyRecapSkipReason({ tradeCount: 3, netPnL: 12.5 })).toBe(null)
+    expect(getWeeklyRecapSkipReason({ tradeCount: 1, netPnL: 0 })).toBe(null)
+  })
+
+  it("returns no_trades when there are no trades", () => {
+    expect(getWeeklyRecapSkipReason({ tradeCount: 0, netPnL: 0 })).toBe(
+      "no_trades",
+    )
+  })
+
+  it("returns negative_net_pnl for a red week", () => {
+    expect(getWeeklyRecapSkipReason({ tradeCount: 5, netPnL: -0.01 })).toBe(
+      "negative_net_pnl",
+    )
   })
 })

--- a/lib/weekly-newsletter-window.test.ts
+++ b/lib/weekly-newsletter-window.test.ts
@@ -1,42 +1,53 @@
 import { describe, expect, it } from "vitest"
 import {
-  getLastCompleteWeekUtc,
+  getRecapWeekUtc,
   getWeeklyRecapSkipReason,
   isEntryInWeek,
   shouldSendWeeklyRecap,
 } from "./weekly-newsletter-window"
 
-describe("getLastCompleteWeekUtc", () => {
-  it("returns the previous Mon–Sun when mid-week (Wed)", () => {
-    // Wed 2026-08-12 → last complete week Mon 2026-08-03 .. Sun 2026-08-09
-    const week = getLastCompleteWeekUtc(new Date("2026-08-12T15:30:00.000Z"))
-    expect(week.start.toISOString()).toBe("2026-08-03T00:00:00.000Z")
-    expect(week.endExclusive.toISOString()).toBe("2026-08-10T00:00:00.000Z")
+describe("getRecapWeekUtc", () => {
+  it("on the Sunday cron covers the week just traded, not the one before", () => {
+    // Cron fires Sun 2026-08-16 07:00 UTC → Mon 08-10 .. Sun 08-16
+    const week = getRecapWeekUtc(new Date("2026-08-16T07:00:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-08-10T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-08-17T00:00:00.000Z")
   })
 
-  it("on Sunday still uses the previous complete week (current week unfinished)", () => {
-    // Sun 2026-08-09 08:00 UTC — current week Mon 08-03..Sun 08-09 is not complete
-    const week = getLastCompleteWeekUtc(new Date("2026-08-09T08:00:00.000Z"))
-    expect(week.start.toISOString()).toBe("2026-07-27T00:00:00.000Z")
-    expect(week.endExclusive.toISOString()).toBe("2026-08-03T00:00:00.000Z")
+  it("resolves to the same week when re-run Monday morning", () => {
+    // A repair run the next day must not jump to the fresh, empty week —
+    // same window means the same Resend idempotency key.
+    const sunday = getRecapWeekUtc(new Date("2026-08-16T07:00:00.000Z"))
+    const mondayRetry = getRecapWeekUtc(new Date("2026-08-17T06:59:00.000Z"))
+    expect(mondayRetry.start.toISOString()).toBe(sunday.start.toISOString())
+    expect(mondayRetry.endExclusive.toISOString()).toBe(
+      sunday.endExclusive.toISOString(),
+    )
   })
 
-  it("on Monday 00:00 UTC the week that just ended becomes complete", () => {
-    const week = getLastCompleteWeekUtc(new Date("2026-08-10T00:00:00.000Z"))
-    expect(week.start.toISOString()).toBe("2026-08-03T00:00:00.000Z")
-    expect(week.endExclusive.toISOString()).toBe("2026-08-10T00:00:00.000Z")
+  it("moves on once the 24h retry grace has passed", () => {
+    // Tue 2026-08-18 → anchor Mon 08-17 → the new week
+    const week = getRecapWeekUtc(new Date("2026-08-18T07:00:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-08-17T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-08-24T00:00:00.000Z")
+  })
+
+  it("returns the in-progress week when called mid-week (Wed)", () => {
+    const week = getRecapWeekUtc(new Date("2026-08-12T15:30:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-08-10T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-08-17T00:00:00.000Z")
   })
 
   it("crosses month boundaries", () => {
-    // Wed 2026-09-02 → last complete Mon 2026-08-24 .. Sun 2026-08-30
-    const week = getLastCompleteWeekUtc(new Date("2026-09-02T12:00:00.000Z"))
-    expect(week.start.toISOString()).toBe("2026-08-24T00:00:00.000Z")
-    expect(week.endExclusive.toISOString()).toBe("2026-08-31T00:00:00.000Z")
+    // Wed 2026-09-02 → anchor Tue 09-01 → Mon 2026-08-31 .. Sun 2026-09-06
+    const week = getRecapWeekUtc(new Date("2026-09-02T12:00:00.000Z"))
+    expect(week.start.toISOString()).toBe("2026-08-31T00:00:00.000Z")
+    expect(week.endExclusive.toISOString()).toBe("2026-09-07T00:00:00.000Z")
   })
 })
 
 describe("isEntryInWeek", () => {
-  const week = getLastCompleteWeekUtc(new Date("2026-08-12T12:00:00.000Z"))
+  const week = getRecapWeekUtc(new Date("2026-08-05T12:00:00.000Z"))
   // week = 2026-08-03 .. 2026-08-10 exclusive
 
   it("includes Monday 00:00 UTC of the week", () => {

--- a/lib/weekly-newsletter-window.ts
+++ b/lib/weekly-newsletter-window.ts
@@ -54,3 +54,16 @@ export function shouldSendWeeklyRecap(params: {
 }): boolean {
   return params.tradeCount > 0 && params.netPnL >= 0
 }
+
+export type WeeklyRecapSkipReason = "no_trades" | "negative_net_pnl"
+
+/** Null means send. Does not change the green-week gate. */
+export function getWeeklyRecapSkipReason(params: {
+  tradeCount: number
+  netPnL: number
+}): WeeklyRecapSkipReason | null {
+  if (shouldSendWeeklyRecap(params)) {
+    return null
+  }
+  return params.tradeCount === 0 ? "no_trades" : "negative_net_pnl"
+}

--- a/lib/weekly-newsletter-window.ts
+++ b/lib/weekly-newsletter-window.ts
@@ -1,8 +1,8 @@
 /**
  * Weekly performance newsletter window (UTC v1).
  *
- * Stats and send decisions use the last complete Monday–Sunday week in UTC,
- * not a rolling lookback.
+ * Stats and send decisions use a Monday–Sunday week in UTC, not a rolling
+ * lookback.
  */
 
 export type UtcWeekWindow = {
@@ -12,26 +12,41 @@ export type UtcWeekWindow = {
   endExclusive: Date
 }
 
+/** How long after the Sunday send a re-run still resolves to the same week. */
+const RETRY_GRACE_MS = 24 * 60 * 60 * 1000
+
 /**
- * Most recent fully finished Mon–Sun week in UTC.
- * While the current UTC week is in progress, returns the previous Mon–Sun.
+ * The Mon–Sun UTC week a recap sent *now* should cover: the week the
+ * subscriber has just traded, not the one before it.
+ *
+ * The cron fires Sunday 07:00 UTC while that week still has ~17h to run, so
+ * "the last fully finished week" would describe trading that ended eight days
+ * earlier. Futures are closed Sunday daytime, so the week is complete in
+ * practice by the time the mail goes out.
+ *
+ * The 24h grace makes a re-run safe: a cron re-triggered Monday morning to
+ * repair a partial send resolves to the same week as Sunday's run — and so to
+ * the same Resend idempotency key — instead of jumping to the fresh, empty
+ * week and mailing nobody.
  */
-export function getLastCompleteWeekUtc(now: Date = new Date()): UtcWeekWindow {
-  const utcDay = now.getUTCDay() // 0 Sun .. 6 Sat
+export function getRecapWeekUtc(now: Date = new Date()): UtcWeekWindow {
+  const anchor = new Date(now.getTime() - RETRY_GRACE_MS)
+
+  const utcDay = anchor.getUTCDay() // 0 Sun .. 6 Sat
   const daysSinceMonday = utcDay === 0 ? 6 : utcDay - 1
 
-  const thisMonday = new Date(
+  const start = new Date(
     Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth(),
-      now.getUTCDate() - daysSinceMonday,
+      anchor.getUTCFullYear(),
+      anchor.getUTCMonth(),
+      anchor.getUTCDate() - daysSinceMonday,
     ),
   )
 
-  const start = new Date(thisMonday)
-  start.setUTCDate(start.getUTCDate() - 7)
+  const endExclusive = new Date(start)
+  endExclusive.setUTCDate(endExclusive.getUTCDate() + 7)
 
-  return { start, endExclusive: thisMonday }
+  return { start, endExclusive }
 }
 
 /** Whether an entryDate string falls in [start, endExclusive). */

--- a/lib/weekly-recap-email.test.ts
+++ b/lib/weekly-recap-email.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { assertWeeklyRecapRecipient } from "./weekly-recap-recipient"
+
+describe("assertWeeklyRecapRecipient", () => {
+  it("accepts the same user id and email the cron resolved", () => {
+    expect(() =>
+      assertWeeklyRecapRecipient(
+        { id: "user-1", email: "trader@example.com" },
+        { userId: "user-1", email: "trader@example.com" },
+      ),
+    ).not.toThrow()
+  })
+
+  it("rejects a different user id", () => {
+    expect(() =>
+      assertWeeklyRecapRecipient(
+        { id: "user-2", email: "trader@example.com" },
+        { userId: "user-1", email: "trader@example.com" },
+      ),
+    ).toThrow("Weekly recap user mismatch")
+  })
+
+  it("rejects a different email on the same id", () => {
+    expect(() =>
+      assertWeeklyRecapRecipient(
+        { id: "user-1", email: "other@example.com" },
+        { userId: "user-1", email: "trader@example.com" },
+      ),
+    ).toThrow("Weekly recap user mismatch")
+  })
+})

--- a/lib/weekly-recap-email.ts
+++ b/lib/weekly-recap-email.ts
@@ -1,0 +1,103 @@
+import TraderStatsEmail from "@/components/emails/weekly-recap"
+import { render } from "@react-email/render"
+import { generateTradingAnalysis } from "@/app/api/email/weekly-summary/[userid]/actions/analysis"
+import { getUserData, computeTradingStats } from "@/app/api/email/weekly-summary/[userid]/actions/user-data"
+import {
+  getWeeklyRecapSkipReason,
+  type WeeklyRecapSkipReason,
+} from "@/lib/weekly-newsletter-window"
+
+export type { WeeklyRecapSkipReason }
+
+export type WeeklyRecapEmailData = {
+  from: string
+  to: string[]
+  subject: string
+  html: string
+  headers: {
+    "List-Unsubscribe": string
+    "List-Unsubscribe-Post": string
+  }
+  replyTo: string
+}
+
+export type WeeklyRecapBuildResult =
+  | {
+      success: true
+      emailData: WeeklyRecapEmailData
+    }
+  | {
+      success: true
+      emailData: null
+      skipped: true
+      reason: WeeklyRecapSkipReason
+    }
+
+/**
+ * Build the weekly recap Resend payload (or skip) for one subscriber.
+ * Shared by GET /api/cron and POST /api/email/weekly-summary/[userid]
+ * so the Sunday cron never HTTP-self-fetches through a public URL.
+ *
+ * Green-week gate is unchanged: send only if trades exist AND net PnL ≥ 0.
+ */
+export async function buildWeeklyRecapEmail(
+  userId: string,
+): Promise<WeeklyRecapBuildResult> {
+  const { user, newsletter, trades } = await getUserData(userId)
+  const stats = await computeTradingStats(trades, user.language)
+
+  // CPO gate: no trades or red week (net PnL < 0) → cron drops null emailData.
+  // Do not send missing-you / empty-week / consolation mail from this flow.
+  const skipReason = getWeeklyRecapSkipReason({
+    tradeCount: trades.length,
+    netPnL: stats.thisWeekPnL,
+  })
+  if (skipReason) {
+    return {
+      success: true,
+      emailData: null,
+      skipped: true,
+      reason: skipReason,
+    }
+  }
+
+  const analysis = await generateTradingAnalysis(
+    stats.dailyPnL,
+    user.language as "fr" | "en",
+  )
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ""
+  const apiUrl = baseUrl.startsWith("http") ? baseUrl : `http://${baseUrl}`
+
+  const unsubscribeUrl = `${apiUrl}/api/email/unsubscribe?email=${encodeURIComponent(user.email)}`
+
+  const weeklyStatsEmailHtml = await render(
+    TraderStatsEmail({
+      firstName: newsletter.firstName || "trader",
+      dailyPnL: stats.dailyPnL,
+      winLossStats: stats.winLossStats,
+      email: newsletter.email,
+      resultAnalysisIntro: analysis.resultAnalysisIntro,
+      tipsForNextWeek: analysis.tipsForNextWeek,
+      language: user.language,
+    }),
+  )
+
+  return {
+    success: true,
+    emailData: {
+      from: "Deltalytix <newsletter@eu.updates.deltalytix.app>",
+      to: [user.email],
+      subject:
+        user.language === "fr"
+          ? "Vos statistiques de trading de la semaine 📈"
+          : "Your trading statistics for the week 📈",
+      html: weeklyStatsEmailHtml,
+      headers: {
+        "List-Unsubscribe": `<${unsubscribeUrl}>`,
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
+      replyTo: '[REDACTED]',
+    },
+  }
+}

--- a/lib/weekly-recap-email.ts
+++ b/lib/weekly-recap-email.ts
@@ -6,6 +6,9 @@ import {
   getWeeklyRecapSkipReason,
   type WeeklyRecapSkipReason,
 } from "@/lib/weekly-newsletter-window"
+import { assertWeeklyRecapRecipient } from "@/lib/weekly-recap-recipient"
+
+export { assertWeeklyRecapRecipient }
 
 export type { WeeklyRecapSkipReason }
 
@@ -38,12 +41,19 @@ export type WeeklyRecapBuildResult =
  * Shared by GET /api/cron and POST /api/email/weekly-summary/[userid]
  * so the Sunday cron never HTTP-self-fetches through a public URL.
  *
+ * Loads the same User.id the cron already resolved (trades.userId = User.id).
+ * When `expectedEmail` is set, refuses to build if the row does not match.
+ *
  * Green-week gate is unchanged: send only if trades exist AND net PnL ≥ 0.
  */
 export async function buildWeeklyRecapEmail(
   userId: string,
+  expectedEmail?: string,
 ): Promise<WeeklyRecapBuildResult> {
   const { user, newsletter, trades } = await getUserData(userId)
+  if (expectedEmail !== undefined) {
+    assertWeeklyRecapRecipient(user, { userId, email: expectedEmail })
+  }
   const stats = await computeTradingStats(trades, user.language)
 
   // CPO gate: no trades or red week (net PnL < 0) → cron drops null emailData.

--- a/lib/weekly-recap-idempotency.test.ts
+++ b/lib/weekly-recap-idempotency.test.ts
@@ -4,26 +4,45 @@ import { weeklyRecapBatchIdempotencyKey } from "./weekly-recap-idempotency"
 const week = new Date("2026-08-03T00:00:00.000Z")
 
 describe("weeklyRecapBatchIdempotencyKey", () => {
-  it("is stable across runs for the same week and recipients", () => {
-    const emails = [{ to: ["a@example.com"] }, { to: ["b@example.com"] }]
+  it("is stable across runs for the same week and input batch", () => {
+    const input = ["a@example.com", "b@example.com"]
 
-    expect(weeklyRecapBatchIdempotencyKey(week, emails)).toBe(
-      weeklyRecapBatchIdempotencyKey(week, emails),
+    expect(weeklyRecapBatchIdempotencyKey(week, input)).toBe(
+      weeklyRecapBatchIdempotencyKey(week, input),
     )
   })
 
-  it("ignores recipient order, so a reshuffled batch still dedupes", () => {
-    const first = [{ to: ["a@example.com"] }, { to: ["b@example.com"] }]
-    const second = [{ to: ["b@example.com"] }, { to: ["A@Example.com "] }]
+  it("ignores recipient order and email casing, so a reshuffled batch still dedupes", () => {
+    const first = ["a@example.com", "b@example.com"]
+    const second = ["b@example.com", "A@Example.com "]
 
     expect(weeklyRecapBatchIdempotencyKey(week, second)).toBe(
       weeklyRecapBatchIdempotencyKey(week, first),
     )
   })
 
-  it("changes when the batch loses a recipient", () => {
-    const full = [{ to: ["a@example.com"] }, { to: ["b@example.com"] }]
-    const afterUnsubscribe = [{ to: ["a@example.com"] }]
+  it("stays the same when more of the input batch pass the gate on retry", () => {
+    const inputBatch = [
+      "a@example.com",
+      "b@example.com",
+      "c@example.com",
+    ]
+    const passedFirstRun = ["a@example.com", "b@example.com"]
+
+    // Keying on who passed would change on a 70 → 100 recovery and re-mail
+    // the original 70. The input-batch key must not follow that set.
+    expect(
+      weeklyRecapBatchIdempotencyKey(week, passedFirstRun),
+    ).not.toBe(weeklyRecapBatchIdempotencyKey(week, inputBatch))
+
+    expect(weeklyRecapBatchIdempotencyKey(week, inputBatch)).toBe(
+      weeklyRecapBatchIdempotencyKey(week, [...inputBatch].reverse()),
+    )
+  })
+
+  it("changes when the input batch loses a subscriber", () => {
+    const full = ["a@example.com", "b@example.com"]
+    const afterUnsubscribe = ["a@example.com"]
 
     expect(weeklyRecapBatchIdempotencyKey(week, afterUnsubscribe)).not.toBe(
       weeklyRecapBatchIdempotencyKey(week, full),
@@ -31,7 +50,7 @@ describe("weeklyRecapBatchIdempotencyKey", () => {
   })
 
   it("changes from one recap week to the next", () => {
-    const emails = [{ to: ["a@example.com"] }]
+    const emails = ["a@example.com"]
     const nextWeek = new Date("2026-08-10T00:00:00.000Z")
 
     expect(weeklyRecapBatchIdempotencyKey(nextWeek, emails)).not.toBe(
@@ -40,8 +59,8 @@ describe("weeklyRecapBatchIdempotencyKey", () => {
   })
 
   it("prefixes the key with the recap week", () => {
-    expect(
-      weeklyRecapBatchIdempotencyKey(week, [{ to: ["a@example.com"] }]),
-    ).toMatch(/^weekly-recap:2026-08-03:[0-9a-f]{32}$/)
+    expect(weeklyRecapBatchIdempotencyKey(week, ["a@example.com"])).toMatch(
+      /^weekly-recap:2026-08-03:[0-9a-f]{32}$/,
+    )
   })
 })

--- a/lib/weekly-recap-idempotency.test.ts
+++ b/lib/weekly-recap-idempotency.test.ts
@@ -1,66 +1,65 @@
 import { describe, expect, it } from "vitest"
-import { weeklyRecapBatchIdempotencyKey } from "./weekly-recap-idempotency"
+import {
+  isResendIdempotentReplay,
+  weeklyRecapIdempotencyKey,
+} from "./weekly-recap-idempotency"
 
-const week = new Date("2026-08-03T00:00:00.000Z")
+const week = new Date("2026-08-10T00:00:00.000Z")
 
-describe("weeklyRecapBatchIdempotencyKey", () => {
-  it("is stable across runs for the same week and input batch", () => {
-    const input = ["a@example.com", "b@example.com"]
-
-    expect(weeklyRecapBatchIdempotencyKey(week, input)).toBe(
-      weeklyRecapBatchIdempotencyKey(week, input),
+describe("weeklyRecapIdempotencyKey", () => {
+  it("is stable for the same week and recipient", () => {
+    expect(weeklyRecapIdempotencyKey(week, "trader@example.com")).toBe(
+      weeklyRecapIdempotencyKey(week, "trader@example.com"),
     )
   })
 
-  it("ignores recipient order and email casing, so a reshuffled batch still dedupes", () => {
-    const first = ["a@example.com", "b@example.com"]
-    const second = ["b@example.com", "A@Example.com "]
-
-    expect(weeklyRecapBatchIdempotencyKey(week, second)).toBe(
-      weeklyRecapBatchIdempotencyKey(week, first),
+  it("normalizes casing and whitespace so a retry still 409s", () => {
+    expect(weeklyRecapIdempotencyKey(week, " Trader@Example.com ")).toBe(
+      weeklyRecapIdempotencyKey(week, "trader@example.com"),
     )
   })
 
-  it("stays the same when more of the input batch pass the gate on retry", () => {
-    const inputBatch = [
-      "a@example.com",
-      "b@example.com",
-      "c@example.com",
-    ]
-    const passedFirstRun = ["a@example.com", "b@example.com"]
-
-    // Keying on who passed would change on a 70 → 100 recovery and re-mail
-    // the original 70. The input-batch key must not follow that set.
-    expect(
-      weeklyRecapBatchIdempotencyKey(week, passedFirstRun),
-    ).not.toBe(weeklyRecapBatchIdempotencyKey(week, inputBatch))
-
-    expect(weeklyRecapBatchIdempotencyKey(week, inputBatch)).toBe(
-      weeklyRecapBatchIdempotencyKey(week, [...inputBatch].reverse()),
-    )
+  it("does not change when another subscriber is added", () => {
+    const existing = weeklyRecapIdempotencyKey(week, "a@example.com")
+    weeklyRecapIdempotencyKey(week, "new@example.com")
+    expect(weeklyRecapIdempotencyKey(week, "a@example.com")).toBe(existing)
   })
 
-  it("changes when the input batch loses a subscriber", () => {
-    const full = ["a@example.com", "b@example.com"]
-    const afterUnsubscribe = ["a@example.com"]
-
-    expect(weeklyRecapBatchIdempotencyKey(week, afterUnsubscribe)).not.toBe(
-      weeklyRecapBatchIdempotencyKey(week, full),
+  it("differs per recipient in the same week", () => {
+    expect(weeklyRecapIdempotencyKey(week, "a@example.com")).not.toBe(
+      weeklyRecapIdempotencyKey(week, "b@example.com"),
     )
   })
 
   it("changes from one recap week to the next", () => {
-    const emails = ["a@example.com"]
-    const nextWeek = new Date("2026-08-10T00:00:00.000Z")
-
-    expect(weeklyRecapBatchIdempotencyKey(nextWeek, emails)).not.toBe(
-      weeklyRecapBatchIdempotencyKey(week, emails),
+    const nextWeek = new Date("2026-08-17T00:00:00.000Z")
+    expect(weeklyRecapIdempotencyKey(nextWeek, "a@example.com")).not.toBe(
+      weeklyRecapIdempotencyKey(week, "a@example.com"),
     )
   })
 
-  it("prefixes the key with the recap week", () => {
-    expect(weeklyRecapBatchIdempotencyKey(week, ["a@example.com"])).toMatch(
-      /^weekly-recap:2026-08-03:[0-9a-f]{32}$/,
+  it("is week + normalized email", () => {
+    expect(weeklyRecapIdempotencyKey(week, "trader@example.com")).toBe(
+      "weekly-recap:2026-08-10:trader@example.com",
     )
+  })
+})
+
+describe("isResendIdempotentReplay", () => {
+  it("treats a changed-payload retry as already sent", () => {
+    expect(
+      isResendIdempotentReplay({ name: "invalid_idempotent_request" }),
+    ).toBe(true)
+  })
+
+  it("treats an in-flight retry as already sent", () => {
+    expect(
+      isResendIdempotentReplay({ name: "concurrent_idempotent_requests" }),
+    ).toBe(true)
+  })
+
+  it("does not swallow a real send error", () => {
+    expect(isResendIdempotentReplay({ name: "application_error" })).toBe(false)
+    expect(isResendIdempotentReplay(null)).toBe(false)
   })
 })

--- a/lib/weekly-recap-idempotency.test.ts
+++ b/lib/weekly-recap-idempotency.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { weeklyRecapBatchIdempotencyKey } from "./weekly-recap-idempotency"
+
+const week = new Date("2026-08-03T00:00:00.000Z")
+
+describe("weeklyRecapBatchIdempotencyKey", () => {
+  it("is stable across runs for the same week and recipients", () => {
+    const emails = [{ to: ["a@example.com"] }, { to: ["b@example.com"] }]
+
+    expect(weeklyRecapBatchIdempotencyKey(week, emails)).toBe(
+      weeklyRecapBatchIdempotencyKey(week, emails),
+    )
+  })
+
+  it("ignores recipient order, so a reshuffled batch still dedupes", () => {
+    const first = [{ to: ["a@example.com"] }, { to: ["b@example.com"] }]
+    const second = [{ to: ["b@example.com"] }, { to: ["A@Example.com "] }]
+
+    expect(weeklyRecapBatchIdempotencyKey(week, second)).toBe(
+      weeklyRecapBatchIdempotencyKey(week, first),
+    )
+  })
+
+  it("changes when the batch loses a recipient", () => {
+    const full = [{ to: ["a@example.com"] }, { to: ["b@example.com"] }]
+    const afterUnsubscribe = [{ to: ["a@example.com"] }]
+
+    expect(weeklyRecapBatchIdempotencyKey(week, afterUnsubscribe)).not.toBe(
+      weeklyRecapBatchIdempotencyKey(week, full),
+    )
+  })
+
+  it("changes from one recap week to the next", () => {
+    const emails = [{ to: ["a@example.com"] }]
+    const nextWeek = new Date("2026-08-10T00:00:00.000Z")
+
+    expect(weeklyRecapBatchIdempotencyKey(nextWeek, emails)).not.toBe(
+      weeklyRecapBatchIdempotencyKey(week, emails),
+    )
+  })
+
+  it("prefixes the key with the recap week", () => {
+    expect(
+      weeklyRecapBatchIdempotencyKey(week, [{ to: ["a@example.com"] }]),
+    ).toMatch(/^weekly-recap:2026-08-03:[0-9a-f]{32}$/)
+  })
+})

--- a/lib/weekly-recap-idempotency.ts
+++ b/lib/weekly-recap-idempotency.ts
@@ -1,34 +1,25 @@
-import { createHash } from "node:crypto"
-
 /**
- * Stable `Idempotency-Key` for one Resend weekly-recap batch send.
+ * Per-recipient `Idempotency-Key` for one weekly recap send.
  *
- * Keyed on the recap week plus the **input batch** (the subscribers this
- * slice set out to process) — not on who passed the green-week gate or
- * whose build succeeded.
+ * Resend's batch API takes a single key for the whole request. Any key derived
+ * from a set of people (who passed the gate, or the input slice) changes when
+ * that set changes — a new subscriber, an unsubscribe, or 30 recoveries on
+ * retry — and the original recipients can be mailed twice.
  *
- * If run 1 builds 70 and sends them, then a retry builds 100 (30 recoveries),
- * a key derived from the sent set would change and the original 70 would be
- * mailed twice. Keying on the input batch keeps the key stable, so Resend
- * 409s the retry as designed.
- *
- * Never key on the loop index. Batches are `users.slice(i, i + 100)`, so one
- * unsubscribe between a timed-out run and its retry shifts every boundary.
+ * One send per recipient, keyed on week + that email, is stable: a retry 409s
+ * for anyone already mailed and still delivers recoveries and new subscribers.
  */
-export function weeklyRecapBatchIdempotencyKey(
+export function weeklyRecapIdempotencyKey(
   weekStart: Date,
-  inputBatchEmails: string[],
+  email: string,
 ): string {
-  const recipients = inputBatchEmails
-    .map((address) => address.trim().toLowerCase())
-    .filter(Boolean)
-    .sort()
-    .join(",")
+  const recipient = email.trim().toLowerCase()
+  return `weekly-recap:${weekStart.toISOString().slice(0, 10)}:${recipient}`
+}
 
-  const digest = createHash("sha256")
-    .update(recipients)
-    .digest("hex")
-    .slice(0, 32)
-
-  return `weekly-recap:${weekStart.toISOString().slice(0, 10)}:${digest}`
+export function isResendIdempotentReplay(error: { name?: string } | null): boolean {
+  return (
+    error?.name === "invalid_idempotent_request" ||
+    error?.name === "concurrent_idempotent_requests"
+  )
 }

--- a/lib/weekly-recap-idempotency.ts
+++ b/lib/weekly-recap-idempotency.ts
@@ -3,20 +3,25 @@ import { createHash } from "node:crypto"
 /**
  * Stable `Idempotency-Key` for one Resend weekly-recap batch send.
  *
- * Derived from the recap week plus the batch's own recipients — never from the
- * loop index. Batches are `users.slice(i, i + 100)`, so a single unsubscribe
- * between a timed-out run and its retry shifts every boundary and makes
- * "batch 0" mean a different set of people. Keying on the contents survives
- * that: same week + same recipients = same key, and Resend refuses the
- * duplicate instead of mailing everyone twice.
+ * Keyed on the recap week plus the **input batch** (the subscribers this
+ * slice set out to process) — not on who passed the green-week gate or
+ * whose build succeeded.
+ *
+ * If run 1 builds 70 and sends them, then a retry builds 100 (30 recoveries),
+ * a key derived from the sent set would change and the original 70 would be
+ * mailed twice. Keying on the input batch keeps the key stable, so Resend
+ * 409s the retry as designed.
+ *
+ * Never key on the loop index. Batches are `users.slice(i, i + 100)`, so one
+ * unsubscribe between a timed-out run and its retry shifts every boundary.
  */
 export function weeklyRecapBatchIdempotencyKey(
   weekStart: Date,
-  emails: { to: string[] }[],
+  inputBatchEmails: string[],
 ): string {
-  const recipients = emails
-    .flatMap((email) => email.to)
+  const recipients = inputBatchEmails
     .map((address) => address.trim().toLowerCase())
+    .filter(Boolean)
     .sort()
     .join(",")
 

--- a/lib/weekly-recap-idempotency.ts
+++ b/lib/weekly-recap-idempotency.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto"
+
+/**
+ * Stable `Idempotency-Key` for one Resend weekly-recap batch send.
+ *
+ * Derived from the recap week plus the batch's own recipients — never from the
+ * loop index. Batches are `users.slice(i, i + 100)`, so a single unsubscribe
+ * between a timed-out run and its retry shifts every boundary and makes
+ * "batch 0" mean a different set of people. Keying on the contents survives
+ * that: same week + same recipients = same key, and Resend refuses the
+ * duplicate instead of mailing everyone twice.
+ */
+export function weeklyRecapBatchIdempotencyKey(
+  weekStart: Date,
+  emails: { to: string[] }[],
+): string {
+  const recipients = emails
+    .flatMap((email) => email.to)
+    .map((address) => address.trim().toLowerCase())
+    .sort()
+    .join(",")
+
+  const digest = createHash("sha256")
+    .update(recipients)
+    .digest("hex")
+    .slice(0, 32)
+
+  return `weekly-recap:${weekStart.toISOString().slice(0, 10)}:${digest}`
+}

--- a/lib/weekly-recap-recipient.ts
+++ b/lib/weekly-recap-recipient.ts
@@ -1,0 +1,9 @@
+/** Throws if the loaded row is not the subscriber the cron already resolved. */
+export function assertWeeklyRecapRecipient(
+  loaded: { id: string; email: string },
+  expected: { userId: string; email: string },
+): void {
+  if (loaded.id !== expected.userId || loaded.email !== expected.email) {
+    throw new Error("Weekly recap user mismatch")
+  }
+}


### PR DESCRIPTION
## Summary

Same fix as #457, retargeted to `main` only. No dashboard / Settings / design.

Today’s production cron authenticated on `/api/cron`, then every inner weekly-summary call returned `Unauthorized` because apex `deltalytix.app` 308s to www and `fetch` drops `Authorization` on that hop.

- `GET /api/cron` builds recaps in-process (no public hop)
- Green-week gate unchanged
- Recap window is the Mon–Sun week just traded
- One-by-one Resend send, paced under 10 req/s, per-recipient idempotency keys

`vercel.json` cron `{ "path": "/api/cron", "schedule": "0 7 * * 0" }` unchanged.

Do not merge until Vercel is green. This is not a beta → main of #442/#458.

## Test plan

- [ ] Diff is cron/email only (no dashboard chrome)
- [ ] Vercel build on this PR is green
- [ ] After merge: Sunday production `/api/cron` does not 401