### PR TITLE
Wait for an existing dockerd in Cloud Agent start

### DIFF
--- a/scripts/docker-bootstrap.sh
+++ b/scripts/docker-bootstrap.sh
@@ -5,9 +5,45 @@ docker_ready() {
   docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1
 }
 
+wait_for_docker() {
+  local label=$1
+  echo "[docker-bootstrap] ${label}"
+  for _ in $(seq 1 30); do
+    if docker_ready; then
+      echo "[docker-bootstrap] Docker is ready"
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 if docker_ready; then
   echo "[docker-bootstrap] Docker daemon already running"
   exit 0
+fi
+
+# Another start (or the snapshot) may already be bringing dockerd up. Wait
+# for that process instead of launching a second daemon that fails on the pid file.
+existing_pid=""
+if [ -f /var/run/docker.pid ]; then
+  existing_pid="$(tr -d '[:space:]' < /var/run/docker.pid || true)"
+fi
+if [ -z "${existing_pid}" ]; then
+  existing_pid="$(pgrep -x dockerd | head -n 1 || true)"
+fi
+
+if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+  if wait_for_docker "Waiting for existing dockerd (pid ${existing_pid})"; then
+    exit 0
+  fi
+  echo "[docker-bootstrap] Existing dockerd did not become ready. See /tmp/dockerd.log"
+  exit 1
+fi
+
+if [ -f /var/run/docker.pid ]; then
+  echo "[docker-bootstrap] Removing stale /var/run/docker.pid"
+  sudo rm -f /var/run/docker.pid
 fi
 
 echo "[docker-bootstrap] Starting Docker daemon (vfs storage, iptables disabled for restricted VMs)"
@@ -17,13 +53,9 @@ sudo dockerd \
   --storage-driver=vfs \
   >/tmp/dockerd.log 2>&1 &
 
-for _ in $(seq 1 30); do
-  if docker_ready; then
-    echo "[docker-bootstrap] Docker is ready"
-    exit 0
-  fi
-  sleep 1
-done
+if wait_for_docker "Waiting for new dockerd"; then
+  exit 0
+fi
 
 echo "[docker-bootstrap] Docker failed to start. See /tmp/dockerd.log"
 exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Agent `start` (`bash scripts/docker-bootstrap.sh`) was exiting 1 when a snapshot `dockerd` was already running or still coming up. The script launched a second daemon, hit `/var/run/docker.pid`, and skipped Tailscale bootstrap.

## Change

`scripts/docker-bootstrap.sh` now:

- Returns immediately if Docker is already ready
- Waits for a live existing `dockerd` pid instead of starting another
- Removes a stale pid file, then starts `dockerd` only if nothing is running

## Validation

Local VM (after network access was approved):

- `bash scripts/docker-bootstrap.sh` twice: "Docker daemon already running"
- Compose `db` healthy on `5432`
- `GET /dashboard` → `x-auth-status: authenticated`, `x-user-id: local-dashboard-user`
- `GET /authentication?next=dashboard` → `307` to `/dashboard`

Draft environment build [bld-20260828-ed9062e6-88be-4296-a949-9e416f45750a](https://cursor.com/dashboard/cloud-agents/builds/bld-20260828-ed9062e6-88be-4296-a949-9e416f45750a) **SUCCEEDED** at commit `3e8f60e26d5ab3c2476616882b3c2f203afdb312`.

Fresh-agent verification on that build:

- Start path twice: exit 0, same dockerd pid, no second daemon
- Postgres healthy on `5432`
- Dashboard authenticated as `local-dashboard-user`
- Auth redirect `307` to `/dashboard`

This draft build does not become the default for new agents. Merging into `beta` is required before new Cloud Agents pick up the script.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ba86cf-91d6-4891-a1e5-c7d95c33da23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ba86cf-91d6-4891-a1e5-c7d95c33da23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

