### PR TITLE
Remove the 2–4px gap at the top of the dashboard navbar

### DIFF
--- a/app/[locale]/dashboard/components/dashboard-home-chrome.tsx
+++ b/app/[locale]/dashboard/components/dashboard-home-chrome.tsx
@@ -130,7 +130,7 @@ export function DashboardHomeChrome({ children }: { children: ReactNode }) {
       ref={mainRef}
       id="dashboard-content"
       tabIndex={-1}
-      className="min-h-[calc(100dvh-var(--navbar-height,4rem))] overflow-x-hidden bg-[#FAFAFA] dark:bg-background"
+      className="min-h-[calc(100dvh-var(--navbar-height,3.5rem))] overflow-x-hidden bg-[#FAFAFA] dark:bg-background"
     >
       <a
         href="#dashboard-content"
@@ -147,7 +147,7 @@ export function DashboardHomeChrome({ children }: { children: ReactNode }) {
       >
         <div
           ref={connectionsStripRef}
-          className="fixed inset-x-0 top-(--navbar-height,4rem) z-30 w-full border-b border-[#E5E5E5] bg-white dark:border-border dark:bg-background"
+          className="fixed inset-x-0 top-(--navbar-height,3.5rem) z-30 w-full border-b border-[#E5E5E5] bg-white dark:border-border dark:bg-background"
         >
           <ConnectionsStrip className="bg-white dark:bg-background" />
         </div>

--- a/app/[locale]/dashboard/layout.tsx
+++ b/app/[locale]/dashboard/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({
         <DashboardPostHogIdentity params={params} />
       </Suspense>
       <TooltipProvider>
-        <ThemeProvider>
+        <ThemeProvider safariThemeSampler={false}>
           <DataProvider>
             <RithmicSyncContextProvider>
               <RithmicProtocolSyncContextProvider>

--- a/app/globals.css
+++ b/app/globals.css
@@ -250,9 +250,9 @@
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
     --radius: 0.5rem;
-    /* Dashboard sticky nav is h-16 (4rem) + optional iOS safe-area inset.
+    /* Dashboard sticky nav is h-14 (3.5rem) + optional iOS safe-area inset.
        Fixed tab chrome uses this before JS measures the real nav height. */
-    --navbar-height: calc(4rem + env(safe-area-inset-top, 0px));
+    --navbar-height: calc(3.5rem + env(safe-area-inset-top, 0px));
     --tabs-height: 3rem;
     --sidebar-background: 0 0% var(--theme-intensity, 98%);
     --sidebar-foreground: 240 5.3% 26.1%;

--- a/context/theme-provider.tsx
+++ b/context/theme-provider.tsx
@@ -24,7 +24,14 @@ const ThemeContext = createContext<ThemeContextType>({
 
 export const useTheme = () => useContext(ThemeContext)
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
+export function ThemeProvider({
+  children,
+  safariThemeSampler = true,
+}: {
+  children: React.ReactNode
+  /** Landing-only: 8px canvas strip for Safari chrome. Off on app shells with a white navbar. */
+  safariThemeSampler?: boolean
+}) {
   const [theme, setThemeState] = useState<Theme>('system')
   const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>('light')
   const [intensity, setIntensityState] = useState<number>(100)
@@ -115,12 +122,16 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         Safari samples a fixed top-edge element for browser-chrome tinting.
         Remount on theme change so the status-bar region stays in sync and
         does not leave a light strip after toggling light/dark.
+        Keep this off on dashboard / app shells: the strip is canvas gray
+        and reads as a 2–8px gap on the white navbar.
       */}
-      <span
-        key={`safari-theme-top-${effectiveTheme}`}
-        className="safari-theme-sampler"
-        aria-hidden="true"
-      />
+      {safariThemeSampler ? (
+        <span
+          key={`safari-theme-top-${effectiveTheme}`}
+          className="safari-theme-sampler"
+          aria-hidden="true"
+        />
+      ) : null}
       {children}
     </ThemeContext.Provider>
   )

--- a/lib/canvas-theme-color.test.ts
+++ b/lib/canvas-theme-color.test.ts
@@ -28,6 +28,24 @@ describe("static Safari chrome", () => {
     expect(provider).not.toContain("colorScheme");
   });
 
+  it("does not paint the landing canvas sampler over the dashboard navbar", () => {
+    const layout = readFileSync("app/[locale]/dashboard/layout.tsx", "utf8");
+    const css = readFileSync("app/globals.css", "utf8");
+    const navbar = readFileSync(
+      "app/[locale]/dashboard/components/navbar.tsx",
+      "utf8",
+    );
+
+    expect(layout).toContain("safariThemeSampler={false}");
+    expect(navbar).toContain("h-14");
+    expect(css).toContain(
+      "--navbar-height: calc(3.5rem + env(safe-area-inset-top, 0px))",
+    );
+    expect(css).not.toContain(
+      "--navbar-height: calc(4rem + env(safe-area-inset-top, 0px))",
+    );
+  });
+
   it("paints the marketing header with the landing canvas, not bg-background", () => {
     const source = readFileSync(
       "app/[locale]/(landing)/components/navbar.tsx",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The dashboard navbar sat a few pixels below the top of the viewport, so a sliver of canvas gray showed above the white bar.

Two leftovers from the v6 chrome shrink (`h-16` → `h-14`) caused it:

1. **Safari theme sampler** — `ThemeProvider` always paints an 8px `oklch(0.97)` strip at `top: 0` / `z-60` for landing iOS chrome. On the dashboard that strip sits on the white navbar and reads as a hairline gap.
2. **`--navbar-height` still `4rem`** — fixed connections-strip chrome used the old `h-16` fallback (`64px`) against the current `h-14` bar (`56px` + 1px border), which can leave a gray strip between the navbar and the strip before JS measures.

## Change

- Disable the Safari canvas sampler on the dashboard `ThemeProvider`.
- Set `--navbar-height` to `3.5rem` (+ safe-area) so first paint matches `h-14`.
- Align the connections-strip `top` fallback to `3.5rem`.

Landing and other shells keep the sampler.

## Test plan

- [x] `bunx vitest run lib/canvas-theme-color.test.ts`
- [x] Dashboard `/dashboard`: navbar flush with the viewport; no gray sliver above the bar
- [x] Connections strip sits flush under the navbar
- [ ] Landing header unchanged (sampler still present)

![Dashboard navbar flush with the top of the viewport](https://cursor.com/artifacts/c/art-342edb0f-23a3-47b8-a04d-2495661a35a3)
<a href="https://cursor.com/agents/bc-edef0814-be47-45d1-9acf-f74b104d76c1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_navbar_top_flush_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-7e782e66-3434-42d7-bfaf-9d72fb3226b7" alt="dashboard_navbar_top_flush_walkthrough.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edef0814-be47-45d1-9acf-f74b104d76c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edef0814-be47-45d1-9acf-f74b104d76c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

