### PR TITLE
Auto-apply Back to Work promo on new Plus Checkout sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,10 @@ NEXT_PUBLIC_NINJATRADER_PERFORMANCE_TUTORIAL_VIDEO='your_video_url_here'
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY='your_stripe_publishable_key_here'
 STRIPE_SECRET_KEY='your_stripe_secret_key_here'
 STRIPE_WEBHOOK_SECRET='your_stripe_webhook_secret_here'
+# Optional: auto-apply a Plus Checkout discount per interval. Empty = off.
+STRIPE_BTW_MONTHLY_PROMO=
+STRIPE_BTW_QUARTERLY_PROMO=
+STRIPE_BTW_YEARLY_PROMO=
 
 # Interactive Brokers Flex Web Service
 # No app-level credentials: each user supplies their own Flex token + query ID.

--- a/app/[locale]/(landing)/pricing/page.tsx
+++ b/app/[locale]/(landing)/pricing/page.tsx
@@ -1,9 +1,8 @@
-"use client";
-
-import { useEffect } from "react";
 import PricingPlans from "@/components/pricing-plans";
-import { useI18n } from "@/locales/landing-client";
-import { getReferralCode } from "@/lib/referral-storage";
+import { getCurrentLocale, getI18n } from "@/locales/server";
+import { getBackToWorkPricingDisplay } from "@/server/back-to-work-pricing";
+import { isBackToWorkOfferActive } from "@/lib/back-to-work-promo";
+import { setStaticParamsLocale } from "next-international/server";
 
 /**
  * Also rendered as the pricing section of the landing page. There it is nested
@@ -11,12 +10,29 @@ import { getReferralCode } from "@/lib/referral-storage";
  * to drop to a `<div>` and an `<h2>` and keep the document outline valid — the
  * styling is identical either way.
  */
-export default function PricingPage({ embedded = false }: { embedded?: boolean }) {
-  const t = useI18n();
-  // Store referral code from URL on mount
-  useEffect(() => {
-    getReferralCode();
-  }, []);
+export default async function PricingPage({
+  embedded = false,
+  params,
+}: {
+  embedded?: boolean;
+  params?: Promise<{ locale: string }>;
+}) {
+  if (params) {
+    setStaticParamsLocale((await params).locale);
+  }
+
+  const t = await getI18n();
+  const locale = await getCurrentLocale();
+  const promo = await getBackToWorkPricingDisplay();
+  const offerActive = isBackToWorkOfferActive(promo);
+  const offerUntil =
+    promo.validUntilMs && promo.validUntilMs > Date.now()
+      ? new Intl.DateTimeFormat(locale === "fr" ? "fr-FR" : "en-GB", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+        }).format(new Date(promo.validUntilMs))
+      : null;
 
   const Container = embedded ? "div" : "main";
   const Heading = embedded ? "h2" : "h1";
@@ -30,8 +46,15 @@ export default function PricingPage({ embedded = false }: { embedded?: boolean }
         <p className="mx-auto mt-5 max-w-xl text-pretty text-base leading-relaxed text-black/55 dark:text-white/55 md:text-lg">
           {t("pricing.subheading")}
         </p>
+        {offerActive ? (
+          <p className="mx-auto mt-3 max-w-xl text-pretty text-sm leading-relaxed text-black/55 dark:text-white/55">
+            {offerUntil
+              ? t("pricing.backToWork.sectionNoteUntil", { date: offerUntil })
+              : t("pricing.backToWork.sectionNote")}
+          </p>
+        ) : null}
       </div>
-      <PricingPlans />
+      <PricingPlans promo={promo} />
     </Container>
   );
 }

--- a/app/[locale]/dashboard/billing/components/billing-plan-list.tsx
+++ b/app/[locale]/dashboard/billing/components/billing-plan-list.tsx
@@ -26,6 +26,11 @@ import {
   isLifetimeSubscription,
   type BillingPeriod,
 } from '@/lib/billing-plan-catalog'
+import {
+  backToWorkPeriodDisplay,
+  type BackToWorkPricingDisplay,
+} from '@/lib/back-to-work-promo'
+import { getBackToWorkPricingDisplay } from '@/server/back-to-work-pricing'
 import { changeBillingPlan } from '@/lib/billing-plan-change.client'
 
 function planIsPaid(planName: string | undefined): boolean {
@@ -62,6 +67,7 @@ export function BillingPlanList({
   const [changeLoading, setChangeLoading] = useState(false)
   const [pendingLifetime, setPendingLifetime] = useState(false)
   const [referralCode, setReferralCode] = useState<string | null>(null)
+  const [promo, setPromo] = useState<BackToWorkPricingDisplay | null>(null)
 
   const isLifetime = isLifetimeSubscription(subscription)
   const currentPeriod: BillingPeriod | null = !subscription
@@ -125,6 +131,11 @@ export function BillingPlanList({
     })
   }, [])
 
+  useEffect(() => {
+    if (subscription) return
+    void getBackToWorkPricingDisplay().then(setPromo)
+  }, [subscription])
+
   const periodLabel = (period: BillingPeriod) => {
     switch (period) {
       case 'monthly':
@@ -139,25 +150,22 @@ export function BillingPlanList({
   }
 
   const periodDetail = (period: BillingPeriod) => {
+    const offer = subscription
+      ? undefined
+      : backToWorkPeriodDisplay(promo, period)
+    const monthlyEquivalent =
+      offer?.saleMonthlyEquivalent ?? billingPeriodMonthlyEquivalent(period)
     if (isPage) {
       switch (period) {
         case 'monthly':
           return t('dashboard.billingPage.monthlyDetail')
         case 'quarterly':
           return t('dashboard.billingPage.quarterlyDetail', {
-            price: formatBillingAmount(
-              billingPeriodMonthlyEquivalent('quarterly'),
-              currency,
-              locale
-            ),
+            price: formatBillingAmount(monthlyEquivalent, currency, locale),
           })
         case 'yearly':
           return t('dashboard.billingPage.yearlyDetail', {
-            price: formatBillingAmount(
-              billingPeriodMonthlyEquivalent('yearly'),
-              currency,
-              locale
-            ),
+            price: formatBillingAmount(monthlyEquivalent, currency, locale),
           })
         case 'lifetime':
           return t('dashboard.billingPage.lifetimeDetail')
@@ -302,8 +310,16 @@ export function BillingPlanList({
               </p>
               {periods.map((period) => {
                 const isSelected = effectiveSelected === period
-                const price = formatBillingAmount(
+                const offer = subscription
+                  ? undefined
+                  : backToWorkPeriodDisplay(promo, period)
+                const listPrice = formatBillingAmount(
                   billingPeriodCharge(period),
+                  currency,
+                  locale
+                )
+                const price = formatBillingAmount(
+                  offer?.saleCharge ?? billingPeriodCharge(period),
                   currency,
                   locale
                 )
@@ -337,6 +353,11 @@ export function BillingPlanList({
                         <span className="text-sm font-semibold text-[#171917] dark:text-foreground">
                           {t('pricing.plus.name')} · {periodLabel(period)}
                         </span>
+                        {offer?.offerActive ? (
+                          <span className="rounded-full bg-[#EFF5EC] px-2 py-0.5 text-[10px] font-medium text-[#3E7550] dark:bg-[#243028] dark:text-[#9BC4A8]">
+                            {t('pricing.backToWork.badge')}
+                          </span>
+                        ) : null}
                         {(isPage && period === 'yearly') ||
                         (!isPage &&
                           (period === 'yearly' ||
@@ -355,6 +376,11 @@ export function BillingPlanList({
                       </p>
                     </div>
                     <div className="flex shrink-0 items-center gap-2">
+                      {offer?.saleCharge !== undefined ? (
+                        <s className="text-xs tabular-nums text-[#686D67] dark:text-muted-foreground">
+                          {listPrice}
+                        </s>
+                      ) : null}
                       <span className="text-base font-semibold tabular-nums text-[#171917] dark:text-foreground">
                         {price}
                       </span>

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -17,6 +17,10 @@ import {
   pendingPurchaseSetCookieHeader,
   readAttributionFromCookies,
 } from "@/lib/attribution-server";
+import {
+  resolveBackToWorkPromoCode,
+  stripeCheckoutPromoParams,
+} from "@/lib/back-to-work-promo";
 
 // This endpoint renders no page of ours — it redirects straight to Stripe — so
 // a signup marker arriving here would never reach the Google tag. Forward it to
@@ -171,7 +175,19 @@ async function handleCheckoutSession(lookup_key: string, user: any, websiteURL: 
         // Abandoning checkout does not undo the registration, so the marker
         // rides the cancel path too.
         cancel_url: buildReturnUrl(websiteURL, 'pricing', { canceled: 'true' }, signupSuccess),
-        allow_promotion_codes: true,
+        // promo_code query/form field stays metadata-only. Auto-apply uses the
+        // env-var helper only — Stripe forbids combining discounts with
+        // allow_promotion_codes.
+        ...stripeCheckoutPromoParams(
+            resolveBackToWorkPromoCode({
+                lookupKey: lookup_key,
+                interval: price.recurring?.interval,
+                intervalCount: price.recurring?.interval_count,
+                currency: price.currency,
+                isLifetime: isLifetimePlan,
+                priceType: price.type,
+            }),
+        ),
     };
 
     if (isLifetimePlan) {

--- a/components/pricing-plans.tsx
+++ b/components/pricing-plans.tsx
@@ -31,6 +31,11 @@ import {
   type BillingPeriod,
 } from "@/lib/billing-plan-catalog";
 import {
+  backToWorkPeriodDisplay,
+  type BackToWorkPricingDisplay,
+} from "@/lib/back-to-work-promo";
+import { getBackToWorkPricingDisplay } from "@/server/back-to-work-pricing";
+import {
   changeBillingPlan,
   submitBillingCheckout,
 } from "@/lib/billing-plan-change.client";
@@ -52,6 +57,7 @@ interface PricingPlansProps {
   isModal?: boolean;
   onClose?: () => void;
   trigger?: React.ReactNode;
+  promo?: BackToWorkPricingDisplay | null;
   currentSubscription?: {
     id: string;
     status: string;
@@ -67,6 +73,7 @@ export default function PricingPlans({
   isModal,
   onClose,
   trigger,
+  promo: promoProp,
   currentSubscription,
 }: PricingPlansProps) {
   const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
@@ -74,9 +81,13 @@ export default function PricingPlans({
   const [showLifetimeConfirm, setShowLifetimeConfirm] = useState(false);
   const [pendingLookupKey, setPendingLookupKey] = useState<string>("");
   const [referralCode, setReferralCode] = useState<string | null>(null);
+  const [loadedPromo, setLoadedPromo] = useState<BackToWorkPricingDisplay | null>(
+    promoProp ?? null,
+  );
   const t = useI18n();
   const locale = useCurrentLocale();
   const { currency, symbol } = useBillingCurrency();
+  const promo = promoProp ?? loadedPromo;
 
   // Read referral code from URL params or localStorage on mount
   useEffect(() => {
@@ -89,6 +100,11 @@ export default function PricingPlans({
       });
     }
   }, []);
+
+  useEffect(() => {
+    if (promoProp !== undefined || currentSubscription) return;
+    void getBackToWorkPricingDisplay().then(setLoadedPromo);
+  }, [promoProp, currentSubscription]);
 
   // Compatibility wrappers keep full pricing behavior on the shared catalog.
   const isCurrentPlan = (lookupKey: string) => {
@@ -288,7 +304,10 @@ export default function PricingPlans({
     </article>
   );
 
-  const currentPricing =
+  const periodOffer = currentSubscription
+    ? undefined
+    : backToWorkPeriodDisplay(promo, billingPeriod);
+  const listMonthly =
     billingPeriod === "yearly"
       ? plans.plus.price.yearly / 12
       : billingPeriod === "quarterly"
@@ -296,23 +315,36 @@ export default function PricingPlans({
         : billingPeriod === "lifetime"
           ? plans.plus.price.lifetime
           : plans.plus.price.monthly;
+  const currentPricing = periodOffer?.saleMonthlyEquivalent ?? listMonthly;
+  const showSale = Boolean(
+    periodOffer?.offerActive && periodOffer.saleMonthlyEquivalent !== undefined,
+  );
+  const listCharge =
+    billingPeriod === "yearly"
+      ? plans.plus.price.yearly
+      : billingPeriod === "quarterly"
+        ? plans.plus.price.quarterly
+        : plans.plus.price.monthly;
+  const billedTotal = periodOffer?.saleCharge ?? listCharge;
+  const listMonthlyFormatted = formatBillingAmount(
+    listMonthly,
+    currency,
+    locale,
+  );
+  const saleMonthlyFormatted = formatBillingAmount(
+    currentPricing,
+    currency,
+    locale,
+  );
 
   const billingDetail =
     billingPeriod === "yearly"
       ? t("pricing.billedYearly", {
-          total: formatBillingAmount(
-            plans.plus.price.yearly,
-            currency,
-            locale,
-          ),
+          total: formatBillingAmount(billedTotal, currency, locale),
         })
       : billingPeriod === "quarterly"
         ? t("pricing.billedQuarterly", {
-          total: formatBillingAmount(
-              plans.plus.price.quarterly,
-              currency,
-              locale,
-            ),
+            total: formatBillingAmount(billedTotal, currency, locale),
           })
         : billingPeriod === "lifetime"
           ? t("pricing.oneTimePayment")
@@ -353,10 +385,37 @@ export default function PricingPlans({
       </div>
       <div>
         <div className="flex items-baseline justify-between gap-4">
-          <h3 className="text-2xl font-normal tracking-tight">
-            {plans.plus.name}
-          </h3>
-          <div className="flex min-w-[11rem] shrink-0 items-baseline justify-end sm:min-w-[12rem]">
+          <div className="min-w-0">
+            <h3 className="text-2xl font-normal tracking-tight">
+              {plans.plus.name}
+            </h3>
+            {periodOffer?.offerActive ? (
+              <p className="mt-1 text-xs text-black/55 dark:text-white/55">
+                {t("pricing.backToWork.badge")}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex min-w-[11rem] shrink-0 flex-wrap items-baseline justify-end gap-x-2 gap-y-0.5 sm:min-w-[12rem]">
+            {showSale ? (
+              <>
+                <span className="sr-only">
+                  {t("pricing.backToWork.regularPrice", {
+                    price: listMonthlyFormatted,
+                  })}
+                </span>
+                <s
+                  aria-hidden
+                  className="text-sm tabular-nums text-black/40 dark:text-white/40"
+                >
+                  {listMonthlyFormatted}
+                </s>
+                <span className="sr-only">
+                  {t("pricing.backToWork.offerPrice", {
+                    price: saleMonthlyFormatted,
+                  })}
+                </span>
+              </>
+            ) : null}
             <span className="text-2xl font-normal tabular-nums">
               <NumberFlow
                 prefix={currency === "EUR" ? undefined : symbol}

--- a/components/pricing-plans.tsx
+++ b/components/pricing-plans.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/billing-plan-catalog";
 import {
   backToWorkPeriodDisplay,
+  isBackToWorkOfferActive,
   type BackToWorkPricingDisplay,
 } from "@/lib/back-to-work-promo";
 import { getBackToWorkPricingDisplay } from "@/server/back-to-work-pricing";
@@ -304,6 +305,8 @@ export default function PricingPlans({
     </article>
   );
 
+  const campaignActive =
+    !currentSubscription && isBackToWorkOfferActive(promo);
   const periodOffer = currentSubscription
     ? undefined
     : backToWorkPeriodDisplay(promo, billingPeriod);
@@ -384,54 +387,69 @@ export default function PricingPlans({
         {billingPeriodSelector}
       </div>
       <div>
-        <div className="flex items-baseline justify-between gap-4">
+        <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
             <h3 className="text-2xl font-normal tracking-tight">
               {plans.plus.name}
             </h3>
-            {periodOffer?.offerActive ? (
-              <p className="mt-1 text-xs text-black/55 dark:text-white/55">
+            {campaignActive ? (
+              <p
+                className={cn(
+                  "mt-1 text-xs text-black/55 dark:text-white/55",
+                  !periodOffer?.offerActive && "invisible",
+                )}
+                aria-hidden={!periodOffer?.offerActive}
+              >
                 {t("pricing.backToWork.badge")}
               </p>
             ) : null}
           </div>
-          <div className="flex min-w-[11rem] shrink-0 flex-wrap items-baseline justify-end gap-x-2 gap-y-0.5 sm:min-w-[12rem]">
-            {showSale ? (
+          <div className="flex min-w-[11rem] shrink-0 flex-col items-end sm:min-w-[12rem]">
+            {campaignActive ? (
               <>
-                <span className="sr-only">
-                  {t("pricing.backToWork.regularPrice", {
-                    price: listMonthlyFormatted,
-                  })}
-                </span>
+                {showSale ? (
+                  <span className="sr-only">
+                    {t("pricing.backToWork.regularPrice", {
+                      price: listMonthlyFormatted,
+                    })}
+                  </span>
+                ) : null}
                 <s
                   aria-hidden
-                  className="text-sm tabular-nums text-black/40 dark:text-white/40"
+                  className={cn(
+                    "h-5 text-sm tabular-nums text-black/40 dark:text-white/40",
+                    !showSale && "invisible",
+                  )}
                 >
                   {listMonthlyFormatted}
                 </s>
-                <span className="sr-only">
-                  {t("pricing.backToWork.offerPrice", {
-                    price: saleMonthlyFormatted,
-                  })}
-                </span>
+                {showSale ? (
+                  <span className="sr-only">
+                    {t("pricing.backToWork.offerPrice", {
+                      price: saleMonthlyFormatted,
+                    })}
+                  </span>
+                ) : null}
               </>
             ) : null}
-            <span className="text-2xl font-normal tabular-nums">
-              <NumberFlow
-                prefix={currency === "EUR" ? undefined : symbol}
-                suffix={currency === "EUR" ? symbol : undefined}
-                value={currentPricing}
-                digits={{ 1: { max: 2 } }}
-              />
-            </span>
-            <span
-              className={cn(
-                "ml-1 text-sm text-black/55 dark:text-white/55",
-                billingPeriod === "lifetime" && "invisible",
-              )}
-            >
-              / {t("pricing.month")}
-            </span>
+            <div className="flex items-baseline">
+              <span className="text-2xl font-normal tabular-nums">
+                <NumberFlow
+                  prefix={currency === "EUR" ? undefined : symbol}
+                  suffix={currency === "EUR" ? symbol : undefined}
+                  value={currentPricing}
+                  digits={{ 1: { max: 2 } }}
+                />
+              </span>
+              <span
+                className={cn(
+                  "ml-1 text-sm text-black/55 dark:text-white/55",
+                  billingPeriod === "lifetime" && "invisible",
+                )}
+              >
+                / {t("pricing.month")}
+              </span>
+            </div>
           </div>
         </div>
         <p

--- a/lib/back-to-work-promo.test.ts
+++ b/lib/back-to-work-promo.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { billingLookupKey } from "./billing-plan-catalog";
+import {
+  resolveBackToWorkPromoCode,
+  stripeCheckoutPromoParams,
+  type BackToWorkPromoEnv,
+} from "./back-to-work-promo";
+
+const env: BackToWorkPromoEnv = {
+  STRIPE_BTW_MONTHLY_PROMO: "test-monthly-promo",
+  STRIPE_BTW_QUARTERLY_PROMO: "test-quarterly-promo",
+  STRIPE_BTW_YEARLY_PROMO: "test-yearly-promo",
+};
+
+describe("resolveBackToWorkPromoCode", () => {
+  it("maps monthly, quarterly, and yearly Plus lookup keys", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_usd", currency: "usd" },
+        env,
+      ),
+    ).toBe("test-monthly-promo");
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_quarterly_usd", currency: "usd" },
+        env,
+      ),
+    ).toBe("test-quarterly-promo");
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_yearly_usd", currency: "usd" },
+        env,
+      ),
+    ).toBe("test-yearly-promo");
+  });
+
+  it("applies for both usd and eur Plus prices", () => {
+    for (const currency of ["usd", "eur"] as const) {
+      expect(
+        resolveBackToWorkPromoCode(
+          { lookupKey: `plus_monthly_${currency}`, currency },
+          env,
+        ),
+      ).toBe("test-monthly-promo");
+    }
+  });
+
+  it("uses catalog lookup keys for every sold Plus recurring period and currency", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: billingLookupKey("monthly", "USD"), currency: "usd" },
+        env,
+      ),
+    ).toBe("test-monthly-promo");
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: billingLookupKey("quarterly", "EUR"), currency: "eur" },
+        env,
+      ),
+    ).toBe("test-quarterly-promo");
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: billingLookupKey("yearly", "USD"), currency: "usd" },
+        env,
+      ),
+    ).toBe("test-yearly-promo");
+  });
+
+  it("treats Stripe month+interval_count 3 as quarterly", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        {
+          lookupKey: "plus_quarterly_eur",
+          interval: "month",
+          intervalCount: 3,
+          currency: "eur",
+        },
+        env,
+      ),
+    ).toBe("test-quarterly-promo");
+  });
+
+  it("uses Stripe recurring interval when the lookup key is only Plus-shaped", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_custom_usd", interval: "year", currency: "usd" },
+        env,
+      ),
+    ).toBe("test-yearly-promo");
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_custom_usd", interval: "month", currency: "usd" },
+        env,
+      ),
+    ).toBe("test-monthly-promo");
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_custom_usd", interval: "quarter", currency: "usd" },
+        env,
+      ),
+    ).toBe("test-quarterly-promo");
+  });
+
+  it("skips non-usd/eur currencies even when the lookup key says usd", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_usd", currency: "gbp" },
+        env,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_cad", currency: "cad" },
+        env,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("skips lifetime, one_time, and lifetime lookup keys", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_lifetime_usd", currency: "usd" },
+        env,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: billingLookupKey("lifetime", "EUR"), currency: "eur" },
+        env,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_usd", currency: "usd", isLifetime: true },
+        env,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_usd", currency: "usd", priceType: "one_time" },
+        env,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("skips when the matching env var is missing or empty", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_usd", currency: "usd" },
+        {},
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_usd", currency: "usd" },
+        { STRIPE_BTW_MONTHLY_PROMO: "" },
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_quarterly_usd", currency: "usd" },
+        { STRIPE_BTW_MONTHLY_PROMO: "test-monthly-promo" },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("skips whitespace-only env values and trims usable ones", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_monthly_usd", currency: "usd" },
+        { STRIPE_BTW_MONTHLY_PROMO: "   " },
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "plus_yearly_eur", currency: "eur" },
+        { STRIPE_BTW_YEARLY_PROMO: "  test-yearly-promo  " },
+      ),
+    ).toBe("test-yearly-promo");
+  });
+
+  it("skips non-Plus plans", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "team_monthly_usd", currency: "usd" },
+        env,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { lookupKey: "pro_yearly_eur", currency: "eur", interval: "year" },
+        env,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode({ lookupKey: "", currency: "usd" }, env),
+    ).toBeUndefined();
+    expect(
+      resolveBackToWorkPromoCode(
+        { interval: "month", currency: "usd" },
+        env,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("skips unsupported Stripe intervals even if the lookup key is monthly", () => {
+    expect(
+      resolveBackToWorkPromoCode(
+        {
+          lookupKey: "plus_monthly_usd",
+          interval: "week",
+          currency: "usd",
+        },
+        env,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("stripeCheckoutPromoParams", () => {
+  it("sets discounts and omits allow_promotion_codes when a code is present", () => {
+    const params = stripeCheckoutPromoParams("test-monthly-promo");
+    expect(params).toEqual({
+      discounts: [{ promotion_code: "test-monthly-promo" }],
+    });
+    expect(params).not.toHaveProperty("allow_promotion_codes");
+  });
+
+  it("keeps typed codes enabled when no auto discount applies", () => {
+    const params = stripeCheckoutPromoParams(undefined);
+    expect(params).toEqual({ allow_promotion_codes: true });
+    expect(params).not.toHaveProperty("discounts");
+  });
+});

--- a/lib/back-to-work-promo.test.ts
+++ b/lib/back-to-work-promo.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { billingLookupKey } from "./billing-plan-catalog";
 import {
+  activeBackToWorkIntervals,
+  applyBackToWorkCoupon,
+  backToWorkPeriodDisplay,
+  buildBackToWorkPricingDisplay,
+  isBackToWorkOfferActive,
   resolveBackToWorkPromoCode,
   stripeCheckoutPromoParams,
   type BackToWorkPromoEnv,
@@ -230,5 +235,80 @@ describe("stripeCheckoutPromoParams", () => {
     const params = stripeCheckoutPromoParams(undefined);
     expect(params).toEqual({ allow_promotion_codes: true });
     expect(params).not.toHaveProperty("discounts");
+  });
+});
+
+describe("back-to-work pricing display", () => {
+  it("lists only intervals with a non-empty env value", () => {
+    expect(
+      activeBackToWorkIntervals({
+        STRIPE_BTW_MONTHLY_PROMO: "test-monthly-promo",
+        STRIPE_BTW_QUARTERLY_PROMO: "  ",
+      }),
+    ).toEqual(["monthly"]);
+  });
+
+  it("applies percent and amount coupons to list charges", () => {
+    expect(applyBackToWorkCoupon(19.99, { percentOff: 20 })).toBe(15.99);
+    expect(applyBackToWorkCoupon(45, { percentOff: 20 })).toBe(36);
+    expect(applyBackToWorkCoupon(120, { amountOffMinor: 2400 })).toBe(96);
+    expect(applyBackToWorkCoupon(19.99, {})).toBeUndefined();
+  });
+
+  it("builds client-safe sale prices for usd/eur catalog amounts", () => {
+    const display = buildBackToWorkPricingDisplay(env, {
+      monthly: { percentOff: 20 },
+      quarterly: { percentOff: 20 },
+      yearly: { percentOff: 20 },
+    });
+
+    expect(display.monthly).toMatchObject({
+      offerActive: true,
+      listCharge: 19.99,
+      saleCharge: 15.99,
+      saleMonthlyEquivalent: 15.99,
+    });
+    expect(display.quarterly).toMatchObject({
+      listCharge: 45,
+      saleCharge: 36,
+      saleMonthlyEquivalent: 12,
+    });
+    expect(display.yearly).toMatchObject({
+      listCharge: 120,
+      saleCharge: 96,
+      saleMonthlyEquivalent: 8,
+    });
+    expect(JSON.stringify(display)).not.toMatch(/test-monthly-promo|promo_/);
+    expect(isBackToWorkOfferActive(display)).toBe(true);
+    expect(backToWorkPeriodDisplay(display, "lifetime")).toBeUndefined();
+  });
+
+  it("marks an interval active from env even when the coupon cannot be resolved", () => {
+    const display = buildBackToWorkPricingDisplay(
+      { STRIPE_BTW_MONTHLY_PROMO: "test-monthly-promo" },
+      {},
+    );
+
+    expect(display.monthly).toEqual({
+      offerActive: true,
+      listCharge: 19.99,
+      saleCharge: undefined,
+      listMonthlyEquivalent: 19.99,
+      saleMonthlyEquivalent: undefined,
+      percentOff: undefined,
+    });
+    expect(display.quarterly).toBeUndefined();
+  });
+
+  it("skips lifetime and empty env in the display map", () => {
+    expect(buildBackToWorkPricingDisplay({}, { monthly: { percentOff: 20 } })).toEqual(
+      {},
+    );
+    expect(
+      backToWorkPeriodDisplay(
+        buildBackToWorkPricingDisplay(env, { monthly: { percentOff: 20 } }),
+        "lifetime",
+      ),
+    ).toBeUndefined();
   });
 });

--- a/lib/back-to-work-promo.ts
+++ b/lib/back-to-work-promo.ts
@@ -1,0 +1,139 @@
+export const BACK_TO_WORK_PROMO_ENV_KEYS = [
+  "STRIPE_BTW_MONTHLY_PROMO",
+  "STRIPE_BTW_QUARTERLY_PROMO",
+  "STRIPE_BTW_YEARLY_PROMO",
+] as const;
+
+export type BackToWorkPromoEnvKey = (typeof BACK_TO_WORK_PROMO_ENV_KEYS)[number];
+
+export type BackToWorkPromoEnv = Partial<
+  Record<BackToWorkPromoEnvKey, string | undefined>
+>;
+
+export type BackToWorkPromoInterval = "monthly" | "quarterly" | "yearly";
+
+export type BackToWorkPromoInput = {
+  lookupKey?: string | null;
+  interval?: string | null;
+  intervalCount?: number | null;
+  currency?: string | null;
+  isLifetime?: boolean;
+  priceType?: string | null;
+};
+
+const ENV_BY_INTERVAL: Record<BackToWorkPromoInterval, BackToWorkPromoEnvKey> = {
+  monthly: "STRIPE_BTW_MONTHLY_PROMO",
+  quarterly: "STRIPE_BTW_QUARTERLY_PROMO",
+  yearly: "STRIPE_BTW_YEARLY_PROMO",
+};
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function isPlusLookupKey(lookupKey: string | null | undefined): boolean {
+  return normalize(lookupKey).startsWith("plus_");
+}
+
+function periodFromLookupKey(
+  lookupKey: string | null | undefined,
+): BackToWorkPromoInterval | "lifetime" | undefined {
+  const match = normalize(lookupKey).match(
+    /^plus_(monthly|quarterly|yearly|lifetime)_/,
+  );
+  return match?.[1] as BackToWorkPromoInterval | "lifetime" | undefined;
+}
+
+function currencyFromLookupKey(
+  lookupKey: string | null | undefined,
+): string | undefined {
+  const match = normalize(lookupKey).match(/^plus_[a-z]+_([a-z0-9]+)$/);
+  return match?.[1];
+}
+
+function resolveCurrency(input: BackToWorkPromoInput): string | undefined {
+  const fromPrice = normalize(input.currency);
+  if (fromPrice) return fromPrice;
+  return currencyFromLookupKey(input.lookupKey);
+}
+
+function resolveInterval(
+  input: BackToWorkPromoInput,
+): BackToWorkPromoInterval | undefined {
+  if (input.intervalCount === 3) return "quarterly";
+
+  const interval = normalize(input.interval);
+  if (interval) {
+    if (interval === "year") return "yearly";
+    if (interval === "quarter") return "quarterly";
+    if (interval === "month") return "monthly";
+    return undefined;
+  }
+
+  const fromKey = periodFromLookupKey(input.lookupKey);
+  if (fromKey === "monthly" || fromKey === "quarterly" || fromKey === "yearly") {
+    return fromKey;
+  }
+  return undefined;
+}
+
+function trimmedEnvValue(
+  env: BackToWorkPromoEnv,
+  key: BackToWorkPromoEnvKey,
+): string | undefined {
+  const trimmed = env[key]?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Returns the Stripe promotion_code id to auto-apply on a new Plus Checkout,
+ * or undefined when this purchase is ineligible or the matching env var is unset.
+ * Reads the provided env bag only — call with process.env at request time.
+ */
+export function resolveBackToWorkPromoCode(
+  input: BackToWorkPromoInput,
+  env: BackToWorkPromoEnv = process.env,
+): string | undefined {
+  const lookupKey = normalize(input.lookupKey);
+
+  if (
+    input.isLifetime ||
+    input.priceType === "one_time" ||
+    lookupKey.includes("lifetime")
+  ) {
+    return undefined;
+  }
+
+  if (!isPlusLookupKey(input.lookupKey)) {
+    return undefined;
+  }
+
+  const currency = resolveCurrency(input);
+  if (currency !== "usd" && currency !== "eur") {
+    return undefined;
+  }
+
+  const interval = resolveInterval(input);
+  if (!interval) {
+    return undefined;
+  }
+
+  return trimmedEnvValue(env, ENV_BY_INTERVAL[interval]);
+}
+
+export type StripeCheckoutPromoParams =
+  | { discounts: [{ promotion_code: string }] }
+  | { allow_promotion_codes: true };
+
+/**
+ * Stripe forbids setting both `discounts` and `allow_promotion_codes` on a
+ * Checkout Session. Auto-apply uses discounts; otherwise typed codes stay on.
+ */
+export function stripeCheckoutPromoParams(
+  promotionCode: string | undefined,
+): StripeCheckoutPromoParams {
+  if (promotionCode) {
+    return { discounts: [{ promotion_code: promotionCode }] };
+  }
+  return { allow_promotion_codes: true };
+}

--- a/lib/back-to-work-promo.ts
+++ b/lib/back-to-work-promo.ts
@@ -1,3 +1,9 @@
+import {
+  PLUS_PLAN_PRICES,
+  billingPeriodMonthlyEquivalent,
+  type BillingPeriod,
+} from "./billing-plan-catalog";
+
 export const BACK_TO_WORK_PROMO_ENV_KEYS = [
   "STRIPE_BTW_MONTHLY_PROMO",
   "STRIPE_BTW_QUARTERLY_PROMO",
@@ -137,4 +143,120 @@ export function stripeCheckoutPromoParams(
     return { discounts: [{ promotion_code: promotionCode }] };
   }
   return { allow_promotion_codes: true };
+}
+
+export function activeBackToWorkIntervals(
+  env: BackToWorkPromoEnv = process.env,
+): BackToWorkPromoInterval[] {
+  return (["monthly", "quarterly", "yearly"] as const).filter((interval) =>
+    Boolean(trimmedEnvValue(env, ENV_BY_INTERVAL[interval])),
+  );
+}
+
+export type BackToWorkCouponLike = {
+  percentOff?: number | null;
+  amountOffMinor?: number | null;
+  redeemByMs?: number | null;
+};
+
+export type BackToWorkPeriodDisplay = {
+  offerActive: boolean;
+  listCharge: number;
+  saleCharge?: number;
+  listMonthlyEquivalent: number;
+  saleMonthlyEquivalent?: number;
+  percentOff?: number;
+};
+
+export type BackToWorkPricingDisplay = {
+  monthly?: BackToWorkPeriodDisplay;
+  quarterly?: BackToWorkPeriodDisplay;
+  yearly?: BackToWorkPeriodDisplay;
+  validUntilMs?: number;
+};
+
+export function roundBillingMoney(amount: number): number {
+  return Math.round(amount * 100) / 100;
+}
+
+export function applyBackToWorkCoupon(
+  listCharge: number,
+  coupon: BackToWorkCouponLike | undefined,
+): number | undefined {
+  if (!coupon) return undefined;
+
+  if (typeof coupon.percentOff === "number" && coupon.percentOff > 0) {
+    return roundBillingMoney(listCharge * (1 - coupon.percentOff / 100));
+  }
+
+  if (typeof coupon.amountOffMinor === "number" && coupon.amountOffMinor > 0) {
+    return roundBillingMoney(Math.max(0, listCharge - coupon.amountOffMinor / 100));
+  }
+
+  return undefined;
+}
+
+function saleMonthlyEquivalent(
+  interval: BackToWorkPromoInterval,
+  saleCharge: number,
+): number {
+  if (interval === "quarterly") return roundBillingMoney(saleCharge / 3);
+  if (interval === "yearly") return roundBillingMoney(saleCharge / 12);
+  return saleCharge;
+}
+
+/**
+ * Builds client-safe pricing display. Never include promotion ids in the result.
+ */
+export function buildBackToWorkPricingDisplay(
+  env: BackToWorkPromoEnv,
+  coupons: Partial<
+    Record<BackToWorkPromoInterval, BackToWorkCouponLike | undefined>
+  >,
+  validUntilMs?: number,
+): BackToWorkPricingDisplay {
+  const display: BackToWorkPricingDisplay = {};
+
+  for (const interval of ["monthly", "quarterly", "yearly"] as const) {
+    if (!trimmedEnvValue(env, ENV_BY_INTERVAL[interval])) continue;
+
+    const listCharge = PLUS_PLAN_PRICES[interval];
+    const rawSale = applyBackToWorkCoupon(listCharge, coupons[interval]);
+    const saleCharge =
+      rawSale !== undefined && rawSale < listCharge ? rawSale : undefined;
+    const percentOff = coupons[interval]?.percentOff;
+
+    display[interval] = {
+      offerActive: true,
+      listCharge,
+      saleCharge,
+      listMonthlyEquivalent: billingPeriodMonthlyEquivalent(interval),
+      saleMonthlyEquivalent:
+        saleCharge === undefined
+          ? undefined
+          : saleMonthlyEquivalent(interval, saleCharge),
+      percentOff:
+        typeof percentOff === "number" && percentOff > 0 ? percentOff : undefined,
+    };
+  }
+
+  if (validUntilMs) {
+    display.validUntilMs = validUntilMs;
+  }
+
+  return display;
+}
+
+export function backToWorkPeriodDisplay(
+  display: BackToWorkPricingDisplay | null | undefined,
+  period: BillingPeriod,
+): BackToWorkPeriodDisplay | undefined {
+  if (period === "lifetime") return undefined;
+  return display?.[period];
+}
+
+export function isBackToWorkOfferActive(
+  display: BackToWorkPricingDisplay | null | undefined,
+): boolean {
+  return Boolean(display?.monthly || display?.quarterly || display?.yearly);
 }

--- a/lib/back-to-work-promo.ts
+++ b/lib/back-to-work-promo.ts
@@ -6,9 +6,9 @@ export const BACK_TO_WORK_PROMO_ENV_KEYS = [
 
 export type BackToWorkPromoEnvKey = (typeof BACK_TO_WORK_PROMO_ENV_KEYS)[number];
 
-export type BackToWorkPromoEnv = Partial<
-  Record<BackToWorkPromoEnvKey, string | undefined>
->;
+export type BackToWorkPromoEnv = {
+  [key: string]: string | undefined;
+};
 
 export type BackToWorkPromoInterval = "monthly" | "quarterly" | "yearly";
 
@@ -81,7 +81,8 @@ function trimmedEnvValue(
   env: BackToWorkPromoEnv,
   key: BackToWorkPromoEnvKey,
 ): string | undefined {
-  const trimmed = env[key]?.trim();
+  const raw = env[key];
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
   return trimmed ? trimmed : undefined;
 }
 

--- a/locales/en/pricing.ts
+++ b/locales/en/pricing.ts
@@ -2,6 +2,13 @@ export default {
     pricing: {
         heading: 'Pricing',
         subheading: 'Store, explore and improve your trading data with the right plan for your needs.',
+        backToWork: {
+            badge: 'Back to Work',
+            sectionNote: 'Back to Work prices on Plus. The discount is applied automatically at checkout.',
+            sectionNoteUntil: 'Back to Work prices on Plus until {date}. The discount is applied automatically at checkout.',
+            regularPrice: 'Regular price {price}',
+            offerPrice: 'Offer price {price}',
+        },
         includes: 'Includes',
         loading: 'Loading...',
         yearly: 'Yearly',

--- a/locales/en/pricing.ts
+++ b/locales/en/pricing.ts
@@ -4,8 +4,8 @@ export default {
         subheading: 'Store, explore and improve your trading data with the right plan for your needs.',
         backToWork: {
             badge: 'Back to Work',
-            sectionNote: 'Back to Work prices on Plus. The discount is applied automatically at checkout.',
-            sectionNoteUntil: 'Back to Work prices on Plus until {date}. The discount is applied automatically at checkout.',
+            sectionNote: 'Back to Work prices on monthly, quarterly, and yearly Plus. The discount is applied automatically at checkout.',
+            sectionNoteUntil: 'Back to Work prices on monthly, quarterly, and yearly Plus until {date}. The discount is applied automatically at checkout.',
             regularPrice: 'Regular price {price}',
             offerPrice: 'Offer price {price}',
         },

--- a/locales/fr/pricing.ts
+++ b/locales/fr/pricing.ts
@@ -2,6 +2,13 @@ export default {
     pricing: {
         heading: 'Tarification',
         subheading: 'Stockez, explorez et améliorez vos données de trading avec le plan adapté à vos besoins.',
+        backToWork: {
+            badge: 'Rentrée',
+            sectionNote: 'Tarifs rentrée sur Plus. La réduction s\'applique automatiquement au paiement.',
+            sectionNoteUntil: 'Tarifs rentrée sur Plus jusqu\'au {date}. La réduction s\'applique automatiquement au paiement.',
+            regularPrice: 'Prix habituel {price}',
+            offerPrice: 'Prix de l\'offre {price}',
+        },
         includes: 'Inclus',
         loading: 'Chargement...',
         yearly: 'annuel',

--- a/locales/fr/pricing.ts
+++ b/locales/fr/pricing.ts
@@ -4,8 +4,8 @@ export default {
         subheading: 'Stockez, explorez et améliorez vos données de trading avec le plan adapté à vos besoins.',
         backToWork: {
             badge: 'Rentrée',
-            sectionNote: 'Tarifs rentrée sur Plus. La réduction s\'applique automatiquement au paiement.',
-            sectionNoteUntil: 'Tarifs rentrée sur Plus jusqu\'au {date}. La réduction s\'applique automatiquement au paiement.',
+            sectionNote: 'Tarifs rentrée sur Plus en mensuel, trimestriel et annuel. La réduction s\'applique automatiquement au paiement.',
+            sectionNoteUntil: 'Tarifs rentrée sur Plus en mensuel, trimestriel et annuel jusqu\'au {date}. La réduction s\'applique automatiquement au paiement.',
             regularPrice: 'Prix habituel {price}',
             offerPrice: 'Prix de l\'offre {price}',
         },

--- a/server/back-to-work-pricing.ts
+++ b/server/back-to-work-pricing.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { unstable_cache } from "next/cache";
+import { stripe } from "@/server/stripe";
+import {
+  activeBackToWorkIntervals,
+  buildBackToWorkPricingDisplay,
+  type BackToWorkCouponLike,
+  type BackToWorkPricingDisplay,
+  type BackToWorkPromoInterval,
+} from "@/lib/back-to-work-promo";
+
+const INTERVAL_ENV_KEY = {
+  monthly: "STRIPE_BTW_MONTHLY_PROMO",
+  quarterly: "STRIPE_BTW_QUARTERLY_PROMO",
+  yearly: "STRIPE_BTW_YEARLY_PROMO",
+} as const;
+
+async function couponFromEnvValue(
+  value: string,
+): Promise<BackToWorkCouponLike | undefined> {
+  try {
+    const promotion = await stripe.promotionCodes.retrieve(value, {
+      expand: ["promotion.coupon"],
+    });
+    if (!promotion.active) return undefined;
+
+    const coupon = promotion.promotion?.coupon;
+    if (!coupon || typeof coupon === "string") return undefined;
+    if (coupon.valid === false) return undefined;
+
+    const endsAt = promotion.expires_at ?? coupon.redeem_by ?? null;
+
+    return {
+      percentOff: coupon.percent_off ?? null,
+      amountOffMinor: coupon.amount_off ?? null,
+      redeemByMs: endsAt ? endsAt * 1000 : null,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadBackToWorkPricingDisplay(): Promise<BackToWorkPricingDisplay> {
+  const env = process.env;
+  const intervals = activeBackToWorkIntervals(env);
+  const coupons: Partial<
+    Record<BackToWorkPromoInterval, BackToWorkCouponLike>
+  > = {};
+  let validUntilMs: number | undefined;
+
+  await Promise.all(
+    intervals.map(async (interval) => {
+      const value = env[INTERVAL_ENV_KEY[interval]]?.trim();
+      if (!value) return;
+
+      const coupon = await couponFromEnvValue(value);
+      if (!coupon) return;
+
+      coupons[interval] = coupon;
+      if (coupon.redeemByMs) {
+        validUntilMs =
+          validUntilMs === undefined
+            ? coupon.redeemByMs
+            : Math.min(validUntilMs, coupon.redeemByMs);
+      }
+    }),
+  );
+
+  return buildBackToWorkPricingDisplay(env, coupons, validUntilMs);
+}
+
+const loadCachedBackToWorkPricingDisplay = unstable_cache(
+  loadBackToWorkPricingDisplay,
+  ["back-to-work-pricing-display"],
+  { revalidate: 3600 },
+);
+
+export async function getBackToWorkPricingDisplay(): Promise<BackToWorkPricingDisplay> {
+  if (activeBackToWorkIntervals().length === 0) {
+    return {};
+  }
+
+  try {
+    return await loadCachedBackToWorkPricingDisplay();
+  } catch {
+    return buildBackToWorkPricingDisplay(process.env, {});
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Checkout-only hook plus matching **pricing-section display**.

When someone starts a **new** Plus purchase through `POST`/`GET` `/api/stripe/create-checkout-session`, and the matching env var is set, the Stripe Checkout Session is created with `discounts: [{ promotion_code: }]`. Stripe Checkout then shows the discounted total.

Public pricing (landing `#pricing`, `/pricing`) and the Plus picker for users without a subscription now show the same offer: Back to Work / Rentrée label, strikethrough list price, and sale total when the coupon can be resolved. Lifetime stays at list price. Existing subscribers still see list price on plan-switch (they do not go through this checkout hook).

This is **not** first-time-only and **not** first-invoice-only. `isFirstOrder` in the route is unused and is not used as a gate. Anyone who starts a new Plus checkout through this route gets the auto-apply if the env var is set.

Empty / whitespace-only env is the off switch. The app does not hardcode a campaign end date; when Stripe stops new redemptions on its side, leftover env values simply stop working.

## Eligibility

Verified against `lib/billing-plan-catalog.ts`: Plus lookup keys are `plus_<period>_<currency>` (`plus_monthly_usd`, `plus_quarterly_eur`, `plus_yearly_usd`, …).

Applies only when all of these hold:

- Plan is Plus (lookup key starts with `plus_`)
- Recurring monthly, quarterly (`interval_count === 3` or `quarter` / `quarterly` key), or yearly
- Currency is `usd` or `eur`
- Matching env var is non-empty after trim

Skipped for lifetime / `one_time` / lookup keys containing `lifetime`, other currencies, non-Plus plans, and empty env.

Existing active subscriptions still bounce with `already_subscribed`. Lifetime is unchanged (no discount). Team checkout (`create-team-checkout-session`) is untouched.

The existing `promo_code` query/form field stays **metadata-only**. It is not applied as a Stripe discount. Auto-apply is the env-var value only.

Stripe cannot set both `allow_promotion_codes` and `discounts` on the same Checkout Session. When the helper returns a value, the session gets `discounts` and omits `allow_promotion_codes`. Otherwise today’s `allow_promotion_codes: true` stays so typed codes still work.

Sale amounts on the site are resolved server-side from the env-gated promotion and passed to the client as numbers only. Promotion ids never go to the browser, comments, or tests.

## Layout

Switching the period selector to Lifetime used to drop the Back to Work badge and strikethrough list price, which collapsed the Plus card. Those slots now stay mounted and `invisible` on Lifetime (same pattern as the billed-detail line and lifetime disclaimers), so the card height does not jump.

## Env vars (Gaby)

Please set these on **Vercel for beta and production** (server-only, not `NEXT_PUBLIC_`). Values are the Stripe promotion_code ids for each interval:

- `STRIPE_BTW_MONTHLY_PROMO`
- `STRIPE_BTW_QUARTERLY_PROMO`
- `STRIPE_BTW_YEARLY_PROMO`

Leave a var empty to skip that interval (checkout and pricing UI). Names are listed (empty) in `.env.example`. Do not commit values.

## Out of scope

No ads or email changes. Compare-page “from 19.99/month” lines stay at list price.

## Tests

Unit tests in `lib/back-to-work-promo.test.ts` cover monthly/quarterly/yearly mapping, usd+eur apply, other-currency skip, lifetime skip, empty/whitespace env skip, non-Plus skip, `discounts` vs `allow_promotion_codes` exclusivity, and sale-price math for the pricing cards.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb0e1d60-9ada-4520-b05a-911b286e2530?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0e1d60-9ada-4520-b05a-911b286e2530&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

