### PR TITLE
Write an agent parser for any trade export

### DIFF
--- a/.claude/skills/import-file-parse
+++ b/.claude/skills/import-file-parse
@@ -1,0 +1,1 @@
+../../agents/skills/import-file-parse

--- a/.cursor/skills/import-file-parse
+++ b/.cursor/skills/import-file-parse
@@ -1,0 +1,1 @@
+../../agents/skills/import-file-parse

--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -22,6 +22,10 @@ ln -s "../../agents/skills/<name>" ".cursor/skills/<name>"
 
 Windows contributors need `git config core.symlinks true` (and Developer Mode) for the links to check out as links rather than plain text files.
 
+## Import
+
+- [`import-file-parse`](./import-file-parse/SKILL.md): parse any trading CSV (closed trades or order fills) through Intelligent Import. Use a parse plan, not Vercel Eve.
+
 ## Deltalytix workflows
 
 - [`changelog-review`](./changelog-review/SKILL.md): review a release diff and prepare the editorial outline.

--- a/agents/skills/import-file-parse/SKILL.md
+++ b/agents/skills/import-file-parse/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: import-file-parse
+description: >-
+  Parse any trading CSV (closed trades or order fills) through Deltalytix
+  Intelligent Import. Use when testing CSV with AI, reproducing import bugs,
+  adding header aliases, or deciding whether a file needs AI. Do not embed
+  Vercel Eve in this flow.
+---
+
+# Import file parse
+
+Intelligent Import turns a spreadsheet into `Trade` rows with a **parse plan**, not a row-by-row LLM rewrite.
+
+Eve is the right *idea* (inspect the file, write a script, run it, repair the script). It is the wrong *runtime* here: this is an existing Next.js dialog that must work on self-host/VPS without Vercel Sandbox, Workflows, or AI Gateway. Keep the plan interpreter in-process.
+
+## Pipeline
+
+1. `planFromHeaders` / `planFromMappings` in [`lib/import/parse-plan.ts`](../../../lib/import/parse-plan.ts) build a JSON plan (column indexes + `closed-trades` vs `orders`).
+2. `executeParsePlan` runs that plan on every row. Order files are FIFO-paired.
+3. `/api/ai/import-parse-plan` is only for files the heuristic cannot map. It returns a plan, never formatted rows. A dummy or missing `OPENAI_API_KEY` must 503 with `AI_UNAVAILABLE`.
+4. Review Trades (`FormatPreview`) executes the plan immediately. Do not bring back batched `useObject` formatting.
+
+## How to verify a file
+
+```ts
+import { executeParsePlan, planFromHeaders } from "@/lib/import/parse-plan";
+
+const plan = planFromHeaders(headers);
+const { trades } = executeParsePlan(rows, plan);
+```
+
+Add a unit test in `lib/import/parse-plan.test.ts` for a new layout before changing UI.
+
+UI path: Connections → Upload a file → CSV with AI → map columns (pre-filled) → account → Review Trades. Expect trades in the table without Start Processing. Save stays disabled until at least one trade has `entryDate`.
+
+## When to extend what
+
+| Change | Where |
+| --- | --- |
+| New column name | `HEADER_ALIASES` in `parse-plan.ts` |
+| New date/number quirk | `parseDateToIso` / `parseNumber` |
+| New fill-pairing rule | `pairOrderFills` |
+| Weird files that still need a model | `app/api/ai/import-parse-plan` prompt/schema |
+
+Do not add `eve`, `agent/`, or a sandbox eval of model-generated JavaScript to this import path.

--- a/agents/skills/import-file-parse/SKILL.md
+++ b/agents/skills/import-file-parse/SKILL.md
@@ -1,50 +1,42 @@
 ---
 name: import-file-parse
 description: >-
-  Parse any trading CSV (closed trades or order fills) through Deltalytix
-  Intelligent Import. Use when testing CSV with AI, reproducing import bugs,
-  adding header aliases, or deciding whether a file needs AI. Do not embed
-  Vercel Eve in this flow.
+  Parse any trading export through Deltalytix Intelligent Import. An agent
+  writes a parseChunk script when headers are not enough. Use when testing
+  CSV with AI, adding parse-script contracts, or running chunks in a Vercel
+  Sandbox. Column mapping is not part of this flow.
 ---
 
 # Import file parse
 
-Intelligent Import turns a spreadsheet into `Trade` rows with a **parse plan**, not a row-by-row LLM rewrite.
-
-Eve is the right *idea* (inspect the file, write a script, run it, repair the script). It is the wrong *runtime* here: this is an existing Next.js dialog that must work on self-host/VPS without Vercel Sandbox, Workflows, or AI Gateway. Keep the plan interpreter in-process.
+Intelligent Import is web-only. The user drops a file. We peek headers + a few rows, write a parser, prove it on the sample, then stream the file in chunks. There is no column-mapping step.
 
 ## Pipeline
 
-1. `planFromHeaders` / `planFromMappings` in [`lib/import/parse-plan.ts`](../../../lib/import/parse-plan.ts) build a JSON plan (column indexes + `closed-trades` vs `orders`).
-2. `executeParsePlanChunk` runs that plan in slices of `PARSE_PLAN_CHUNK_SIZE` (2500 rows). Closed-trade rows are independent. Order fills keep open lots on a `ParsePlanSession` so a buy in chunk 1 can close in a later chunk. An empty chunk is not success or failure.
-3. `/api/ai/import-parse-plan` is only for files the heuristic cannot map. It sees at most 8 sample rows. A dummy or missing `OPENAI_API_KEY` must 503 with `AI_UNAVAILABLE`.
-4. Review Trades (`FormatPreview`) walks chunks and yields to the main thread. The table shows the first `PARSE_PREVIEW_LIMIT` (200) trades. The full list is stored only after parsing finishes, for Save. Do not bring back batched `useObject` formatting, and do not call `executeParsePlan` on the whole file in the UI.
+1. `peekDelimitedFile` reads the first 32KB only. The `File` stays a blob. Do not `readAsText` the whole file.
+2. If `planFromHeaders` is complete, `executeParsePlanChunk` runs locally while Papa streams the `File`.
+3. Otherwise `/api/ai/import-parse-script` writes `function parseChunk(rows, session)`. `/api/import/parse-chunk` runs it in a Vercel Sandbox when OIDC/token creds exist, or a sealed Node `vm` in local/dev. Repair up to 3 times if the sample yields no trades.
+4. One sandbox per import (`sandboxName`), not one VM per chunk. Empty chunks are not success or failure.
+5. Review shows the first 200 trades. Save still holds the full trade list (batch save is a follow-up).
 
-## How to verify a file
+Do not bring back batched `useObject` row formatting or a mapping table on this path.
+
+## Script contract
+
+See `PARSE_SCRIPT_CONTRACT` in [`lib/import/parse-script.ts`](../../../lib/import/parse-script.ts). The function must be named `parseChunk`, take `(rows, session)`, and return `{ trades, session, skipped }`. No `import` / `require` / `fetch`.
+
+## How to verify
 
 ```ts
-import {
-  createParsePlanSession,
-  executeParsePlanChunk,
-  planFromHeaders,
-} from "@/lib/import/parse-plan";
+import { runInVm } from "@/lib/import/run-parse-script";
 
-const plan = planFromHeaders(headers);
-const session = createParsePlanSession();
-const { trades } = executeParsePlanChunk(rows.slice(0, 2500), plan, session);
+const { trades } = runInVm(script, sampleRows, {});
 ```
 
-Add a unit test in `lib/import/parse-plan.test.ts` for a new layout before changing UI.
-
-UI path: Connections → Upload a file → CSV with AI → map columns (pre-filled) → account → Review Trades. Expect trades in the table without Start Processing. Save stays disabled until at least one trade has `entryDate`.
-
-## When to extend what
+UI path: Connections → Upload a file → CSV with AI → account → Review Trades. Expect trades without Map Columns or Start Processing.
 
 | Change | Where |
 | --- | --- |
-| New column name | `HEADER_ALIASES` in `parse-plan.ts` |
-| New date/number quirk | `parseDateToIso` / `parseNumber` |
-| New fill-pairing rule | `pairOrderFills` |
-| Weird files that still need a model | `app/api/ai/import-parse-plan` prompt/schema |
-
-Do not add `eve`, `agent/`, or a sandbox eval of model-generated JavaScript to this import path.
+| New column name (common CSVs) | `HEADER_ALIASES` in `parse-plan.ts` |
+| Agent prompt / contract | `parse-script.ts`, `app/api/ai/import-parse-script` |
+| Sandbox vs vm | `run-parse-script.ts` |

--- a/agents/skills/import-file-parse/SKILL.md
+++ b/agents/skills/import-file-parse/SKILL.md
@@ -16,17 +16,22 @@ Eve is the right *idea* (inspect the file, write a script, run it, repair the sc
 ## Pipeline
 
 1. `planFromHeaders` / `planFromMappings` in [`lib/import/parse-plan.ts`](../../../lib/import/parse-plan.ts) build a JSON plan (column indexes + `closed-trades` vs `orders`).
-2. `executeParsePlan` runs that plan on every row. Order files are FIFO-paired.
-3. `/api/ai/import-parse-plan` is only for files the heuristic cannot map. It returns a plan, never formatted rows. A dummy or missing `OPENAI_API_KEY` must 503 with `AI_UNAVAILABLE`.
-4. Review Trades (`FormatPreview`) executes the plan immediately. Do not bring back batched `useObject` formatting.
+2. `executeParsePlanChunk` runs that plan in slices of `PARSE_PLAN_CHUNK_SIZE` (2500 rows). Closed-trade rows are independent. Order fills keep open lots on a `ParsePlanSession` so a buy in chunk 1 can close in a later chunk. An empty chunk is not success or failure.
+3. `/api/ai/import-parse-plan` is only for files the heuristic cannot map. It sees at most 8 sample rows. A dummy or missing `OPENAI_API_KEY` must 503 with `AI_UNAVAILABLE`.
+4. Review Trades (`FormatPreview`) walks chunks and yields to the main thread. The table shows the first `PARSE_PREVIEW_LIMIT` (200) trades. The full list is stored only after parsing finishes, for Save. Do not bring back batched `useObject` formatting, and do not call `executeParsePlan` on the whole file in the UI.
 
 ## How to verify a file
 
 ```ts
-import { executeParsePlan, planFromHeaders } from "@/lib/import/parse-plan";
+import {
+  createParsePlanSession,
+  executeParsePlanChunk,
+  planFromHeaders,
+} from "@/lib/import/parse-plan";
 
 const plan = planFromHeaders(headers);
-const { trades } = executeParsePlan(rows, plan);
+const session = createParsePlanSession();
+const { trades } = executeParsePlanChunk(rows.slice(0, 2500), plan, session);
 ```
 
 Add a unit test in `lib/import/parse-plan.test.ts` for a new layout before changing UI.

--- a/app/[locale]/dashboard/components/import/column-mapping.tsx
+++ b/app/[locale]/dashboard/components/import/column-mapping.tsx
@@ -9,6 +9,7 @@ import { ImportType } from './import-type-selection'
 import { mappingSchema } from '@/app/api/ai/mappings/schema'
 import { cn } from '@/lib/utils'
 import { z } from 'zod/v3';
+import { mappingsFromPlan, planFromHeaders } from '@/lib/import/parse-plan'
 
 type MappingObject = z.infer<typeof mappingSchema>
 type MappingKey = keyof MappingObject
@@ -57,6 +58,13 @@ const getColumnDisplayName = (header: string, index: number, headers: string[]) 
 };
 
 export default function ColumnMapping({ headers, csvData, mappings, setMappings, error, importType }: ColumnMappingProps) {
+  useEffect(() => {
+    if (Object.keys(mappings).length > 0 || headers.length === 0) return;
+    const next = mappingsFromPlan(headers, planFromHeaders(headers));
+    if (Object.keys(next).length > 0) {
+      setMappings(next);
+    }
+  }, [headers, mappings, setMappings]);
 
   const { object, submit, isLoading } = useObject({
     api: '/api/ai/mappings',

--- a/app/[locale]/dashboard/components/import/components/format-preview.tsx
+++ b/app/[locale]/dashboard/components/import/components/format-preview.tsx
@@ -28,13 +28,23 @@ import {
   parseFormatTradesApiError,
 } from "@/lib/ai/openai-availability";
 import {
-  executeParsePlan,
+  PARSE_PLAN_CHUNK_SIZE,
+  PARSE_PREVIEW_LIMIT,
+  createParsePlanSession,
+  executeParsePlanChunk,
   isParsePlanComplete,
   missingRequiredFields,
   resolveParsePlan,
+  type ExecutedTrade,
   type ParsePlan,
 } from "@/lib/import/parse-plan";
 import { planFromAiResponse } from "@/lib/import/plan-from-ai";
+
+function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
 
 interface FormatPreviewProps {
   trades: string[][];
@@ -48,7 +58,7 @@ interface FormatPreviewProps {
 
 export function FormatPreview({
   trades: initialTrades,
-  processedTrades,
+  processedTrades: _processedTrades,
   setProcessedTrades,
   setIsLoading,
   headers,
@@ -60,49 +70,95 @@ export function FormatPreview({
   const [parseKind, setParseKind] = useState<"closed-trades" | "orders" | null>(
     null,
   );
+  const [previewTrades, setPreviewTrades] = useState<Partial<Trade>[]>([]);
+  const [formattedCount, setFormattedCount] = useState(0);
+  const [rowsProcessed, setRowsProcessed] = useState(0);
+  const [isParsing, setIsParsing] = useState(false);
+  const [totals, setTotals] = useState({
+    totalPnl: 0,
+    totalCommission: 0,
+    netPnl: 0,
+  });
   const askedAiRef = useRef(false);
 
-  const validTrades = useMemo(
-    () => initialTrades.filter((row) => row.length > 0 && row[0] !== ""),
-    [initialTrades],
-  );
-
-  const applyPlan = (plan: ParsePlan) => {
-    const result = executeParsePlan(validTrades, plan);
-    setParseKind(result.kind);
-    setProcessedTrades(result.trades);
-    return result;
-  };
+  const totalRows = initialTrades.length;
 
   useEffect(() => {
-    const plan = resolveParsePlan(headers, mappings);
-    if (isParsePlanComplete(plan)) {
-      const result = applyPlan(plan);
+    let cancelled = false;
+
+    const runChunks = async (plan: ParsePlan) => {
+      setParseKind(plan.kind);
       setError(null);
+      setIsParsing(true);
+      setIsLoading(true);
+      setPreviewTrades([]);
+      setFormattedCount(0);
+      setRowsProcessed(0);
+      setTotals({ totalPnl: 0, totalCommission: 0, netPnl: 0 });
+      setProcessedTrades([]);
+
+      const session = createParsePlanSession();
+      const all: ExecutedTrade[] = [];
+      let totalPnl = 0;
+      let totalCommission = 0;
+
+      for (let offset = 0; offset < initialTrades.length; offset += PARSE_PLAN_CHUNK_SIZE) {
+        if (cancelled) return;
+        const { trades } = executeParsePlanChunk(
+          initialTrades.slice(offset, offset + PARSE_PLAN_CHUNK_SIZE),
+          plan,
+          session,
+        );
+        for (const trade of trades) {
+          all.push(trade);
+          totalPnl += trade.pnl || 0;
+          totalCommission += trade.commission || 0;
+        }
+        const processed = Math.min(offset + PARSE_PLAN_CHUNK_SIZE, initialTrades.length);
+        setRowsProcessed(processed);
+        setFormattedCount(all.length);
+        setPreviewTrades(all.slice(0, PARSE_PREVIEW_LIMIT));
+        setTotals({
+          totalPnl,
+          totalCommission,
+          netPnl: totalPnl - totalCommission,
+        });
+        await yieldToMain();
+      }
+
+      if (cancelled) return;
+      setProcessedTrades(all);
+      setIsParsing(false);
       setIsLoading(false);
-      if (result.trades.length === 0) {
+      if (all.length === 0) {
         setError(t("import.processing.noTradesFormatted"));
       }
-      return;
-    }
+    };
 
-    if (askedAiRef.current) return;
-    askedAiRef.current = true;
-    setIsLoading(true);
-    setError(null);
+    const start = async () => {
+      const plan = resolveParsePlan(headers, mappings);
+      if (isParsePlanComplete(plan)) {
+        await runChunks(plan);
+        return;
+      }
 
-    const missing = missingRequiredFields(plan);
-    void (async () => {
+      if (askedAiRef.current) return;
+      askedAiRef.current = true;
+      setIsLoading(true);
+      setError(null);
+      const missing = missingRequiredFields(plan);
+
       try {
         const response = await fetch("/api/ai/import-parse-plan", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             headers,
-            rows: validTrades.slice(0, 8),
+            rows: initialTrades.slice(0, 8),
           }),
         });
         const raw = await response.text();
+        if (cancelled) return;
         if (!response.ok) {
           const code = parseFormatTradesApiError(raw).code;
           setError(
@@ -111,6 +167,7 @@ export function FormatPreview({
               : t("import.processing.noTradesFormatted"),
           );
           setProcessedTrades([]);
+          setIsLoading(false);
           return;
         }
         const aiPlan = planFromAiResponse(headers, JSON.parse(raw));
@@ -121,24 +178,23 @@ export function FormatPreview({
             }),
           );
           setProcessedTrades([]);
+          setIsLoading(false);
           return;
         }
-        const result = applyPlan(aiPlan);
-        if (result.trades.length === 0) {
-          setError(t("import.processing.noTradesFormatted"));
-        }
+        await runChunks(aiPlan);
       } catch {
+        if (cancelled) return;
         setError(t("import.processing.noTradesFormatted"));
         setProcessedTrades([]);
-      } finally {
         setIsLoading(false);
       }
-    })();
-  }, [headers, mappings, validTrades, setProcessedTrades, setIsLoading, t]);
+    };
 
-  const formattedTradeCount = processedTrades.filter(
-    (trade) => trade.entryDate,
-  ).length;
+    void start();
+    return () => {
+      cancelled = true;
+    };
+  }, [headers, mappings, initialTrades, setProcessedTrades, setIsLoading, t]);
 
   const columns = useMemo<ColumnDef<Partial<Trade>>[]>(
     () => [
@@ -237,7 +293,7 @@ export function FormatPreview({
   );
 
   const table = useReactTable({
-    data: processedTrades,
+    data: previewTrades,
     columns,
     getCoreRowModel: getCoreRowModel(),
     defaultColumn: {
@@ -246,39 +302,44 @@ export function FormatPreview({
     },
   });
 
-  const totals = useMemo(() => {
-    const totalPnl = processedTrades.reduce(
-      (sum, trade) => sum + (trade.pnl || 0),
-      0,
-    );
-    const totalCommission = processedTrades.reduce(
-      (sum, trade) => sum + (trade.commission || 0),
-      0,
-    );
-    return {
-      totalPnl,
-      totalCommission,
-      netPnl: totalPnl - totalCommission,
-    };
-  }, [processedTrades]);
-
   return (
     <div className="flex h-full flex-col gap-4">
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
           <p className="text-sm text-muted-foreground">
             {t("import.parse.tradesFormatted", {
-              formatted: formattedTradeCount,
-              total: validTrades.length,
+              formatted: formattedCount,
+              total: totalRows,
             })}
           </p>
           <p className="text-xs text-muted-foreground">
-            {parseKind === "orders"
-              ? t("import.processing.ordersPaired")
-              : t("import.processing.parsedFromColumns")}
+            {isParsing
+              ? t("import.parse.rowsProcessed", {
+                  processed: rowsProcessed,
+                  total: totalRows,
+                })
+              : parseKind === "orders"
+                ? t("import.processing.ordersPaired")
+                : t("import.processing.parsedFromColumns")}
           </p>
+          {formattedCount > PARSE_PREVIEW_LIMIT && (
+            <p className="text-xs text-muted-foreground">
+              {t("import.table.showingFirst", {
+                count: previewTrades.length,
+                total: formattedCount,
+              })}
+            </p>
+          )}
         </div>
-        {formattedTradeCount > 0 && !error && (
+        {isParsing && (
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 animate-pulse rounded-full bg-green-500"></div>
+            <span className="text-xs font-medium text-green-600">
+              {t("import.processing.parsing")}
+            </span>
+          </div>
+        )}
+        {!isParsing && formattedCount > 0 && !error && (
           <div className="flex items-center gap-2">
             <div className="h-2 w-2 rounded-full bg-green-500"></div>
             <span className="text-xs font-medium text-green-600">
@@ -303,23 +364,19 @@ export function FormatPreview({
         </Alert>
       )}
 
-      {validTrades.length > 0 && (
+      {totalRows > 0 && (
         <div className="space-y-2">
           <div className="flex justify-between text-xs text-muted-foreground">
             <span>{t("import.processing.processingProgress")}</span>
             <span>
-              {validTrades.length === 0
+              {totalRows === 0
                 ? 0
-                : Math.round((formattedTradeCount / validTrades.length) * 100)}
+                : Math.round((rowsProcessed / totalRows) * 100)}
               %
             </span>
           </div>
           <Progress
-            value={
-              validTrades.length === 0
-                ? 0
-                : (formattedTradeCount / validTrades.length) * 100
-            }
+            value={totalRows === 0 ? 0 : (rowsProcessed / totalRows) * 100}
             className="h-2"
           />
         </div>
@@ -386,7 +443,7 @@ export function FormatPreview({
             </Table>
           </ScrollArea>
 
-          {processedTrades.length > 0 && (
+          {formattedCount > 0 && (
             <div className="border-t bg-muted/30">
               <Table>
                 <TableBody>

--- a/app/[locale]/dashboard/components/import/components/format-preview.tsx
+++ b/app/[locale]/dashboard/components/import/components/format-preview.tsx
@@ -36,6 +36,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Progress } from "@/components/ui/progress";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { evaluateFormatTradesBatchResult } from "@/lib/ai/format-trades-batch";
+import {
+  AI_UNAVAILABLE_ERROR,
+  parseFormatTradesApiError,
+} from "@/lib/ai/openai-availability";
 
 interface FormatPreviewProps {
   trades: string[][];
@@ -136,6 +142,8 @@ export function FormatPreview({
   const currentBatchIndex2Ref = useRef<number>(currentBatchIndex2);
   const isAutoProcessingRef = useRef<boolean>(isAutoProcessing);
   const isStoppedRef = useRef<boolean>(isStopped);
+  const stop1Ref = useRef<() => void>(() => {});
+  const stop2Ref = useRef<() => void>(() => {});
   
   // Update refs when state changes
   useEffect(() => {
@@ -192,47 +200,87 @@ export function FormatPreview({
     console.log(`Split batches - Set 1: ${set1.join(', ')}, Set 2: ${set2.join(', ')}`);
   };
 
+  const failProcessing = (message: string) => {
+    isAutoProcessingRef.current = false;
+    isStoppedRef.current = true;
+    setIsAutoProcessing(false);
+    setIsStopped(true);
+    setError(message);
+    stop1Ref.current();
+    stop2Ref.current();
+  };
+
+  const messageForFormatError = (error?: Error) => {
+    if (error && parseFormatTradesApiError(error.message).code === AI_UNAVAILABLE_ERROR) {
+      return t('import.processing.aiUnavailable');
+    }
+    return t('import.processing.noTradesFormatted');
+  };
+
+  const handleStreamFinish = (
+    event: { object: unknown; error?: Error },
+    instance: 1 | 2,
+  ) => {
+    if (isStoppedRef.current) {
+      return;
+    }
+
+    const result = evaluateFormatTradesBatchResult(event);
+    if (result.status === 'failed') {
+      console.error(`Batch set ${instance} finished without formatted trades:`, event.error ?? result.reason);
+      failProcessing(messageForFormatError(event.error));
+      return;
+    }
+
+    const batchSet = instance === 1 ? batchSet1Ref.current : batchSet2Ref.current;
+    const currentIndex = instance === 1 ? currentBatchIndex1Ref.current : currentBatchIndex2Ref.current;
+    const currentBatch = batchSet[currentIndex];
+    if (currentBatch === undefined) {
+      return;
+    }
+
+    console.log(`Batch ${currentBatch} completed by instance ${instance}`);
+    setCompletedBatches(prev => {
+      const newSet = new Set([...prev, currentBatch]);
+      console.log(`Completed batches now: ${Array.from(newSet).join(', ')}`);
+      return newSet;
+    });
+
+    if (instance === 1) {
+      setCurrentBatchIndex1(prev => prev + 1);
+    } else {
+      setCurrentBatchIndex2(prev => prev + 1);
+    }
+
+    if (completedBatchesRef.current.size + 1 === totalBatches) {
+      console.log('All batches completed, stopping auto-processing');
+      setIsAutoProcessing(false);
+    } else if (isAutoProcessingRef.current && !isStoppedRef.current) {
+      setTimeout(() => {
+        if (instance === 1) {
+          processNextBatchInSet1();
+        } else {
+          processNextBatchInSet2();
+        }
+      }, 500);
+    }
+  };
+
   // First useObject instance - processes batchSet1
   const { 
     object: object1, 
     submit: submit1, 
-    isLoading: isProcessing1 
+    isLoading: isProcessing1,
+    stop: stop1,
   } = useObject({
     api: '/api/ai/format-trades',
     schema: z.array(tradeSchema),
     onError(error) {
       console.error('Error processing batch set 1:', error);
-      setError(`Failed to process batch set 1: ${error.message}`);
+      failProcessing(messageForFormatError(error));
     },
-    onFinish() {
-      console.log('useObject 1 streaming completed');
-      const currentBatch = batchSet1Ref.current[currentBatchIndex1Ref.current];
-      if (currentBatch !== undefined) {
-        console.log(`Batch ${currentBatch} completed by instance 1`);
-        setCompletedBatches(prev => {
-          const newSet = new Set([...prev, currentBatch]);
-          console.log(`Completed batches now: ${Array.from(newSet).join(', ')}`);
-          return newSet;
-        });
-        
-        // Move to next batch in set 1
-        setCurrentBatchIndex1(prev => {
-          const newIndex = prev + 1;
-          console.log(`Set 1 index moved from ${prev} to ${newIndex}`);
-          return newIndex;
-        });
-        
-        // Check if all batches are completed
-        if (completedBatchesRef.current.size + 1 === totalBatches) {
-          console.log('All batches completed, stopping auto-processing');
-          setIsAutoProcessing(false);
-        } else if (isAutoProcessingRef.current && !isStoppedRef.current) {
-          // Process next batch in set 1 if available and not stopped
-          setTimeout(() => {
-            processNextBatchInSet1();
-          }, 500);
-        }
-      }
+    onFinish(event) {
+      handleStreamFinish(event, 1);
     }
   });
 
@@ -240,50 +288,30 @@ export function FormatPreview({
   const { 
     object: object2, 
     submit: submit2, 
-    isLoading: isProcessing2 
+    isLoading: isProcessing2,
+    stop: stop2,
   } = useObject({
     api: '/api/ai/format-trades',
     schema: z.array(tradeSchema),
     onError(error) {
       console.error('Error processing batch set 2:', error);
-      setError(`Failed to process batch set 2: ${error.message}`);
+      failProcessing(messageForFormatError(error));
     },
-    onFinish() {
-      console.log('useObject 2 streaming completed');
-      const currentBatch = batchSet2Ref.current[currentBatchIndex2Ref.current];
-      if (currentBatch !== undefined) {
-        console.log(`Batch ${currentBatch} completed by instance 2`);
-        setCompletedBatches(prev => {
-          const newSet = new Set([...prev, currentBatch]);
-          console.log(`Completed batches now: ${Array.from(newSet).join(', ')}`);
-          return newSet;
-        });
-        
-        // Move to next batch in set 2
-        setCurrentBatchIndex2(prev => {
-          const newIndex = prev + 1;
-          console.log(`Set 2 index moved from ${prev} to ${newIndex}`);
-          return newIndex;
-        });
-        
-        // Check if all batches are completed
-        if (completedBatchesRef.current.size + 1 === totalBatches) {
-          console.log('All batches completed, stopping auto-processing');
-          setIsAutoProcessing(false);
-        } else if (isAutoProcessingRef.current && !isStoppedRef.current) {
-          // Process next batch in set 2 if available and not stopped
-          setTimeout(() => {
-            processNextBatchInSet2();
-          }, 500);
-        }
-      }
+    onFinish(event) {
+      handleStreamFinish(event, 2);
     }
   });
+
+  stop1Ref.current = stop1;
+  stop2Ref.current = stop2;
 
   const isProcessing = isProcessing1 || isProcessing2;
 
   // Process next batch in set 1
   const processNextBatchInSet1 = () => {
+    if (isStoppedRef.current) {
+      return;
+    }
     const currentIndex = currentBatchIndex1Ref.current;
     const batchSet = batchSet1Ref.current;
     
@@ -309,6 +337,9 @@ export function FormatPreview({
 
   // Process next batch in set 2
   const processNextBatchInSet2 = () => {
+    if (isStoppedRef.current) {
+      return;
+    }
     const currentIndex = currentBatchIndex2Ref.current;
     const batchSet = batchSet2Ref.current;
     
@@ -333,6 +364,7 @@ export function FormatPreview({
   };
 
   const startProcessing = () => {
+    setError(null);
     setIsAutoProcessing(true);
     setIsStopped(false);
     splitBatches();
@@ -354,6 +386,7 @@ export function FormatPreview({
   };
 
   const resetProcessing = () => {
+    setError(null);
     setIsAutoProcessing(false);
     setIsStopped(false);
     setCurrentBatch(0);
@@ -708,13 +741,13 @@ export function FormatPreview({
 
 
 
-  if (error) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-red-500">{error}</div>
-      </div>
-    );
-  }
+  const formattedTradeCount = processedTrades.filter(trade => trade.entryDate).length;
+  const allBatchesSucceeded =
+    !isAutoProcessing &&
+    !error &&
+    completedBatches.size === totalBatches &&
+    totalBatches > 0 &&
+    formattedTradeCount > 0;
 
   return (
     <div className="flex flex-col gap-4 h-full">
@@ -722,7 +755,7 @@ export function FormatPreview({
         <div className="flex items-center gap-4">
           <div className="flex flex-col gap-1">
         <p className="text-sm text-muted-foreground">
-          {processedTrades.filter(trade => trade.entryDate).length} of {validTrades.length} trades formatted
+          {formattedTradeCount} of {validTrades.length} trades formatted
         </p>
             <p className="text-xs text-muted-foreground">
               Batches: {completedBatches.size}/{totalBatches} completed
@@ -735,10 +768,16 @@ export function FormatPreview({
               <span className="text-xs text-green-600 font-medium">{t('import.processing.autoProcessing')}</span>
             </div>
           )}
-          {!isAutoProcessing && completedBatches.size === totalBatches && totalBatches > 0 && (
+          {allBatchesSucceeded && (
             <div className="flex items-center gap-2">
               <div className="w-2 h-2 bg-green-500 rounded-full"></div>
               <span className="text-xs text-green-600 font-medium">{t('import.processing.allBatchesCompleted')}</span>
+            </div>
+          )}
+          {error && !isAutoProcessing && (
+            <div className="flex items-center gap-2">
+              <div className="w-2 h-2 bg-red-500 rounded-full"></div>
+              <span className="text-xs text-red-600 font-medium">{t('import.processing.batchFailed')}</span>
             </div>
           )}
         </div>
@@ -782,6 +821,13 @@ export function FormatPreview({
           </Button>
         </div>
       </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTitle>{t('import.processing.batchFailed')}</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
       
       {/* Progress Bar */}
       {totalBatches > 0 && (

--- a/app/[locale]/dashboard/components/import/components/format-preview.tsx
+++ b/app/[locale]/dashboard/components/import/components/format-preview.tsx
@@ -33,18 +33,21 @@ import {
   createParsePlanSession,
   executeParsePlanChunk,
   isParsePlanComplete,
-  missingRequiredFields,
-  resolveParsePlan,
+  planFromHeaders,
   type ExecutedTrade,
   type ParsePlan,
 } from "@/lib/import/parse-plan";
-import { planFromAiResponse } from "@/lib/import/plan-from-ai";
+import { obtainAgentParseScript } from "@/lib/import/obtain-agent-script";
+import { streamDelimitedFile } from "@/lib/import/stream-delimited-file";
+import type { ParseScriptSession } from "@/lib/import/parse-script";
 
 function yieldToMain(): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, 0);
   });
 }
+
+type ParserPhase = "writing" | "checking" | "reading" | "ready" | "error";
 
 interface FormatPreviewProps {
   trades: string[][];
@@ -54,6 +57,9 @@ interface FormatPreviewProps {
   isLoading: boolean;
   headers: string[];
   mappings: { [key: string]: string };
+  importFile?: File | null;
+  delimiter?: string;
+  peekText?: string;
 }
 
 export function FormatPreview({
@@ -62,131 +68,210 @@ export function FormatPreview({
   setProcessedTrades,
   setIsLoading,
   headers,
-  mappings,
+  mappings: _mappings,
+  importFile = null,
+  delimiter = ",",
+  peekText,
 }: FormatPreviewProps) {
   const t = useI18n();
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [parseKind, setParseKind] = useState<"closed-trades" | "orders" | null>(
+  const [parseKind, setParseKind] = useState<"closed-trades" | "orders" | "script" | null>(
     null,
   );
   const [previewTrades, setPreviewTrades] = useState<Partial<Trade>[]>([]);
   const [formattedCount, setFormattedCount] = useState(0);
   const [rowsProcessed, setRowsProcessed] = useState(0);
+  const [bytesRead, setBytesRead] = useState(0);
   const [isParsing, setIsParsing] = useState(false);
+  const [phase, setPhase] = useState<ParserPhase>("writing");
+  const [agentScript, setAgentScript] = useState<string | null>(null);
   const [totals, setTotals] = useState({
     totalPnl: 0,
     totalCommission: 0,
     netPnl: 0,
   });
-  const askedAiRef = useRef(false);
 
-  const totalRows = initialTrades.length;
+  const fileSize = importFile?.size ?? 0;
 
   useEffect(() => {
     let cancelled = false;
 
-    const runChunks = async (plan: ParsePlan) => {
+    const applyTrades = (
+      all: ExecutedTrade[],
+      incoming: ExecutedTrade[],
+      processedRows: number,
+      readBytes: number,
+    ) => {
+      for (const trade of incoming) {
+        all.push(trade);
+      }
+      const totalsFromAll = all.reduce(
+        (acc, trade) => {
+          acc.totalPnl += trade.pnl || 0;
+          acc.totalCommission += trade.commission || 0;
+          return acc;
+        },
+        { totalPnl: 0, totalCommission: 0 },
+      );
+      setRowsProcessed(processedRows);
+      setBytesRead(readBytes);
+      setFormattedCount(all.length);
+      setPreviewTrades(all.slice(0, PARSE_PREVIEW_LIMIT));
+      setTotals({
+        totalPnl: totalsFromAll.totalPnl,
+        totalCommission: totalsFromAll.totalCommission,
+        netPnl: totalsFromAll.totalPnl - totalsFromAll.totalCommission,
+      });
+    };
+
+    const finish = (all: ExecutedTrade[]) => {
+      if (cancelled) return;
+      setProcessedTrades(all);
+      setIsParsing(false);
+      setIsLoading(false);
+      setPhase(all.length === 0 ? "error" : "ready");
+      if (all.length === 0) {
+        setError(t("import.processing.noTradesFormatted"));
+      }
+    };
+
+    const runPlanChunks = async (plan: ParsePlan, rows: string[][]) => {
       setParseKind(plan.kind);
+      const session = createParsePlanSession();
+      const all: ExecutedTrade[] = [];
+      let processed = 0;
+      for (let offset = 0; offset < rows.length; offset += PARSE_PLAN_CHUNK_SIZE) {
+        if (cancelled) return;
+        const { trades } = executeParsePlanChunk(
+          rows.slice(offset, offset + PARSE_PLAN_CHUNK_SIZE),
+          plan,
+          session,
+        );
+        processed = Math.min(offset + PARSE_PLAN_CHUNK_SIZE, rows.length);
+        applyTrades(all, trades, processed, 0);
+        await yieldToMain();
+      }
+      finish(all);
+    };
+
+    const runFileWithPlan = async (plan: ParsePlan, file: File) => {
+      setParseKind(plan.kind);
+      const session = createParsePlanSession();
+      const all: ExecutedTrade[] = [];
+      let processed = 0;
+      await streamDelimitedFile(file, {
+        delimiter,
+        headers,
+        onChunk: async (rows, readBytes) => {
+          if (cancelled) return;
+          const { trades } = executeParsePlanChunk(rows, plan, session);
+          processed += rows.length;
+          applyTrades(all, trades, processed, readBytes);
+          await yieldToMain();
+        },
+      });
+      finish(all);
+    };
+
+    const runFileWithScript = async (script: string, file: File) => {
+      setParseKind("script");
+      setAgentScript(script);
+      const all: ExecutedTrade[] = [];
+      let session: ParseScriptSession = {};
+      let sandboxName: string | undefined;
+      let processed = 0;
+      await streamDelimitedFile(file, {
+        delimiter,
+        headers,
+        onChunk: async (rows, readBytes) => {
+          if (cancelled) return;
+          const response = await fetch("/api/import/parse-chunk", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ script, rows, session, sandboxName }),
+          });
+          const raw = await response.text();
+          if (!response.ok) throw new Error(raw);
+          const result = JSON.parse(raw) as {
+            trades: ExecutedTrade[];
+            session: ParseScriptSession;
+            sandboxName?: string;
+          };
+          session = result.session;
+          sandboxName = result.sandboxName;
+          processed += rows.length;
+          applyTrades(all, result.trades, processed, readBytes);
+          await yieldToMain();
+        },
+      });
+      finish(all);
+    };
+
+    const start = async () => {
       setError(null);
       setIsParsing(true);
       setIsLoading(true);
       setPreviewTrades([]);
       setFormattedCount(0);
       setRowsProcessed(0);
+      setBytesRead(0);
+      setAgentScript(null);
       setTotals({ totalPnl: 0, totalCommission: 0, netPnl: 0 });
       setProcessedTrades([]);
+      setPhase("writing");
 
-      const session = createParsePlanSession();
-      const all: ExecutedTrade[] = [];
-      let totalPnl = 0;
-      let totalCommission = 0;
-
-      for (let offset = 0; offset < initialTrades.length; offset += PARSE_PLAN_CHUNK_SIZE) {
-        if (cancelled) return;
-        const { trades } = executeParsePlanChunk(
-          initialTrades.slice(offset, offset + PARSE_PLAN_CHUNK_SIZE),
-          plan,
-          session,
-        );
-        for (const trade of trades) {
-          all.push(trade);
-          totalPnl += trade.pnl || 0;
-          totalCommission += trade.commission || 0;
-        }
-        const processed = Math.min(offset + PARSE_PLAN_CHUNK_SIZE, initialTrades.length);
-        setRowsProcessed(processed);
-        setFormattedCount(all.length);
-        setPreviewTrades(all.slice(0, PARSE_PREVIEW_LIMIT));
-        setTotals({
-          totalPnl,
-          totalCommission,
-          netPnl: totalPnl - totalCommission,
-        });
-        await yieldToMain();
-      }
-
-      if (cancelled) return;
-      setProcessedTrades(all);
-      setIsParsing(false);
-      setIsLoading(false);
-      if (all.length === 0) {
-        setError(t("import.processing.noTradesFormatted"));
-      }
-    };
-
-    const start = async () => {
-      const plan = resolveParsePlan(headers, mappings);
-      if (isParsePlanComplete(plan)) {
-        await runChunks(plan);
-        return;
-      }
-
-      if (askedAiRef.current) return;
-      askedAiRef.current = true;
-      setIsLoading(true);
-      setError(null);
-      const missing = missingRequiredFields(plan);
+      const plan = planFromHeaders(headers);
+      const sourceRows = initialTrades;
 
       try {
-        const response = await fetch("/api/ai/import-parse-plan", {
+        if (isParsePlanComplete(plan)) {
+          setPhase("reading");
+          if (importFile) {
+            await runFileWithPlan(plan, importFile);
+            return;
+          }
+          await runPlanChunks(plan, sourceRows);
+          return;
+        }
+
+        setPhase("checking");
+        const script = await obtainAgentParseScript({
+          headers,
+          rows: sourceRows.slice(0, 8),
+          peekText,
+        });
+        if (cancelled) return;
+        setPhase("reading");
+        if (importFile) {
+          await runFileWithScript(script, importFile);
+          return;
+        }
+        const response = await fetch("/api/import/parse-chunk", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            headers,
-            rows: initialTrades.slice(0, 8),
-          }),
+          body: JSON.stringify({ script, rows: sourceRows, session: {} }),
         });
         const raw = await response.text();
+        if (!response.ok) throw new Error(raw);
+        const result = JSON.parse(raw) as { trades: ExecutedTrade[] };
+        applyTrades([], result.trades, sourceRows.length, 0);
+        finish(result.trades);
+      } catch (caught) {
         if (cancelled) return;
-        if (!response.ok) {
-          const code = parseFormatTradesApiError(raw).code;
-          setError(
-            code === AI_UNAVAILABLE_ERROR
-              ? t("import.processing.aiUnavailable")
-              : t("import.processing.noTradesFormatted"),
-          );
-          setProcessedTrades([]);
-          setIsLoading(false);
-          return;
-        }
-        const aiPlan = planFromAiResponse(headers, JSON.parse(raw));
-        if (!isParsePlanComplete(aiPlan)) {
-          setError(
-            t("import.parse.missingColumns", {
-              columns: missing.join(", "),
-            }),
-          );
-          setProcessedTrades([]);
-          setIsLoading(false);
-          return;
-        }
-        await runChunks(aiPlan);
-      } catch {
-        if (cancelled) return;
-        setError(t("import.processing.noTradesFormatted"));
+        const code =
+          caught instanceof Error
+            ? parseFormatTradesApiError(caught.message).code || caught.message
+            : "";
+        setError(
+          code === AI_UNAVAILABLE_ERROR
+            ? t("import.processing.aiUnavailable")
+            : t("import.processing.noTradesFormatted"),
+        );
         setProcessedTrades([]);
+        setIsParsing(false);
         setIsLoading(false);
+        setPhase("error");
       }
     };
 
@@ -194,7 +279,16 @@ export function FormatPreview({
     return () => {
       cancelled = true;
     };
-  }, [headers, mappings, initialTrades, setProcessedTrades, setIsLoading, t]);
+  }, [
+    headers,
+    initialTrades,
+    importFile,
+    delimiter,
+    peekText,
+    setProcessedTrades,
+    setIsLoading,
+    t,
+  ]);
 
   const columns = useMemo<ColumnDef<Partial<Trade>>[]>(
     () => [
@@ -312,15 +406,30 @@ export function FormatPreview({
             })}
           </p>
           <p className="text-xs text-muted-foreground">
-            {isParsing
-              ? t("import.parse.rowsProcessed", {
-                  processed: rowsProcessed,
-                  total: totalRows,
-                })
-              : parseKind === "orders"
-                ? t("import.processing.ordersPaired")
-                : t("import.processing.parsedFromColumns")}
+            {phase === "writing"
+              ? t("import.processing.writingParser")
+              : phase === "checking"
+                ? t("import.processing.checkingSample")
+                : isParsing
+                  ? t("import.parse.rowsRead", {
+                      processed: rowsProcessed,
+                    })
+                  : parseKind === "script"
+                    ? t("import.processing.parserFromAgent")
+                    : parseKind === "orders"
+                      ? t("import.processing.ordersPaired")
+                      : t("import.processing.parsedFromColumns")}
           </p>
+          {agentScript && (
+            <details className="text-xs text-muted-foreground">
+              <summary className="cursor-pointer">
+                {t("import.parse.scriptLabel")}
+              </summary>
+              <pre className="mt-2 max-h-40 overflow-auto rounded-sm bg-muted/50 p-2 font-mono text-[11px] leading-relaxed">
+                {agentScript}
+              </pre>
+            </details>
+          )}
           {formattedCount > PARSE_PREVIEW_LIMIT && (
             <p className="text-xs text-muted-foreground">
               {t("import.table.showingFirst", {
@@ -334,7 +443,11 @@ export function FormatPreview({
           <div className="flex items-center gap-2">
             <div className="h-2 w-2 animate-pulse rounded-full bg-green-500"></div>
             <span className="text-xs font-medium text-green-600">
-              {t("import.processing.parsing")}
+              {phase === "writing"
+                ? t("import.processing.writingParser")
+                : phase === "checking"
+                  ? t("import.processing.checkingSample")
+                  : t("import.processing.readingFile")}
             </span>
           </div>
         )}
@@ -363,19 +476,27 @@ export function FormatPreview({
         </Alert>
       )}
 
-      {totalRows > 0 && (
+      {(fileSize > 0 || rowsProcessed > 0 || isParsing) && (
         <div className="space-y-2">
           <div className="flex justify-between text-xs text-muted-foreground">
             <span>{t("import.processing.processingProgress")}</span>
             <span>
-              {totalRows === 0
-                ? 0
-                : Math.round((rowsProcessed / totalRows) * 100)}
+              {fileSize > 0
+                ? Math.round((Math.min(bytesRead, fileSize) / fileSize) * 100)
+                : isParsing
+                  ? 0
+                  : 100}
               %
             </span>
           </div>
           <Progress
-            value={totalRows === 0 ? 0 : (rowsProcessed / totalRows) * 100}
+            value={
+              fileSize > 0
+                ? (Math.min(bytesRead, fileSize) / fileSize) * 100
+                : isParsing
+                  ? 0
+                  : 100
+            }
             className="h-2"
           />
         </div>

--- a/app/[locale]/dashboard/components/import/components/format-preview.tsx
+++ b/app/[locale]/dashboard/components/import/components/format-preview.tsx
@@ -309,7 +309,6 @@ export function FormatPreview({
           <p className="text-sm text-muted-foreground">
             {t("import.parse.tradesFormatted", {
               formatted: formattedCount,
-              total: totalRows,
             })}
           </p>
           <p className="text-xs text-muted-foreground">

--- a/app/[locale]/dashboard/components/import/components/format-preview.tsx
+++ b/app/[locale]/dashboard/components/import/components/format-preview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Trade } from "@/prisma/generated/prisma/browser";
-import { useEffect, useState, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Table,
   TableBody,
@@ -11,10 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { format, isValid } from "date-fns";
-import { Skeleton } from "@/components/ui/skeleton";
-import { cn } from "@/lib/utils"; // Assuming you have a utility for className merging
-import { Button } from "@/components/ui/button";
-import { ArrowDownToLine, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { parsePositionTime } from "@/lib/utils";
 import { useI18n } from "@/locales/client";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -24,24 +21,20 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import React from "react";
-import { experimental_useObject as useObject } from '@ai-sdk/react'
-import { tradeSchema } from '@/app/api/ai/format-trades/schema'
-import { z } from 'zod/v3';
-import { Badge } from "@/components/ui/badge";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Progress } from "@/components/ui/progress";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { evaluateFormatTradesBatchResult } from "@/lib/ai/format-trades-batch";
+import { Progress } from "@/components/ui/progress";
 import {
   AI_UNAVAILABLE_ERROR,
   parseFormatTradesApiError,
 } from "@/lib/ai/openai-availability";
+import {
+  executeParsePlan,
+  isParsePlanComplete,
+  missingRequiredFields,
+  resolveParsePlan,
+  type ParsePlan,
+} from "@/lib/import/parse-plan";
+import { planFromAiResponse } from "@/lib/import/plan-from-ai";
 
 interface FormatPreviewProps {
   trades: string[][];
@@ -53,656 +46,195 @@ interface FormatPreviewProps {
   mappings: { [key: string]: string };
 }
 
-function transformHeaders(headers: string[], mappings: { [key: string]: string }): string[] {
-  return headers.map(header => {
-    const mappingKey = Object.keys(mappings).find(key => key === header);
-    return mappingKey ? mappings[mappingKey] : header;
-  });
-}
-
-function transformRowData(rows: string[][], headers: string[], mappings: { [key: string]: string }): string[][] {
-  return rows.map(row => {
-    const transformedRow: string[] = [];
-    
-    // Create a mapping from unique ID to destination column and source index
-    const uniqueIdToMapping: { [key: string]: { destination: string; sourceIndex: number } } = {};
-    headers.forEach((header, index) => {
-      const uniqueId = `${header}_${index}`;
-      if (mappings[uniqueId]) {
-        uniqueIdToMapping[uniqueId] = {
-          destination: mappings[uniqueId],
-          sourceIndex: index
-        };
-      }
-    });
-    
-    // Get all unique destination columns that are mapped, in the order they appear in mappings
-    const destinationColumns = [...new Set(Object.values(mappings))];
-    
-    // For each destination column, find the corresponding data using the unique ID
-    destinationColumns.forEach(destColumn => {
-      const mapping = Object.entries(uniqueIdToMapping).find(([_, mapping]) => mapping.destination === destColumn);
-      if (mapping) {
-        const [, { sourceIndex }] = mapping;
-        transformedRow.push(row[sourceIndex] || '');
-      } else {
-        transformedRow.push('');
-      }
-    });
-    
-    return transformedRow;
-  });
-}
-
-
 export function FormatPreview({
   trades: initialTrades,
   processedTrades,
   setProcessedTrades,
   setIsLoading,
-  isLoading,
   headers,
   mappings,
 }: FormatPreviewProps) {
   const t = useI18n();
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [parseKind, setParseKind] = useState<"closed-trades" | "orders" | null>(
+    null,
+  );
+  const askedAiRef = useRef(false);
 
-  // Transform headers using mappings - get the destination columns in the correct order
-  const transformedHeaders = useMemo(() => {
-    const destinationColumns = [...new Set(Object.values(mappings))];
-    return destinationColumns;
-  }, [mappings]);
-
-  // Calculate valid trades only when initialTrades changes
-  const validTrades = useMemo(() =>
-    initialTrades.filter(row => row.length > 0 && row[0] !== ""),
-    [initialTrades]
+  const validTrades = useMemo(
+    () => initialTrades.filter((row) => row.length > 0 && row[0] !== ""),
+    [initialTrades],
   );
 
-  const [error, setError] = useState<string | null>(null);
-  const [currentBatch, setCurrentBatch] = useState(0);
-  const [processedBatches, setProcessedBatches] = useState<Set<number>>(new Set());
-  const [processingBatches, setProcessingBatches] = useState<Set<number>>(new Set());
-  const [isAutoProcessing, setIsAutoProcessing] = useState(false);
-  const [isStopped, setIsStopped] = useState(false);
-  const [completedBatches, setCompletedBatches] = useState<Set<number>>(new Set());
-  const [batchSet1, setBatchSet1] = useState<number[]>([]);
-  const [batchSet2, setBatchSet2] = useState<number[]>([]);
-  const [currentBatchIndex1, setCurrentBatchIndex1] = useState(0);
-  const [currentBatchIndex2, setCurrentBatchIndex2] = useState(0);
-  const batchSize = 5;
-  const totalBatches = Math.ceil(validTrades.length / batchSize);
+  const applyPlan = (plan: ParsePlan) => {
+    const result = executeParsePlan(validTrades, plan);
+    setParseKind(result.kind);
+    setProcessedTrades(result.trades);
+    return result;
+  };
 
-  // Use refs to avoid infinite loops in useEffect
-  const processedTradesRef = useRef<Partial<Trade>[]>(processedTrades);
-  const completedBatchesRef = useRef<Set<number>>(completedBatches);
-  const batchSet1Ref = useRef<number[]>(batchSet1);
-  const batchSet2Ref = useRef<number[]>(batchSet2);
-  const currentBatchIndex1Ref = useRef<number>(currentBatchIndex1);
-  const currentBatchIndex2Ref = useRef<number>(currentBatchIndex2);
-  const isAutoProcessingRef = useRef<boolean>(isAutoProcessing);
-  const isStoppedRef = useRef<boolean>(isStopped);
-  const stop1Ref = useRef<() => void>(() => {});
-  const stop2Ref = useRef<() => void>(() => {});
-  
-  // Update refs when state changes
   useEffect(() => {
-    processedTradesRef.current = processedTrades;
-  }, [processedTrades]);
-  
-  useEffect(() => {
-    completedBatchesRef.current = completedBatches;
-  }, [completedBatches]);
-  
-  useEffect(() => {
-    batchSet1Ref.current = batchSet1;
-  }, [batchSet1]);
-  
-  useEffect(() => {
-    batchSet2Ref.current = batchSet2;
-  }, [batchSet2]);
-  
-  useEffect(() => {
-    currentBatchIndex1Ref.current = currentBatchIndex1;
-  }, [currentBatchIndex1]);
-  
-  useEffect(() => {
-    currentBatchIndex2Ref.current = currentBatchIndex2;
-  }, [currentBatchIndex2]);
-  
-  useEffect(() => {
-    isAutoProcessingRef.current = isAutoProcessing;
-  }, [isAutoProcessing]);
-  
-  useEffect(() => {
-    isStoppedRef.current = isStopped;
-  }, [isStopped]);
-
-  // Split batches into two sets
-  const splitBatches = () => {
-    const allBatches = Array.from({ length: totalBatches }, (_, i) => i);
-    const set1: number[] = [];
-    const set2: number[] = [];
-    
-    allBatches.forEach((batch, index) => {
-      if (index % 2 === 0) {
-        set1.push(batch);
-      } else {
-        set2.push(batch);
+    const plan = resolveParsePlan(headers, mappings);
+    if (isParsePlanComplete(plan)) {
+      const result = applyPlan(plan);
+      setError(null);
+      setIsLoading(false);
+      if (result.trades.length === 0) {
+        setError(t("import.processing.noTradesFormatted"));
       }
-    });
-    
-    setBatchSet1(set1);
-    setBatchSet2(set2);
-    setCurrentBatchIndex1(0);
-    setCurrentBatchIndex2(0);
-    
-    console.log(`Split batches - Set 1: ${set1.join(', ')}, Set 2: ${set2.join(', ')}`);
-  };
-
-  const failProcessing = (message: string) => {
-    isAutoProcessingRef.current = false;
-    isStoppedRef.current = true;
-    setIsAutoProcessing(false);
-    setIsStopped(true);
-    setError(message);
-    stop1Ref.current();
-    stop2Ref.current();
-  };
-
-  const messageForFormatError = (error?: Error) => {
-    if (error && parseFormatTradesApiError(error.message).code === AI_UNAVAILABLE_ERROR) {
-      return t('import.processing.aiUnavailable');
-    }
-    return t('import.processing.noTradesFormatted');
-  };
-
-  const handleStreamFinish = (
-    event: { object: unknown; error?: Error },
-    instance: 1 | 2,
-  ) => {
-    if (isStoppedRef.current) {
       return;
     }
 
-    const result = evaluateFormatTradesBatchResult(event);
-    if (result.status === 'failed') {
-      console.error(`Batch set ${instance} finished without formatted trades:`, event.error ?? result.reason);
-      failProcessing(messageForFormatError(event.error));
-      return;
-    }
+    if (askedAiRef.current) return;
+    askedAiRef.current = true;
+    setIsLoading(true);
+    setError(null);
 
-    const batchSet = instance === 1 ? batchSet1Ref.current : batchSet2Ref.current;
-    const currentIndex = instance === 1 ? currentBatchIndex1Ref.current : currentBatchIndex2Ref.current;
-    const currentBatch = batchSet[currentIndex];
-    if (currentBatch === undefined) {
-      return;
-    }
-
-    console.log(`Batch ${currentBatch} completed by instance ${instance}`);
-    setCompletedBatches(prev => {
-      const newSet = new Set([...prev, currentBatch]);
-      console.log(`Completed batches now: ${Array.from(newSet).join(', ')}`);
-      return newSet;
-    });
-
-    if (instance === 1) {
-      setCurrentBatchIndex1(prev => prev + 1);
-    } else {
-      setCurrentBatchIndex2(prev => prev + 1);
-    }
-
-    if (completedBatchesRef.current.size + 1 === totalBatches) {
-      console.log('All batches completed, stopping auto-processing');
-      setIsAutoProcessing(false);
-    } else if (isAutoProcessingRef.current && !isStoppedRef.current) {
-      setTimeout(() => {
-        if (instance === 1) {
-          processNextBatchInSet1();
-        } else {
-          processNextBatchInSet2();
+    const missing = missingRequiredFields(plan);
+    void (async () => {
+      try {
+        const response = await fetch("/api/ai/import-parse-plan", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            headers,
+            rows: validTrades.slice(0, 8),
+          }),
+        });
+        const raw = await response.text();
+        if (!response.ok) {
+          const code = parseFormatTradesApiError(raw).code;
+          setError(
+            code === AI_UNAVAILABLE_ERROR
+              ? t("import.processing.aiUnavailable")
+              : t("import.processing.noTradesFormatted"),
+          );
+          setProcessedTrades([]);
+          return;
         }
-      }, 500);
-    }
-  };
+        const aiPlan = planFromAiResponse(headers, JSON.parse(raw));
+        if (!isParsePlanComplete(aiPlan)) {
+          setError(
+            t("import.parse.missingColumns", {
+              columns: missing.join(", "),
+            }),
+          );
+          setProcessedTrades([]);
+          return;
+        }
+        const result = applyPlan(aiPlan);
+        if (result.trades.length === 0) {
+          setError(t("import.processing.noTradesFormatted"));
+        }
+      } catch {
+        setError(t("import.processing.noTradesFormatted"));
+        setProcessedTrades([]);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [headers, mappings, validTrades, setProcessedTrades, setIsLoading, t]);
 
-  // First useObject instance - processes batchSet1
-  const { 
-    object: object1, 
-    submit: submit1, 
-    isLoading: isProcessing1,
-    stop: stop1,
-  } = useObject({
-    api: '/api/ai/format-trades',
-    schema: z.array(tradeSchema),
-    onError(error) {
-      console.error('Error processing batch set 1:', error);
-      failProcessing(messageForFormatError(error));
-    },
-    onFinish(event) {
-      handleStreamFinish(event, 1);
-    }
-  });
+  const formattedTradeCount = processedTrades.filter(
+    (trade) => trade.entryDate,
+  ).length;
 
-  // Second useObject instance - processes batchSet2
-  const { 
-    object: object2, 
-    submit: submit2, 
-    isLoading: isProcessing2,
-    stop: stop2,
-  } = useObject({
-    api: '/api/ai/format-trades',
-    schema: z.array(tradeSchema),
-    onError(error) {
-      console.error('Error processing batch set 2:', error);
-      failProcessing(messageForFormatError(error));
-    },
-    onFinish(event) {
-      handleStreamFinish(event, 2);
-    }
-  });
-
-  stop1Ref.current = stop1;
-  stop2Ref.current = stop2;
-
-  const isProcessing = isProcessing1 || isProcessing2;
-
-  // Process next batch in set 1
-  const processNextBatchInSet1 = () => {
-    if (isStoppedRef.current) {
-      return;
-    }
-    const currentIndex = currentBatchIndex1Ref.current;
-    const batchSet = batchSet1Ref.current;
-    
-    console.log(`processNextBatchInSet1 - currentIndex: ${currentIndex}, batchSet: ${batchSet.join(', ')}, length: ${batchSet.length}`);
-    
-    if (currentIndex < batchSet.length) {
-      const nextBatch = batchSet[currentIndex];
-      console.log(`Processing batch ${nextBatch} in set 1 (index ${currentIndex})`);
-      const batchData = getBatchData(nextBatch);
-      console.log('=== BATCH DATA DEBUG ===');
-      console.log('Original headers:', headers);
-      console.log('Mappings:', mappings);
-      console.log('Transformed headers:', transformedHeaders);
-      console.log('Transformed rows:', batchData);
-      submit1({
-        headers: transformedHeaders,
-        rows: batchData
-      });
-    } else {
-      console.log('No more batches in set 1 - reached end of set');
-    }
-  };
-
-  // Process next batch in set 2
-  const processNextBatchInSet2 = () => {
-    if (isStoppedRef.current) {
-      return;
-    }
-    const currentIndex = currentBatchIndex2Ref.current;
-    const batchSet = batchSet2Ref.current;
-    
-    console.log(`processNextBatchInSet2 - currentIndex: ${currentIndex}, batchSet: ${batchSet.join(', ')}, length: ${batchSet.length}`);
-    
-    if (currentIndex < batchSet.length) {
-      const nextBatch = batchSet[currentIndex];
-      console.log(`Processing batch ${nextBatch} in set 2 (index ${currentIndex})`);
-      const batchData = getBatchData(nextBatch);
-      console.log('=== BATCH DATA DEBUG (Set 2) ===');
-      console.log('Original headers:', headers);
-      console.log('Mappings:', mappings);
-      console.log('Transformed headers:', transformedHeaders);
-      console.log('Transformed rows:', batchData);
-      submit2({
-        headers: transformedHeaders,
-        rows: batchData
-      });
-    } else {
-      console.log('No more batches in set 2 - reached end of set');
-    }
-  };
-
-  const startProcessing = () => {
-    setError(null);
-    setIsAutoProcessing(true);
-    setIsStopped(false);
-    splitBatches();
-    // Start both instances with their first batches after a small delay to ensure state is updated
-    setTimeout(() => {
-      processNextBatchInSet1();
-      processNextBatchInSet2();
-    }, 100);
-  };
-
-  const stopProcessing = () => {
-    console.log('Stop processing clicked - stopping auto-processing');
-    setIsAutoProcessing(false);
-    setIsStopped(true);
-    
-    // Don't mark currently processing batches as completed - let them finish naturally
-    // The onFinish callbacks will handle completion when they finish streaming
-    console.log('Stopped - current batches will finish streaming but no new ones will start');
-  };
-
-  const resetProcessing = () => {
-    setError(null);
-    setIsAutoProcessing(false);
-    setIsStopped(false);
-    setCurrentBatch(0);
-    setProcessedTrades([]);
-    setCompletedBatches(new Set());
-    setBatchSet1([]);
-    setBatchSet2([]);
-    setCurrentBatchIndex1(0);
-    setCurrentBatchIndex2(0);
-    processedTradesRef.current = [];
-  };
-
-  const getBatchData = (batchIndex: number) => {
-    const startIndex = batchIndex * batchSize;
-    const endIndex = Math.min(startIndex + batchSize, validTrades.length);
-    const batchRows = validTrades.slice(startIndex, endIndex);
-    return transformRowData(batchRows, headers, mappings);
-  };
-
-  const batchToProcess = useMemo(() => {
-    const startIndex = currentBatch * batchSize;
-    const endIndex = Math.min(startIndex + batchSize, validTrades.length);
-    return validTrades.slice(startIndex, endIndex);
-  }, [currentBatch, validTrades, batchSize]);
-
-
-  // Handle streaming results from first useObject
-  useEffect(() => {
-    if (object1) {
-      const newTrades = object1.filter((trade): trade is NonNullable<typeof trade> => trade !== undefined) as Trade[];
-      const uniqueTrades = newTrades.filter(newTrade =>
-        !processedTradesRef.current.some(existingTrade =>
-          existingTrade.entryDate === newTrade.entryDate &&
-          existingTrade.instrument === newTrade.instrument &&
-          existingTrade.quantity === newTrade.quantity &&
-          existingTrade.side === newTrade.side &&
-          existingTrade.entryPrice === newTrade.entryPrice &&
-          existingTrade.closePrice === newTrade.closePrice &&
-          existingTrade.pnl === newTrade.pnl &&
-          existingTrade.commission === newTrade.commission &&
-          existingTrade.timeInPosition === newTrade.timeInPosition
-        )
-      );
-      setProcessedTrades([...processedTradesRef.current, ...uniqueTrades]);
-      
-      setTimeout(() => {
-        scrollToBottom()
-      }, 100)
-    }
-  }, [object1])
-
-  // Handle streaming results from second useObject
-  useEffect(() => {
-    if (object2) {
-      const newTrades = object2.filter((trade): trade is NonNullable<typeof trade> => trade !== undefined) as Trade[];
-      const uniqueTrades = newTrades.filter(newTrade =>
-        !processedTradesRef.current.some(existingTrade =>
-          existingTrade.entryDate === newTrade.entryDate &&
-          existingTrade.instrument === newTrade.instrument &&
-          existingTrade.quantity === newTrade.quantity &&
-          existingTrade.side === newTrade.side &&
-          existingTrade.entryPrice === newTrade.entryPrice &&
-          existingTrade.closePrice === newTrade.closePrice &&
-          existingTrade.pnl === newTrade.pnl &&
-          existingTrade.commission === newTrade.commission &&
-          existingTrade.timeInPosition === newTrade.timeInPosition
-        )
-      );
-      setProcessedTrades([...processedTradesRef.current, ...uniqueTrades]);
-      
-      setTimeout(() => {
-        scrollToBottom()
-      }, 100)
-    }
-  }, [object2])
-
-  const columns = useMemo<ColumnDef<Partial<Trade>>[]>(() => [
-    {
-      accessorKey: "entryDate",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.entryDate')}</div>
-      ),
-      cell: ({ row }) => {
-        const entryDate = row.original.entryDate ? new Date(row.original.entryDate) : null;
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'entryDate')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                {entryDate && isValid(entryDate) ? format(entryDate, "yyyy-MM-dd HH:mm") : "Invalid Date"}
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+  const columns = useMemo<ColumnDef<Partial<Trade>>[]>(
+    () => [
+      {
+        accessorKey: "entryDate",
+        header: () => (
+          <div className="font-medium">{t("trade-table.entryDate")}</div>
+        ),
+        cell: ({ row }) => {
+          const entryDate = row.original.entryDate
+            ? new Date(row.original.entryDate)
+            : null;
+          return entryDate && isValid(entryDate)
+            ? format(entryDate, "yyyy-MM-dd HH:mm")
+            : "—";
+        },
+        size: 180,
       },
-      size: 180,
-    },
-    {
-      accessorKey: "instrument",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.instrument')}</div>
-      ),
-      cell: ({ row }) => {
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'instrument')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                {row.original.instrument}
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "instrument",
+        header: () => (
+          <div className="font-medium">{t("trade-table.instrument")}</div>
+        ),
+        cell: ({ row }) => row.original.instrument,
+        size: 120,
       },
-      size: 120,
-    },
-    {
-      accessorKey: "side",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.direction')}</div>
-      ),
-      cell: ({ row }) => {
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'side')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                <span className="capitalize">{row.original.side}</span>
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "side",
+        header: () => (
+          <div className="font-medium">{t("trade-table.direction")}</div>
+        ),
+        cell: ({ row }) => (
+          <span className="capitalize">{row.original.side}</span>
+        ),
+        size: 100,
       },
-      size: 100,
-    },
-    {
-      accessorKey: "quantity",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.quantity')}</div>
-      ),
-      cell: ({ row }) => {
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'quantity')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                {row.original.quantity}
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "quantity",
+        header: () => (
+          <div className="font-medium">{t("trade-table.quantity")}</div>
+        ),
+        cell: ({ row }) => row.original.quantity,
+        size: 100,
       },
-      size: 100,
-    },
-    {
-      accessorKey: "entryPrice",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.entryPrice')}</div>
-      ),
-      cell: ({ row }) => {
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'entryPrice')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                ${row.original.entryPrice}
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "entryPrice",
+        header: () => (
+          <div className="font-medium">{t("trade-table.entryPrice")}</div>
+        ),
+        cell: ({ row }) =>
+          row.original.entryPrice ? `$${row.original.entryPrice}` : "—",
+        size: 120,
       },
-      size: 120,
-    },
-    {
-      accessorKey: "closePrice",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.exitPrice')}</div>
-      ),
-      cell: ({ row }) => {
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'closePrice')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                ${row.original.closePrice}
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "closePrice",
+        header: () => (
+          <div className="font-medium">{t("trade-table.exitPrice")}</div>
+        ),
+        cell: ({ row }) =>
+          row.original.closePrice ? `$${row.original.closePrice}` : "—",
+        size: 120,
       },
-      size: 120,
-    },
-    {
-      accessorKey: "pnl",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.pnl')}</div>
-      ),
-      cell: ({ row }) => {
-        const pnl = row.original.pnl ?? 0;
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'pnl')];
-        const originalPnl = originalData ? parseFloat(originalData.replace(/[,$]/g, '')) : null;
-        const isMismatch = originalPnl !== null && Math.abs(pnl - originalPnl) > 0.01;
-        
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                <div className="flex items-center gap-1">
-                  <span className={pnl >= 0 ? "text-green-600" : "text-red-600"}>
-                    ${pnl.toFixed(2)}
-                  </span>
-                  {isMismatch && (
-                    <span className="text-orange-500 text-xs" title="PnL value doesn't match original data">
-                      ⚠️
-                    </span>
-                  )}
-                </div>
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <div className="space-y-1">
-                    <p>Original: {originalData}</p>
-                    {isMismatch && (
-                      <p className="text-orange-500 text-sm">
-                        ⚠️ Mismatch detected! Expected: ${originalPnl?.toFixed(2)}, Got: ${pnl.toFixed(2)}
-                      </p>
-                    )}
-                  </div>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "pnl",
+        header: () => (
+          <div className="font-medium">{t("trade-table.pnl")}</div>
+        ),
+        cell: ({ row }) => {
+          const pnl = row.original.pnl ?? 0;
+          return (
+            <span className={pnl >= 0 ? "text-green-600" : "text-red-600"}>
+              ${pnl.toFixed(2)}
+            </span>
+          );
+        },
+        size: 120,
       },
-      size: 120,
-    },
-    {
-      accessorKey: "commission",
-      header: ({ column }) => (
-        <div className="font-medium">{t('calendar.modal.commission')}</div>
-      ),
-      cell: ({ row }) => {
-        const commission = row.original.commission ?? 0;
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'commission')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                ${commission.toFixed(2)}
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "commission",
+        header: () => (
+          <div className="font-medium">{t("calendar.modal.commission")}</div>
+        ),
+        cell: ({ row }) => `$${(row.original.commission ?? 0).toFixed(2)}`,
+        size: 120,
       },
-      size: 120,
-    },
-    {
-      accessorKey: "timeInPosition",
-      header: ({ column }) => (
-        <div className="font-medium">{t('trade-table.positionTime')}</div>
-      ),
-      cell: ({ row }) => {
-        const originalData = validTrades[row.index]?.[headers.findIndex(h => mappings[h] === 'timeInPosition')];
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                {parsePositionTime(row.original.timeInPosition || 0)}
-              </TooltipTrigger>
-              {originalData && (
-                <TooltipContent>
-                  <p>Original: {originalData}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        );
+      {
+        accessorKey: "timeInPosition",
+        header: () => (
+          <div className="font-medium">{t("trade-table.positionTime")}</div>
+        ),
+        cell: ({ row }) => parsePositionTime(row.original.timeInPosition || 0),
+        size: 120,
       },
-      size: 120,
-    },
-  ], [t, validTrades, headers, mappings]);
+    ],
+    [t],
+  );
 
   const table = useReactTable({
     data: processedTrades,
@@ -714,137 +246,87 @@ export function FormatPreview({
     },
   });
 
-  const scrollToBottom = () => {
-    if (tableContainerRef.current) {
-      const scrollContainer = tableContainerRef.current.querySelector('[data-radix-scroll-area-viewport]');
-      if (scrollContainer) {
-        scrollContainer.scrollTo({
-          top: scrollContainer.scrollHeight,
-          behavior: 'smooth'
-        });
-      }
-    }
-  };
-
-  // Calculate totals for footer
   const totals = useMemo(() => {
-    const totalPnl = processedTrades.reduce((sum, trade) => sum + (trade.pnl || 0), 0);
-    const totalCommission = processedTrades.reduce((sum, trade) => sum + (trade.commission || 0), 0);
-    const netPnl = totalPnl - totalCommission;
-    
+    const totalPnl = processedTrades.reduce(
+      (sum, trade) => sum + (trade.pnl || 0),
+      0,
+    );
+    const totalCommission = processedTrades.reduce(
+      (sum, trade) => sum + (trade.commission || 0),
+      0,
+    );
     return {
       totalPnl,
       totalCommission,
-      netPnl
+      netPnl: totalPnl - totalCommission,
     };
   }, [processedTrades]);
 
-
-
-  const formattedTradeCount = processedTrades.filter(trade => trade.entryDate).length;
-  const allBatchesSucceeded =
-    !isAutoProcessing &&
-    !error &&
-    completedBatches.size === totalBatches &&
-    totalBatches > 0 &&
-    formattedTradeCount > 0;
-
   return (
-    <div className="flex flex-col gap-4 h-full">
+    <div className="flex h-full flex-col gap-4">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <div className="flex flex-col gap-1">
-        <p className="text-sm text-muted-foreground">
-          {formattedTradeCount} of {validTrades.length} trades formatted
-        </p>
-            <p className="text-xs text-muted-foreground">
-              Batches: {completedBatches.size}/{totalBatches} completed
-              {processingBatches.size > 0 && `, ${processingBatches.size} processing`}
-            </p>
+        <div className="flex flex-col gap-1">
+          <p className="text-sm text-muted-foreground">
+            {t("import.parse.tradesFormatted", {
+              formatted: formattedTradeCount,
+              total: validTrades.length,
+            })}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {parseKind === "orders"
+              ? t("import.processing.ordersPaired")
+              : t("import.processing.parsedFromColumns")}
+          </p>
+        </div>
+        {formattedTradeCount > 0 && !error && (
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-green-500"></div>
+            <span className="text-xs font-medium text-green-600">
+              {t("import.processing.parseReady")}
+            </span>
           </div>
-          {isAutoProcessing && (
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-              <span className="text-xs text-green-600 font-medium">{t('import.processing.autoProcessing')}</span>
-            </div>
-          )}
-          {allBatchesSucceeded && (
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-              <span className="text-xs text-green-600 font-medium">{t('import.processing.allBatchesCompleted')}</span>
-            </div>
-          )}
-          {error && !isAutoProcessing && (
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-red-500 rounded-full"></div>
-              <span className="text-xs text-red-600 font-medium">{t('import.processing.batchFailed')}</span>
-            </div>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {!isAutoProcessing && completedBatches.size === 0 && (
-            <Button
-              onClick={startProcessing}
-              disabled={isProcessing}
-              className="bg-green-600 hover:bg-green-700 text-white"
-            >
-              {isProcessing ? t('import.processing.starting') : t('import.processing.startProcessing')}
-            </Button>
-          )}
-          
-          {isAutoProcessing && (
-            <Button
-              onClick={stopProcessing}
-              variant="destructive"
-            >
-              {t('import.processing.stopProcessing')}
-            </Button>
-          )}
-          
-          {!isAutoProcessing && completedBatches.size > 0 && (
-        <Button
-              onClick={startProcessing}
-              disabled={isProcessing}
-          variant="outline"
-        >
-              {isProcessing ? t('import.processing.resuming') : t('import.processing.resumeProcessing')}
-        </Button>
-          )}
-          
-          <Button
-            onClick={resetProcessing}
-            disabled={isProcessing}
-            variant="outline"
-            className="border-red-200 text-red-600 hover:bg-red-50"
-        >
-          {t('import.processing.reset')}
-          </Button>
-        </div>
+        )}
+        {error && (
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-red-500"></div>
+            <span className="text-xs font-medium text-red-600">
+              {t("import.processing.batchFailed")}
+            </span>
+          </div>
+        )}
       </div>
 
       {error && (
         <Alert variant="destructive">
-          <AlertTitle>{t('import.processing.batchFailed')}</AlertTitle>
+          <AlertTitle>{t("import.processing.batchFailed")}</AlertTitle>
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
-      
-      {/* Progress Bar */}
-      {totalBatches > 0 && (
+
+      {validTrades.length > 0 && (
         <div className="space-y-2">
           <div className="flex justify-between text-xs text-muted-foreground">
-            <span>{t('import.processing.processingProgress')}</span>
-            <span>{Math.round((completedBatches.size / totalBatches) * 100)}%</span>
+            <span>{t("import.processing.processingProgress")}</span>
+            <span>
+              {validTrades.length === 0
+                ? 0
+                : Math.round((formattedTradeCount / validTrades.length) * 100)}
+              %
+            </span>
           </div>
-          <Progress 
-            value={(completedBatches.size / totalBatches) * 100} 
+          <Progress
+            value={
+              validTrades.length === 0
+                ? 0
+                : (formattedTradeCount / validTrades.length) * 100
+            }
             className="h-2"
           />
         </div>
       )}
-      
-      <div className="flex-1 min-h-0 overflow-hidden">
-        <div className="flex flex-col h-full">
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <div className="flex h-full flex-col">
           <Table>
             <TableHeader className="sticky top-0 z-10 bg-background shadow-xs">
               {table.getHeaderGroups().map((headerGroup) => (
@@ -858,9 +340,9 @@ export function FormatPreview({
                       {header.isPlaceholder
                         ? null
                         : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
                     </TableHead>
                   ))}
                 </TableRow>
@@ -871,82 +353,73 @@ export function FormatPreview({
             <Table>
               <TableBody>
                 {table.getRowModel().rows?.length ? (
-                    table.getRowModel().rows.map((row) => (
-                      <TableRow
-                        key={row.id}
-                        data-state={row.getIsSelected() && "selected"}
-                        className={cn(
-                          "border-b transition-colors hover:bg-muted",
-                          row.getIsExpanded()
-                            ? "bg-muted"
-                            : row.getCanExpand()
-                              ? ""
-                              : "bg-muted/50"
-                        )}
-                      >
-                        {row.getVisibleCells().map((cell) => (
-                          <TableCell
-                            key={cell.id}
-                            className="whitespace-nowrap px-4 py-2.5 text-sm"
-                            style={{ width: cell.column.getSize() }}
-                          >
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    ))
-                ) : isProcessing || (
+                  table.getRowModel().rows.map((row) => (
+                    <TableRow
+                      key={row.id}
+                      className={cn("border-b transition-colors hover:bg-muted")}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell
+                          key={cell.id}
+                          className="whitespace-nowrap px-4 py-2.5 text-sm"
+                          style={{ width: cell.column.getSize() }}
+                        >
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                ) : (
                   <TableRow>
                     <TableCell
                       colSpan={columns.length}
                       className="h-24 text-center"
                     >
-                      No results.
+                      {t("import.processing.emptyTable")}
                     </TableCell>
-                  </TableRow>
-                )}
-                {isProcessing && (
-                  <TableRow>
-                    {columns.map((column, index) => (
-                      <TableCell
-                        key={`loading-${index}`}
-                        className="whitespace-nowrap px-4 py-2.5 text-sm"
-                        style={{ width: column.size }}
-                      >
-                        <Skeleton className="h-6 w-full" />
-                      </TableCell>
-                    ))}
                   </TableRow>
                 )}
               </TableBody>
             </Table>
           </ScrollArea>
-          
-          {/* Table Footer with Totals */}
+
           {processedTrades.length > 0 && (
             <div className="border-t bg-muted/30">
               <Table>
                 <TableBody>
                   <TableRow className="font-medium">
                     <TableCell className="px-4 py-3 text-sm font-semibold">
-                      {t('trade-table.footer.totalPnl')}
+                      {t("trade-table.footer.totalPnl")}
                     </TableCell>
                     <TableCell className="px-4 py-3 text-sm">
-                      <span className={totals.totalPnl >= 0 ? "text-green-600" : "text-red-600"}>
+                      <span
+                        className={
+                          totals.totalPnl >= 0
+                            ? "text-green-600"
+                            : "text-red-600"
+                        }
+                      >
                         ${totals.totalPnl.toFixed(2)}
                       </span>
                     </TableCell>
                     <TableCell className="px-4 py-3 text-sm font-semibold">
-                      {t('trade-table.footer.totalCommission')}
+                      {t("trade-table.footer.totalCommission")}
                     </TableCell>
                     <TableCell className="px-4 py-3 text-sm">
                       ${totals.totalCommission.toFixed(2)}
                     </TableCell>
                     <TableCell className="px-4 py-3 text-sm font-semibold">
-                      {t('trade-table.footer.netPnl')}
+                      {t("trade-table.footer.netPnl")}
                     </TableCell>
                     <TableCell className="px-4 py-3 text-sm">
-                      <span className={totals.netPnl >= 0 ? "text-green-600" : "text-red-600"}>
+                      <span
+                        className={
+                          totals.netPnl >= 0 ? "text-green-600" : "text-red-600"
+                        }
+                      >
                         ${totals.netPnl.toFixed(2)}
                       </span>
                     </TableCell>

--- a/app/[locale]/dashboard/components/import/config/platforms.tsx
+++ b/app/[locale]/dashboard/components/import/config/platforms.tsx
@@ -296,12 +296,6 @@ export const platforms: PlatformConfig[] = [
         component: FileUpload
       },
       {
-        id: 'map-columns',
-        title: 'import.steps.mapColumns',
-        description: 'import.steps.mapColumnsDescription',
-        component: ColumnMapping
-      },
-      {
         id: 'select-account',
         title: 'import.steps.selectAccount',
         description: 'import.steps.selectAccountDescription',

--- a/app/[locale]/dashboard/components/import/file-upload.tsx
+++ b/app/[locale]/dashboard/components/import/file-upload.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils"
 import { useI18n } from "@/locales/client"
 import { platforms } from './config/platforms'
 import { Step } from './import-button'
+import { peekDelimitedFile } from '@/lib/import/peek-delimited-file'
 
 interface FileUploadProps {
   importType: ImportType
@@ -19,6 +20,9 @@ interface FileUploadProps {
   setHeaders: React.Dispatch<React.SetStateAction<string[]>>
   setStep: React.Dispatch<React.SetStateAction<Step>>
   setError: React.Dispatch<React.SetStateAction<string | null>>
+  setImportFile?: (file: File | null) => void
+  setDelimiter?: (delimiter: string) => void
+  setPeekText?: (text: string) => void
 }
 
 export default function FileUpload({
@@ -27,7 +31,10 @@ export default function FileUpload({
   setCsvData,
   setHeaders,
   setStep,
-  setError
+  setError,
+  setImportFile,
+  setDelimiter,
+  setPeekText,
 }: FileUploadProps) {
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([])
   const [uploadProgress, setUploadProgress] = useState<{ [key: string]: number }>({})
@@ -35,39 +42,59 @@ export default function FileUpload({
   const t = useI18n()
 
   const processFile = useCallback((file: File, index: number) => {
+    const platform =
+      platforms.find((p) => p.type === importType) ||
+      platforms.find((p) => p.platformName === "csv-ai");
+
+    if (platform?.platformName === "csv-ai") {
+      return peekDelimitedFile(file).then((peeked) => {
+        if (!peeked.headers.length) {
+          throw new Error("The CSV file appears to be empty or invalid.");
+        }
+        setImportFile?.(file);
+        setDelimiter?.(peeked.delimiter);
+        setPeekText?.(peeked.peekText);
+        setParsedFiles((prevFiles) => {
+          const newFiles = [...prevFiles];
+          newFiles[index] = [peeked.headers, ...peeked.sampleRows];
+          return newFiles;
+        });
+        setError(null);
+      });
+    }
+
     return new Promise<void>((resolve, reject) => {
-      // First read the first line to detect delimiter
       const reader = new FileReader();
       reader.onload = (e) => {
-        const firstLine = e.target?.result?.toString().split('\n')[0] || '';
-        const delimiter = firstLine.includes(';') ? ';' : ',';
-        
+        const firstLine = e.target?.result?.toString().split("\n")[0] || "";
+        const delimiter = firstLine.includes(";") ? ";" : ",";
+
         Papa.parse(file, {
           delimiter,
           complete: (result) => {
             if (result.data && Array.isArray(result.data) && result.data.length > 0) {
-              setParsedFiles(prevFiles => {
-                const newFiles = [...prevFiles]
-                newFiles[index] = result.data as string[][]
-                return newFiles
-              })
-              setError(null)
-              resolve()
+              setParsedFiles((prevFiles) => {
+                const newFiles = [...prevFiles];
+                newFiles[index] = result.data as string[][];
+                return newFiles;
+              });
+              setError(null);
+              resolve();
             } else {
-              reject(new Error("The CSV file appears to be empty or invalid."))
+              reject(new Error("The CSV file appears to be empty or invalid."));
             }
           },
           error: (error) => {
-            reject(new Error(`Error parsing CSV: ${error.message}`))
-          }
-        })
+            reject(new Error(`Error parsing CSV: ${error.message}`));
+          },
+        });
       };
       reader.onerror = () => {
-        reject(new Error("Error reading file"))
+        reject(new Error("Error reading file"));
       };
       reader.readAsText(file);
-    })
-  }, [setError])
+    });
+  }, [importType, setError, setImportFile, setDelimiter, setPeekText]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     setUploadedFiles(prevFiles => [...prevFiles, ...acceptedFiles])

--- a/app/[locale]/dashboard/components/import/import-button.tsx
+++ b/app/[locale]/dashboard/components/import/import-button.tsx
@@ -480,6 +480,12 @@ export default function ImportButton({
     )
       return true;
 
+    if (
+      currentStep.component === FormatPreview &&
+      processedTrades.filter((trade) => trade.entryDate).length === 0
+    )
+      return true;
+
     return false;
   };
 

--- a/app/[locale]/dashboard/components/import/import-button.tsx
+++ b/app/[locale]/dashboard/components/import/import-button.tsx
@@ -79,6 +79,9 @@ export default function ImportButton({
   const [step, setStep] = useState<Step>("select-import-type");
   const [importType, setImportType] = useState<ImportType>("");
   const [files, setFiles] = useState<File[]>([]);
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [delimiter, setDelimiter] = useState<string>(",");
+  const [peekText, setPeekText] = useState<string>("");
   const [rawCsvData, setRawCsvData] = useState<string[][]>([]);
   const [csvData, setCsvData] = useState<string[][]>([]);
   const [headers, setHeaders] = useState<string[]>([]);
@@ -237,6 +240,9 @@ export default function ImportButton({
     setRawCsvData([]);
     setCsvData([]);
     setHeaders([]);
+    setImportFile(null);
+    setDelimiter(",");
+    setPeekText("");
     setMappings({});
     setAccountNumbers([]);
     setNewAccountNumber("");
@@ -328,6 +334,9 @@ export default function ImportButton({
           setHeaders={setHeaders}
           setStep={setStep}
           setError={setError}
+          setImportFile={setImportFile}
+          setDelimiter={setDelimiter}
+          setPeekText={setPeekText}
         />
       );
     }
@@ -394,6 +403,9 @@ export default function ImportButton({
           isLoading={isLoading}
           headers={headers}
           mappings={mappings}
+          importFile={importFile}
+          delimiter={delimiter}
+          peekText={peekText}
         />
       );
     }
@@ -449,7 +461,11 @@ export default function ImportButton({
     if (!currentStep) return true;
 
     // File upload step
-    if (currentStep.component === FileUpload && csvData.length === 0)
+    if (
+      currentStep.component === FileUpload &&
+      csvData.length === 0 &&
+      !importFile
+    )
       return true;
 
     // PDF upload step

--- a/app/api/ai/format-trades/route.ts
+++ b/app/api/ai/format-trades/route.ts
@@ -3,6 +3,7 @@ import { streamObject } from "ai";
 import { NextRequest } from "next/server";
 import { tradeSchema } from "./schema";
 import { z } from 'zod/v3';
+import { getOpenAiAvailabilityError } from "@/lib/ai/openai-availability";
 
 export const maxDuration = 30;
 
@@ -13,6 +14,14 @@ const requestSchema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
+    const availabilityError = getOpenAiAvailabilityError();
+    if (availabilityError) {
+      return new Response(JSON.stringify(availabilityError), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const body = await req.json();
     const { headers, rows } = requestSchema.parse(body);
 console.log(headers, rows);

--- a/app/api/ai/import-parse-plan/route.ts
+++ b/app/api/ai/import-parse-plan/route.ts
@@ -1,0 +1,63 @@
+import { generateObject } from "ai";
+import { NextRequest } from "next/server";
+import { z } from "zod/v3";
+import { getOpenAiAvailabilityError } from "@/lib/ai/openai-availability";
+import { importParsePlanSchema } from "./schema";
+
+export const maxDuration = 30;
+
+const requestSchema = z.object({
+  headers: z.array(z.string()).min(1),
+  rows: z.array(z.array(z.string())).max(20),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const availabilityError = getOpenAiAvailabilityError();
+    if (availabilityError) {
+      return new Response(JSON.stringify(availabilityError), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const body = await req.json();
+    const { headers, rows } = requestSchema.parse(body);
+
+    const result = await generateObject({
+      model: "openai/gpt-5-mini",
+      schema: importParsePlanSchema,
+      temperature: 0,
+      prompt: `You write a parse plan for a trading CSV. Map each database field to an exact header name from the file, or null if it is not present.
+
+Decide kind:
+- closed-trades: a row already has entry and exit (two dates/prices, or a PnL column)
+- orders: a row is a single fill/order that must be FIFO-paired later
+
+Headers:
+${headers.map((header, index) => `${index + 1}. ${header}`).join("\n")}
+
+Sample rows:
+${rows
+  .slice(0, 8)
+  .map((row, index) => `Row ${index + 1}: ${row.join(" | ")}`)
+  .join("\n")}
+
+Use the header text exactly as given. Do not invent headers.`,
+    });
+
+    return Response.json(result.object);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return new Response(JSON.stringify({ error: error.errors }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    console.error("import-parse-plan failed:", error);
+    return new Response(JSON.stringify({ error: "AI_UNAVAILABLE" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/app/api/ai/import-parse-plan/schema.ts
+++ b/app/api/ai/import-parse-plan/schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod/v3";
+
+export const importParsePlanSchema = z.object({
+  kind: z
+    .enum(["closed-trades", "orders"])
+    .describe(
+      "closed-trades: each row is already an entry+exit. orders: each row is a fill that must be paired.",
+    ),
+  columns: z.object({
+    instrument: z.string().nullable(),
+    quantity: z.string().nullable(),
+    entryPrice: z.string().nullable(),
+    closePrice: z.string().nullable(),
+    entryDate: z.string().nullable(),
+    closeDate: z.string().nullable(),
+    pnl: z.string().nullable(),
+    side: z.string().nullable(),
+    commission: z.string().nullable(),
+    accountNumber: z.string().nullable(),
+    entryId: z.string().nullable(),
+    closeId: z.string().nullable(),
+    timeInPosition: z.string().nullable(),
+  }),
+});

--- a/app/api/ai/import-parse-script/route.ts
+++ b/app/api/ai/import-parse-script/route.ts
@@ -1,0 +1,82 @@
+import { generateText } from "ai";
+import { NextRequest } from "next/server";
+import { z } from "zod/v3";
+import { getOpenAiAvailabilityError } from "@/lib/ai/openai-availability";
+import {
+  PARSE_SCRIPT_CONTRACT,
+  extractParseScript,
+} from "@/lib/import/parse-script";
+
+export const maxDuration = 60;
+
+const requestSchema = z.object({
+  headers: z.array(z.string()).min(1),
+  rows: z.array(z.array(z.string())).max(20),
+  peekText: z.string().max(8_000).optional(),
+  previousScript: z.string().max(20_000).optional(),
+  error: z.string().max(2_000).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const availabilityError = getOpenAiAvailabilityError();
+    if (availabilityError) {
+      return new Response(JSON.stringify(availabilityError), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const body = await req.json();
+    const { headers, rows, peekText, previousScript, error } =
+      requestSchema.parse(body);
+
+    const repair = previousScript
+      ? `
+The previous script failed: ${error ?? "unknown error"}
+
+Previous script:
+${previousScript}
+
+Fix it. Keep parseChunk as the only entry point.
+`
+      : "";
+
+    const result = await generateText({
+      model: "openai/gpt-5-mini",
+      temperature: 0,
+      prompt: `You write a dedicated parser for one trading export. The file may be CSV, TSV, or a messy broker dump. Do not ask the user to map columns.
+
+${PARSE_SCRIPT_CONTRACT}
+
+Headers:
+${headers.map((header, index) => `${index + 1}. ${header}`).join("\n")}
+
+Sample rows:
+${rows
+  .slice(0, 8)
+  .map((row, index) => `Row ${index + 1}: ${row.join(" | ")}`)
+  .join("\n")}
+
+${peekText ? `Raw peek:\n${peekText}\n` : ""}
+${repair}
+
+Reply with a single javascript code block that defines function parseChunk.`,
+    });
+
+    const script = extractParseScript(result.text);
+    return Response.json({ script });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return new Response(JSON.stringify({ error: error.errors }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    console.error("import-parse-script failed:", error);
+    return new Response(JSON.stringify({ error: "AI_UNAVAILABLE" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/app/api/import/parse-chunk/route.ts
+++ b/app/api/import/parse-chunk/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import { z } from "zod/v3";
+import { extractParseScript } from "@/lib/import/parse-script";
+import { runParseScriptChunk } from "@/lib/import/run-parse-script";
+
+export const maxDuration = 60;
+
+const requestSchema = z.object({
+  script: z.string().min(20).max(40_000),
+  rows: z.array(z.array(z.string())).max(10_000),
+  session: z.record(z.unknown()).optional(),
+  sandboxName: z.string().max(200).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = requestSchema.parse(await req.json());
+    const script = extractParseScript(body.script);
+    const result = await runParseScriptChunk(
+      script,
+      body.rows,
+      body.session ?? {},
+      { sandboxName: body.sandboxName },
+    );
+    return Response.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return new Response(JSON.stringify({ error: error.errors }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    console.error("import parse-chunk failed:", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "PARSE_SCRIPT_FAILED",
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "@types/pg": "^8.16.0",
         "@vercel/analytics": "^1.5.0",
         "@vercel/functions": "^2.2.13",
+        "@vercel/sandbox": "^3.0.0",
         "@vercel/speed-insights": "^1.2.0",
         "ai": "^6.0.31",
         "canvas": "^3.2.0",
@@ -1101,6 +1102,8 @@
 
     "@vercel/oidc": ["@vercel/oidc@2.0.2", "", { "dependencies": { "@types/ms": "2.1.0", "ms": "2.1.3" } }, "sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g=="],
 
+    "@vercel/sandbox": ["@vercel/sandbox@3.0.0", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@workflow/serde": "4.1.0-beta.2", "async-retry": "1.3.3", "jose": "6.2.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.27.1", "xdg-app-paths": "5.1.0", "zod": "^4.1.1" } }, "sha512-1pF3id7LIG2GfjkEAZW+ZngMDdywJw7aFLOyIlry/lj8v3b4GMn3WCuBbvG4N4wTmYUfFzHaVHfdwVpqALEFkw=="],
+
     "@vercel/speed-insights": ["@vercel/speed-insights@1.3.1", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
@@ -1116,6 +1119,8 @@
     "@vitest/spy": ["@vitest/spy@4.1.8", "", {}, "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA=="],
 
     "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
+
+    "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
@@ -1178,6 +1183,8 @@
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "atomically": ["atomically@1.7.0", "", {}, "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="],
 
@@ -2057,6 +2064,8 @@
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
+    "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
+
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
     "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
@@ -2389,6 +2398,8 @@
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
+    "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
+
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -2711,7 +2722,7 @@
 
     "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
 
-    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -3081,6 +3092,10 @@
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
+    "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
+
+    "xdg-portable": ["xdg-portable@7.3.0", "", { "dependencies": { "os-paths": "^4.0.1" } }, "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw=="],
+
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -3241,6 +3256,8 @@
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
+    "@vercel/sandbox/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -3382,6 +3399,8 @@
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 

--- a/lib/ai/format-trades-batch.test.ts
+++ b/lib/ai/format-trades-batch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { evaluateFormatTradesBatchResult } from "./format-trades-batch";
+
+const formattedTrade = {
+  entryDate: "2026-01-06T17:35:22.000Z",
+  instrument: "MNQ",
+};
+
+describe("evaluateFormatTradesBatchResult", () => {
+  it("does not treat an empty onFinish payload as success", () => {
+    expect(
+      evaluateFormatTradesBatchResult({ object: undefined, error: undefined }),
+    ).toEqual({ status: "failed", reason: "invalid", formattedCount: 0 });
+  });
+
+  it("does not treat a schema validation error as success", () => {
+    expect(
+      evaluateFormatTradesBatchResult({
+        object: undefined,
+        error: new Error("invalid"),
+      }),
+    ).toEqual({ status: "failed", reason: "error", formattedCount: 0 });
+  });
+
+  it("does not treat an empty array as a completed batch", () => {
+    expect(evaluateFormatTradesBatchResult({ object: [] })).toEqual({
+      status: "failed",
+      reason: "empty",
+      formattedCount: 0,
+    });
+  });
+
+  it("does not count trades that are missing an entry date", () => {
+    expect(
+      evaluateFormatTradesBatchResult({
+        object: [{ instrument: "MNQ" }, null],
+      }),
+    ).toEqual({ status: "failed", reason: "empty", formattedCount: 0 });
+  });
+
+  it("accepts a batch that produced formatted trades", () => {
+    expect(
+      evaluateFormatTradesBatchResult({
+        object: [formattedTrade, { instrument: "ES" }],
+      }),
+    ).toEqual({ status: "success", formattedCount: 1 });
+  });
+});

--- a/lib/ai/format-trades-batch.ts
+++ b/lib/ai/format-trades-batch.ts
@@ -1,0 +1,43 @@
+export type FormatTradesBatchFailureReason = "error" | "empty" | "invalid";
+
+export type FormatTradesBatchResult =
+  | { status: "success"; formattedCount: number }
+  | {
+      status: "failed";
+      reason: FormatTradesBatchFailureReason;
+      formattedCount: 0;
+    };
+
+function hasEntryDate(trade: unknown): boolean {
+  if (!trade || typeof trade !== "object") return false;
+  if (!("entryDate" in trade)) return false;
+  const entryDate = trade.entryDate;
+  return typeof entryDate === "string" && entryDate.length > 0;
+}
+
+export function countFormattedTrades(object: unknown): number {
+  if (!Array.isArray(object)) return 0;
+  return object.filter(hasEntryDate).length;
+}
+
+/**
+ * useObject always calls onFinish when the HTTP stream closes — including
+ * empty bodies, schema mismatches, and mid-stream provider failures.
+ * Those must not be treated as a completed batch.
+ */
+export function evaluateFormatTradesBatchResult(event: {
+  object: unknown;
+  error?: Error;
+}): FormatTradesBatchResult {
+  if (event.error) {
+    return { status: "failed", reason: "error", formattedCount: 0 };
+  }
+  if (!Array.isArray(event.object)) {
+    return { status: "failed", reason: "invalid", formattedCount: 0 };
+  }
+  const formattedCount = countFormattedTrades(event.object);
+  if (formattedCount === 0) {
+    return { status: "failed", reason: "empty", formattedCount: 0 };
+  }
+  return { status: "success", formattedCount };
+}

--- a/lib/ai/openai-availability.test.ts
+++ b/lib/ai/openai-availability.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  AI_UNAVAILABLE_ERROR,
+  getOpenAiAvailabilityError,
+  isPlaceholderOpenAiApiKey,
+  parseFormatTradesApiError,
+} from "./openai-availability";
+
+describe("isPlaceholderOpenAiApiKey", () => {
+  it("treats missing and blank values as placeholders", () => {
+    expect(isPlaceholderOpenAiApiKey(undefined)).toBe(true);
+    expect(isPlaceholderOpenAiApiKey(null)).toBe(true);
+    expect(isPlaceholderOpenAiApiKey("")).toBe(true);
+    expect(isPlaceholderOpenAiApiKey("   ")).toBe(true);
+  });
+
+  it("treats the self-host dummy key as a placeholder", () => {
+    expect(isPlaceholderOpenAiApiKey("dummy")).toBe(true);
+    expect(isPlaceholderOpenAiApiKey("DUMMY")).toBe(true);
+    expect(isPlaceholderOpenAiApiKey(" dummy ")).toBe(true);
+    expect(isPlaceholderOpenAiApiKey("your_openai_api_key_here")).toBe(true);
+  });
+
+  it("accepts a configured key", () => {
+    expect(isPlaceholderOpenAiApiKey("sk-proj-abc123")).toBe(false);
+    expect(isPlaceholderOpenAiApiKey("gateway-key")).toBe(false);
+  });
+});
+
+describe("getOpenAiAvailabilityError", () => {
+  it("returns AI_UNAVAILABLE for the self-host dummy key", () => {
+    expect(getOpenAiAvailabilityError("dummy")).toEqual({
+      error: AI_UNAVAILABLE_ERROR,
+    });
+  });
+
+  it("returns null when a key is configured", () => {
+    expect(getOpenAiAvailabilityError("sk-proj-abc123")).toBeNull();
+  });
+});
+
+describe("parseFormatTradesApiError", () => {
+  it("reads the error code from a JSON body", () => {
+    expect(
+      parseFormatTradesApiError(JSON.stringify({ error: AI_UNAVAILABLE_ERROR })),
+    ).toEqual({ code: AI_UNAVAILABLE_ERROR });
+  });
+
+  it("returns a null code for non-JSON bodies", () => {
+    expect(parseFormatTradesApiError("Failed to fetch the response.")).toEqual({
+      code: null,
+    });
+  });
+});

--- a/lib/ai/openai-availability.ts
+++ b/lib/ai/openai-availability.ts
@@ -1,0 +1,50 @@
+/** Error code returned by AI routes when no usable OpenAI key is configured. */
+export const AI_UNAVAILABLE_ERROR = "AI_UNAVAILABLE";
+
+const PLACEHOLDER_KEYS = new Set([
+  "dummy",
+  "placeholder",
+  "your_openai_api_key_here",
+]);
+
+/**
+ * Self-host / VPS setups ship `OPENAI_API_KEY=dummy` so the app can boot
+ * without a real key. Treat that (and other placeholders) as unavailable
+ * instead of sending requests that fail mid-stream.
+ */
+export function isPlaceholderOpenAiApiKey(
+  apiKey: string | undefined | null,
+): boolean {
+  if (typeof apiKey !== "string") return true;
+  const normalized = apiKey.trim().toLowerCase();
+  if (!normalized) return true;
+  return PLACEHOLDER_KEYS.has(normalized);
+}
+
+export function getOpenAiAvailabilityError(
+  apiKey: string | undefined | null = process.env.OPENAI_API_KEY,
+): { error: typeof AI_UNAVAILABLE_ERROR } | null {
+  if (isPlaceholderOpenAiApiKey(apiKey)) {
+    return { error: AI_UNAVAILABLE_ERROR };
+  }
+  return null;
+}
+
+export function parseFormatTradesApiError(raw: string): {
+  code: string | null;
+} {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "error" in parsed &&
+      typeof parsed.error === "string"
+    ) {
+      return { code: parsed.error };
+    }
+  } catch {
+    // useObject surfaces the raw response body as Error.message
+  }
+  return { code: null };
+}

--- a/lib/import/obtain-agent-script.ts
+++ b/lib/import/obtain-agent-script.ts
@@ -1,0 +1,53 @@
+import {
+  PARSE_SCRIPT_MAX_ATTEMPTS,
+  sampleValidationError,
+  type ParseScriptChunkResult,
+} from "./parse-script";
+import { parseFormatTradesApiError } from "@/lib/ai/openai-availability";
+
+export async function obtainAgentParseScript(input: {
+  headers: string[];
+  rows: string[][];
+  peekText?: string;
+}): Promise<string> {
+  let previousScript: string | undefined;
+  let lastError: string | undefined;
+
+  for (let attempt = 0; attempt < PARSE_SCRIPT_MAX_ATTEMPTS; attempt += 1) {
+    const generated = await fetch("/api/ai/import-parse-script", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        headers: input.headers,
+        rows: input.rows,
+        peekText: input.peekText,
+        previousScript,
+        error: lastError,
+      }),
+    });
+    const raw = await generated.text();
+    if (!generated.ok) {
+      const code = parseFormatTradesApiError(raw).code;
+      throw new Error(code === "AI_UNAVAILABLE" ? "AI_UNAVAILABLE" : "PARSE_SCRIPT_UNABLE");
+    }
+    const script = (JSON.parse(raw) as { script: string }).script;
+    const checked = await fetch("/api/import/parse-chunk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ script, rows: input.rows, session: {} }),
+    });
+    const checkRaw = await checked.text();
+    if (!checked.ok) {
+      previousScript = script;
+      lastError = checkRaw;
+      continue;
+    }
+    const result = JSON.parse(checkRaw) as ParseScriptChunkResult;
+    const sampleError = sampleValidationError(result);
+    if (!sampleError) return script;
+    previousScript = script;
+    lastError = sampleError;
+  }
+
+  throw new Error("PARSE_SCRIPT_UNABLE");
+}

--- a/lib/import/parse-plan.test.ts
+++ b/lib/import/parse-plan.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  createParsePlanSession,
   executeParsePlan,
+  executeParsePlanChunk,
   isParsePlanComplete,
   mappingsFromPlan,
   mergeParsePlans,
@@ -150,5 +152,81 @@ describe("pairOrderFills", () => {
     expect(result.kind).toBe("orders");
     expect(result.trades).toHaveLength(1);
     expect(result.trades[0]?.pnl).toBe(10);
+  });
+});
+
+describe("executeParsePlanChunk", () => {
+  it("matches one-shot results for closed trades", () => {
+    const { headers, rows } = parseSemicolonCsv(USER_CSV);
+    const plan = planFromHeaders(headers);
+    const session = createParsePlanSession();
+    const chunked: ReturnType<typeof executeParsePlan>["trades"] = [];
+    for (let i = 0; i < rows.length; i += 3) {
+      const { trades } = executeParsePlanChunk(rows.slice(i, i + 3), plan, session);
+      chunked.push(...trades);
+    }
+    expect(chunked).toEqual(executeParsePlan(rows, plan).trades);
+  });
+
+  it("does not treat an empty early chunk as failure", () => {
+    const { headers, rows } = parseSemicolonCsv(USER_CSV);
+    const plan = planFromHeaders(headers);
+    const session = createParsePlanSession();
+    const first = executeParsePlanChunk([], plan, session);
+    expect(first.trades).toEqual([]);
+    const rest = executeParsePlanChunk(rows, plan, session);
+    expect(rest.trades).toHaveLength(17);
+  });
+
+  it("walks many closed-trade chunks without a one-shot pass", () => {
+    const headers = [
+      "Symbol",
+      "Quantity",
+      "Entry DT",
+      "Entry Price",
+      "Exit DT",
+      "Exit Price",
+      "ProfitLoss",
+    ];
+    const rows = Array.from({ length: 10_000 }, () => [
+      "ES",
+      "1",
+      "2026-01-06 17:00:00",
+      "5000",
+      "2026-01-06 17:01:00",
+      "5001",
+      "1",
+    ]);
+    const plan = planFromHeaders(headers);
+    const session = createParsePlanSession();
+    let produced = 0;
+    for (let offset = 0; offset < rows.length; offset += 2_500) {
+      const { trades } = executeParsePlanChunk(
+        rows.slice(offset, offset + 2_500),
+        plan,
+        session,
+      );
+      produced += trades.length;
+    }
+    expect(produced).toBe(10_000);
+    expect(session.skippedRows).toBe(0);
+  });
+
+  it("pairs order fills that span chunks", () => {
+    const plan = planFromHeaders(["Symbol", "Qty", "Side", "Price", "Time"]);
+    const session = createParsePlanSession();
+    const buy = executeParsePlanChunk(
+      [["ES", "1", "buy", "5000", "2026-01-06 17:00:00"]],
+      plan,
+      session,
+    );
+    expect(buy.trades).toEqual([]);
+    const sell = executeParsePlanChunk(
+      [["ES", "1", "sell", "5010", "2026-01-06 17:05:00"]],
+      plan,
+      session,
+    );
+    expect(sell.trades).toHaveLength(1);
+    expect(sell.trades[0]?.pnl).toBe(10);
   });
 });

--- a/lib/import/parse-plan.test.ts
+++ b/lib/import/parse-plan.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  executeParsePlan,
+  isParsePlanComplete,
+  mappingsFromPlan,
+  mergeParsePlans,
+  missingRequiredFields,
+  pairOrderFills,
+  planFromHeaders,
+  planFromMappings,
+} from "./parse-plan";
+
+const USER_CSV = `Symbol;Quantity;Entry DT;Entry Price;Exit DT;Exit Price;ProfitLoss
+MNQ;2;2026-01-06 17:35:22;25629.25;2026-01-06 17:51:31.186;25746.5;469
+MNQ;1;2026-01-06 17:39:52;25638.75;2026-01-06 17:47:05.497;25702.75;128
+MNQ;-2;2026-01-06 18:14:14;25756.5;2026-01-06 18:26:22.417;25778.5;-88
+MNQ;-2;2026-01-06 18:14:22;25752.75;2026-01-06 18:25:25.492;25774.75;-88
+MNQ;-4;2026-01-06 18:53:05;25707.75;2026-01-06 19:04:36.385;25660;382
+MNQ;1;2026-01-07 17:29:51;25788.5;2026-01-07 17:34:26.483;25817.25;57.5
+MNQ;3;2026-01-07 17:29:51;25788.5;2026-01-07 17:41:14.630;25844.5;336
+MNQ;1;2026-01-07 17:58:23;25863.75;2026-01-07 18:39:04.605;25810.5;-106.5
+MNQ;1;2026-01-07 19:58:23;25969.25;2026-01-07 21:15:56.798;25943;-52.5
+MNQ;-1;2026-01-07 22:06:18;25942.75;2026-01-07 23:13:04.555;25882.25;121
+MNQ;-3;2026-01-08 17:33:01;25749;2026-01-08 17:38:24.780;25681.5;405
+MNQ;-2;2026-01-08 17:49:47;25651.75;2026-01-08 18:02:08.169;25572;319
+MNQ;2;2026-01-09 17:45:16;25736.5;2026-01-09 18:07:22.652;25660;-306
+MNQ;-1;2026-01-09 18:26:01;25818.25;2026-01-09 18:26:29.931;25812.75;11
+MNQ;2;2026-01-09 19:47:19;25874.5;2026-01-09 21:36:00.399;25942;270
+MNQ;1;2026-01-12 17:51:00;25906.5;2026-01-12 22:27:11.202;26003.25;193.5
+MNQ;1;2026-01-12 17:51:00;25906.5;2026-01-12 23:57:00.977;25964.75;116.5`;
+
+function parseSemicolonCsv(text: string): { headers: string[]; rows: string[][] } {
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines[0]?.split(";") ?? [];
+  const rows = lines.slice(1).map((line) => line.split(";"));
+  return { headers, rows };
+}
+
+describe("planFromHeaders", () => {
+  it("maps the reported MNQ closed-trade file without AI", () => {
+    const { headers } = parseSemicolonCsv(USER_CSV);
+    const plan = planFromHeaders(headers);
+
+    expect(plan.kind).toBe("closed-trades");
+    expect(plan.columns.instrument?.header).toBe("Symbol");
+    expect(plan.columns.quantity?.header).toBe("Quantity");
+    expect(plan.columns.entryDate?.header).toBe("Entry DT");
+    expect(plan.columns.entryPrice?.header).toBe("Entry Price");
+    expect(plan.columns.closeDate?.header).toBe("Exit DT");
+    expect(plan.columns.closePrice?.header).toBe("Exit Price");
+    expect(plan.columns.pnl?.header).toBe("ProfitLoss");
+    expect(isParsePlanComplete(plan)).toBe(true);
+    expect(missingRequiredFields(plan)).toEqual([]);
+  });
+
+  it("treats a fill-only file as orders", () => {
+    const plan = planFromHeaders(["Symbol", "Qty", "Side", "Price", "Time"]);
+    expect(plan.kind).toBe("orders");
+    expect(plan.columns.instrument?.header).toBe("Symbol");
+    expect(plan.columns.quantity?.header).toBe("Qty");
+    expect(plan.columns.side?.header).toBe("Side");
+    expect(plan.columns.entryPrice?.header).toBe("Price");
+    expect(plan.columns.entryDate?.header).toBe("Time");
+    expect(isParsePlanComplete(plan)).toBe(true);
+  });
+});
+
+describe("executeParsePlan", () => {
+  it("formats every closed trade from the reported file", () => {
+    const { headers, rows } = parseSemicolonCsv(USER_CSV);
+    const result = executeParsePlan(rows, planFromHeaders(headers));
+
+    expect(result.skippedRows).toBe(0);
+    expect(result.trades).toHaveLength(17);
+    expect(result.trades[0]).toMatchObject({
+      instrument: "MNQ",
+      quantity: 2,
+      side: "long",
+      entryPrice: "25629.25",
+      closePrice: "25746.5",
+      pnl: 469,
+    });
+    expect(result.trades[2]).toMatchObject({
+      instrument: "MNQ",
+      quantity: 2,
+      side: "short",
+      pnl: -88,
+    });
+    expect(result.trades.every((trade) => trade.entryDate && trade.closeDate)).toBe(
+      true,
+    );
+  });
+
+  it("uses explicit mappings over weaker header guesses", () => {
+    const headers = ["Symbol", "Qty", "Profit"];
+    const heuristic = planFromHeaders(headers);
+    const mappings = planFromMappings(headers, {
+      Symbol_0: "instrument",
+      Qty_1: "quantity",
+    });
+    const merged = mergeParsePlans(heuristic, mappings);
+    expect(merged.columns.pnl?.header).toBe("Profit");
+    expect(mappingsFromPlan(headers, merged).Qty_1).toBe("quantity");
+  });
+});
+
+describe("pairOrderFills", () => {
+  it("pairs a buy then sell into one long trade", () => {
+    const trades = pairOrderFills([
+      {
+        instrument: "ES",
+        quantity: 1,
+        side: "long",
+        price: "5000",
+        date: "2026-01-06T17:00:00.000Z",
+        accountNumber: "A1",
+        commission: 1,
+        id: "1",
+      },
+      {
+        instrument: "ES",
+        quantity: 1,
+        side: "short",
+        price: "5010",
+        date: "2026-01-06T17:05:00.000Z",
+        accountNumber: "A1",
+        commission: 1,
+        id: "2",
+      },
+    ]);
+
+    expect(trades).toHaveLength(1);
+    expect(trades[0]).toMatchObject({
+      instrument: "ES",
+      quantity: 1,
+      side: "long",
+      entryPrice: "5000",
+      closePrice: "5010",
+      pnl: 10,
+    });
+  });
+
+  it("executes an orders plan into paired trades", () => {
+    const headers = ["Symbol", "Qty", "Side", "Price", "Time"];
+    const rows = [
+      ["ES", "1", "buy", "5000", "2026-01-06 17:00:00"],
+      ["ES", "1", "sell", "5010", "2026-01-06 17:05:00"],
+    ];
+    const result = executeParsePlan(rows, planFromHeaders(headers));
+    expect(result.kind).toBe("orders");
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0]?.pnl).toBe(10);
+  });
+});

--- a/lib/import/parse-plan.ts
+++ b/lib/import/parse-plan.ts
@@ -1,7 +1,8 @@
 /**
  * Deterministic import "script": infer a parse plan from headers (or AI),
- * then run it on every row. This is the Eve idea — inspect, write a plan,
+ * then run it in chunks. This is the Eve idea — inspect, write a plan,
  * execute, repair — without embedding the Eve runtime or eval'ing model JS.
+ * Never parse a multi-million-row file in one synchronous call from the UI.
  */
 import type { Trade } from "@/prisma/generated/prisma/browser";
 
@@ -48,6 +49,34 @@ export type ExecuteParsePlanResult = {
   missingRequired: ParsePlanField[];
   skippedRows: number;
 };
+
+/** Rows per chunk. Large enough to stay fast, small enough to yield the UI. */
+export const PARSE_PLAN_CHUNK_SIZE = 2_500;
+
+/** Rows shown in Review Trades. The full set is kept for save. */
+export const PARSE_PREVIEW_LIMIT = 200;
+
+type OpenLot = {
+  quantity: number;
+  price: number;
+  date: string;
+  commission: number;
+  id: string;
+};
+
+type LotBook = {
+  longs: OpenLot[];
+  shorts: OpenLot[];
+};
+
+export type ParsePlanSession = {
+  skippedRows: number;
+  books: Map<string, LotBook>;
+};
+
+export function createParsePlanSession(): ParsePlanSession {
+  return { skippedRows: 0, books: new Map() };
+}
 
 const HEADER_ALIASES: Record<ParsePlanField, string[]> = {
   instrument: ["instrument", "symbol", "ticker", "sym", "contract", "product"],
@@ -303,46 +332,38 @@ function secondsBetween(startIso: string, endIso: string): number {
   return Math.max(0, Math.round((end - start) / 1000));
 }
 
-export function executeParsePlan(
-  rows: string[][],
-  plan: ParsePlan,
-): ExecuteParsePlanResult {
-  const missingRequired = missingRequiredFields(plan);
-  if (missingRequired.length > 0) {
-    return { trades: [], kind: plan.kind, missingRequired, skippedRows: rows.length };
+type ParsedRow =
+  | { type: "skip" }
+  | { type: "trade"; trade: ExecutedTrade }
+  | { type: "fill"; fill: OrderFill };
+
+function parseRow(row: string[], plan: ParsePlan): ParsedRow {
+  if (!row.length || row.every((value) => !value?.trim())) {
+    return { type: "skip" };
   }
 
-  const fills: OrderFill[] = [];
-  const trades: ExecutedTrade[] = [];
-  let skippedRows = 0;
+  const rawQuantity = parseNumber(cell(row, plan.columns.quantity));
+  const instrument = normalizeInstrument(cell(row, plan.columns.instrument));
+  const entryDate = parseDateToIso(cell(row, plan.columns.entryDate));
+  const entryPrice = cell(row, plan.columns.entryPrice).trim();
 
-  for (const row of rows) {
-    if (!row.length || row.every((value) => !value?.trim())) {
-      skippedRows += 1;
-      continue;
-    }
+  if (rawQuantity == null || !instrument || !entryDate || !entryPrice) {
+    return { type: "skip" };
+  }
 
-    const rawQuantity = parseNumber(cell(row, plan.columns.quantity));
-    const instrument = normalizeInstrument(cell(row, plan.columns.instrument));
-    const entryDate = parseDateToIso(cell(row, plan.columns.entryDate));
-    const entryPrice = cell(row, plan.columns.entryPrice).trim();
+  const side = normalizeSide(
+    cell(row, plan.columns.side),
+    rawQuantity,
+    plan.quantitySignIsSide,
+  );
+  const quantity = Math.abs(rawQuantity);
+  const accountNumber = cell(row, plan.columns.accountNumber).trim();
+  const commission = parseNumber(cell(row, plan.columns.commission)) ?? 0;
 
-    if (rawQuantity == null || !instrument || !entryDate || !entryPrice) {
-      skippedRows += 1;
-      continue;
-    }
-
-    const side = normalizeSide(
-      cell(row, plan.columns.side),
-      rawQuantity,
-      plan.quantitySignIsSide,
-    );
-    const quantity = Math.abs(rawQuantity);
-    const accountNumber = cell(row, plan.columns.accountNumber).trim();
-    const commission = parseNumber(cell(row, plan.columns.commission)) ?? 0;
-
-    if (plan.kind === "orders") {
-      fills.push({
+  if (plan.kind === "orders") {
+    return {
+      type: "fill",
+      fill: {
         instrument,
         quantity,
         side,
@@ -351,23 +372,24 @@ export function executeParsePlan(
         accountNumber,
         commission,
         id: cell(row, plan.columns.entryId).trim(),
-      });
-      continue;
-    }
+      },
+    };
+  }
 
-    const closeDate = parseDateToIso(cell(row, plan.columns.closeDate));
-    const closePrice = cell(row, plan.columns.closePrice).trim();
-    if (!closeDate || !closePrice) {
-      skippedRows += 1;
-      continue;
-    }
+  const closeDate = parseDateToIso(cell(row, plan.columns.closeDate));
+  const closePrice = cell(row, plan.columns.closePrice).trim();
+  if (!closeDate || !closePrice) {
+    return { type: "skip" };
+  }
 
-    const pnl = parseNumber(cell(row, plan.columns.pnl)) ?? 0;
-    const timeInPosition =
-      parseNumber(cell(row, plan.columns.timeInPosition)) ??
-      secondsBetween(entryDate, closeDate);
+  const pnl = parseNumber(cell(row, plan.columns.pnl)) ?? 0;
+  const timeInPosition =
+    parseNumber(cell(row, plan.columns.timeInPosition)) ??
+    secondsBetween(entryDate, closeDate);
 
-    trades.push({
+  return {
+    type: "trade",
+    trade: {
       instrument,
       quantity,
       side,
@@ -381,19 +403,81 @@ export function executeParsePlan(
       accountNumber,
       entryId: cell(row, plan.columns.entryId).trim() || undefined,
       closeId: cell(row, plan.columns.closeId).trim() || undefined,
-    });
+    },
+  };
+}
+
+function bookKey(fill: OrderFill): string {
+  return `${fill.accountNumber}::${fill.instrument}`;
+}
+
+function getBook(session: ParsePlanSession, fill: OrderFill): LotBook {
+  const key = bookKey(fill);
+  const existing = session.books.get(key);
+  if (existing) return existing;
+  const created: LotBook = { longs: [], shorts: [] };
+  session.books.set(key, created);
+  return created;
+}
+
+/**
+ * Apply one chunk. Closed-trade rows are independent. Order fills keep
+ * open lots on `session` so a buy in chunk 1 can close in chunk 4000.
+ * An empty chunk is not a failure — later rows may still produce trades.
+ */
+export function executeParsePlanChunk(
+  rows: string[][],
+  plan: ParsePlan,
+  session: ParsePlanSession,
+): { trades: ExecutedTrade[] } {
+  const trades: ExecutedTrade[] = [];
+  for (const row of rows) {
+    const parsed = parseRow(row, plan);
+    if (parsed.type === "skip") {
+      session.skippedRows += 1;
+      continue;
+    }
+    if (parsed.type === "trade") {
+      trades.push(parsed.trade);
+      continue;
+    }
+    trades.push(...applyFill(parsed.fill, getBook(session, parsed.fill)));
+  }
+  return { trades };
+}
+
+export function executeParsePlan(
+  rows: string[][],
+  plan: ParsePlan,
+): ExecuteParsePlanResult {
+  const missingRequired = missingRequiredFields(plan);
+  if (missingRequired.length > 0) {
+    return { trades: [], kind: plan.kind, missingRequired, skippedRows: rows.length };
   }
 
-  if (plan.kind === "orders") {
-    return {
-      trades: pairOrderFills(fills),
-      kind: plan.kind,
-      missingRequired,
-      skippedRows,
-    };
+  if (plan.kind === "closed-trades") {
+    const session = createParsePlanSession();
+    const { trades } = executeParsePlanChunk(rows, plan, session);
+    return { trades, kind: plan.kind, missingRequired, skippedRows: session.skippedRows };
   }
 
-  return { trades, kind: plan.kind, missingRequired, skippedRows };
+  const fills: OrderFill[] = [];
+  let skippedRows = 0;
+  for (const row of rows) {
+    const parsed = parseRow(row, plan);
+    if (parsed.type === "skip") {
+      skippedRows += 1;
+      continue;
+    }
+    if (parsed.type === "fill") fills.push(parsed.fill);
+  }
+
+  return {
+    trades: pairOrderFills(fills),
+    kind: plan.kind,
+    missingRequired,
+    skippedRows,
+  };
 }
 
 export type OrderFill = {
@@ -407,18 +491,10 @@ export type OrderFill = {
   id: string;
 };
 
-type OpenLot = {
-  quantity: number;
-  price: number;
-  date: string;
-  commission: number;
-  id: string;
-};
-
 export function pairOrderFills(fills: OrderFill[]): ExecutedTrade[] {
   const groups = new Map<string, OrderFill[]>();
   for (const fill of fills) {
-    const key = `${fill.accountNumber}::${fill.instrument}`;
+    const key = bookKey(fill);
     const list = groups.get(key) ?? [];
     list.push(fill);
     groups.set(key, list);
@@ -427,61 +503,59 @@ export function pairOrderFills(fills: OrderFill[]): ExecutedTrade[] {
   const trades: ExecutedTrade[] = [];
   for (const group of groups.values()) {
     group.sort((a, b) => a.date.localeCompare(b.date));
-    trades.push(...pairFillGroup(group));
+    const book: LotBook = { longs: [], shorts: [] };
+    for (const fill of group) {
+      trades.push(...applyFill(fill, book));
+    }
   }
   return trades;
 }
 
-function pairFillGroup(fills: OrderFill[]): ExecutedTrade[] {
-  const longs: OpenLot[] = [];
-  const shorts: OpenLot[] = [];
+function applyFill(fill: OrderFill, book: LotBook): ExecutedTrade[] {
+  const incoming: OpenLot = {
+    quantity: fill.quantity,
+    price: Number(fill.price),
+    date: fill.date,
+    commission: fill.commission,
+    id: fill.id,
+  };
+  const opposite = fill.side === "long" ? book.shorts : book.longs;
+  const same = fill.side === "long" ? book.longs : book.shorts;
   const trades: ExecutedTrade[] = [];
 
-  for (const fill of fills) {
-    const incoming: OpenLot = {
-      quantity: fill.quantity,
-      price: Number(fill.price),
-      date: fill.date,
-      commission: fill.commission,
-      id: fill.id,
-    };
-    const opposite = fill.side === "long" ? shorts : longs;
-    const same = fill.side === "long" ? longs : shorts;
+  while (incoming.quantity > 0 && opposite.length > 0) {
+    const open = opposite[0];
+    const matched = Math.min(incoming.quantity, open.quantity);
+    const entryPrice = open.price;
+    const closePrice = incoming.price;
+    const pnl =
+      fill.side === "long"
+        ? (entryPrice - closePrice) * matched
+        : (closePrice - entryPrice) * matched;
 
-    while (incoming.quantity > 0 && opposite.length > 0) {
-      const open = opposite[0];
-      const matched = Math.min(incoming.quantity, open.quantity);
-      const entryPrice = open.price;
-      const closePrice = incoming.price;
-      const pnl =
-        fill.side === "long"
-          ? (entryPrice - closePrice) * matched
-          : (closePrice - entryPrice) * matched;
+    trades.push({
+      instrument: fill.instrument,
+      accountNumber: fill.accountNumber,
+      quantity: matched,
+      side: fill.side === "long" ? "short" : "long",
+      entryDate: open.date,
+      closeDate: fill.date,
+      entryPrice: String(entryPrice),
+      closePrice: String(closePrice),
+      pnl,
+      commission: open.commission + incoming.commission,
+      timeInPosition: secondsBetween(open.date, fill.date),
+      entryId: open.id || undefined,
+      closeId: fill.id || undefined,
+    });
 
-      trades.push({
-        instrument: fill.instrument,
-        accountNumber: fill.accountNumber,
-        quantity: matched,
-        side: fill.side === "long" ? "short" : "long",
-        entryDate: open.date,
-        closeDate: fill.date,
-        entryPrice: String(entryPrice),
-        closePrice: String(closePrice),
-        pnl,
-        commission: open.commission + incoming.commission,
-        timeInPosition: secondsBetween(open.date, fill.date),
-        entryId: open.id || undefined,
-        closeId: fill.id || undefined,
-      });
+    incoming.quantity -= matched;
+    open.quantity -= matched;
+    if (open.quantity <= 0) opposite.shift();
+  }
 
-      incoming.quantity -= matched;
-      open.quantity -= matched;
-      if (open.quantity <= 0) opposite.shift();
-    }
-
-    if (incoming.quantity > 0) {
-      same.push(incoming);
-    }
+  if (incoming.quantity > 0) {
+    same.push(incoming);
   }
 
   return trades;

--- a/lib/import/parse-plan.ts
+++ b/lib/import/parse-plan.ts
@@ -1,0 +1,499 @@
+/**
+ * Deterministic import "script": infer a parse plan from headers (or AI),
+ * then run it on every row. This is the Eve idea — inspect, write a plan,
+ * execute, repair — without embedding the Eve runtime or eval'ing model JS.
+ */
+import type { Trade } from "@/prisma/generated/prisma/browser";
+
+export const PARSE_PLAN_FIELDS = [
+  "instrument",
+  "quantity",
+  "entryPrice",
+  "closePrice",
+  "entryDate",
+  "closeDate",
+  "pnl",
+  "side",
+  "commission",
+  "accountNumber",
+  "entryId",
+  "closeId",
+  "timeInPosition",
+] as const;
+
+export type ParsePlanField = (typeof PARSE_PLAN_FIELDS)[number];
+
+export type ParsePlanKind = "closed-trades" | "orders";
+
+export type ParsePlanColumn = {
+  header: string;
+  index: number;
+};
+
+export type ParsePlan = {
+  kind: ParsePlanKind;
+  columns: Partial<Record<ParsePlanField, ParsePlanColumn>>;
+  quantitySignIsSide: boolean;
+};
+
+export type ParsePlanSource = "heuristic" | "mappings" | "ai";
+
+export type ExecutedTrade = Partial<Trade> & {
+  entryDate?: string;
+};
+
+export type ExecuteParsePlanResult = {
+  trades: ExecutedTrade[];
+  kind: ParsePlanKind;
+  missingRequired: ParsePlanField[];
+  skippedRows: number;
+};
+
+const HEADER_ALIASES: Record<ParsePlanField, string[]> = {
+  instrument: ["instrument", "symbol", "ticker", "sym", "contract", "product"],
+  quantity: ["quantity", "qty", "amount", "size", "lots", "contracts"],
+  entryPrice: [
+    "entryprice",
+    "entry price",
+    "buyprice",
+    "buy price",
+    "openprice",
+    "open price",
+    "avgentry",
+    "price",
+    "fillprice",
+    "fill price",
+  ],
+  closePrice: [
+    "closeprice",
+    "close price",
+    "exitprice",
+    "exit price",
+    "sellprice",
+    "sell price",
+  ],
+  entryDate: [
+    "entrydate",
+    "entry date",
+    "entrydt",
+    "entry dt",
+    "buydate",
+    "buy date",
+    "opendate",
+    "open date",
+    "entrytime",
+    "open time",
+    "time",
+    "timestamp",
+    "datetime",
+    "date",
+  ],
+  closeDate: [
+    "closedate",
+    "close date",
+    "exitdate",
+    "exit date",
+    "exitdt",
+    "exit dt",
+    "selldate",
+    "sell date",
+    "closetime",
+    "close time",
+  ],
+  pnl: [
+    "pnl",
+    "profitloss",
+    "profit loss",
+    "profit",
+    "pl",
+    "netpnl",
+    "net pnl",
+    "realizedpnl",
+    "realized",
+  ],
+  side: ["side", "direction", "bs", "buysell", "buy/sell"],
+  commission: ["commission", "fee", "fees", "comm"],
+  accountNumber: [
+    "accountnumber",
+    "account number",
+    "account",
+    "acct",
+    "accountid",
+  ],
+  entryId: ["entryid", "buyid", "buyorderid", "entryorderid"],
+  closeId: ["closeid", "sellid", "sellorderid", "exitid"],
+  timeInPosition: ["timeinposition", "time in position", "duration", "holdtime"],
+};
+
+export function normalizeHeader(header: string): string {
+  return header
+    .trim()
+    .toLowerCase()
+    .replace(/[_\-./]+/g, " ")
+    .replace(/[^a-z0-9 ]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function columnId(header: string, index: number): string {
+  return `${header}_${index}`;
+}
+
+function aliasScore(normalizedHeader: string, alias: string): number {
+  const compactHeader = normalizedHeader.replace(/\s+/g, "");
+  const compactAlias = alias.replace(/\s+/g, "");
+  if (compactHeader === compactAlias) return 100 + compactAlias.length;
+  if (compactHeader.includes(compactAlias) && compactAlias.length >= 3) {
+    return 40 + compactAlias.length;
+  }
+  return 0;
+}
+
+export function planFromHeaders(headers: string[]): ParsePlan {
+  const columns: ParsePlan["columns"] = {};
+  const usedIndexes = new Set<number>();
+
+  for (const field of PARSE_PLAN_FIELDS) {
+    let best:
+      | { index: number; header: string; score: number }
+      | undefined;
+    headers.forEach((header, index) => {
+      if (usedIndexes.has(index)) return;
+      const normalized = normalizeHeader(header);
+      let score = 0;
+      for (const alias of HEADER_ALIASES[field]) {
+        score = Math.max(score, aliasScore(normalized, alias));
+      }
+      if (score > 0 && (!best || score > best.score)) {
+        best = { index, header, score };
+      }
+    });
+    if (best) {
+      columns[field] = { header: best.header, index: best.index };
+      usedIndexes.add(best.index);
+    }
+  }
+
+  return {
+    kind: inferKind(columns),
+    columns,
+    quantitySignIsSide: !columns.side,
+  };
+}
+
+export function planFromMappings(
+  headers: string[],
+  mappings: Record<string, string>,
+): ParsePlan {
+  const columns: ParsePlan["columns"] = {};
+  headers.forEach((header, index) => {
+    const field = mappings[columnId(header, index)];
+    if (!field || !isParsePlanField(field)) return;
+    columns[field] = { header, index };
+  });
+  return {
+    kind: inferKind(columns),
+    columns,
+    quantitySignIsSide: !columns.side,
+  };
+}
+
+export function resolveParsePlan(
+  headers: string[],
+  mappings: Record<string, string> = {},
+): ParsePlan {
+  const heuristic = planFromHeaders(headers);
+  if (Object.keys(mappings).length === 0) return heuristic;
+  return mergeParsePlans(heuristic, planFromMappings(headers, mappings));
+}
+
+export function mergeParsePlans(base: ParsePlan, override: ParsePlan): ParsePlan {
+  const columns = { ...base.columns, ...override.columns };
+  return {
+    kind: override.kind || inferKind(columns),
+    columns,
+    quantitySignIsSide:
+      override.columns.side !== undefined
+        ? false
+        : base.quantitySignIsSide && !columns.side,
+  };
+}
+
+export function mappingsFromPlan(
+  headers: string[],
+  plan: ParsePlan,
+): Record<string, string> {
+  const mappings: Record<string, string> = {};
+  for (const [field, column] of Object.entries(plan.columns)) {
+    if (!column) continue;
+    if (headers[column.index] !== column.header) continue;
+    mappings[columnId(column.header, column.index)] = field;
+  }
+  return mappings;
+}
+
+export function missingRequiredFields(plan: ParsePlan): ParsePlanField[] {
+  const required: ParsePlanField[] =
+    plan.kind === "orders"
+      ? ["instrument", "quantity", "entryDate", "entryPrice"]
+      : ["instrument", "quantity", "entryDate", "entryPrice", "closeDate", "closePrice"];
+  return required.filter((field) => !plan.columns[field]);
+}
+
+export function isParsePlanComplete(plan: ParsePlan): boolean {
+  return missingRequiredFields(plan).length === 0;
+}
+
+export function parseNumber(value: string | undefined): number | null {
+  if (value == null) return null;
+  const cleaned = value.replace(/[$€£,\s]/g, "").trim();
+  if (!cleaned) return null;
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function parseDateToIso(value: string | undefined): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const candidates = [
+    trimmed,
+    trimmed.includes("T") ? trimmed : trimmed.replace(" ", "T"),
+  ];
+  for (const candidate of candidates) {
+    const parsed = Date.parse(candidate);
+    if (!Number.isNaN(parsed)) return new Date(parsed).toISOString();
+  }
+  return null;
+}
+
+export function normalizeSide(
+  value: string | undefined,
+  quantity: number,
+  quantitySignIsSide: boolean,
+): "long" | "short" {
+  const token = (value ?? "").trim().toLowerCase();
+  if (token === "long" || token === "buy" || token === "b" || token === "1") {
+    return "long";
+  }
+  if (token === "short" || token === "sell" || token === "s" || token === "-1") {
+    return "short";
+  }
+  if (quantitySignIsSide && quantity < 0) return "short";
+  return "long";
+}
+
+export function normalizeInstrument(value: string): string {
+  const clean = value.trim().toUpperCase();
+  if (clean.length > 2 && /[FGHJKMNQUVXZ]\d{1,2}$/.test(clean)) {
+    return clean.replace(/[FGHJKMNQUVXZ]\d{1,2}$/, "");
+  }
+  return value.trim();
+}
+
+function cell(row: string[], column: ParsePlanColumn | undefined): string {
+  if (!column) return "";
+  return row[column.index] ?? "";
+}
+
+function secondsBetween(startIso: string, endIso: string): number {
+  const start = Date.parse(startIso);
+  const end = Date.parse(endIso);
+  if (Number.isNaN(start) || Number.isNaN(end)) return 0;
+  return Math.max(0, Math.round((end - start) / 1000));
+}
+
+export function executeParsePlan(
+  rows: string[][],
+  plan: ParsePlan,
+): ExecuteParsePlanResult {
+  const missingRequired = missingRequiredFields(plan);
+  if (missingRequired.length > 0) {
+    return { trades: [], kind: plan.kind, missingRequired, skippedRows: rows.length };
+  }
+
+  const fills: OrderFill[] = [];
+  const trades: ExecutedTrade[] = [];
+  let skippedRows = 0;
+
+  for (const row of rows) {
+    if (!row.length || row.every((value) => !value?.trim())) {
+      skippedRows += 1;
+      continue;
+    }
+
+    const rawQuantity = parseNumber(cell(row, plan.columns.quantity));
+    const instrument = normalizeInstrument(cell(row, plan.columns.instrument));
+    const entryDate = parseDateToIso(cell(row, plan.columns.entryDate));
+    const entryPrice = cell(row, plan.columns.entryPrice).trim();
+
+    if (rawQuantity == null || !instrument || !entryDate || !entryPrice) {
+      skippedRows += 1;
+      continue;
+    }
+
+    const side = normalizeSide(
+      cell(row, plan.columns.side),
+      rawQuantity,
+      plan.quantitySignIsSide,
+    );
+    const quantity = Math.abs(rawQuantity);
+    const accountNumber = cell(row, plan.columns.accountNumber).trim();
+    const commission = parseNumber(cell(row, plan.columns.commission)) ?? 0;
+
+    if (plan.kind === "orders") {
+      fills.push({
+        instrument,
+        quantity,
+        side,
+        price: entryPrice,
+        date: entryDate,
+        accountNumber,
+        commission,
+        id: cell(row, plan.columns.entryId).trim(),
+      });
+      continue;
+    }
+
+    const closeDate = parseDateToIso(cell(row, plan.columns.closeDate));
+    const closePrice = cell(row, plan.columns.closePrice).trim();
+    if (!closeDate || !closePrice) {
+      skippedRows += 1;
+      continue;
+    }
+
+    const pnl = parseNumber(cell(row, plan.columns.pnl)) ?? 0;
+    const timeInPosition =
+      parseNumber(cell(row, plan.columns.timeInPosition)) ??
+      secondsBetween(entryDate, closeDate);
+
+    trades.push({
+      instrument,
+      quantity,
+      side,
+      entryDate,
+      closeDate,
+      entryPrice,
+      closePrice,
+      pnl,
+      commission,
+      timeInPosition,
+      accountNumber,
+      entryId: cell(row, plan.columns.entryId).trim() || undefined,
+      closeId: cell(row, plan.columns.closeId).trim() || undefined,
+    });
+  }
+
+  if (plan.kind === "orders") {
+    return {
+      trades: pairOrderFills(fills),
+      kind: plan.kind,
+      missingRequired,
+      skippedRows,
+    };
+  }
+
+  return { trades, kind: plan.kind, missingRequired, skippedRows };
+}
+
+export type OrderFill = {
+  instrument: string;
+  quantity: number;
+  side: "long" | "short";
+  price: string;
+  date: string;
+  accountNumber: string;
+  commission: number;
+  id: string;
+};
+
+type OpenLot = {
+  quantity: number;
+  price: number;
+  date: string;
+  commission: number;
+  id: string;
+};
+
+export function pairOrderFills(fills: OrderFill[]): ExecutedTrade[] {
+  const groups = new Map<string, OrderFill[]>();
+  for (const fill of fills) {
+    const key = `${fill.accountNumber}::${fill.instrument}`;
+    const list = groups.get(key) ?? [];
+    list.push(fill);
+    groups.set(key, list);
+  }
+
+  const trades: ExecutedTrade[] = [];
+  for (const group of groups.values()) {
+    group.sort((a, b) => a.date.localeCompare(b.date));
+    trades.push(...pairFillGroup(group));
+  }
+  return trades;
+}
+
+function pairFillGroup(fills: OrderFill[]): ExecutedTrade[] {
+  const longs: OpenLot[] = [];
+  const shorts: OpenLot[] = [];
+  const trades: ExecutedTrade[] = [];
+
+  for (const fill of fills) {
+    const incoming: OpenLot = {
+      quantity: fill.quantity,
+      price: Number(fill.price),
+      date: fill.date,
+      commission: fill.commission,
+      id: fill.id,
+    };
+    const opposite = fill.side === "long" ? shorts : longs;
+    const same = fill.side === "long" ? longs : shorts;
+
+    while (incoming.quantity > 0 && opposite.length > 0) {
+      const open = opposite[0];
+      const matched = Math.min(incoming.quantity, open.quantity);
+      const entryPrice = open.price;
+      const closePrice = incoming.price;
+      const pnl =
+        fill.side === "long"
+          ? (entryPrice - closePrice) * matched
+          : (closePrice - entryPrice) * matched;
+
+      trades.push({
+        instrument: fill.instrument,
+        accountNumber: fill.accountNumber,
+        quantity: matched,
+        side: fill.side === "long" ? "short" : "long",
+        entryDate: open.date,
+        closeDate: fill.date,
+        entryPrice: String(entryPrice),
+        closePrice: String(closePrice),
+        pnl,
+        commission: open.commission + incoming.commission,
+        timeInPosition: secondsBetween(open.date, fill.date),
+        entryId: open.id || undefined,
+        closeId: fill.id || undefined,
+      });
+
+      incoming.quantity -= matched;
+      open.quantity -= matched;
+      if (open.quantity <= 0) opposite.shift();
+    }
+
+    if (incoming.quantity > 0) {
+      same.push(incoming);
+    }
+  }
+
+  return trades;
+}
+
+function inferKind(columns: ParsePlan["columns"]): ParsePlanKind {
+  if (columns.closeDate || columns.closePrice || columns.pnl) {
+    return "closed-trades";
+  }
+  return "orders";
+}
+
+function isParsePlanField(value: string): value is ParsePlanField {
+  return (PARSE_PLAN_FIELDS as readonly string[]).includes(value);
+}

--- a/lib/import/parse-script.test.ts
+++ b/lib/import/parse-script.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { extractParseScript, sampleValidationError } from "./parse-script";
+import { parsePeekText } from "./peek-delimited-file";
+import { runInVm } from "./run-parse-script";
+
+const MNQ_SCRIPT = `
+function parseChunk(rows, session) {
+  session = session || {};
+  const trades = [];
+  let skipped = 0;
+  for (const row of rows) {
+    if (!row || row.every((cell) => !String(cell || "").trim())) {
+      skipped += 1;
+      continue;
+    }
+    const qty = Number(String(row[1]).replace(/,/g, ""));
+    if (!Number.isFinite(qty) || !row[0] || !row[2] || !row[3] || !row[4] || !row[5]) {
+      skipped += 1;
+      continue;
+    }
+    trades.push({
+      instrument: String(row[0]).replace(/[FGHJKMNQUVXZ]\\d{1,2}$/i, ""),
+      quantity: Math.abs(qty),
+      side: qty < 0 ? "short" : "long",
+      entryDate: new Date(row[2]).toISOString(),
+      closeDate: new Date(row[4]).toISOString(),
+      entryPrice: String(row[3]),
+      closePrice: String(row[5]),
+      pnl: Number(row[6]) || 0,
+      commission: 0,
+    });
+  }
+  return { trades, session, skipped };
+}
+`;
+
+const NARRATIVE_SCRIPT = `
+function parseChunk(rows, session) {
+  session = session || {};
+  session.opens = session.opens || [];
+  const trades = [];
+  let skipped = 0;
+  const buy = /bought\\s+(\\d+)\\s+(\\w+)\\s+@\\s+([0-9.]+)/i;
+  const sell = /sold\\s+(\\d+)\\s+(\\w+)\\s+@\\s+([0-9.]+)/i;
+  for (const row of rows) {
+    const date = row[0];
+    const details = row[1] || "";
+    const bought = details.match(buy);
+    const sold = details.match(sell);
+    if (bought) {
+      session.opens.push({
+        instrument: bought[2],
+        quantity: Number(bought[1]),
+        price: bought[3],
+        date,
+      });
+      continue;
+    }
+    if (sold && session.opens.length) {
+      const open = session.opens.shift();
+      const qty = Number(sold[1]);
+      const close = Number(sold[3]);
+      const entry = Number(open.price);
+      trades.push({
+        instrument: open.instrument,
+        quantity: qty,
+        side: "long",
+        entryDate: new Date(open.date).toISOString(),
+        closeDate: new Date(date).toISOString(),
+        entryPrice: String(entry),
+        closePrice: String(close),
+        pnl: (close - entry) * qty,
+        commission: 0,
+      });
+      continue;
+    }
+    skipped += 1;
+  }
+  return { trades, session, skipped };
+}
+`;
+
+describe("extractParseScript", () => {
+  it("takes a fenced function and rejects imports", () => {
+    const script = extractParseScript(
+      "```js\nfunction parseChunk(rows, session) { return { trades: [], session, skipped: 0 }; }\n```",
+    );
+    expect(script).toContain("function parseChunk");
+    expect(() =>
+      extractParseScript("function parseChunk() {}\nimport fs from 'fs'"),
+    ).toThrow("PARSE_SCRIPT_UNSAFE");
+  });
+});
+
+describe("runInVm", () => {
+  it("parses the reported MNQ layout", () => {
+    const peek = parsePeekText(`Symbol;Quantity;Entry DT;Entry Price;Exit DT;Exit Price;ProfitLoss
+MNQ;2;2026-01-06 17:35:22;25629.25;2026-01-06 17:51:31;25746.5;469
+MNQ;-2;2026-01-06 18:14:14;25756.5;2026-01-06 18:26:22;25778.5;-88`);
+    const first = runInVm(MNQ_SCRIPT, peek.sampleRows.slice(0, 1), {});
+    expect(first.trades[0]).toMatchObject({
+      instrument: "MNQ",
+      quantity: 2,
+      side: "long",
+      pnl: 469,
+    });
+    const empty = runInVm(MNQ_SCRIPT, [], first.session);
+    expect(empty.trades).toEqual([]);
+    expect(sampleValidationError(empty)).toBe("SAMPLE_PRODUCED_NO_TRADES");
+  });
+
+  it("pairs narrative fills that span chunks", () => {
+    const buy = runInVm(
+      NARRATIVE_SCRIPT,
+      [["2026-01-06", "Bought 2 MNQ @ 25629.25"]],
+      {},
+    );
+    expect(buy.trades).toEqual([]);
+    const sell = runInVm(
+      NARRATIVE_SCRIPT,
+      [["2026-01-06", "Sold 2 MNQ @ 25746.5"]],
+      buy.session,
+    );
+    expect(sell.trades).toHaveLength(1);
+    expect(sell.trades[0]?.pnl).toBeCloseTo((25746.5 - 25629.25) * 2);
+  });
+});

--- a/lib/import/parse-script.ts
+++ b/lib/import/parse-script.ts
@@ -1,0 +1,112 @@
+/**
+ * Contract for an agent-written import parser.
+ * The model emits a function, we validate I/O, then run it on every chunk.
+ */
+import type { ExecutedTrade } from "./parse-plan";
+
+export const PARSE_SCRIPT_MAX_ATTEMPTS = 3;
+
+export type ParseScriptSession = Record<string, unknown>;
+
+export type ParseScriptChunkResult = {
+  trades: ExecutedTrade[];
+  session: ParseScriptSession;
+  skipped: number;
+};
+
+export const PARSE_SCRIPT_CONTRACT = `Write a JavaScript function named parseChunk.
+
+Signature:
+  function parseChunk(rows, session) -> { trades, session, skipped }
+
+- rows: string[][]  (one chunk of the file; do not assume the whole file)
+- session: a JSON object you persist across chunks (open lots, leftover rows, …).
+  Initialize any arrays you use (session.opens = session.opens || []).
+- Return only closed trades. Keep unmatched fills in session.
+- An empty chunk is not a failure. Return { trades: [], session, skipped: 0 }.
+- No import, require, fetch, process, or filesystem access.
+- Dates as ISO strings. side is "long" or "short". quantity is a positive number.
+
+Each trade:
+  instrument, quantity, side, entryDate, closeDate, entryPrice, closePrice,
+  pnl (number), commission (number), timeInPosition (seconds, optional),
+  accountNumber (optional), entryId (optional), closeId (optional)`;
+
+export function extractParseScript(text: string): string {
+  const fenced = text.match(/```(?:javascript|js)?\s*([\s\S]*?)```/i);
+  const raw = (fenced?.[1] ?? text).trim();
+  if (!/\bfunction\s+parseChunk\s*\(/.test(raw)) {
+    throw new Error("PARSE_SCRIPT_MISSING_FUNCTION");
+  }
+  if (
+    /\bimport\b|\brequire\s*\(|\bfetch\s*\(|\bprocess\b|\bXMLHttpRequest\b/.test(
+      raw,
+    )
+  ) {
+    throw new Error("PARSE_SCRIPT_UNSAFE");
+  }
+  return raw;
+}
+
+export function validateParseScriptResult(
+  raw: unknown,
+): ParseScriptChunkResult {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("PARSE_SCRIPT_INVALID_RESULT");
+  }
+  const value = raw as Record<string, unknown>;
+  if (!Array.isArray(value.trades)) {
+    throw new Error("PARSE_SCRIPT_INVALID_TRADES");
+  }
+  const session =
+    value.session && typeof value.session === "object" && !Array.isArray(value.session)
+      ? (value.session as ParseScriptSession)
+      : {};
+  const skipped =
+    typeof value.skipped === "number" && Number.isFinite(value.skipped)
+      ? value.skipped
+      : 0;
+
+  const trades: ExecutedTrade[] = [];
+  for (const item of value.trades) {
+    const trade = asExecutedTrade(item);
+    if (trade) trades.push(trade);
+  }
+
+  return { trades, session, skipped };
+}
+
+function asExecutedTrade(item: unknown): ExecutedTrade | null {
+  if (!item || typeof item !== "object") return null;
+  const trade = item as Record<string, unknown>;
+  const instrument = String(trade.instrument ?? "").trim();
+  const entryDate = String(trade.entryDate ?? "").trim();
+  const entryPrice = String(trade.entryPrice ?? "").trim();
+  const quantity = Number(trade.quantity);
+  if (!instrument || !entryDate || !entryPrice || !Number.isFinite(quantity)) {
+    return null;
+  }
+  const side = trade.side === "short" ? "short" : "long";
+  return {
+    instrument,
+    quantity: Math.abs(quantity),
+    side,
+    entryDate,
+    closeDate: trade.closeDate ? String(trade.closeDate) : undefined,
+    entryPrice,
+    closePrice: trade.closePrice ? String(trade.closePrice) : undefined,
+    pnl: Number(trade.pnl) || 0,
+    commission: Number(trade.commission) || 0,
+    timeInPosition: Number(trade.timeInPosition) || 0,
+    accountNumber: trade.accountNumber ? String(trade.accountNumber) : "",
+    entryId: trade.entryId ? String(trade.entryId) : undefined,
+    closeId: trade.closeId ? String(trade.closeId) : undefined,
+  };
+}
+
+export function sampleValidationError(
+  result: ParseScriptChunkResult,
+): string | null {
+  if (result.trades.length > 0) return null;
+  return "SAMPLE_PRODUCED_NO_TRADES";
+}

--- a/lib/import/peek-delimited-file.ts
+++ b/lib/import/peek-delimited-file.ts
@@ -1,0 +1,39 @@
+export const PEEK_BYTES = 32_768;
+
+export type PeekedDelimitedFile = {
+  headers: string[];
+  sampleRows: string[][];
+  delimiter: string;
+  peekText: string;
+};
+
+export function detectDelimiter(firstLine: string): string {
+  const tab = (firstLine.match(/\t/g) ?? []).length;
+  const semi = (firstLine.match(/;/g) ?? []).length;
+  const comma = (firstLine.match(/,/g) ?? []).length;
+  if (tab > semi && tab > comma) return "\t";
+  return semi > comma ? ";" : ",";
+}
+
+export function parsePeekText(text: string): PeekedDelimitedFile {
+  const lines = text.split(/\r?\n/);
+  if (lines.length > 1) lines.pop();
+  const nonempty = lines.filter((line) => line.trim().length > 0);
+  const firstLine = nonempty[0] ?? "";
+  const delimiter = detectDelimiter(firstLine);
+  const rows = nonempty.map((line) => line.split(delimiter));
+  return {
+    headers: rows[0] ?? [],
+    sampleRows: rows.slice(1, 9),
+    delimiter,
+    peekText: nonempty.slice(0, 16).join("\n"),
+  };
+}
+
+export async function peekDelimitedFile(
+  file: File,
+): Promise<PeekedDelimitedFile> {
+  const slice = file.slice(0, PEEK_BYTES);
+  const text = await slice.text();
+  return parsePeekText(text);
+}

--- a/lib/import/plan-from-ai.test.ts
+++ b/lib/import/plan-from-ai.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { isParsePlanComplete } from "./parse-plan";
+import { planFromAiResponse } from "./plan-from-ai";
+
+describe("planFromAiResponse", () => {
+  it("resolves header names to column indexes", () => {
+    const plan = planFromAiResponse(
+      ["Symbol", "Qty", "Side", "Price", "Time"],
+      {
+        kind: "orders",
+        columns: {
+          instrument: "Symbol",
+          quantity: "Qty",
+          side: "Side",
+          entryPrice: "Price",
+          entryDate: "Time",
+          closePrice: null,
+          closeDate: null,
+          pnl: null,
+          commission: null,
+          accountNumber: null,
+          entryId: null,
+          closeId: null,
+          timeInPosition: null,
+        },
+      },
+    );
+
+    expect(plan.kind).toBe("orders");
+    expect(plan.columns.entryPrice).toEqual({ header: "Price", index: 3 });
+    expect(isParsePlanComplete(plan)).toBe(true);
+  });
+
+  it("ignores headers that are not in the file", () => {
+    const plan = planFromAiResponse(["Symbol"], {
+      kind: "closed-trades",
+      columns: { instrument: "Ticker" },
+    });
+    expect(plan.columns.instrument).toBeUndefined();
+  });
+});

--- a/lib/import/plan-from-ai.ts
+++ b/lib/import/plan-from-ai.ts
@@ -1,0 +1,26 @@
+import type { ParsePlan, ParsePlanField } from "./parse-plan";
+import { PARSE_PLAN_FIELDS } from "./parse-plan";
+
+type AiParsePlan = {
+  kind: "closed-trades" | "orders";
+  columns: Partial<Record<ParsePlanField, string | null>>;
+};
+
+export function planFromAiResponse(
+  headers: string[],
+  aiPlan: AiParsePlan,
+): ParsePlan {
+  const columns: ParsePlan["columns"] = {};
+  for (const field of PARSE_PLAN_FIELDS) {
+    const headerName = aiPlan.columns[field];
+    if (!headerName) continue;
+    const index = headers.findIndex((header) => header === headerName);
+    if (index === -1) continue;
+    columns[field] = { header: headerName, index };
+  }
+  return {
+    kind: aiPlan.kind,
+    columns,
+    quantitySignIsSide: !columns.side,
+  };
+}

--- a/lib/import/run-parse-script.ts
+++ b/lib/import/run-parse-script.ts
@@ -1,0 +1,122 @@
+import { Sandbox } from "@vercel/sandbox";
+import vm from "node:vm";
+import {
+  validateParseScriptResult,
+  type ParseScriptChunkResult,
+  type ParseScriptSession,
+} from "./parse-script";
+
+const SANDBOX_RUNNER = `import { readFileSync } from "node:fs";
+import { parseChunk } from "./parse.mjs";
+const input = JSON.parse(readFileSync("input.json", "utf8"));
+const result = parseChunk(input.rows ?? [], input.session ?? {});
+process.stdout.write(JSON.stringify(result));
+`;
+
+function wrapAsModule(script: string): string {
+  if (script.includes("export function parseChunk")) return script;
+  return `${script}\nexport { parseChunk };\n`;
+}
+
+function sandboxCredentials() {
+  if (
+    process.env.VERCEL_TOKEN &&
+    process.env.VERCEL_TEAM_ID &&
+    process.env.VERCEL_PROJECT_ID
+  ) {
+    return {
+      token: process.env.VERCEL_TOKEN,
+      teamId: process.env.VERCEL_TEAM_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    };
+  }
+  return {};
+}
+
+export function canUseVercelSandbox(): boolean {
+  return Boolean(
+    process.env.VERCEL_OIDC_TOKEN ||
+      (process.env.VERCEL_TOKEN &&
+        process.env.VERCEL_TEAM_ID &&
+        process.env.VERCEL_PROJECT_ID),
+  );
+}
+
+/**
+ * Run untrusted agent JS. Prefers a Vercel Sandbox (Firecracker).
+ * Falls back to a sealed Node vm for local/dev when Sandbox creds are missing.
+ */
+export async function runParseScriptChunk(
+  script: string,
+  rows: string[][],
+  session: ParseScriptSession,
+  options?: { sandboxName?: string },
+): Promise<ParseScriptChunkResult & { sandboxName?: string }> {
+  if (canUseVercelSandbox()) {
+    return runInSandbox(script, rows, session, options?.sandboxName);
+  }
+  return {
+    ...runInVm(script, rows, session),
+  };
+}
+
+export function runInVm(
+  script: string,
+  rows: string[][],
+  session: ParseScriptSession,
+): ParseScriptChunkResult {
+  const wrapped = `"use strict";\n${script}\n;if (typeof parseChunk !== "function") { throw new Error("parseChunk is not defined"); }\nparseChunk;`;
+  const context = vm.createContext({
+    console: { log() {}, warn() {}, error() {} },
+  });
+  const parseChunk = vm.runInContext(wrapped, context, {
+    timeout: 5_000,
+    displayErrors: true,
+  }) as (chunkRows: string[][], chunkSession: ParseScriptSession) => unknown;
+  return validateParseScriptResult(parseChunk(rows, session));
+}
+
+async function runInSandbox(
+  script: string,
+  rows: string[][],
+  session: ParseScriptSession,
+  sandboxName?: string,
+): Promise<ParseScriptChunkResult & { sandboxName: string }> {
+  const name = sandboxName ?? `import-parse-${crypto.randomUUID()}`;
+  const sandbox = sandboxName
+    ? await Sandbox.get({ ...sandboxCredentials(), name })
+    : await Sandbox.create({
+        ...sandboxCredentials(),
+        name,
+        runtime: "node24",
+        timeout: 15 * 60 * 1000,
+        networkPolicy: "deny-all",
+      });
+
+  await sandbox.writeFiles([
+    ...(!sandboxName
+      ? [
+          { path: "parse.mjs", content: Buffer.from(wrapAsModule(script)) },
+          { path: "run.mjs", content: Buffer.from(SANDBOX_RUNNER) },
+        ]
+      : []),
+    {
+      path: "input.json",
+      content: Buffer.from(JSON.stringify({ rows, session })),
+    },
+  ]);
+
+  const result = await sandbox.runCommand({
+    cmd: "node",
+    args: ["run.mjs"],
+  });
+  if (result.exitCode !== 0) {
+    const stderr = await result.stderr();
+    throw new Error(stderr || "PARSE_SCRIPT_SANDBOX_FAILED");
+  }
+  const stdout = await result.stdout();
+  return {
+    ...validateParseScriptResult(JSON.parse(stdout)),
+    sandboxName: name,
+  };
+}

--- a/lib/import/stream-delimited-file.ts
+++ b/lib/import/stream-delimited-file.ts
@@ -1,0 +1,41 @@
+import Papa from "papaparse";
+
+export function streamDelimitedFile(
+  file: File,
+  options: {
+    delimiter: string;
+    headers: string[];
+    onChunk: (rows: string[][], bytesRead: number) => Promise<void>;
+  },
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let skippedHeader = false;
+    Papa.parse<string[]>(file, {
+      delimiter: options.delimiter,
+      skipEmptyLines: "greedy",
+      chunk: (results, parser) => {
+        parser.pause();
+        let rows = results.data;
+        if (!skippedHeader && rows[0] && sameRow(rows[0], options.headers)) {
+          rows = rows.slice(1);
+          skippedHeader = true;
+        }
+        const bytesRead = results.meta.cursor ?? 0;
+        void options
+          .onChunk(rows, bytesRead)
+          .then(() => parser.resume())
+          .catch((error) => {
+            parser.abort();
+            reject(error);
+          });
+      },
+      complete: () => resolve(),
+      error: (error) => reject(error),
+    });
+  });
+}
+
+function sameRow(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((cell, index) => cell === right[index]);
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -527,6 +527,11 @@ export default {
     tradesFormatted: "{formatted} of {total} trades formatted",
     batchesCompleted: "Batches: {completed}/{total} completed",
     batchesProcessing: ", {processing} processing",
+    batchFailed: "Unable to format trades",
+    aiUnavailable:
+      "AI formatting is unavailable. Ask your administrator to configure an OpenAI API key, then try again.",
+    noTradesFormatted:
+      "No trades were formatted. Check that AI is configured on this server, then try again.",
   },
 
   "import.table.instrument": "Instrument",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -538,7 +538,7 @@ export default {
     emptyTable: "No trades to review yet",
     parsing: "Parsing",
   },
-  "import.parse.tradesFormatted": "{formatted} of {total} trades formatted",
+  "import.parse.tradesFormatted": "{formatted} trades formatted",
   "import.parse.missingColumns": "Map these columns to continue: {columns}",
   "import.parse.rowsProcessed": "{processed} of {total} rows",
 

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -536,9 +536,11 @@ export default {
     ordersPaired: "Order fills were paired into trades",
     parseReady: "Ready to import",
     emptyTable: "No trades to review yet",
+    parsing: "Parsing",
   },
   "import.parse.tradesFormatted": "{formatted} of {total} trades formatted",
   "import.parse.missingColumns": "Map these columns to continue: {columns}",
+  "import.parse.rowsProcessed": "{processed} of {total} rows",
 
   "import.table.instrument": "Instrument",
   "import.table.entryDate": "Entry Date",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -537,10 +537,16 @@ export default {
     parseReady: "Ready to import",
     emptyTable: "No trades to review yet",
     parsing: "Parsing",
+    writingParser: "Writing a parser",
+    checkingSample: "Checking the first rows",
+    readingFile: "Reading the file",
+    parserFromAgent: "Wrote a parser for this file",
   },
   "import.parse.tradesFormatted": "{formatted} trades formatted",
   "import.parse.missingColumns": "Map these columns to continue: {columns}",
   "import.parse.rowsProcessed": "{processed} of {total} rows",
+  "import.parse.rowsRead": "{processed} rows read",
+  "import.parse.scriptLabel": "How this file is read",
 
   "import.table.instrument": "Instrument",
   "import.table.entryDate": "Entry Date",
@@ -572,7 +578,7 @@ export default {
   "import.type.rithmicProtocolSync.details":
     "Sync order history through Rithmic R | Protocol API from Deltalytix servers (TypeScript), similar to Tradovate and DxFeed.",
   "import.type.csvAi.name": "CSV with AI",
-  "import.type.csvAi.description": "Any CSV file",
+  "import.type.csvAi.description": "Any trade export — we write a parser for it",
   "import.type.rithmicPerf.name": "Rithmic Performance",
   "import.type.rithmicPerf.description": "Rithmic Performance CSV",
   "import.type.rithmicPerf.details":

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -532,7 +532,13 @@ export default {
       "AI formatting is unavailable. Ask your administrator to configure an OpenAI API key, then try again.",
     noTradesFormatted:
       "No trades were formatted. Check that AI is configured on this server, then try again.",
+    parsedFromColumns: "Parsed from the file columns",
+    ordersPaired: "Order fills were paired into trades",
+    parseReady: "Ready to import",
+    emptyTable: "No trades to review yet",
   },
+  "import.parse.tradesFormatted": "{formatted} of {total} trades formatted",
+  "import.parse.missingColumns": "Map these columns to continue: {columns}",
 
   "import.table.instrument": "Instrument",
   "import.table.entryDate": "Entry Date",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -584,7 +584,7 @@ export default {
     emptyTable: "Aucun trade à revoir pour le moment",
     parsing: "Analyse",
   },
-  "import.parse.tradesFormatted": "{formatted} sur {total} trades formatés",
+  "import.parse.tradesFormatted": "{formatted} trades formatés",
   "import.parse.missingColumns":
     "Associez ces colonnes pour continuer : {columns}",
   "import.parse.rowsProcessed": "{processed} lignes sur {total}",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -583,11 +583,17 @@ export default {
     parseReady: "Prêt à importer",
     emptyTable: "Aucun trade à revoir pour le moment",
     parsing: "Analyse",
+    writingParser: "Rédaction d'un parseur",
+    checkingSample: "Vérification des premières lignes",
+    readingFile: "Lecture du fichier",
+    parserFromAgent: "Un parseur a été écrit pour ce fichier",
   },
   "import.parse.tradesFormatted": "{formatted} trades formatés",
   "import.parse.missingColumns":
     "Associez ces colonnes pour continuer : {columns}",
   "import.parse.rowsProcessed": "{processed} lignes sur {total}",
+  "import.parse.rowsRead": "{processed} lignes lues",
+  "import.parse.scriptLabel": "Lecture de ce fichier",
   "import.table.instrument": "Instrument",
   "import.table.entryDate": "Date d'entrée",
   "import.table.closeDate": "Date de sortie",
@@ -619,7 +625,8 @@ export default {
   "import.type.rithmicProtocolSync.details":
     "Importez l'historique d'ordres via R | Protocol API depuis les serveurs Deltalytix (TypeScript), comme Tradovate et DxFeed.",
   "import.type.csvAi.name": "CSV avec IA",
-  "import.type.csvAi.description": "N'importe quel fichier CSV",
+  "import.type.csvAi.description":
+    "N'importe quel export — un parseur est écrit pour le fichier",
   "import.type.rithmicPerf.name": "Performance Rithmic",
   "import.type.rithmicPerf.description": "CSV Performance Rithmic",
   "import.type.rithmicPerf.details":

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -578,7 +578,14 @@ export default {
       "Le formatage IA est indisponible. Demandez à votre administrateur de configurer une clé API OpenAI, puis réessayez.",
     noTradesFormatted:
       "Aucun trade n'a été formaté. Vérifiez que l'IA est configurée sur ce serveur, puis réessayez.",
+    parsedFromColumns: "Lu depuis les colonnes du fichier",
+    ordersPaired: "Les ordres ont été appariés en trades",
+    parseReady: "Prêt à importer",
+    emptyTable: "Aucun trade à revoir pour le moment",
   },
+  "import.parse.tradesFormatted": "{formatted} sur {total} trades formatés",
+  "import.parse.missingColumns":
+    "Associez ces colonnes pour continuer : {columns}",
   "import.table.instrument": "Instrument",
   "import.table.entryDate": "Date d'entrée",
   "import.table.closeDate": "Date de sortie",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -582,10 +582,12 @@ export default {
     ordersPaired: "Les ordres ont été appariés en trades",
     parseReady: "Prêt à importer",
     emptyTable: "Aucun trade à revoir pour le moment",
+    parsing: "Analyse",
   },
   "import.parse.tradesFormatted": "{formatted} sur {total} trades formatés",
   "import.parse.missingColumns":
     "Associez ces colonnes pour continuer : {columns}",
+  "import.parse.rowsProcessed": "{processed} lignes sur {total}",
   "import.table.instrument": "Instrument",
   "import.table.entryDate": "Date d'entrée",
   "import.table.closeDate": "Date de sortie",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -573,6 +573,11 @@ export default {
     tradesFormatted: "{formatted} sur {total} trades formatés",
     batchesCompleted: "Lots : {completed}/{total} terminés",
     batchesProcessing: ", {processing} en cours",
+    batchFailed: "Impossible de formater les trades",
+    aiUnavailable:
+      "Le formatage IA est indisponible. Demandez à votre administrateur de configurer une clé API OpenAI, puis réessayez.",
+    noTradesFormatted:
+      "Aucun trade n'a été formaté. Vérifiez que l'IA est configurée sur ce serveur, puis réessayez.",
   },
   "import.table.instrument": "Instrument",
   "import.table.entryDate": "Date d'entrée",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/pg": "^8.16.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/functions": "^2.2.13",
+    "@vercel/sandbox": "^3.0.0",
     "@vercel/speed-insights": "^1.2.0",
     "ai": "^6.0.31",
     "canvas": "^3.2.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Intelligent Import is web-only and no longer asks the user to map columns.

1. Peek the first 32KB of the `File` (do not Papa-load the whole CSV).
2. If headers are enough, run the existing parse plan on streamed chunks.
3. If not, an agent writes `function parseChunk(rows, session)`, we prove it on the sample (up to 3 repairs), then stream every chunk through that script.
4. Vercel Sandbox runs the script on production (one VM per import). Local/dev uses a sealed Node `vm` when Sandbox creds are missing.

## Why

Column mapping cannot express messy broker dumps. Agents can write a dedicated parser. Sandbox is for untrusted JS, not for booting a VM per 2500-row chunk.

## Verify

- `bunx vitest run lib/import/parse-script.test.ts lib/import/parse-plan.test.ts`
- MNQ semicolon CSV: Upload → account → Review (no Map Columns). 17 trades from columns.

![Stepper is Upload, Account, Review — no Map Columns](https://cursor.com/artifacts/c/art-aa491aa2-c960-43f4-b882-a52a6a898cf6)
![17 MNQ trades ready to import](https://cursor.com/artifacts/c/art-d7ed6725-d1ca-406c-a8ca-275a4d454a1e)
<a href="https://cursor.com/agents/bc-01a00b71-3b9f-750b-969e-fec64a8dc142/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcsv_ai_no_mapping_mnq_review.mp4"><img src="https://cursor.com/artifacts/c/art-b706c327-f9e6-407d-b8dd-4da40b4ff847" alt="csv_ai_no_mapping_mnq_review.mp4" /></a>

## Follow-up

Batch save still holds the full trade list. Multi-GB files still need object storage + a job.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00b71-3b9f-750b-969e-fec64a8dc142?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00b71-3b9f-750b-969e-fec64a8dc142&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

