### PR TITLE
fix(landing): drop Date.now() from pricing prerender

### DIFF
--- a/app/[locale]/(landing)/landing-ssr-content.test.ts
+++ b/app/[locale]/(landing)/landing-ssr-content.test.ts
@@ -73,6 +73,16 @@ describe("landing page server-rendered content", () => {
     expect(pricing).toContain('const Container = embedded ? "div" : "main";');
   });
 
+  it("does not read the wall clock while prerendering landing pricing", () => {
+    const pricing = read("pricing/page.tsx");
+
+    // Next.js rejects Date.now() / new Date() during static generation of
+    // /[locale]. Format promo.validUntilMs via the clock-free helper instead.
+    expect(pricing).not.toMatch(/Date\.now\s*\(/);
+    expect(pricing).not.toMatch(/new Date\s*\(\s*\)/);
+    expect(pricing).toContain("formatBackToWorkOfferUntil");
+  });
+
   it("keeps enough English landing copy for an agent to understand the product", async () => {
     const [{ default: landing }, { default: faq }] = await Promise.all([
       import("@/locales/en/landing"),

--- a/app/[locale]/(landing)/pricing/page.tsx
+++ b/app/[locale]/(landing)/pricing/page.tsx
@@ -1,7 +1,10 @@
 import PricingPlans from "@/components/pricing-plans";
 import { getCurrentLocale, getI18n } from "@/locales/server";
 import { getBackToWorkPricingDisplay } from "@/server/back-to-work-pricing";
-import { isBackToWorkOfferActive } from "@/lib/back-to-work-promo";
+import {
+  formatBackToWorkOfferUntil,
+  isBackToWorkOfferActive,
+} from "@/lib/back-to-work-promo";
 import { setStaticParamsLocale } from "next-international/server";
 
 /**
@@ -25,14 +28,7 @@ export default async function PricingPage({
   const locale = await getCurrentLocale();
   const promo = await getBackToWorkPricingDisplay();
   const offerActive = isBackToWorkOfferActive(promo);
-  const offerUntil =
-    promo.validUntilMs && promo.validUntilMs > Date.now()
-      ? new Intl.DateTimeFormat(locale === "fr" ? "fr-FR" : "en-GB", {
-          day: "numeric",
-          month: "short",
-          year: "numeric",
-        }).format(new Date(promo.validUntilMs))
-      : null;
+  const offerUntil = formatBackToWorkOfferUntil(promo.validUntilMs, locale);
 
   const Container = embedded ? "div" : "main";
   const Heading = embedded ? "h2" : "h1";

--- a/lib/back-to-work-promo.test.ts
+++ b/lib/back-to-work-promo.test.ts
@@ -5,6 +5,7 @@ import {
   applyBackToWorkCoupon,
   backToWorkPeriodDisplay,
   buildBackToWorkPricingDisplay,
+  formatBackToWorkOfferUntil,
   isBackToWorkOfferActive,
   resolveBackToWorkPromoCode,
   stripeCheckoutPromoParams,
@@ -310,5 +311,34 @@ describe("back-to-work pricing display", () => {
         "lifetime",
       ),
     ).toBeUndefined();
+  });
+
+  it("treats offer activity as period presence, not a wall-clock expiry check", () => {
+    const pastUntilMs = Date.UTC(2020, 0, 1);
+    const display = buildBackToWorkPricingDisplay(
+      { STRIPE_BTW_MONTHLY_PROMO: "test-monthly-promo" },
+      { monthly: { percentOff: 20 } },
+      pastUntilMs,
+    );
+
+    expect(isBackToWorkOfferActive(display)).toBe(true);
+    expect(isBackToWorkOfferActive({})).toBe(false);
+    expect(isBackToWorkOfferActive(undefined)).toBe(false);
+    expect(display.validUntilMs).toBe(pastUntilMs);
+  });
+});
+
+describe("formatBackToWorkOfferUntil", () => {
+  // Midday UTC so en-GB / fr-FR calendar days stay stable across host TZ.
+  const untilMs = Date.UTC(2026, 8, 30, 12, 0, 0);
+
+  it("formats a known timestamp for en and fr without reading the clock", () => {
+    expect(formatBackToWorkOfferUntil(untilMs, "en")).toBe("30 Sept 2026");
+    expect(formatBackToWorkOfferUntil(untilMs, "fr")).toBe("30 sept. 2026");
+  });
+
+  it("returns null when no expiry is present", () => {
+    expect(formatBackToWorkOfferUntil(undefined, "en")).toBeNull();
+    expect(formatBackToWorkOfferUntil(0, "fr")).toBeNull();
   });
 });

--- a/lib/back-to-work-promo.ts
+++ b/lib/back-to-work-promo.ts
@@ -260,3 +260,23 @@ export function isBackToWorkOfferActive(
 ): boolean {
   return Boolean(display?.monthly || display?.quarterly || display?.yearly);
 }
+
+/**
+ * Formats `validUntilMs` for the landing/pricing note. Do not compare against
+ * `Date.now()` here — this helper is called from a prerendered server
+ * component, and Next.js rejects wall-clock reads during static generation.
+ * Offer visibility is `isBackToWorkOfferActive`; this only formats a date
+ * when the display already includes one.
+ */
+export function formatBackToWorkOfferUntil(
+  validUntilMs: number | undefined,
+  locale: string,
+): string | null {
+  if (!validUntilMs) return null;
+
+  return new Intl.DateTimeFormat(locale === "fr" ? "fr-FR" : "en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(validUntilMs));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Vercel beta deploy failed: https://vercel.com/deltalytix/deltalytix/CBvuJ2S4s5Z83zzUCW53sFjiTFgk

Commit `38203d08` on `beta` (`#494`). Command `bun run build` exited 1.

```
Error: Route "/[locale]": Next.js encountered the unstable value `Date.now()` while prerendering.
  at app/[locale]/(landing)/pricing/page.tsx:29
    promo.validUntilMs && promo.validUntilMs > Date.now()
Export encountered an error on /[locale]/(landing)/page: /en
```

The landing page embeds `PricingPage`. During static generation, `Date.now()` is illegal.

## Fix

- `isBackToWorkOfferActive(promo)` already decides whether the offer note shows.
- `formatBackToWorkOfferUntil()` formats `promo.validUntilMs` when it exists. No wall-clock comparison on the prerendered page.
- Checkout helper `new Date()` stays in the request-time Stripe route (not prerendered).

## Tests

- Unit tests for date formatting and offer-active helper use a fixed UTC timestamp, not `Date.now()`.
- Landing SSR source test fails if `pricing/page.tsx` reads the clock again.

## Out of scope

No offer copy, list prices, ads/email, or `force-dynamic` / `connection()` on landing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cd3b943-e2c1-4b5f-a2ec-a64f4389b691?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cd3b943-e2c1-4b5f-a2ec-a64f4389b691&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

