### PR TITLE
Restore 390 Widget minimap on the dashboard pill

### DIFF
--- a/app/[locale]/dashboard/components/mobile-widget-delete-dialog.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-delete-dialog.tsx
@@ -67,7 +67,7 @@ export function MobileWidgetDeleteDialog({
       <AlertDialog open={mainOpen} onOpenChange={setMainOpen}>
         <AlertDialogTrigger asChild>
           <Button
-            variant={appearance === "pill" ? "ghost" : "destructive"}
+            variant={appearance === "default" ? "destructive" : "ghost"}
             className={cn(
               appearance === "strip"
                 ? "inline-flex size-8 items-center justify-center rounded-full text-[#DC2626] hover:bg-black/5 hover:text-[#DC2626]"

--- a/app/[locale]/dashboard/components/mobile-widget-delete-dialog.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-delete-dialog.tsx
@@ -24,7 +24,7 @@ interface MobileWidgetDeleteDialogProps {
   onRemoveWidget: (widgetId: string) => void
   onRemoveAll: () => void | Promise<void>
   compact?: boolean
-  appearance?: "default" | "pill"
+  appearance?: "default" | "pill" | "strip"
 }
 
 export function MobileWidgetDeleteDialog({
@@ -69,15 +69,17 @@ export function MobileWidgetDeleteDialog({
           <Button
             variant={appearance === "pill" ? "ghost" : "destructive"}
             className={cn(
-              appearance === "pill"
-                ? "inline-flex size-8 items-center justify-center rounded-none text-[#DC2626] hover:bg-transparent hover:text-[#DC2626]"
-                : "h-10 rounded-full flex items-center justify-center transition-transform active:scale-95",
-              appearance !== "pill" && (compact ? "w-10 shrink-0 p-0" : "min-w-[120px] gap-3 px-4")
+              appearance === "strip"
+                ? "inline-flex size-8 items-center justify-center rounded-full text-[#DC2626] hover:bg-black/5 hover:text-[#DC2626]"
+                : appearance === "pill"
+                  ? "inline-flex size-8 items-center justify-center rounded-none text-[#DC2626] hover:bg-transparent hover:text-[#DC2626]"
+                  : "h-10 rounded-full flex items-center justify-center transition-transform active:scale-95",
+              appearance === "default" && (compact ? "w-10 shrink-0 p-0" : "min-w-[120px] gap-3 px-4")
             )}
             aria-label={t("widgets.mobile.deleteDialogTitle")}
           >
             <Trash2 className="h-4 w-4 shrink-0" />
-            {appearance !== "pill" && !compact && (
+            {appearance === "default" && !compact && (
               <span className="text-sm font-medium">{t("widgets.removeWidget")}</span>
             )}
           </Button>

--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -21,6 +21,11 @@ const STACK_CARD_WIDTH = 36
 const STACK_CARD_HEIGHT = 26
 const STACK_CARD_OFFSET = 3
 const MAX_STACK_CARDS = 3
+const MAX_VISIBLE_STACK_COUNT = 99
+
+function formatWidgetStackCount(count: number): string {
+  return count > MAX_VISIBLE_STACK_COUNT ? `${MAX_VISIBLE_STACK_COUNT}+` : String(count)
+}
 
 /**
  * Loading placeholder for the toolbar minimap trigger — same stacked sheet
@@ -276,13 +281,16 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
   // Use a div with role="button" (not <button>) because ScaledWidgetPreview
   // mounts live widgets that may contain their own buttons — nested <button>
   // elements are invalid HTML and cause hydration errors.
-  const openMinimap = () => setIsExpanded(true)
+  const openMinimap = () => {
+    if (isExpanded) return
+    setIsExpanded(true)
+  }
 
   return (
     <div
       ref={triggerRef}
       role="button"
-      tabIndex={0}
+      tabIndex={isExpanded ? -1 : 0}
       aria-expanded={isExpanded}
       aria-haspopup="dialog"
       aria-label={t("widgets.mobile.minimapOpen", {
@@ -292,6 +300,7 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
       className={cn(
         "flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-full transition-transform active:scale-95",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        isExpanded && "pointer-events-none",
         className
       )}
       onClick={openMinimap}
@@ -306,6 +315,14 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
         className="relative block"
         style={{ width: STACK_CARD_WIDTH + 6, height: STACK_CARD_HEIGHT + 6 }}
       >
+        <span
+          aria-hidden
+          data-testid="widget-minimap-stack-count"
+          data-widget-count={widgets.length}
+          className="pointer-events-none absolute -right-1 -top-1 z-10 inline-flex h-4 min-w-4 items-center justify-center rounded-full border-2 border-white bg-[#171717] px-1 text-[9px] font-semibold leading-none tabular-nums text-white"
+        >
+          {formatWidgetStackCount(widgets.length)}
+        </span>
         <AnimatePresence initial={false} custom={navigationDirection}>
           {stackWidgets.map(({ widget, stackOffset }) => {
             const deepestOffset = Math.max(0, stackWidgets.length - 1)

--- a/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-minimap.tsx
@@ -292,7 +292,6 @@ export function MobileWidgetMinimapTrigger({ className }: { className?: string }
       className={cn(
         "flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-full transition-transform active:scale-95",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-        isExpanded && "pointer-events-none opacity-0",
         className
       )}
       onClick={openMinimap}

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -4,9 +4,9 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useI18n } from "@/locales/client"
 import { useData } from "@/context/data-provider"
-import { Check, Pencil, Trash2, RotateCcw } from "lucide-react"
+import { Pencil, Trash2, RotateCcw } from "lucide-react"
 import { AddWidgetSheet } from "./add-widget-sheet"
-import { DASHBOARD_COMPACT_BREAKPOINT, WidgetType, WidgetSize, Layouts, Widget } from "../types/dashboard"
+import { WidgetType, WidgetSize, Layouts, Widget } from "../types/dashboard"
 import { MobileWidgetDeleteDialog } from "./mobile-widget-delete-dialog"
 import {
   AlertDialog,
@@ -20,14 +20,13 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { useState, useEffect, useRef, type ReactNode } from "react"
-import { useMediaQuery } from "@/hooks/use-media-query"
 
 const PILL_CELL =
   "inline-flex h-8 items-center justify-center gap-1.5 rounded-none px-2.5 text-sm font-medium text-[#171717] hover:bg-transparent"
-const PILL_ICON_CELL =
-  "inline-flex size-8 items-center justify-center rounded-none text-[#171717] hover:bg-transparent"
-const PILL_DELETE_CELL =
-  "inline-flex size-8 items-center justify-center rounded-none text-[#DC2626] hover:bg-transparent hover:text-[#DC2626]"
+const STRIP_CELL =
+  "inline-flex size-8 items-center justify-center rounded-full text-[#171717] hover:bg-black/5"
+const STRIP_DELETE_CELL =
+  "inline-flex size-8 items-center justify-center rounded-full text-[#DC2626] hover:bg-black/5 hover:text-[#DC2626]"
 
 function PillDivider() {
   return <span aria-hidden className="h-4 w-px shrink-0 bg-[#E5E5E5]" />
@@ -54,11 +53,10 @@ export function Toolbar({
   onRestoreDefaults,
   mobileActiveWidget = null,
   onRemoveWidget,
+  minimapTrigger,
 }: ToolbarProps) {
   const t = useI18n()
   const { isMobile } = useData()
-  const isCompactScreen = useMediaQuery(`(max-width: ${DASHBOARD_COMPACT_BREAKPOINT}px)`)
-  const isNarrowScreen = useMediaQuery("(max-width: 767px)")
   const [isConsentVisible, setIsConsentVisible] = useState(false)
   const toolbarRef = useRef<HTMLDivElement>(null)
 
@@ -75,9 +73,6 @@ export function Toolbar({
 
     return () => observer.disconnect()
   }, [])
-
-  const useCompactLayout = isMobile || isCompactScreen
-  const iconOnly = isMobile || isNarrowScreen
 
   useEffect(() => {
     const toolbar = toolbarRef.current
@@ -101,12 +96,12 @@ export function Toolbar({
       resizeObserver.disconnect()
       window.removeEventListener("resize", updateToolbarMetrics)
     }
-  }, [isConsentVisible])
+  }, [isConsentVisible, isCustomizing, minimapTrigger])
 
   const restoreButton = (
     <Button
       variant="ghost"
-      className={PILL_ICON_CELL}
+      className={STRIP_CELL}
       aria-label={t('widgets.restoreDefaults')}
       title={t('widgets.restoreDefaults')}
     >
@@ -117,7 +112,7 @@ export function Toolbar({
   const deleteIconButton = (
     <Button
       variant="ghost"
-      className={PILL_DELETE_CELL}
+      className={STRIP_DELETE_CELL}
       aria-label={t('widgets.deleteAll')}
       title={t('widgets.deleteAll')}
     >
@@ -125,38 +120,40 @@ export function Toolbar({
     </Button>
   )
 
+  const addAndMinimap = (
+    <>
+      <AddWidgetSheet
+        onAddWidget={onAddWidget}
+        isCustomizing={isCustomizing}
+        currentLayout={currentLayout}
+        appearance="pill"
+      />
+      {minimapTrigger ? (
+        <>
+          <PillDivider />
+          <div className="-my-1.5 flex shrink-0 items-center justify-center">
+            {minimapTrigger}
+          </div>
+        </>
+      ) : null}
+    </>
+  )
+
   return (
     <div
       ref={toolbarRef}
       className={cn(
-        "fixed inset-x-4 z-10 mx-auto w-auto md:inset-x-0 md:w-fit md:max-w-[calc(100vw-1rem)]",
+        "fixed inset-x-0 z-10 mx-auto w-fit max-w-[calc(100vw-2rem)]",
         isConsentVisible ? "bottom-36 sm:bottom-20" : "bottom-4"
       )}
     >
-      <div className="relative flex max-w-full items-center rounded-full border border-[#E5E5E5] bg-white px-2 py-[6px] shadow-none">
+      <div className="relative w-fit max-w-full">
         {isCustomizing ? (
-          <>
-            <Button
-              onClick={onEditToggle}
-              aria-label={t('widgets.done')}
-              className={cn(
-                "shadow-none",
-                iconOnly
-                  ? "size-8 rounded-full bg-[#171717] p-0 text-white hover:bg-[#171717]/90"
-                  : "h-8 rounded-full bg-[#171717] px-3.5 text-sm font-medium text-white hover:bg-[#171717]/90"
-              )}
-            >
-              {iconOnly ? <Check className="h-4 w-4" strokeWidth={2} /> : t('widgets.done')}
-            </Button>
-            <PillDivider />
-            <AddWidgetSheet
-              onAddWidget={onAddWidget}
-              isCustomizing={isCustomizing}
-              currentLayout={currentLayout}
-              compact={iconOnly}
-              appearance="pill"
-            />
-            <PillDivider />
+          <div
+            role="group"
+            aria-label={t('widgets.edit')}
+            className="absolute bottom-full left-2 mb-2 flex items-center rounded-full bg-[#F5F5F5] p-0.5"
+          >
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 {restoreButton}
@@ -176,14 +173,12 @@ export function Toolbar({
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
-            <PillDivider />
             {isMobile && onRemoveWidget ? (
               <MobileWidgetDeleteDialog
                 activeWidget={mobileActiveWidget}
                 onRemoveWidget={onRemoveWidget}
                 onRemoveAll={onRemoveAll}
-                compact={useCompactLayout}
-                appearance="pill"
+                appearance="strip"
               />
             ) : (
               <AlertDialog>
@@ -209,28 +204,32 @@ export function Toolbar({
                 </AlertDialogContent>
               </AlertDialog>
             )}
-          </>
-        ) : (
-          <>
+          </div>
+        ) : null}
+
+        <div className="flex max-w-full items-center rounded-full border border-[#E5E5E5] bg-white px-2 py-[6px] shadow-none">
+          {isCustomizing ? (
+            <Button
+              onClick={onEditToggle}
+              aria-label={t('widgets.done')}
+              className="h-8 rounded-full bg-[#171717] px-3.5 text-sm font-medium text-white shadow-none hover:bg-[#171717]/90"
+            >
+              {t('widgets.done')}
+            </Button>
+          ) : (
             <Button
               variant="ghost"
               onClick={onEditToggle}
               aria-label={t('widgets.edit')}
-              className={iconOnly ? PILL_ICON_CELL : PILL_CELL}
+              className={PILL_CELL}
             >
               <Pencil className="h-4 w-4 shrink-0" strokeWidth={1.75} />
-              {!iconOnly ? t('widgets.edit') : null}
+              {t('widgets.edit')}
             </Button>
-            <PillDivider />
-            <AddWidgetSheet
-              onAddWidget={onAddWidget}
-              isCustomizing={isCustomizing}
-              currentLayout={currentLayout}
-              compact={iconOnly}
-              appearance="pill"
-            />
-          </>
-        )}
+          )}
+          <PillDivider />
+          {addAndMinimap}
+        </div>
       </div>
     </div>
   )

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -74,6 +74,8 @@ export function Toolbar({
     return () => observer.disconnect()
   }, [])
 
+  const hasMinimapTrigger = Boolean(minimapTrigger)
+
   useEffect(() => {
     const toolbar = toolbarRef.current
     if (!toolbar) return
@@ -96,7 +98,7 @@ export function Toolbar({
       resizeObserver.disconnect()
       window.removeEventListener("resize", updateToolbarMetrics)
     }
-  }, [isConsentVisible, isCustomizing, minimapTrigger])
+  }, [isConsentVisible, hasMinimapTrigger])
 
   const restoreButton = (
     <Button
@@ -151,7 +153,6 @@ export function Toolbar({
         {isCustomizing ? (
           <div
             role="group"
-            aria-label={t('widgets.edit')}
             className="absolute bottom-full left-2 mb-2 flex items-center rounded-full bg-[#F5F5F5] p-0.5"
           >
             <AlertDialog>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Lock (Drop)

Hugo locked the 390 Widget minimap back onto the dashboard pill. This remounts the existing trigger — it does not invent new chrome.

- **390 default:** Edit (text) + Add (text) + stacked card deck after Add. Tap the stack → existing Widget minimap.
- **Desktop:** Edit + Add only. No stack, no minimap.
- **Labels stay.** Icon-only is gone.
- **Edit:** Done is the only loud control. Restore / delete park in a strip above the pill. Stack stays on 390 in edit too.
- Feedback is not on the navbar or the pill.

## Cause

`widget-toolbar-host.tsx` still builds `minimapTrigger` and wraps mobile in `MobileWidgetMinimapProvider` + overlay. The v6 `Toolbar` accepted the prop but never rendered the slot, so the stack disappeared.

## Change

- Render the existing `minimapTrigger` after Add on both default and edit.
- Always show Edit / Add / Done labels.
- Move restore / delete out of the pill into a floating strip above Done.
- Keep the stack visible while the minimap overlay is open (pill stays the anchor).
- Strip delete uses the ghost icon (not a filled destructive button).

## Verification

- `OPENAI_API_KEY=dummy bun run build` compiled
- `bun run typecheck` passed
- `bun run seed:self-host` seeded 132 trades
- Dashboard health: `x-auth-status: authenticated`, `x-user-id: local-dashboard-user`
- `/authentication?next=dashboard` → 307 `/dashboard`
- Playwright at 390: stack count 1 (default + edit); minimap title “Widget minimap”; labels present
- Playwright at 1280: stack count 0 (default + edit)

![390 default pill with Edit, Add, and stack](https://cursor.com/artifacts/c/art-340579ef-972a-473b-9b20-b0edb2cffcaf)
![390 Widget minimap overlay open above the pill](https://cursor.com/artifacts/c/art-8edd0943-c225-4388-a42c-a64ad88bc1a8)
![390 edit pill with loud Done, parked restore/delete, and stack](https://cursor.com/artifacts/c/art-7a2893b7-53d3-4f06-8330-9d10c3b4e820)
![Desktop default pill is Edit and Add only](https://cursor.com/artifacts/c/art-79050d64-7a5c-49d0-b0de-6a2104d39977)
![Desktop edit pill with loud Done and parked restore/delete, no stack](https://cursor.com/artifacts/c/art-20ee4174-daeb-4d25-accc-2e20fb90865b)

<a href="https://cursor.com/agents/bc-f626864a-bf92-44b6-a53c-b774f514bfb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F390_pill_minimap_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-af78db7a-ab0c-41bb-837a-a85a869441cd" alt="390_pill_minimap_walkthrough.mp4" /></a>

Base: **beta**. Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f626864a-bf92-44b6-a53c-b774f514bfb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f626864a-bf92-44b6-a53c-b774f514bfb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

