### PR TITLE
Allow non-email usernames on DxFeed connect

### DIFF
--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-connect-form.tsx
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-connect-form.tsx
@@ -14,6 +14,7 @@ import {
   captureConnectionFailed,
 } from '@/lib/connection-analytics'
 import { DxFeedErrorCode } from '@/lib/dxfeed-errors'
+import { getDxFeedConnectFieldErrors } from '@/lib/dxfeed-connect-fields'
 import { authenticateDxFeed } from './actions'
 
 const fieldClassName =
@@ -25,7 +26,7 @@ const primaryButtonClassName =
 const invalidFieldClassName =
   'border-destructive/60 focus-visible:border-destructive/70 dark:border-destructive/60 dark:focus-visible:border-destructive/70'
 
-type DxFeedFieldErrors = Partial<Record<'email' | 'password', string>>
+type DxFeedFieldErrors = Partial<Record<'username' | 'password', string>>
 
 function FieldBorderError({
   id,
@@ -53,21 +54,21 @@ function FieldBorderError({
 
 export function DxFeedConnectForm({
   onConnected,
-  initialEmail,
+  initialUsername,
   sourceUi = 'connect_view',
 }: {
   onConnected?: () => void
-  initialEmail?: string
+  initialUsername?: string
   /** Which surface rendered this form; reported with connection analytics. */
   sourceUi?: 'connect_view' | 'credentials_manager'
 }) {
   const t = useI18n()
   const { loadAccounts } = useDxFeedSyncContext()
-  const [loginEmail, setLoginEmail] = useState(initialEmail ?? '')
+  const [loginUsername, setLoginUsername] = useState(initialUsername ?? '')
   const [loginPassword, setLoginPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [fieldErrors, setFieldErrors] = useState<DxFeedFieldErrors>({})
-  const emailInputRef = useRef<HTMLInputElement>(null)
+  const usernameInputRef = useRef<HTMLInputElement>(null)
   const passwordInputRef = useRef<HTMLInputElement>(null)
 
   const clearFieldError = useCallback((field: keyof DxFeedFieldErrors) => {
@@ -81,20 +82,22 @@ export function DxFeedConnectForm({
 
   const validateForm = useCallback(() => {
     const errors: DxFeedFieldErrors = {}
+    const missing = getDxFeedConnectFieldErrors({
+      username: loginUsername,
+      password: loginPassword,
+    })
 
-    if (!loginEmail.trim()) {
-      errors.email = t('dxfeedSync.error.emailRequired')
-    } else if (emailInputRef.current?.validity.typeMismatch) {
-      errors.email = t('dxfeedSync.error.emailInvalid')
+    if (missing.includes('username')) {
+      errors.username = t('dxfeedSync.error.usernameRequired')
     }
-    if (!loginPassword) {
+    if (missing.includes('password')) {
       errors.password = t('dxfeedSync.error.passwordRequired')
     }
 
     setFieldErrors(errors)
 
-    const firstInvalidControl = errors.email
-      ? emailInputRef.current
+    const firstInvalidControl = errors.username
+      ? usernameInputRef.current
       : errors.password
         ? passwordInputRef.current
         : null
@@ -103,12 +106,12 @@ export function DxFeedConnectForm({
     }
 
     return Object.keys(errors).length === 0
-  }, [loginEmail, loginPassword, t])
+  }, [loginUsername, loginPassword, t])
 
   const handleConnect = useCallback(async () => {
     try {
       setIsLoading(true)
-      const result = await authenticateDxFeed(loginEmail, loginPassword)
+      const result = await authenticateDxFeed(loginUsername, loginPassword)
 
       if (result.error) {
         captureConnectionFailed('dxfeed', {
@@ -141,7 +144,7 @@ export function DxFeedConnectForm({
         prop_firm_id: result.propFirmId,
         prop_firm_name: result.propfirmName,
       })
-      setLoginEmail('')
+      setLoginUsername('')
       setLoginPassword('')
       setFieldErrors({})
       await loadAccounts()
@@ -159,7 +162,7 @@ export function DxFeedConnectForm({
     } finally {
       setIsLoading(false)
     }
-  }, [loginEmail, loginPassword, sourceUi, t, loadAccounts, onConnected])
+  }, [loginUsername, loginPassword, sourceUi, t, loadAccounts, onConnected])
 
   return (
     <form
@@ -178,37 +181,39 @@ export function DxFeedConnectForm({
 
       <div className="min-w-0 space-y-2">
         <Label
-          htmlFor="dxfeed-email"
+          htmlFor="dxfeed-username"
           className="text-sm text-black/55 dark:text-white/55"
         >
-          {t('dxfeedSync.addAccount.emailLabel')}
+          {t('dxfeedSync.addAccount.usernameLabel')}
         </Label>
         <div className="relative min-w-0">
           <Input
-            ref={emailInputRef}
-            id="dxfeed-email"
-            name="email"
-            type="email"
+            ref={usernameInputRef}
+            id="dxfeed-username"
+            name="username"
             autoComplete="username"
-            value={loginEmail}
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            value={loginUsername}
             onChange={(e) => {
-              setLoginEmail(e.target.value)
-              clearFieldError('email')
+              setLoginUsername(e.target.value)
+              clearFieldError('username')
             }}
-            placeholder={t('dxfeedSync.addAccount.emailPlaceholder')}
+            placeholder={t('dxfeedSync.addAccount.usernamePlaceholder')}
             className={cn(
               fieldClassName,
-              fieldErrors.email && invalidFieldClassName,
+              fieldErrors.username && invalidFieldClassName,
             )}
             required
-            aria-invalid={Boolean(fieldErrors.email)}
+            aria-invalid={Boolean(fieldErrors.username)}
             aria-describedby={
-              fieldErrors.email ? 'dxfeed-email-error' : undefined
+              fieldErrors.username ? 'dxfeed-username-error' : undefined
             }
           />
           <FieldBorderError
-            id="dxfeed-email-error"
-            message={fieldErrors.email}
+            id="dxfeed-username-error"
+            message={fieldErrors.username}
           />
         </div>
       </div>

--- a/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-sync.tsx
+++ b/app/[locale]/dashboard/components/import/dxfeed/sync/dxfeed-sync.tsx
@@ -8,8 +8,8 @@ import { DxFeedConnectForm } from './dxfeed-connect-form'
 interface DxFeedSyncProps {
   /** When false, open on the connect form instead of the saved-accounts list. */
   initialShowAccountsManager?: boolean
-  /** Prefill login email when reconnecting. */
-  initialEmail?: string
+  /** Prefill login username when reconnecting. */
+  initialUsername?: string
   onConnected?: () => void
   /** Accepted for PlatformConfig customComponent compatibility; unused here. */
   setIsOpen?: Dispatch<SetStateAction<boolean>> | ((open: boolean) => void)
@@ -17,7 +17,7 @@ interface DxFeedSyncProps {
 
 export function DxFeedSync({
   initialShowAccountsManager = true,
-  initialEmail,
+  initialUsername,
   onConnected,
   setIsOpen: _setIsOpen,
 }: DxFeedSyncProps = {}) {
@@ -29,7 +29,7 @@ export function DxFeedSync({
         <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
           <DxFeedConnectForm
             onConnected={onConnected}
-            initialEmail={initialEmail}
+            initialUsername={initialUsername}
           />
         </div>
       </div>

--- a/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
+++ b/app/[locale]/dashboard/connections/components/connect-service-modal.tsx
@@ -104,7 +104,7 @@ export function ConnectServiceModal({
             <div className="min-h-0 flex-1 overflow-y-auto">
               <DxFeedSync
                 initialShowAccountsManager={false}
-                initialEmail={prefill?.accountId}
+                initialUsername={prefill?.accountId}
                 onConnected={onClose}
               />
             </div>

--- a/app/[locale]/dashboard/connections/data.ts
+++ b/app/[locale]/dashboard/connections/data.ts
@@ -96,7 +96,7 @@ function getConnectionDisplay(
   if (connection.service === 'dxfeed') {
     const propFirmName = getDxFeedPropFirmName(connection.token)
     if (propFirmName) {
-      // Prop firm name only — do not surface the login email in the row.
+      // Prop firm name only — do not surface the login in the row.
       return { displayName: propFirmName, loginLabel: null }
     }
   }

--- a/lib/dxfeed-connect-fields.test.ts
+++ b/lib/dxfeed-connect-fields.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { getDxFeedConnectFieldErrors } from './dxfeed-connect-fields'
+
+describe('getDxFeedConnectFieldErrors', () => {
+  it('accepts a non-email username', () => {
+    expect(
+      getDxFeedConnectFieldErrors({
+        username: 'trader_ht50',
+        password: 'secret',
+      }),
+    ).toEqual([])
+  })
+
+  it('still accepts an email username', () => {
+    expect(
+      getDxFeedConnectFieldErrors({
+        username: 'trader@hyperticks.com',
+        password: 'secret',
+      }),
+    ).toEqual([])
+  })
+
+  it('requires a non-empty username and password', () => {
+    expect(
+      getDxFeedConnectFieldErrors({
+        username: '   ',
+        password: '',
+      }),
+    ).toEqual(['username', 'password'])
+  })
+})

--- a/lib/dxfeed-connect-fields.ts
+++ b/lib/dxfeed-connect-fields.ts
@@ -1,0 +1,15 @@
+export type DxFeedConnectField = 'username' | 'password'
+
+/**
+ * Client-side required-field checks for DxFeed connect.
+ * Logins may be an email or a non-email username, so there is no format check.
+ */
+export function getDxFeedConnectFieldErrors(input: {
+  username: string
+  password: string
+}): DxFeedConnectField[] {
+  const errors: DxFeedConnectField[] = []
+  if (!input.username.trim()) errors.push('username')
+  if (!input.password) errors.push('password')
+  return errors
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2330,9 +2330,8 @@ export default {
     connected: "DxFeed account connected successfully",
     disconnected: "DxFeed account disconnected",
     error: {
-      credentialsRequired: "Enter your email and password to continue",
-      emailRequired: "Enter your email",
-      emailInvalid: "Enter a valid email",
+      credentialsRequired: "Enter your username and password to continue",
+      usernameRequired: "Enter your username",
       passwordRequired: "Enter your password",
       authFailed: "Could not connect to DxFeed",
     },
@@ -2344,7 +2343,7 @@ export default {
       USER_NOT_AUTHENTICATED:
         "You must be signed in to connect DxFeed. Sign in and try again.",
       AUTH_HTTP_ERROR:
-        "DxFeed rejected the connection (HTTP {status}). Check your email and password, or try again later. Details: {detail}",
+        "DxFeed rejected the connection (HTTP {status}). Check your username and password, or try again later. Details: {detail}",
       AUTH_REJECTED: "DxFeed rejected your login: {reason}",
       HISTORICAL_HOST_UNRESOLVED:
         "DxFeed did not return a trade history server for this login.",
@@ -2372,7 +2371,7 @@ export default {
       hintReconnect:
         "Remove this connection, click Add New, and sign in again with your DxFeed credentials.",
       hintCheckCredentials:
-        "Use the same email and password as on your prop firm's trading platform (demo vs live must match your account type).",
+        "Use the same username and password as on your prop firm's trading platform (demo vs live must match your account type).",
       SYNC_FETCH_FAILED:
         "Could not load trades from DxFeed ({failures} of {total} accounts failed). Reconnect and try again.",
       SYNC_ACCOUNTS_UNAVAILABLE:
@@ -2385,9 +2384,9 @@ export default {
     addAccount: {
       title: "Connect DxFeed Account",
       description:
-        "Sign in with the same email and password you use on your prop firm's DxFeed platform. We detect the firm from that login.",
-      emailLabel: "Email",
-      emailPlaceholder: "Email from your prop firm login",
+        "Sign in with the same username and password you use on your prop firm's DxFeed platform. We detect the firm from that login.",
+      usernameLabel: "Username",
+      usernamePlaceholder: "Username from your prop firm login",
       passwordLabel: "Password",
       passwordPlaceholder: "Password from your prop firm login",
       connecting: "Connecting...",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2461,9 +2461,8 @@ export default {
     connected: "Compte DxFeed connecté avec succès",
     disconnected: "Compte DxFeed déconnecté",
     error: {
-      credentialsRequired: "Saisissez votre e-mail et votre mot de passe",
-      emailRequired: "Saisissez votre e-mail",
-      emailInvalid: "Saisissez un e-mail valide",
+      credentialsRequired: "Saisissez votre nom d'utilisateur et votre mot de passe",
+      usernameRequired: "Saisissez votre nom d'utilisateur",
       passwordRequired: "Saisissez votre mot de passe",
       authFailed: "Impossible de se connecter à DxFeed",
     },
@@ -2475,7 +2474,7 @@ export default {
       USER_NOT_AUTHENTICATED:
         "Vous devez être connecté pour lier DxFeed. Connectez-vous puis réessayez.",
       AUTH_HTTP_ERROR:
-        "DxFeed a refusé la connexion (HTTP {status}). Vérifiez l'e-mail et le mot de passe, ou réessayez plus tard. Détail : {detail}",
+        "DxFeed a refusé la connexion (HTTP {status}). Vérifiez le nom d'utilisateur et le mot de passe, ou réessayez plus tard. Détail : {detail}",
       AUTH_REJECTED: "DxFeed a refusé la connexion : {reason}",
       HISTORICAL_HOST_UNRESOLVED:
         "DxFeed n'a pas renvoyé de serveur d'historique des trades pour cette connexion.",
@@ -2505,7 +2504,7 @@ export default {
       hintReconnect:
         "Supprimez cette connexion, cliquez sur Ajouter, et reconnectez-vous avec vos identifiants DxFeed.",
       hintCheckCredentials:
-        "Utilisez le même e-mail et mot de passe que sur la plateforme de trading de votre propfirm (démo ou live selon votre compte).",
+        "Utilisez le même identifiant et mot de passe que sur la plateforme de trading de votre propfirm (démo ou live selon votre compte).",
       SYNC_FETCH_FAILED:
         "Impossible de charger les trades DxFeed ({failures} sur {total} comptes en échec). Reconnectez-vous et réessayez.",
       SYNC_ACCOUNTS_UNAVAILABLE:
@@ -2518,9 +2517,9 @@ export default {
     addAccount: {
       title: "Connecter un compte DxFeed",
       description:
-        "Connectez-vous avec le même e-mail et mot de passe que sur la plateforme DxFeed de votre propfirm. Nous détectons la firme à partir de cette connexion.",
-      emailLabel: "E-mail",
-      emailPlaceholder: "E-mail de connexion à votre propfirm",
+        "Connectez-vous avec le même identifiant et mot de passe que sur la plateforme DxFeed de votre propfirm. Nous détectons la firme à partir de cette connexion.",
+      usernameLabel: "Nom d'utilisateur",
+      usernamePlaceholder: "Identifiant de connexion à votre propfirm",
       passwordLabel: "Mot de passe",
       passwordPlaceholder: "Mot de passe de votre propfirm",
       connecting: "Connexion...",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
DxFeed logins are not always emails. The connect field is now a username: `type=text`, no email-format check, and EN/FR copy says username.

`trader_ht50` submits without “Enter a valid email”. Empty password still shows “Enter your password”.

![DxFeed connect field labeled Username](https://cursor.com/artifacts/c/art-2584a318-9ec5-4848-b0bc-9bd9df318a51)
![Non-email username accepted; password required](https://cursor.com/artifacts/c/art-a02f22fe-fb46-4852-aab6-4010fa898b08)
<a href="https://cursor.com/agents/bc-c31d5ebd-1c71-4d6c-ab10-8e6e882d7052/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdxfeed_username_not_email.mp4"><img src="https://cursor.com/artifacts/c/art-76a42d8c-30da-45c2-8082-3581db46c735" alt="dxfeed_username_not_email.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c31d5ebd-1c71-4d6c-ab10-8e6e882d7052?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c31d5ebd-1c71-4d6c-ab10-8e6e882d7052&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

