### PR TITLE
fix(analytics): fire user_signed_up once on public User create

### DIFF
--- a/lib/signup-analytics.test.ts
+++ b/lib/signup-analytics.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  USER_SIGNED_UP_EVENT,
+  buildUserSignedUpCapture,
+  userSignedUpInsertId,
+} from "./signup-analytics";
+
+describe("buildUserSignedUpCapture", () => {
+  it("keeps the existing event name and skips the consent cookie gate", () => {
+    const capture = buildUserSignedUpCapture({
+      distinctId: "auth-user-1",
+      properties: { method: "google", language: "en" },
+    });
+
+    expect(capture.event).toBe(USER_SIGNED_UP_EVENT);
+    expect(capture.event).toBe("user_signed_up");
+    expect(capture.consentGranted).toBe(true);
+    expect(capture.distinctId).toBe("auth-user-1");
+    expect(capture.properties.method).toBe("google");
+    expect(capture.properties.language).toBe("en");
+  });
+
+  it("pins $insert_id to the auth user so a retry cannot double-count", () => {
+    const first = buildUserSignedUpCapture({ distinctId: "auth-user-1" });
+    const retry = buildUserSignedUpCapture({
+      distinctId: "auth-user-1",
+      properties: { method: "email" },
+    });
+
+    expect(first.properties.$insert_id).toBe("user_signed_up:auth-user-1");
+    expect(retry.properties.$insert_id).toBe(userSignedUpInsertId("auth-user-1"));
+    expect(retry.properties.$insert_id).toBe(first.properties.$insert_id);
+  });
+
+  it("does not let caller properties override $insert_id", () => {
+    const capture = buildUserSignedUpCapture({
+      distinctId: "auth-user-1",
+      properties: { $insert_id: "forged" },
+    });
+
+    expect(capture.properties.$insert_id).toBe("user_signed_up:auth-user-1");
+  });
+});
+
+describe("ensureUserInDatabase signup capture hook", () => {
+  const source = readFileSync(new URL("../server/auth.ts", import.meta.url), "utf8");
+
+  it("fires user_signed_up only after the public User row is created", () => {
+    const createIdx = source.indexOf("prisma.user.create");
+    const captureIdx = source.indexOf("buildUserSignedUpCapture");
+    const existingReturnIdx = source.indexOf(
+      "return { user: existingUserByAuthId, isNewUser: false }",
+    );
+
+    expect(createIdx).toBeGreaterThan(-1);
+    expect(captureIdx).toBeGreaterThan(createIdx);
+    expect(existingReturnIdx).toBeGreaterThan(-1);
+    expect(existingReturnIdx).toBeLessThan(captureIdx);
+  });
+});

--- a/lib/signup-analytics.test.ts
+++ b/lib/signup-analytics.test.ts
@@ -49,8 +49,10 @@ describe("ensureUserInDatabase signup capture hook", () => {
   const source = readFileSync(new URL("../server/auth.ts", import.meta.url), "utf8");
 
   it("fires user_signed_up only after the public User row is created", () => {
-    const createIdx = source.indexOf("prisma.user.create");
-    const captureIdx = source.indexOf("buildUserSignedUpCapture");
+    const createIdx = source.indexOf("const newUser = await prisma.user.create");
+    const captureIdx = source.indexOf(
+      "await capturePostHogEvent(buildUserSignedUpCapture",
+    );
     const existingReturnIdx = source.indexOf(
       "return { user: existingUserByAuthId, isNewUser: false }",
     );

--- a/lib/signup-analytics.ts
+++ b/lib/signup-analytics.ts
@@ -40,9 +40,14 @@ export function buildUserSignedUpCapture({
 }: {
   distinctId: string;
   properties?: UserSignedUpProperties;
-}) {
+}): {
+  consentGranted: true;
+  distinctId: string;
+  event: typeof USER_SIGNED_UP_EVENT;
+  properties: UserSignedUpProperties;
+} {
   return {
-    consentGranted: true as const,
+    consentGranted: true,
     distinctId,
     event: USER_SIGNED_UP_EVENT,
     properties: {

--- a/lib/signup-analytics.ts
+++ b/lib/signup-analytics.ts
@@ -1,0 +1,53 @@
+/**
+ * First-party account-creation analytics.
+ *
+ * `user_signed_up` is captured server-side when `ensureUserInDatabase`
+ * creates the public `User` row — every first-account path (password,
+ * magic link, OAuth) goes through that helper.
+ *
+ * Consent is granted here on purpose. The analytics cookie is almost
+ * never present yet on the OAuth / magic-link callback (the banner is
+ * answered after the user lands on the dashboard), so gating on it
+ * dropped most real signups while `$identify` still fired later.
+ * Same first-party exception as `feedback_submitted`.
+ */
+
+export const USER_SIGNED_UP_EVENT = "user_signed_up";
+
+type SignupPropertyValue =
+  | boolean
+  | number
+  | string
+  | null
+  | undefined
+  | Record<string, boolean | number | string | null | undefined>;
+
+export type UserSignedUpProperties = Record<string, SignupPropertyValue>;
+
+export function userSignedUpInsertId(distinctId: string): string {
+  return `${USER_SIGNED_UP_EVENT}:${distinctId}`;
+}
+
+/**
+ * Arguments for `capturePostHogEvent`. `$insert_id` is always derived
+ * from the auth user id so a retry of the create path cannot double-count
+ * in PostHog. Callers must still only invoke this after a successful
+ * `prisma.user.create` — existing rows must not emit the event.
+ */
+export function buildUserSignedUpCapture({
+  distinctId,
+  properties = {},
+}: {
+  distinctId: string;
+  properties?: UserSignedUpProperties;
+}) {
+  return {
+    consentGranted: true as const,
+    distinctId,
+    event: USER_SIGNED_UP_EVENT,
+    properties: {
+      ...properties,
+      $insert_id: userSignedUpInsertId(distinctId),
+    },
+  };
+}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -14,6 +14,7 @@ import {
 import { createLocalDashboardBypassAuthStub } from '@/lib/local-dashboard-bypass-client'
 import { ensureLocalDashboardUserInDatabase } from '@/server/local-dashboard-bootstrap'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import { buildUserSignedUpCapture } from '@/lib/signup-analytics'
 import {
   attributionToPersonSetOnce,
   attributionToPostHogProperties,
@@ -428,6 +429,8 @@ export async function setPasswordAction(newPassword: string) {
  * Side effects:
  * - May sign the user out on integrity or identification errors.
  * - May create a default dashboard layout for new users.
+ * - On create only, captures a single PostHog `user_signed_up` event
+ *   (first-party; later logins that find the existing row do not recapture).
  *
  * Errors:
  * - Throws on missing user or id, account conflicts, Prisma integrity/validation issues, or
@@ -521,9 +524,11 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
       // inflate the email share of the signup-method breakdown.
       const method = authProvider;
 
-      await capturePostHogEvent({
+      // First-party conversion: fire once when the public row is created.
+      // Consent is granted in buildUserSignedUpCapture — the analytics cookie
+      // is almost never set yet on the OAuth / magic-link callback.
+      await capturePostHogEvent(buildUserSignedUpCapture({
         distinctId: user.id,
-        event: 'user_signed_up',
         properties: {
           auth_provider: authProvider,
           method,
@@ -532,7 +537,7 @@ export async function ensureUserInDatabase(user: User, locale?: string) {
           ...attributionProps,
           ...(setOnce ? { $set_once: setOnce } : {}),
         },
-      });
+      }));
       
       // Create default dashboard layout for new user
       try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Ads measurement (Gaby) on prod Supabase `fhvmtnvjiotzztimdxbi` vs PostHog project 50101:

- Last 14 days: 38 confirmed Auth users who signed in, 37 with a public `User` row, only 3 `user_signed_up` (Aug 9, 11, 15).
- Last 7 days: 21 real users, 0 of that event.
- `$identify` still fires, so the JS SDK is alive.

## Investigation

The client-only-path hypothesis is **wrong**. Every recent `user_signed_up` in project 50101 has `$lib = deltalytix-server` (the only observed library value). There is no client capture of this event.

Public `User` rows are created in one production place: `ensureUserInDatabase` in `server/auth.ts` (`prisma.user.create`). Every first-account path already calls it:

- `/api/auth/callback` (Google / Discord OAuth, magic-link)
- `signUpWithPasswordAction` / `signInWithPasswordAction`
- `verifyOtp`

That helper already captured `user_signed_up` via the existing `capturePostHogEvent` helper. The drop is the **consent cookie gate**: `capturePostHogEvent` no-ops unless `deltalytix_analytics_consent=granted`. On first-account OAuth / magic-link, the User row is created on the callback **before** the banner is answered, so the event is discarded. `$identify` then fires later on the dashboard once consent (or localStorage fallback) is available.

The 3 events that did land were Google signups that already had the cookie from a prior visit.

## Fix

Keep the hook: **after a successful `prisma.user.create` inside `ensureUserInDatabase`**.

- Same event name: `user_signed_up`
- Same server helper / env: `capturePostHogEvent` + `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`
- `consentGranted: true` — first-party account-creation conversion, same exception as `feedback_submitted`
- Existing properties unchanged (`method`, `auth_provider`, `language` / `lang`, first-touch attribution, `$set_once`)

## Idempotency

1. **Create-only:** returning users hit `findUnique` by `auth_user_id` and return `{ isNewUser: false }` with no capture. A second login cannot emit another event.
2. **PostHog `$insert_id`:** `user_signed_up:<auth user id>` so a retry of the create path cannot double-count.

No backfill of historical User rows.

## Out of scope

Dashboard UI, billing, and compare pages are unchanged. Local dashboard bootstrap still uses its own upsert and does not emit this event.

## Verification

- `bunx vitest run lib/signup-analytics.test.ts` — 4 passed
- `bun run typecheck` — green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1433e3a7-25ff-47b3-8cb5-95fc05af43dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1433e3a7-25ff-47b3-8cb5-95fc05af43dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

