### PR TITLE
Enable PostHog session replay, gated by analytics consent

### DIFF
--- a/components/consent-banner.tsx
+++ b/components/consent-banner.tsx
@@ -21,29 +21,20 @@ import { Label } from "@/components/ui/label"
 import { motion, AnimatePresence } from "framer-motion"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useI18n } from "@/locales/client"
-import type { ConsentSettings } from "@/lib/consent-settings"
+import {
+  ANALYTICS_CONSENT_COOKIE,
+  type ConsentSettings,
+  parseSharedAnalyticsConsent,
+} from "@/lib/consent-settings"
+import { syncPostHogSessionRecording } from "@/lib/posthog-session-recording"
 import posthog from "posthog-js"
 
-const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent"
 const CONSENT_EVENT = "deltalytix:analytics-consent"
 const CONSENT_UPDATED_EVENT = "deltalytix:consent-updated"
 
 function isDeltalytixHost() {
   const host = window.location.hostname
   return host === "deltalytix.app" || host.endsWith(".deltalytix.app")
-}
-
-function getSharedAnalyticsConsent() {
-  const cookie = document.cookie
-    .split("; ")
-    .find((entry) => entry.startsWith(`${ANALYTICS_CONSENT_COOKIE}=`))
-
-  if (!cookie) return null
-
-  const value = cookie.split("=")[1]
-  if (value === "granted") return true
-  if (value === "denied") return false
-  return null
 }
 
 function syncPostHogConsent(analyticsEnabled: boolean) {
@@ -65,12 +56,14 @@ function syncPostHogConsent(analyticsEnabled: boolean) {
     if (!posthog.has_opted_in_capturing()) {
       posthog.opt_in_capturing()
     }
+    syncPostHogSessionRecording(posthog, true)
     window.dispatchEvent(new Event(CONSENT_EVENT))
 
     if (wasOptedOut) {
       posthog.capture("$pageview", { $current_url: window.location.href })
     }
   } else {
+    syncPostHogSessionRecording(posthog, false)
     if (!posthog.has_opted_out_capturing()) {
       posthog.opt_out_capturing()
     }
@@ -168,7 +161,7 @@ function ConsentBannerContent({ t }: { t: ConsentTranslator }) {
   const bannerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const sharedAnalyticsConsent = getSharedAnalyticsConsent()
+    const sharedAnalyticsConsent = parseSharedAnalyticsConsent(document.cookie)
     const hasConsent = localStorage.getItem("cookieConsent")
 
     // Parent-domain cookie is the cross-origin source of truth. Prefer it over

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,52 +1,28 @@
 import posthog from "posthog-js";
 
+import { hasClientAnalyticsConsent } from "@/lib/consent-settings";
+import { syncPostHogSessionRecording } from "@/lib/posthog-session-recording";
+
 const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
 const apiHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
-const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent";
-
-function getSharedAnalyticsConsent() {
-  try {
-    const cookie = document.cookie
-      .split("; ")
-      .find((entry) => entry.startsWith(`${ANALYTICS_CONSENT_COOKIE}=`));
-
-    if (!cookie) return null;
-
-    const value = cookie.split("=")[1];
-    if (value === "granted") return true;
-    if (value === "denied") return false;
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function hasAnalyticsConsent() {
-  const sharedConsent = getSharedAnalyticsConsent();
-  if (sharedConsent !== null) return sharedConsent;
-
-  try {
-    const storedConsent = localStorage.getItem("cookieConsent");
-    if (!storedConsent) return false;
-
-    return JSON.parse(storedConsent).analytics_storage === true;
-  } catch {
-    return false;
-  }
-}
 
 if (projectToken) {
+  const analyticsConsent = hasClientAnalyticsConsent();
+
   posthog.init(projectToken, {
     api_host: apiHost,
     defaults: "2026-05-30",
     person_profiles: "identified_only",
-    opt_out_capturing_by_default: !hasAnalyticsConsent(),
+    opt_out_capturing_by_default: !analyticsConsent,
     opt_out_capturing_persistence_type: "localStorage",
     autocapture: false,
     capture_pageview: true,
     capture_pageleave: true,
-    disable_session_recording: true,
   });
+
+  // Replay is on in PostHog project 50101. Do not hard-disable it here —
+  // start only with analytics consent, and stop if that consent is missing.
+  syncPostHogSessionRecording(posthog, analyticsConsent);
 }
 
 export { posthog };

--- a/lib/consent-settings.test.ts
+++ b/lib/consent-settings.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   type ConsentSettings,
+  hasAnalyticsConsentFromStores,
   isGoogleTagAllowed,
+  parseSharedAnalyticsConsent,
   toGoogleConsent,
 } from "./consent-settings";
 
@@ -50,6 +52,53 @@ describe("isGoogleTagAllowed", () => {
   it("blocks the tag when both are refused", () => {
     expect(
       isGoogleTagAllowed({ ...denyAll, functionality_storage: true }),
+    ).toBe(false);
+  });
+});
+
+describe("parseSharedAnalyticsConsent", () => {
+  it("reads granted and denied from the shared cookie", () => {
+    expect(
+      parseSharedAnalyticsConsent("deltalytix_analytics_consent=granted"),
+    ).toBe(true);
+    expect(
+      parseSharedAnalyticsConsent("other=1; deltalytix_analytics_consent=denied"),
+    ).toBe(false);
+  });
+
+  it("returns null when the cookie is missing or unknown", () => {
+    expect(parseSharedAnalyticsConsent("")).toBeNull();
+    expect(
+      parseSharedAnalyticsConsent("deltalytix_analytics_consent=maybe"),
+    ).toBeNull();
+  });
+});
+
+describe("hasAnalyticsConsentFromStores", () => {
+  it("prefers the shared cookie over a stale localStorage choice", () => {
+    expect(
+      hasAnalyticsConsentFromStores({
+        cookieHeader: "deltalytix_analytics_consent=denied",
+        storedConsent: { analytics_storage: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to localStorage when the cookie is absent", () => {
+    expect(
+      hasAnalyticsConsentFromStores({
+        cookieHeader: "",
+        storedConsent: { analytics_storage: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("denies when neither store has granted analytics", () => {
+    expect(
+      hasAnalyticsConsentFromStores({
+        cookieHeader: "",
+        storedConsent: null,
+      }),
     ).toBe(false);
   });
 });

--- a/lib/consent-settings.ts
+++ b/lib/consent-settings.ts
@@ -19,6 +19,57 @@ export interface ConsentSettings {
 /** Where the banner persists its decision; read by every consent-gated script. */
 export const CONSENT_STORAGE_KEY = "cookieConsent";
 
+/** Shared Domain cookie so beta/prod keep the same analytics (and replay) choice. */
+export const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent";
+
+/**
+ * Reads the cross-origin analytics cookie. `granted` / `denied` are the only
+ * stored values; anything else is treated as "no decision yet".
+ */
+export function parseSharedAnalyticsConsent(
+  cookieHeader: string,
+): boolean | null {
+  try {
+    const cookie = cookieHeader
+      .split("; ")
+      .find((entry) => entry.startsWith(`${ANALYTICS_CONSENT_COOKIE}=`));
+
+    if (!cookie) return null;
+
+    const value = cookie.split("=")[1];
+    if (value === "granted") return true;
+    if (value === "denied") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cookie is the cross-origin source of truth. localStorage is the fallback for
+ * an origin-local decision that has not been migrated onto the shared cookie.
+ */
+export function hasAnalyticsConsentFromStores({
+  cookieHeader,
+  storedConsent,
+}: {
+  cookieHeader: string;
+  storedConsent: Partial<ConsentSettings> | null;
+}): boolean {
+  const shared = parseSharedAnalyticsConsent(cookieHeader);
+  if (shared !== null) return shared;
+  return storedConsent?.analytics_storage === true;
+}
+
+/** Browser-only — used by PostHog init and the cookie banner. */
+export function hasClientAnalyticsConsent(): boolean {
+  if (typeof document === "undefined") return false;
+  return hasAnalyticsConsentFromStores({
+    cookieHeader: document.cookie,
+    storedConsent: readStoredConsentSettings(),
+  });
+}
+
 /**
  * The banner's stored decision, or null when it has not been answered yet.
  * Browser-only — callers are consent-gated client components.

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { cookies } from "next/headers";
 
-const ANALYTICS_CONSENT_COOKIE = "deltalytix_analytics_consent";
+import { ANALYTICS_CONSENT_COOKIE } from "@/lib/consent-settings";
 
 type PostHogPropertyValue =
   | boolean

--- a/lib/posthog-session-recording.test.ts
+++ b/lib/posthog-session-recording.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { syncPostHogSessionRecording } from "./posthog-session-recording";
+
+function createReplayClient() {
+  return {
+    startSessionRecording: vi.fn(),
+    stopSessionRecording: vi.fn(),
+  };
+}
+
+describe("syncPostHogSessionRecording", () => {
+  it("starts recording when analytics consent is granted", () => {
+    const client = createReplayClient();
+
+    syncPostHogSessionRecording(client, true);
+
+    expect(client.startSessionRecording).toHaveBeenCalledOnce();
+    expect(client.stopSessionRecording).not.toHaveBeenCalled();
+  });
+
+  it("stops recording when analytics consent is denied or withdrawn", () => {
+    const client = createReplayClient();
+
+    syncPostHogSessionRecording(client, false);
+
+    expect(client.stopSessionRecording).toHaveBeenCalledOnce();
+    expect(client.startSessionRecording).not.toHaveBeenCalled();
+  });
+});
+
+describe("instrumentation-client replay config", () => {
+  const source = readFileSync(
+    new URL("../instrumentation-client.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("does not hard-disable session recording at init", () => {
+    expect(source).not.toMatch(/disable_session_recording\s*:\s*true/);
+  });
+
+  it("keeps autocapture off and still gates capture on analytics consent", () => {
+    expect(source).toMatch(/autocapture:\s*false/);
+    expect(source).toMatch(/opt_out_capturing_by_default:\s*!analyticsConsent/);
+    expect(source).toMatch(/syncPostHogSessionRecording\(posthog,\s*analyticsConsent\)/);
+  });
+});

--- a/lib/posthog-session-recording.ts
+++ b/lib/posthog-session-recording.ts
@@ -1,0 +1,22 @@
+/**
+ * Session replay follows analytics consent. The SDK is initialized without a
+ * hard `disable_session_recording: true` so recordings can start; these helpers
+ * start or stop the recorder when the banner grants or withdraws analytics.
+ */
+
+export type PostHogReplayClient = {
+  startSessionRecording: () => void;
+  stopSessionRecording: () => void;
+};
+
+export function syncPostHogSessionRecording(
+  client: PostHogReplayClient,
+  analyticsEnabled: boolean,
+) {
+  if (analyticsEnabled) {
+    client.startSessionRecording();
+    return;
+  }
+
+  client.stopSessionRecording();
+}

--- a/locales/en/landing.ts
+++ b/locales/en/landing.ts
@@ -309,7 +309,7 @@ export default {
         analytics: {
           title: "Analytics Cookies",
           description:
-            "These cookies help us understand how visitors interact with our site. They allow us to measure traffic and improve site performance.",
+            "These cookies help us understand how visitors interact with our site. They measure traffic, improve performance, and record sessions so we can see how the product is used.",
         },
         marketing: {
           title: "Marketing Performance Cookies",

--- a/locales/fr/landing.ts
+++ b/locales/fr/landing.ts
@@ -316,7 +316,7 @@ export default {
         analytics: {
           title: "Cookies d'analyse",
           description:
-            "Ces cookies nous aident à comprendre comment les visiteurs interagissent avec notre site. Ils nous permettent de mesurer le trafic et d'améliorer les performances du site.",
+            "Ces cookies nous aident à comprendre comment les visiteurs interagissent avec notre site. Ils mesurent le trafic, améliorent les performances et enregistrent les sessions pour voir comment le produit est utilisé.",
         },
         marketing: {
           title: "Cookies de performance marketing",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PostHog project 50101 already has session replay on (`session_recording_opt_in: true`, no sampling). Production still sent `$recording_status=disabled` on every event because `instrumentation-client.ts` hard-set `disable_session_recording: true`.

Verified on 2026-08-15:
- 0 recordings in the last 30 days
- Last 7 days: 312 `$pageview` events / 135 sessions, all `$recording_status=disabled`

Hugo wants this on **production** so recordings start as soon as this lands on `main`.

## What changed

- Removed the hard `disable_session_recording: true` init flag
- Replay now starts only when analytics consent is granted (`deltalytix_analytics_consent=granted` or `cookieConsent.analytics_storage`)
- Denied or withdrawn analytics consent calls `posthog.stopSessionRecording()` and does not start recording
- Autocapture stays off; `opt_out_capturing_by_default: !hasAnalyticsConsent()` stays
- Cookie banner already has **Reject non-essential** plus an Analytics checkbox. The analytics description now says that granting it also records sessions

## Consent path

| Banner action | Analytics | Replay |
| --- | --- | --- |
| Accept all | granted | `startSessionRecording()` |
| Reject non-essential | denied | `stopSessionRecording()` |
| Preferences → Analytics off | denied | `stopSessionRecording()` |
| Preferences → Analytics on | granted | `startSessionRecording()` |

## Out of scope

No dashboard v6 / Settings / design work. No Mindset/Chat or widget changes.

## Test plan

- [x] Unit tests for cookie/localStorage consent resolution
- [x] Unit tests that granted consent starts recording and denied consent stops it
- [x] Guard that `instrumentation-client.ts` no longer hard-disables replay and keeps `autocapture: false`
- [x] `bunx vitest run lib/consent-settings.test.ts lib/posthog-session-recording.test.ts` — 14 passed
- [x] `bun run typecheck` — passed
- [ ] After merge: confirm new consented sessions appear in [PostHog replay](https://eu.posthog.com/project/50101/replay) with `$recording_status` other than `disabled`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31971b5c-ae26-457d-ba72-7073945411d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31971b5c-ae26-457d-ba72-7073945411d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

