### PR TITLE
fix(dashboard): widget toolbar hover and dark-mode contrast

### DIFF
--- a/app/[locale]/dashboard/components/add-widget-sheet.tsx
+++ b/app/[locale]/dashboard/components/add-widget-sheet.tsx
@@ -18,6 +18,10 @@ import {
   placedTypesForViewport,
   type AddWidgetCategory,
 } from './add-widget-catalog'
+import {
+  WIDGET_TOOLBAR_PILL_CELL,
+  WIDGET_TOOLBAR_PILL_ICON_CELL,
+} from './widget-toolbar-classes'
 
 const CATEGORY_LABEL_KEY = {
   other: 'widgets.categories.other',
@@ -246,8 +250,8 @@ export const AddWidgetSheet = forwardRef<HTMLButtonElement, AddWidgetSheetProps>
             className={cn(
               appearance === 'pill'
                 ? compact
-                  ? 'inline-flex size-8 items-center justify-center rounded-none text-[#171717] hover:bg-transparent'
-                  : 'inline-flex h-8 items-center justify-center gap-1.5 rounded-none px-2.5 text-sm font-medium text-[#171717] hover:bg-transparent'
+                  ? WIDGET_TOOLBAR_PILL_ICON_CELL
+                  : WIDGET_TOOLBAR_PILL_CELL
                 : 'flex shrink-0 items-center justify-center rounded-full transition-transform active:scale-95',
               appearance !== 'pill' && (compact ? 'h-10 w-10 p-0' : 'h-10 gap-2 px-3')
             )}

--- a/app/[locale]/dashboard/components/mobile-widget-delete-dialog.tsx
+++ b/app/[locale]/dashboard/components/mobile-widget-delete-dialog.tsx
@@ -70,9 +70,9 @@ export function MobileWidgetDeleteDialog({
             variant={appearance === "default" ? "destructive" : "ghost"}
             className={cn(
               appearance === "strip"
-                ? "inline-flex size-8 items-center justify-center rounded-full text-[#DC2626] hover:bg-black/5 hover:text-[#DC2626]"
+                ? "inline-flex size-8 items-center justify-center rounded-full text-[#DC2626] transition-colors hover:bg-black/5 hover:text-[#DC2626] dark:hover:bg-white/10"
                 : appearance === "pill"
-                  ? "inline-flex size-8 items-center justify-center rounded-none text-[#DC2626] hover:bg-transparent hover:text-[#DC2626]"
+                  ? "inline-flex size-8 items-center justify-center rounded-[4px] text-[#DC2626] transition-colors hover:bg-[#FAFAFA] hover:text-[#DC2626] dark:hover:bg-muted/40"
                   : "h-10 rounded-full flex items-center justify-center transition-transform active:scale-95",
               appearance === "default" && (compact ? "w-10 shrink-0 p-0" : "min-w-[120px] gap-3 px-4")
             )}

--- a/app/[locale]/dashboard/components/toolbar.tsx
+++ b/app/[locale]/dashboard/components/toolbar.tsx
@@ -20,16 +20,15 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { useState, useEffect, useRef, type ReactNode } from "react"
+import { WIDGET_TOOLBAR_PILL_CELL } from "./widget-toolbar-classes"
 
-const PILL_CELL =
-  "inline-flex h-8 items-center justify-center gap-1.5 rounded-none px-2.5 text-sm font-medium text-[#171717] hover:bg-transparent"
 const STRIP_CELL =
-  "inline-flex size-8 items-center justify-center rounded-full text-[#171717] hover:bg-black/5"
+  "inline-flex size-8 items-center justify-center rounded-full text-[#171717] transition-colors hover:bg-black/5 hover:text-[#171717] dark:text-foreground dark:hover:bg-white/10 dark:hover:text-foreground"
 const STRIP_DELETE_CELL =
-  "inline-flex size-8 items-center justify-center rounded-full text-[#DC2626] hover:bg-black/5 hover:text-[#DC2626]"
+  "inline-flex size-8 items-center justify-center rounded-full text-[#DC2626] transition-colors hover:bg-black/5 hover:text-[#DC2626] dark:hover:bg-white/10"
 
 function PillDivider() {
-  return <span aria-hidden className="h-4 w-px shrink-0 bg-[#E5E5E5]" />
+  return <span aria-hidden className="h-4 w-px shrink-0 bg-[#E5E5E5] dark:bg-border" />
 }
 
 interface ToolbarProps {
@@ -153,7 +152,7 @@ export function Toolbar({
         {isCustomizing ? (
           <div
             role="group"
-            className="absolute bottom-full left-2 mb-2 flex items-center rounded-full bg-[#F5F5F5] p-0.5"
+            className="absolute bottom-full left-2 mb-2 flex items-center rounded-full bg-[#F5F5F5] p-0.5 dark:bg-muted"
           >
             <AlertDialog>
               <AlertDialogTrigger asChild>
@@ -208,12 +207,12 @@ export function Toolbar({
           </div>
         ) : null}
 
-        <div className="flex max-w-full items-center rounded-full border border-[#E5E5E5] bg-white px-2 py-[6px] shadow-none">
+        <div className="flex max-w-full items-center rounded-full border border-[#E5E5E5] bg-white px-2 py-[6px] shadow-none dark:border-border dark:bg-background">
           {isCustomizing ? (
             <Button
               onClick={onEditToggle}
               aria-label={t('widgets.done')}
-              className="h-8 rounded-full bg-[#171717] px-3.5 text-sm font-medium text-white shadow-none hover:bg-[#171717]/90"
+              className="h-8 rounded-full bg-[#171717] px-3.5 text-sm font-medium text-white shadow-none hover:bg-[#171717]/90 dark:bg-foreground dark:text-background dark:hover:bg-foreground/90"
             >
               {t('widgets.done')}
             </Button>
@@ -222,7 +221,7 @@ export function Toolbar({
               variant="ghost"
               onClick={onEditToggle}
               aria-label={t('widgets.edit')}
-              className={PILL_CELL}
+              className={WIDGET_TOOLBAR_PILL_CELL}
             >
               <Pencil className="h-4 w-4 shrink-0" strokeWidth={1.75} />
               {t('widgets.edit')}

--- a/app/[locale]/dashboard/components/widget-toolbar-classes.test.ts
+++ b/app/[locale]/dashboard/components/widget-toolbar-classes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import {
+  WIDGET_TOOLBAR_PILL_CELL,
+  WIDGET_TOOLBAR_PILL_ICON_CELL,
+} from "./widget-toolbar-classes"
+
+describe("widget toolbar pill classes", () => {
+  it.each([
+    ["cell", WIDGET_TOOLBAR_PILL_CELL],
+    ["icon cell", WIDGET_TOOLBAR_PILL_ICON_CELL],
+  ] as const)(
+    "%s keeps a visible hover and readable dark-mode text",
+    (_label, className) => {
+      expect(className).toContain("hover:bg-[#FAFAFA]")
+      expect(className).toContain("hover:text-[#171717]")
+      expect(className).toContain("dark:text-foreground")
+      expect(className).toContain("dark:hover:bg-muted/40")
+      expect(className).toContain("dark:hover:text-foreground")
+      expect(className).not.toContain("hover:bg-transparent")
+    }
+  )
+})

--- a/app/[locale]/dashboard/components/widget-toolbar-classes.ts
+++ b/app/[locale]/dashboard/components/widget-toolbar-classes.ts
@@ -1,0 +1,9 @@
+/** Neutralize ghost `hover:text-accent-foreground` (white in dark mode on a white pill). */
+const PILL_INTERACTIVE =
+  "text-[#171717] transition-colors hover:bg-[#FAFAFA] hover:text-[#171717] dark:text-foreground dark:hover:bg-muted/40 dark:hover:text-foreground"
+
+export const WIDGET_TOOLBAR_PILL_CELL =
+  `inline-flex h-8 items-center justify-center gap-1.5 rounded-[4px] px-2.5 text-sm font-medium ${PILL_INTERACTIVE}`
+
+export const WIDGET_TOOLBAR_PILL_ICON_CELL =
+  `inline-flex size-8 items-center justify-center rounded-[4px] ${PILL_INTERACTIVE}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The widgets-tab floating toolbar had two regressions from the v6 chrome lock-in:

1. **Hover did nothing.** Edit / Add used `hover:bg-transparent`, which cancelled the ghost button hover.
2. **Dark mode hid the labels (white on white).** Ghost buttons still apply `hover:text-accent-foreground`, which is nearly white in dark mode, on a hardcoded `bg-white` pill.

## Fix

- Restore the same hover treatment as other dashboard chrome: `hover:bg-[#FAFAFA]` / `dark:hover:bg-muted/40`
- Pin hover text so ghost `accent-foreground` cannot flip labels to white
- Theme the pill, divider, customize strip, and Done button with `dark:` tokens (`border`, `background`, `foreground`, `muted`)
- Share pill cell classes between the toolbar and add-widget trigger so they stay in sync

## Test plan

- [x] Unit test asserts pill classes keep a visible hover and dark-mode text tokens
- [x] Hover Edit and Add Widget on `/dashboard` widgets tab in light mode — background tint is visible, labels stay dark
- [x] Same hover in dark mode — labels stay readable (no white-on-white)
- [x] Enter customize mode — Done, restore, and delete remain readable in both themes

![Light mode toolbar at rest](https://cursor.com/artifacts/c/art-606a2841-8823-4e77-9895-796fc3be8d82)
![Light mode Edit hover](https://cursor.com/artifacts/c/art-526471f1-88a3-49dd-9e88-c6752f78b4bf)
![Dark mode toolbar at rest](https://cursor.com/artifacts/c/art-07d66250-b850-41f7-b4be-587005194bd6)
![Dark mode Edit hover](https://cursor.com/artifacts/c/art-b2bbb9cb-8f83-4d9e-a088-b612a698e907)
![Dark mode customize toolbar](https://cursor.com/artifacts/c/art-26c10a20-06c6-41c3-9e68-32871a8c641c)
<a href="https://cursor.com/agents/bc-f398fbf1-a4f4-446c-a236-d5af12935d42/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwidget_toolbar_hover_light_and_dark.mp4"><img src="https://cursor.com/artifacts/c/art-f500d027-8cbc-460b-83eb-df08ee3d4536" alt="widget_toolbar_hover_light_and_dark.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f398fbf1-a4f4-446c-a236-d5af12935d42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f398fbf1-a4f4-446c-a236-d5af12935d42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

