### PR TITLE
Auto-apply ADS10 to eligible monthly Plus checkouts

### DIFF
--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { NextResponse } from "next/server";
+import type { User } from "@supabase/supabase-js";
 import type Stripe from "stripe";
 import { createClient, getWebsiteURL } from "@/server/auth";
 import { stripe } from "@/server/stripe";
@@ -75,7 +76,7 @@ async function customerHasPriorBillingHistory(customerId: string): Promise<boole
     }
 }
 
-async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: string, referral?: string | null, promo_code?: string | null, signupSuccess = false) {
+async function handleCheckoutSession(lookup_key: string, user: User, websiteURL: string, referral?: string | null, promo_code?: string | null, signupSuccess = false) {
     const subscriptionDetails = await getSubscriptionDetails();
     
     // If referral code is provided, validate it (but don't block checkout if invalid)

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { NextResponse } from "next/server";
+import type Stripe from "stripe";
 import { createClient, getWebsiteURL } from "@/server/auth";
 import { stripe } from "@/server/stripe";
 import { getSubscriptionDetails } from "@/server/subscription";
@@ -16,7 +17,9 @@ import {
 import {
   pendingPurchaseSetCookieHeader,
   readAttributionFromCookies,
+  readUserCountryFromCookies,
 } from "@/lib/attribution-server";
+import { ads10PromotionCodeForCheckout } from "@/lib/ads10-checkout-promotion";
 
 // This endpoint renders no page of ours — it redirects straight to Stripe — so
 // a signup marker arriving here would never reach the Google tag. Forward it to
@@ -45,6 +48,31 @@ function billingIntervalFromPrice(price: {
     }
     if (price.recurring?.interval_count === 3) return 'quarter';
     return price.recurring?.interval || 'month';
+}
+
+async function customerHasPriorBillingHistory(customerId: string): Promise<boolean> {
+    try {
+        const [subscriptions, charges] = await Promise.all([
+            stripe.subscriptions.list({
+                customer: customerId,
+                status: 'all',
+                limit: 1,
+            }),
+            stripe.charges.list({
+                customer: customerId,
+                limit: 100,
+            }),
+        ]);
+
+        return (
+            subscriptions.data.length > 0 ||
+            charges.data.some((charge) => charge.paid) ||
+            charges.has_more
+        );
+    } catch (error) {
+        console.error('[checkout] Unable to verify prior Stripe billing history:', error);
+        return true;
+    }
 }
 
 async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: string, referral?: string | null, promo_code?: string | null, signupSuccess = false) {
@@ -78,31 +106,28 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
     // First, try to find existing customer
     const existingCustomers = await stripe.customers.list({
         email: user.email,
-        limit: 1,
+        limit: 100,
     });
 
     let customerId: string;
-    let isFirstOrder = false;
+    let hasPriorBillingHistory =
+        Boolean(subscriptionDetails) ||
+        existingCustomers.has_more ||
+        existingCustomers.data.length > 1;
 
     if (existingCustomers.data.length > 0) {
         // Use existing customer
         customerId = existingCustomers.data[0].id;
-        
-        // Check if customer has any previous subscriptions
-        const subscriptions = await stripe.subscriptions.list({
-            customer: customerId,
-            status: 'all', // Include all subscription statuses
-            limit: 1
-        });
-        
-        isFirstOrder = subscriptions.data.length === 0;
+
+        if (!hasPriorBillingHistory) {
+            hasPriorBillingHistory = await customerHasPriorBillingHistory(customerId);
+        }
     } else {
         // Create new customer if none exists
         const newCustomer = await stripe.customers.create({
             email: user.email,
         });
         customerId = newCustomer.id;
-        isFirstOrder = true;
     }
 
     const prices = await stripe.prices.list({
@@ -143,8 +168,16 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
     // Create session with appropriate mode based on price type
     const analyticsConsent = await hasAnalyticsConsent();
     const attribution = await readAttributionFromCookies();
+    const country = await readUserCountryFromCookies();
     const attributionMeta = attributionToStripeMetadata(attribution);
-    const sessionConfig: any = {
+    const ads10PromotionCode = ads10PromotionCodeForCheckout({
+        lookupKey: lookup_key,
+        price,
+        country,
+        gclid: attribution?.gclid,
+        hasPriorBillingHistory,
+    });
+    const sessionConfig: Stripe.Checkout.SessionCreateParams = {
         customer: customerId,
         metadata: {
             plan: lookup_key,
@@ -171,7 +204,9 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
         // Abandoning checkout does not undo the registration, so the marker
         // rides the cancel path too.
         cancel_url: buildReturnUrl(websiteURL, 'pricing', { canceled: 'true' }, signupSuccess),
-        allow_promotion_codes: true,
+        ...(ads10PromotionCode
+            ? { discounts: [{ promotion_code: ads10PromotionCode }] }
+            : { allow_promotion_codes: true }),
     };
 
     if (isLifetimePlan) {

--- a/lib/ads10-checkout-promotion.test.ts
+++ b/lib/ads10-checkout-promotion.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADS10_PROMOTION_CODE_ID,
+  ads10PromotionCodeForCheckout,
+} from "./ads10-checkout-promotion";
+
+const monthlyUsdPlus = {
+  lookupKey: "plus_monthly_usd",
+  price: {
+    currency: "usd",
+    type: "recurring",
+    recurring: { interval: "month", interval_count: 1 },
+  },
+  hasPriorBillingHistory: false,
+};
+
+describe("ADS10 Checkout promotion", () => {
+  it("applies to a first-time US monthly USD Plus checkout", () => {
+    expect(
+      ads10PromotionCodeForCheckout({
+        ...monthlyUsdPlus,
+        country: "us",
+      }),
+    ).toBe(ADS10_PROMOTION_CODE_ID);
+  });
+
+  it("applies to a first-time monthly USD Plus checkout with a gclid", () => {
+    expect(
+      ads10PromotionCodeForCheckout({
+        ...monthlyUsdPlus,
+        country: "CA",
+        gclid: "google-click-id",
+      }),
+    ).toBe(ADS10_PROMOTION_CODE_ID);
+  });
+
+  it("does not apply without US country or a gclid", () => {
+    expect(
+      ads10PromotionCodeForCheckout({
+        ...monthlyUsdPlus,
+        country: "CA",
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["plus_quarterly_usd", "usd", "recurring", "month", 3],
+    ["plus_yearly_usd", "usd", "recurring", "year", 1],
+    ["plus_lifetime_usd", "usd", "one_time", null, null],
+    ["plus_monthly_eur", "eur", "recurring", "month", 1],
+  ])(
+    "does not apply to non-monthly-USD lookup key %s",
+    (lookupKey, currency, type, interval, intervalCount) => {
+      expect(
+        ads10PromotionCodeForCheckout({
+          lookupKey,
+          price: {
+            currency,
+            type,
+            recurring:
+              interval && intervalCount
+                ? { interval, interval_count: intervalCount }
+                : null,
+          },
+          country: "US",
+          gclid: "google-click-id",
+          hasPriorBillingHistory: false,
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it("does not apply when the Stripe price contradicts the monthly lookup key", () => {
+    expect(
+      ads10PromotionCodeForCheckout({
+        ...monthlyUsdPlus,
+        price: {
+          currency: "usd",
+          type: "recurring",
+          recurring: { interval: "month", interval_count: 3 },
+        },
+        country: "US",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not apply to any customer with prior billing history", () => {
+    expect(
+      ads10PromotionCodeForCheckout({
+        ...monthlyUsdPlus,
+        country: "US",
+        gclid: "google-click-id",
+        hasPriorBillingHistory: true,
+      }),
+    ).toBeNull();
+  });
+});

--- a/lib/ads10-checkout-promotion.ts
+++ b/lib/ads10-checkout-promotion.ts
@@ -1,4 +1,4 @@
-import { billingLookupKey } from "@/lib/billing-plan-catalog";
+import { billingLookupKey } from "./billing-plan-catalog";
 
 // Verified live Stripe promotion code for coupon DLX_ADS10_USD_20260822.
 export const ADS10_PROMOTION_CODE_ID = "promo_1U7JkyCgu8zCkThC3eVlGJni";

--- a/lib/ads10-checkout-promotion.ts
+++ b/lib/ads10-checkout-promotion.ts
@@ -1,0 +1,43 @@
+import { billingLookupKey } from "@/lib/billing-plan-catalog";
+
+// Verified live Stripe promotion code for coupon DLX_ADS10_USD_20260822.
+export const ADS10_PROMOTION_CODE_ID = "promo_1U7JkyCgu8zCkThC3eVlGJni";
+
+type Ads10CheckoutEligibility = {
+  lookupKey: string;
+  price: {
+    currency?: string | null;
+    type?: string | null;
+    recurring?: {
+      interval?: string | null;
+      interval_count?: number | null;
+    } | null;
+  };
+  country?: string | null;
+  gclid?: string | null;
+  hasPriorBillingHistory: boolean;
+};
+
+export function ads10PromotionCodeForCheckout({
+  lookupKey,
+  price,
+  country,
+  gclid,
+  hasPriorBillingHistory,
+}: Ads10CheckoutEligibility): string | null {
+  if (hasPriorBillingHistory) return null;
+
+  const isMonthlyUsdPlus =
+    lookupKey === billingLookupKey("monthly", "USD") &&
+    price.currency?.toLowerCase() === "usd" &&
+    price.type === "recurring" &&
+    price.recurring?.interval === "month" &&
+    (price.recurring.interval_count ?? 1) === 1;
+
+  if (!isMonthlyUsdPlus) return null;
+
+  const isUsShopper = country?.trim().toUpperCase() === "US";
+  const hasGoogleClickId = Boolean(gclid?.trim());
+
+  return isUsShopper || hasGoogleClickId ? ADS10_PROMOTION_CODE_ID : null;
+}

--- a/lib/attribution-server.ts
+++ b/lib/attribution-server.ts
@@ -43,6 +43,15 @@ export async function readAttributionFromCookies(): Promise<Attribution | null> 
   }
 }
 
+export async function readUserCountryFromCookies(): Promise<string | null> {
+  try {
+    const country = (await cookies()).get("user-country")?.value.trim();
+    return country ? country.toUpperCase() : null;
+  } catch {
+    return null;
+  }
+}
+
 export function pendingPurchaseSetCookieHeader(purchase: PendingPurchase): string {
   const value = encodeURIComponent(serializePendingPurchase(purchase));
   return `${PENDING_PURCHASE_COOKIE}=${value}; Max-Age=${PENDING_PURCHASE_MAX_AGE_SECONDS}; Path=/; SameSite=Lax${cookieSecureSuffix()}${cookieDomainSuffix()}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- auto-apply the verified live Stripe promotion `ADS10` (`promo_1U7JkyCgu8zCkThC3eVlGJni`, coupon `DLX_ADS10_USD_20260822`) when creating an eligible Checkout Session
- reuse the existing `user-country` cookie, first-touch `gclid`, Plus billing catalog lookup key, and Stripe price details
- fail closed when prior billing history is present or cannot be established

## Eligibility and exclusions
The Checkout Session hook adds `discounts: [{ promotion_code }]` only for first-time monthly USD Plus checkouts where the shopper is in the US or has a stored `gclid`. The route checks local subscription history plus Stripe subscription and paid-charge history before attaching the promotion.

Existing/previous Plus customers are excluded by local or Stripe billing history. Lifetime, quarterly, yearly, EUR, and mismatched Stripe prices are excluded by exact catalog lookup key and price interval/currency checks. Existing active subscribers continue to be redirected before Checkout creation. Ineligible sessions retain manual promotion-code entry; eligible sessions omit `allow_promotion_codes` because Stripe does not permit it together with a pre-applied discount.

The live catalog was verified read-only: `plus_monthly_usd` is an active recurring monthly Plus price at 1,999 cents, and ADS10 is an active one-time USD 1,000-cent discount restricted to first transactions, yielding a 999-cent first Checkout total.

## Testing
- [x] `bunx vitest run lib/ads10-checkout-promotion.test.ts` (9 tests)
- [x] `bun run typecheck`
- [x] changed-file ESLint
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2234baa2-d5f0-42ea-a4f8-6d1ba2d1ffe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2234baa2-d5f0-42ea-a4f8-6d1ba2d1ffe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

