### PR TITLE
Add Tailscale to the Cloud Agent environment install

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,7 @@
 {
   "name": "Deltalytix",
-  "install": "curl -fsSL https://bun.sh/install | bash && export PATH=\"$HOME/.bun/bin:$PATH\" && bun install && bunx prisma generate && sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2 ffmpeg postgresql postgresql-client",
-  "start": "bash scripts/docker-bootstrap.sh",
+  "install": "curl -fsSL https://bun.sh/install | bash\nexport PATH=\"$HOME/.bun/bin:$PATH\"\nbun install\nbunx prisma generate\nsudo apt-get update\nsudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2 ffmpeg postgresql postgresql-client\ncurl -fsSL https://tailscale.com/install.sh | sh",
+  "start": "bash scripts/docker-bootstrap.sh\nif command -v tailscaled >/dev/null 2>&1 && ! pgrep -x tailscaled >/dev/null 2>&1; then\n  sudo mkdir -p /var/run/tailscale /var/lib/tailscale\n  sudo tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock --port=41641 >/tmp/tailscaled.log 2>&1 &\n  for _ in $(seq 1 20); do\n    if [ -S /var/run/tailscale/tailscaled.sock ]; then break; fi\n    sleep 0.5\n  done\nfi",
   "ports": [
     {
       "name": "next",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,7 @@
 {
   "name": "Deltalytix",
   "install": "curl -fsSL https://bun.sh/install | bash\nexport PATH=\"$HOME/.bun/bin:$PATH\"\nbun install\nbunx prisma generate\nsudo apt-get update\nsudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2 ffmpeg postgresql postgresql-client\ncurl -fsSL https://tailscale.com/install.sh | sh",
-  "start": "bash scripts/docker-bootstrap.sh || sudo docker info >/dev/null 2>&1\nif command -v tailscaled >/dev/null 2>&1; then\n  if ! pgrep -x tailscaled >/dev/null 2>&1; then\n    sudo mkdir -p /var/run/tailscale /var/lib/tailscale\n    sudo tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock --port=41641 >/tmp/tailscaled.log 2>&1 &\n    for _ in $(seq 1 20); do\n      if [ -S /var/run/tailscale/tailscaled.sock ]; then break; fi\n      sleep 0.5\n    done\n  fi\n  if [ -n \"${TS_AUTHKEY:-}\" ]; then\n    sudo tailscale up --auth-key=\"$TS_AUTHKEY\" --hostname=\"deltalytix-${HOSTNAME}\" --accept-dns=false --operator=ubuntu --timeout=30s\n  fi\nfi",
+  "start": "bash scripts/docker-bootstrap.sh\nbash scripts/tailscale-bootstrap.sh",
   "ports": [
     {
       "name": "next",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,7 @@
 {
   "name": "Deltalytix",
   "install": "curl -fsSL https://bun.sh/install | bash\nexport PATH=\"$HOME/.bun/bin:$PATH\"\nbun install\nbunx prisma generate\nsudo apt-get update\nsudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2 ffmpeg postgresql postgresql-client\ncurl -fsSL https://tailscale.com/install.sh | sh",
-  "start": "bash scripts/docker-bootstrap.sh || sudo docker info >/dev/null 2>&1\nif command -v tailscaled >/dev/null 2>&1 && ! pgrep -x tailscaled >/dev/null 2>&1; then\n  sudo mkdir -p /var/run/tailscale /var/lib/tailscale\n  sudo tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock --port=41641 >/tmp/tailscaled.log 2>&1 &\n  for _ in $(seq 1 20); do\n    if [ -S /var/run/tailscale/tailscaled.sock ]; then break; fi\n    sleep 0.5\n  done\nfi",
+  "start": "bash scripts/docker-bootstrap.sh || sudo docker info >/dev/null 2>&1\nif command -v tailscaled >/dev/null 2>&1; then\n  if ! pgrep -x tailscaled >/dev/null 2>&1; then\n    sudo mkdir -p /var/run/tailscale /var/lib/tailscale\n    sudo tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock --port=41641 >/tmp/tailscaled.log 2>&1 &\n    for _ in $(seq 1 20); do\n      if [ -S /var/run/tailscale/tailscaled.sock ]; then break; fi\n      sleep 0.5\n    done\n  fi\n  if [ -n \"${TS_AUTHKEY:-}\" ]; then\n    sudo tailscale up --auth-key=\"$TS_AUTHKEY\" --hostname=\"deltalytix-${HOSTNAME}\" --accept-dns=false --operator=ubuntu --timeout=30s\n  fi\nfi",
   "ports": [
     {
       "name": "next",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,7 @@
 {
   "name": "Deltalytix",
   "install": "curl -fsSL https://bun.sh/install | bash\nexport PATH=\"$HOME/.bun/bin:$PATH\"\nbun install\nbunx prisma generate\nsudo apt-get update\nsudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2 ffmpeg postgresql postgresql-client\ncurl -fsSL https://tailscale.com/install.sh | sh",
-  "start": "bash scripts/docker-bootstrap.sh\nif command -v tailscaled >/dev/null 2>&1 && ! pgrep -x tailscaled >/dev/null 2>&1; then\n  sudo mkdir -p /var/run/tailscale /var/lib/tailscale\n  sudo tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock --port=41641 >/tmp/tailscaled.log 2>&1 &\n  for _ in $(seq 1 20); do\n    if [ -S /var/run/tailscale/tailscaled.sock ]; then break; fi\n    sleep 0.5\n  done\nfi",
+  "start": "bash scripts/docker-bootstrap.sh || sudo docker info >/dev/null 2>&1\nif command -v tailscaled >/dev/null 2>&1 && ! pgrep -x tailscaled >/dev/null 2>&1; then\n  sudo mkdir -p /var/run/tailscale /var/lib/tailscale\n  sudo tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock --port=41641 >/tmp/tailscaled.log 2>&1 &\n  for _ in $(seq 1 20); do\n    if [ -S /var/run/tailscale/tailscaled.sock ]; then break; fi\n    sleep 0.5\n  done\nfi",
   "ports": [
     {
       "name": "next",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,7 @@ Open PRs against **`beta`** (not `main`). `main` is production; feature work lan
 - **Docker-in-Docker**: Cloud Agent VMs require `fuse-overlayfs` storage driver and `iptables-legacy` for Docker to work. Run `bash scripts/docker-bootstrap.sh` first; if it fails with overlay errors, install `fuse-overlayfs` (`sudo apt-get install -y fuse-overlayfs`) and set `/etc/docker/daemon.json` to `{"storage-driver": "fuse-overlayfs"}` before starting `dockerd`.
 - **Full local setup**: Run `bash scripts/self-host-quickstart.sh` then `bash scripts/dev.sh`. This handles Docker Postgres, `.env.local`, Bun install, Prisma, seeding, and dev server startup.
 - **Auth**: Uses `LOCAL_DASHBOARD_AUTH_BYPASS=true` — no external Supabase keys needed. The dashboard is accessible at `http://localhost:3000/dashboard` as `local-dashboard-user`.
+- **Tailscale**: Cloud Agent `install` runs `curl -fsSL https://tailscale.com/install.sh | sh`. These VMs have no systemd, so `start` launches `tailscaled` if it is not already running. Join a tailnet with `sudo tailscale up`.
 - **PRs target `beta`**, not `main`.
 
 <!-- BEGIN:nextjs-agent-rules -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Open PRs against **`beta`** (not `main`). `main` is production; feature work lan
 - **Docker-in-Docker**: Cloud Agent VMs require `fuse-overlayfs` storage driver and `iptables-legacy` for Docker to work. Run `bash scripts/docker-bootstrap.sh` first; if it fails with overlay errors, install `fuse-overlayfs` (`sudo apt-get install -y fuse-overlayfs`) and set `/etc/docker/daemon.json` to `{"storage-driver": "fuse-overlayfs"}` before starting `dockerd`.
 - **Full local setup**: Run `bash scripts/self-host-quickstart.sh` then `bash scripts/dev.sh`. This handles Docker Postgres, `.env.local`, Bun install, Prisma, seeding, and dev server startup.
 - **Auth**: Uses `LOCAL_DASHBOARD_AUTH_BYPASS=true` — no external Supabase keys needed. The dashboard is accessible at `http://localhost:3000/dashboard` as `local-dashboard-user`.
-- **Tailscale**: Cloud Agent `install` runs `curl -fsSL https://tailscale.com/install.sh | sh`. These VMs have no systemd, so `start` launches `tailscaled` and, when `TS_AUTHKEY` is set, runs `sudo tailscale up --auth-key="$TS_AUTHKEY"`.
+- **Tailscale**: Cloud Agent `install` runs `curl -fsSL https://tailscale.com/install.sh | sh`. These VMs have no systemd, so `start` runs `bash scripts/tailscale-bootstrap.sh`, which launches `tailscaled` and, when `TS_AUTHKEY` is set, runs `sudo tailscale up`. When `/dev/net/tun` is absent the script falls back to `--tun=userspace-networking` so joining the tailnet still works.
 - **PRs target `beta`**, not `main`.
 
 <!-- BEGIN:nextjs-agent-rules -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Open PRs against **`beta`** (not `main`). `main` is production; feature work lan
 - **Docker-in-Docker**: Cloud Agent VMs require `fuse-overlayfs` storage driver and `iptables-legacy` for Docker to work. Run `bash scripts/docker-bootstrap.sh` first; if it fails with overlay errors, install `fuse-overlayfs` (`sudo apt-get install -y fuse-overlayfs`) and set `/etc/docker/daemon.json` to `{"storage-driver": "fuse-overlayfs"}` before starting `dockerd`.
 - **Full local setup**: Run `bash scripts/self-host-quickstart.sh` then `bash scripts/dev.sh`. This handles Docker Postgres, `.env.local`, Bun install, Prisma, seeding, and dev server startup.
 - **Auth**: Uses `LOCAL_DASHBOARD_AUTH_BYPASS=true` — no external Supabase keys needed. The dashboard is accessible at `http://localhost:3000/dashboard` as `local-dashboard-user`.
-- **Tailscale**: Cloud Agent `install` runs `curl -fsSL https://tailscale.com/install.sh | sh`. These VMs have no systemd, so `start` launches `tailscaled` if it is not already running. Join a tailnet with `sudo tailscale up`.
+- **Tailscale**: Cloud Agent `install` runs `curl -fsSL https://tailscale.com/install.sh | sh`. These VMs have no systemd, so `start` launches `tailscaled` and, when `TS_AUTHKEY` is set, runs `sudo tailscale up --auth-key="$TS_AUTHKEY"`.
 - **PRs target `beta`**, not `main`.
 
 <!-- BEGIN:nextjs-agent-rules -->

--- a/scripts/docker-bootstrap.sh
+++ b/scripts/docker-bootstrap.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if docker info >/dev/null 2>&1; then
+docker_ready() {
+  docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1
+}
+
+if docker_ready; then
   echo "[docker-bootstrap] Docker daemon already running"
   exit 0
 fi
@@ -14,7 +18,7 @@ sudo dockerd \
   >/tmp/dockerd.log 2>&1 &
 
 for _ in $(seq 1 30); do
-  if docker info >/dev/null 2>&1; then
+  if docker_ready; then
     echo "[docker-bootstrap] Docker is ready"
     exit 0
   fi

--- a/scripts/tailscale-bootstrap.sh
+++ b/scripts/tailscale-bootstrap.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bring up Tailscale on Cloud Agent VMs. These VMs have no systemd, so we run
+# tailscaled ourselves and (when TS_AUTHKEY is set) join the tailnet.
+#
+# Cloud Agent hosts do not always expose /dev/net/tun. Kernel TUN mode needs it
+# to create the tailscale0 interface, so we fall back to userspace networking
+# when the device is missing — otherwise `tailscale up` fails to bring up a link.
+
+if ! command -v tailscaled >/dev/null 2>&1; then
+  echo "[tailscale-bootstrap] tailscaled not installed; skipping"
+  exit 0
+fi
+
+SOCKET="/var/run/tailscale/tailscaled.sock"
+
+if ! pgrep -x tailscaled >/dev/null 2>&1; then
+  sudo mkdir -p /var/run/tailscale /var/lib/tailscale
+
+  # Kernel mode uses a real TUN interface (default name tailscale0); the special
+  # value "userspace-networking" needs no /dev/net/tun.
+  tun_arg="tailscale0"
+  if [ ! -c /dev/net/tun ]; then
+    echo "[tailscale-bootstrap] /dev/net/tun missing; using userspace networking"
+    tun_arg="userspace-networking"
+  fi
+
+  # shellcheck disable=SC2024
+  sudo tailscaled \
+    --tun="$tun_arg" \
+    --state=/var/lib/tailscale/tailscaled.state \
+    --socket="$SOCKET" \
+    --port=41641 \
+    >/tmp/tailscaled.log 2>&1 &
+
+  for _ in $(seq 1 20); do
+    [ -S "$SOCKET" ] && break
+    sleep 0.5
+  done
+fi
+
+if [ ! -S "$SOCKET" ]; then
+  echo "[tailscale-bootstrap] tailscaled socket not ready; see /tmp/tailscaled.log"
+  exit 1
+fi
+
+if sudo tailscale status >/dev/null 2>&1; then
+  echo "[tailscale-bootstrap] Already connected to tailnet"
+elif [ -n "${TS_AUTHKEY:-}" ]; then
+  echo "[tailscale-bootstrap] Joining tailnet"
+  sudo tailscale up \
+    --auth-key="$TS_AUTHKEY" \
+    --hostname="deltalytix-${HOSTNAME:-cloud-agent}" \
+    --accept-dns=false \
+    --operator="$(id -un)" \
+    --timeout=30s
+else
+  echo "[tailscale-bootstrap] TS_AUTHKEY not set; tailscaled running, tailnet not joined"
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Install Tailscale in the Cloud Agent environment so new agents have the CLI, then join the tailnet with `TS_AUTHKEY`.

## Changes
- `install` runs the official Tailscale installer (`curl -fsSL https://tailscale.com/install.sh | sh`)
- `start` runs `bash scripts/docker-bootstrap.sh` then `bash scripts/tailscale-bootstrap.sh`
- `scripts/tailscale-bootstrap.sh` (new) launches `tailscaled` (these VMs have no systemd) and, when `TS_AUTHKEY` is set, runs `sudo tailscale up`. It is idempotent (skips `up` when already connected, no duplicate daemon).
- `scripts/docker-bootstrap.sh` treats `sudo docker info` as the daemon already running (fixes the false "Docker failed to start" when the daemon is only reachable via sudo)

## Bugbot fix — userspace networking fallback
Bugbot flagged that `tailscaled` started in kernel TUN mode, which needs `/dev/net/tun` to create the `tailscale0` interface; hosts without that device cannot join the tailnet. `scripts/tailscale-bootstrap.sh` now detects `/dev/net/tun` and falls back to `--tun=userspace-networking` when it is absent, so the join works either way. The Tailscale bring-up was also extracted from the inline `start` block into the script so it is testable and idempotent.

## Validation
Validated end to end on a Cloud Agent VM:
- `TS_AUTHKEY` is present in the environment; a fresh run joined the tailnet (`BackendState=Running`, node `deltalytix-cursor`, IPs `100.120.189.0` / `fd7a:115c:a1e0::f33a:bd01`, DERP Toronto ~11ms)
- Re-running `start` is idempotent (docker "already running", tailscale "Already connected", single daemon each)
- Both TUN modes verified: kernel (`tailscale0`) and `userspace-networking`
- Docker + Postgres + Prisma + seed + `OPENAI_API_KEY=dummy bun run build` + dashboard health checks all pass

## Notes
- `TS_AUTHKEY` is now available as an environment secret (previously listed as a blocker). For multiple/rotating agents, a reusable ephemeral, pre-approved key is recommended so each fresh agent can join.
- Do not commit the key.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82bb563b-216b-4f3d-a783-d227d5a8406c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82bb563b-216b-4f3d-a783-d227d5a8406c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

