### PR TITLE
fix(consent): don't mount 390 drawer on desktop

### DIFF
--- a/app/[locale]/(landing)/components/hero.tsx
+++ b/app/[locale]/(landing)/components/hero.tsx
@@ -85,8 +85,7 @@ export default function Hero() {
   return (
     <div className="mx-auto w-full max-w-[1440px] px-5 pb-5 pt-16 sm:px-8 sm:pb-8 sm:pt-24 lg:px-12 lg:pt-32">
       <div className="flex flex-col gap-14 md:gap-20">
-        <div className="flex items-start justify-between gap-10">
-          <div className="min-w-0 max-w-[900px] flex-1">
+        <div className="max-w-[900px]">
           <Link
             href={localizeLandingHref(locale, "/updates")}
             className="mb-7 inline-flex text-sm text-black/55 transition-colors hover:text-black dark:text-white/55 dark:hover:text-white"
@@ -131,11 +130,6 @@ export default function Hero() {
               {t("landing.features.heading")} <span className="ml-3">↓</span>
             </Link>
           </div>
-          </div>
-          <ConsentRecordPrompt
-            copy={getConsentRecordCopy(t)}
-            privacyHref={localizeLandingHref(locale, "/settings#privacy")}
-          />
         </div>
         <div
           ref={videoContainerRef}
@@ -180,6 +174,10 @@ export default function Hero() {
           </div>
         </div>
       </div>
+      <ConsentRecordPrompt
+        copy={getConsentRecordCopy(t)}
+        privacyHref={localizeLandingHref(locale, "/settings#privacy")}
+      />
     </div>
   );
 }

--- a/components/consent-record.tsx
+++ b/components/consent-record.tsx
@@ -226,7 +226,7 @@ export function ConsentRecordCard({
     <aside
       aria-labelledby="consent-record-card-title"
       className={cn(
-        "w-[22rem] max-w-[22rem] shrink-0 rounded-sm p-5",
+        "fixed right-5 top-[calc(var(--navbar-height,3.5rem)+1rem)] z-50 w-[22rem] max-w-[22rem] rounded-sm p-5 sm:right-8 lg:right-12",
         cardSurfaceClass,
         className,
       )}

--- a/components/consent-record.tsx
+++ b/components/consent-record.tsx
@@ -6,6 +6,7 @@ import { Drawer } from "vaul";
 import "./consent-record-drawer.css";
 
 import { Switch } from "@/components/ui/switch";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import {
   persistConsentSettings,
   reconcileStoredConsent,
@@ -225,7 +226,7 @@ export function ConsentRecordCard({
     <aside
       aria-labelledby="consent-record-card-title"
       className={cn(
-        "w-full max-w-[22rem] rounded-sm p-5",
+        "w-[22rem] max-w-[22rem] shrink-0 rounded-sm p-5",
         cardSurfaceClass,
         className,
       )}
@@ -381,7 +382,7 @@ function ConsentRecordMobileDrawer({
           data-consent-record-drawer=""
           aria-labelledby="consent-record-drawer-title"
           className={cn(
-            "fixed inset-x-0 bottom-0 top-0 z-50 flex flex-col overflow-hidden rounded-t-sm outline-none xl:hidden",
+            "fixed inset-x-0 bottom-0 top-0 z-50 flex flex-col overflow-hidden rounded-t-sm outline-none",
             cardSurfaceClass,
           )}
         >
@@ -424,6 +425,7 @@ export function ConsentRecordPrompt({
   copy: ConsentRecordCopy;
   privacyHref: string;
 }) {
+  const isXl = useMediaQuery("(min-width: 1280px)");
   const [visible, setVisible] = useState(false);
   const [choices, setChoices] = useState<ConsentRecordChoices>({
     productUse: false,
@@ -463,28 +465,29 @@ export function ConsentRecordPrompt({
     setVisible(false);
   };
 
-  return (
-    <div className="contents">
-      <div className="hidden shrink-0 xl:block">
-        <ConsentRecordCard
-          copy={copy}
-          choices={choices}
-          onChoicesChange={setChoices}
-          onContinue={() => save(choices)}
-          onAllowBoth={() => save({ productUse: true, ads: true })}
-          privacyHref={privacyHref}
-        />
-      </div>
-      <ConsentRecordMobileDrawer
+  if (isXl) {
+    return (
+      <ConsentRecordCard
         copy={copy}
         choices={choices}
         onChoicesChange={setChoices}
         onContinue={() => save(choices)}
         onAllowBoth={() => save({ productUse: true, ads: true })}
         privacyHref={privacyHref}
-        open={visible}
       />
-    </div>
+    );
+  }
+
+  return (
+    <ConsentRecordMobileDrawer
+      copy={copy}
+      choices={choices}
+      onChoicesChange={setChoices}
+      onContinue={() => save(choices)}
+      onAllowBoth={() => save({ productUse: true, ads: true })}
+      privacyHref={privacyHref}
+      open={visible}
+    />
   );
 }
 

--- a/components/consent-record.tsx
+++ b/components/consent-record.tsx
@@ -226,7 +226,7 @@ export function ConsentRecordCard({
     <aside
       aria-labelledby="consent-record-card-title"
       className={cn(
-        "fixed right-5 top-[calc(var(--navbar-height,3.5rem)+1rem)] z-50 w-[22rem] max-w-[22rem] rounded-sm p-5 sm:right-8 lg:right-12",
+        "fixed right-5 bottom-[max(1.25rem,env(safe-area-inset-bottom,0px))] z-50 w-[22rem] max-w-[22rem] rounded-sm p-5 sm:right-8 sm:bottom-[max(2rem,env(safe-area-inset-bottom,0px))] lg:right-12 lg:bottom-[max(3rem,env(safe-area-inset-bottom,0px))]",
         cardSurfaceClass,
         className,
       )}

--- a/components/consent-record.tsx
+++ b/components/consent-record.tsx
@@ -263,7 +263,7 @@ function ConsentRecordActions({
         type="button"
         onClick={onContinue}
         className={cn(
-          "inline-flex h-9 flex-1 items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-3 text-sm font-medium text-white transition-[opacity,transform] hover:opacity-85 active:scale-[0.96] dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]",
+          "inline-flex h-9 flex-1 items-center justify-center rounded-sm border border-[#E5E5E5] bg-white px-3 text-sm font-medium text-black transition-[colors,transform] hover:bg-black/5 active:scale-[0.96] dark:border-white/20 dark:bg-transparent dark:text-white dark:hover:bg-white/5",
           hugDesktop && "xl:flex-none",
         )}
       >
@@ -273,7 +273,7 @@ function ConsentRecordActions({
         type="button"
         onClick={onAllowBoth}
         className={cn(
-          "inline-flex h-9 flex-1 items-center justify-center rounded-sm border border-[#E5E5E5] bg-white px-3 text-sm font-medium text-black transition-[colors,transform] hover:bg-black/5 active:scale-[0.96] dark:border-white/20 dark:bg-transparent dark:text-white dark:hover:bg-white/5",
+          "inline-flex h-9 flex-1 items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-3 text-sm font-medium text-white transition-[opacity,transform] hover:opacity-85 active:scale-[0.96] dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]",
           hugDesktop && "xl:flex-none",
         )}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`ConsentRecordPrompt` used to mount both the in-hero desktop card and the mobile vaul drawer. Tailwind `xl:hidden` could not reliably hide vaul’s unlayered `display:flex`, so the 390 sheet leaked onto desktop. The in-flow xl card also sat in the hero flex, squeezing Kit’s headline.

## Fix

XOR mount:

- ≥1280px: `ConsentRecordCard` only
- &lt;1280px: 390 vaul drawer only (`140px` / `480px`, `dismissible={false}`)

Desktop card is a fixed 22rem overlay at the **bottom-right** (typical cookie-banner corner), `z-50`, inset from the viewport edge and the iOS home indicator. Not a Dialog, backdrop, or bottom sheet. It stays on screen while the landing page scrolls.

Hero (`hero.tsx`): undo the #463 `flex items-start justify-between gap-10` wrap. Title block is `max-w-[900px]` again. `ConsentRecordPrompt` still renders on the landing page as a sibling that does not size the headline.

**Allow both** is the filled primary action; Continue is the outline control (same on the desktop card and the 390 drawer).

## Out of scope

No restyle of headline, CTAs, or demo video. No copy, snaps, persist, or shared `drawer.tsx` changes. Not merged.

## Test plan

- ≥1280px: one fixed 22rem card at bottom-right; no vaul portal; card survives scroll; headline is full-width.
- Allow both is filled; Continue is outline.
- Card does not cover the nav; padding from the viewport edge (`bottom` + `right`).
- &lt;1280px: existing 390 two-snap drawer only, with the same button hierarchy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a48a3bc-3676-409c-ba66-10ee074fa758?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a48a3bc-3676-409c-ba66-10ee074fa758&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

