### PR TITLE
fix(ads): map English trading-journal URLs to /en

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -42,10 +42,25 @@ const nextConfig: NextConfig = {
     "localhost",
     "127.0.0.1",
   ],
-  // NOTE: Do not add hardcoded /en redirects for localized routes (e.g. /updates
-  // -> /en/updates). next.config redirects run before middleware, so they force a
-  // single locale and prevent the i18n middleware from routing by the user's
-  // selected language. Locale routing is handled entirely by the i18n middleware.
+  // Do not add hardcoded /en redirects for locale-less routes (e.g. /updates
+  // -> /en/updates). next.config redirects run before proxy, so they force a
+  // single locale and prevent the i18n middleware from routing by language.
+  // English-only aliases that already include /en (paid-search display paths)
+  // may redirect to /en — they do not steal locale-less marketing URLs.
+  async redirects() {
+    return [
+      {
+        source: "/en/trading-journal",
+        destination: "/en",
+        permanent: true,
+      },
+      {
+        source: "/en/trading-journal/futures",
+        destination: "/en",
+        permanent: true,
+      },
+    ];
+  },
   // Instant Navigations: Cache Components + Partial Prefetching (Next.js 16.3+).
   // Opt routes in with `export const instant = true` (and optionally
   // `export const prefetch = 'allow-runtime'` for session-aware prefetch).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Paid Search RSA display paths use “trading journal” / “futures”, but `/en/trading-journal` and `/en/trading-journal/futures` were unmatched `[locale]` routes. They returned HTTP 200 with the custom “Oops! Page not found” body (soft-404).

## Change

Permanent `308` redirects in `next.config.ts`:

- `/en/trading-journal` → `/en`
- `/en/trading-journal/futures` → `/en`

These sources already include the `/en` prefix, so they do not steal locale-less marketing URLs from the i18n proxy (the existing “do not hardcode `/updates` → `/en/updates`” rule).

English only. No hero copy change, no dashboard/app routes, no new product page.

## Local checks

Dev server after `next.config.ts` reload:

- `HEAD /en/trading-journal` → `308` `location: /en`
- `HEAD /en/trading-journal/futures` → `308` `location: /en`
- Follow both → `200` at `/en`, hero “One trading journal for every futures account.”, no Oops 404
- `GET /en` still `200` with the same hero
- Unmatched `/en/this-path-should-404` still `next-error: not-found`
- `/dashboard` still `307` → `/en/dashboard` with `x-auth-status: authenticated`, `x-user-id: local-dashboard-user`
- `/authentication?next=dashboard` still `307` → `/dashboard`

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2041d799-c072-443f-95fa-0978e6d99235?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2041d799-c072-443f-95fa-0978e6d99235&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

