### PR TITLE
fix(cron): valid Resend reply-to on weekly recap

### DIFF
--- a/app/[locale]/admin/actions/send-email.ts
+++ b/app/[locale]/admin/actions/send-email.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma"
 import { createClient, type User } from "@supabase/supabase-js"
 import { render } from "@react-email/render"
 import { renderWelcomeEmailText } from "@/components/emails/welcome"
+import { WEEKLY_RECAP_REPLY_TO } from "@/lib/weekly-recap-reply-to"
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -357,7 +358,8 @@ export async function sendEmailsToUsers(
             from: "Deltalytix <updates@eu.updates.deltalytix.app>",
             to: [user.email],
             subject: emailSubject,
-            reply_to: "hugo.demenez@deltalytix.app",
+            // Same live reply-to as cron weekly recap / August broadcasts.
+            reply_to: WEEKLY_RECAP_REPLY_TO,
             react: React.createElement(EmailComponent, mergedProps),
             ...(template === "welcome"
               ? {

--- a/lib/weekly-recap-email.test.ts
+++ b/lib/weekly-recap-email.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest"
 import { assertWeeklyRecapRecipient } from "./weekly-recap-recipient"
+import {
+  WEEKLY_RECAP_REPLY_TO,
+  isValidResendReplyTo,
+} from "./weekly-recap-reply-to"
+
+/** Resend: `local@domain` or `Name <local@domain>`. */
+const RESEND_REPLY_TO =
+  /^(?:[^\s@<>]+@[^\s@<>]+|.+ <[^\s@<>]+@[^\s@<>]+>)$/
 
 describe("assertWeeklyRecapRecipient", () => {
   it("accepts the same user id and email the cron resolved", () => {
@@ -27,5 +35,25 @@ describe("assertWeeklyRecapRecipient", () => {
         { userId: "user-1", email: "trader@example.com" },
       ),
     ).toThrow("Weekly recap user mismatch")
+  })
+})
+
+describe("weekly recap Resend payload replyTo", () => {
+  it("matches Resend accepted formats (local@domain or Name <local@domain>)", () => {
+    const emailData = { replyTo: WEEKLY_RECAP_REPLY_TO }
+
+    expect(emailData.replyTo).toContain("@")
+    expect(emailData.replyTo).toMatch(RESEND_REPLY_TO)
+    expect(isValidResendReplyTo(emailData.replyTo)).toBe(true)
+  })
+
+  it("rejects the malformed placeholder that caused production 422s", () => {
+    expect("[REDACTED]").not.toContain("@")
+    expect("[REDACTED]").not.toMatch(RESEND_REPLY_TO)
+    expect(isValidResendReplyTo("[REDACTED]")).toBe(false)
+  })
+
+  it("accepts the named-address form Resend also allows", () => {
+    expect(isValidResendReplyTo("Hugo <support@example.com>")).toBe(true)
   })
 })

--- a/lib/weekly-recap-email.ts
+++ b/lib/weekly-recap-email.ts
@@ -7,8 +7,10 @@ import {
   type WeeklyRecapSkipReason,
 } from "@/lib/weekly-newsletter-window"
 import { assertWeeklyRecapRecipient } from "@/lib/weekly-recap-recipient"
+import { WEEKLY_RECAP_REPLY_TO } from "@/lib/weekly-recap-reply-to"
 
 export { assertWeeklyRecapRecipient }
+export { WEEKLY_RECAP_REPLY_TO }
 
 export type { WeeklyRecapSkipReason }
 
@@ -107,7 +109,7 @@ export async function buildWeeklyRecapEmail(
         "List-Unsubscribe": `<${unsubscribeUrl}>`,
         "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
       },
-      replyTo: '[REDACTED]',
+      replyTo: WEEKLY_RECAP_REPLY_TO,
     },
   }
 }

--- a/lib/weekly-recap-reply-to.ts
+++ b/lib/weekly-recap-reply-to.ts
@@ -1,0 +1,17 @@
+/**
+ * Reply-To for weekly recap Resend payloads.
+ * Same address as August PR439 broadcasts and admin newsletter/send-email.
+ * Plain address — Resend accepts `local@domain` or `Name <local@domain>`.
+ */
+export const WEEKLY_RECAP_REPLY_TO = "hugo.demenez@deltalytix.app" // pragma: allowlist secret
+
+/** Resend 422s anything that is not `local@domain` or `Name <local@domain>`. */
+export function isValidResendReplyTo(value: string): boolean {
+  if (!value.includes("@")) {
+    return false
+  }
+  return (
+    /^[^\s@<>]+@[^\s@<>]+$/.test(value) ||
+    /^.+ <[^\s@<>]+@[^\s@<>]+>$/.test(value)
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sunday 2026-08-16 production `GET /api/cron` returned HTTP 200 but sent **0** recap emails. Vercel: 0 sent, 15 failed, 1091 skipped (green-week gate). Every failure was the same Resend 422:

> Invalid `reply_to` field. The email address needs to follow the `email@example.com` or `Name <email@example.com>` format.

`buildWeeklyRecapEmail` in `lib/weekly-recap-email.ts` (added in #460) set `replyTo` to the **literal string** `[REDACTED]`. Hex dump of that line is `replyTo: '[REDACTED]'` — not a viewer overlay. Resend rejects that, so no recap left Resend.

## Fix

- Shared constant `WEEKLY_RECAP_REPLY_TO`: the same live reply-to already used by August PR439 broadcasts and admin `newsletter.ts` / `send-email.ts` (plain `local@domain`, no display-name).
- Cron builder (`lib/weekly-recap-email.ts`) and admin weekly-recap send (`send-email.ts`) both use that constant.
- Weekly-summary API route already calls `buildWeeklyRecapEmail`, so it cannot regress independently.
- Unit tests assert the payload `replyTo` contains `@` and matches `local@domain` or `Name <local@domain>`, and that `[REDACTED]` is rejected.

Cron / email only. No dashboard, Settings, or design. No live Sunday send.

## Test plan

- [x] Hex-verified the production `replyTo` was the literal `[REDACTED]`
- [x] `bunx vitest run lib/weekly-recap-email.test.ts` — 6 passed
- [x] `bun run typecheck` — clean
- [x] Vercel + Typecheck + Bugbot green on this PR
- [ ] After merge: next Sunday cron (or a dry repair) must not 422 on `reply_to`

Do not trigger a live Sunday send or call Resend to mail users.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35526a36-14e8-45b1-bb9a-2846f43c60e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35526a36-14e8-45b1-bb9a-2846f43c60e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

