### PR TITLE
Restyle account-payment renewal notice to Paper chrome

### DIFF
--- a/app/[locale]/admin/actions/send-email.ts
+++ b/app/[locale]/admin/actions/send-email.ts
@@ -110,15 +110,16 @@ export async function getDefaultTemplateProps(template: EmailTemplate): Promise<
       }
     case "renewal-notice":
       return {
-        userFirstName: "Trader",
+        userFirstName: "Hugo",
         userEmail: "user@example.com",
-        accountName: "Sample Account",
-        propFirmName: "Sample Prop Firm",
-        nextPaymentDate: new Date().toISOString(),
+        accountName: "LOCAL-SIM-001",
+        propFirmName: "Apex",
+        nextPaymentDate: "2026-09-12",
         daysUntilRenewal: 7,
         paymentFrequency: "monthly",
         language: "en",
         unsubscribeUrl: "https://deltalytix.app/api/email/unsubscribe?email=user%40example.com",
+        now: "2026-09-05",
       }
     case "team-invitation":
       return {
@@ -417,8 +418,8 @@ function getDefaultSubject(template: EmailTemplate, language: string): string {
       fr: "Découvrez Deltalytix plus simplement",
     },
     "renewal-notice": {
-      en: "Account Renewal Notice",
-      fr: "Avis de renouvellement de compte",
+      en: "Account payment",
+      fr: "Paiement du compte",
     },
     "team-invitation": {
       en: "You've been invited to join a team on Deltalytix",

--- a/app/api/cron/renewal-notice/route.ts
+++ b/app/api/cron/renewal-notice/route.ts
@@ -3,9 +3,12 @@ import { PrismaClient } from "@/prisma/generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
 import { Resend } from 'resend'
 import { headers } from 'next/headers'
-import { format, subDays, isEqual, startOfDay } from 'date-fns'
-import { enUS, fr } from 'date-fns/locale'
+import { subDays, isEqual, startOfDay } from 'date-fns'
 import RenewalNoticeEmail from '@/components/emails/renewal-notice'
+import {
+  buildRenewalNoticeCopy,
+  resolveRenewalNoticeFirstName,
+} from '@/lib/renewal-notice-copy'
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
@@ -14,31 +17,11 @@ const adapter = new PrismaPg({
 const prisma = new PrismaClient({ adapter })
 const resend = new Resend(process.env.RESEND_API_KEY)
 
-// Utility function to get date locale
-const getDateLocale = (language: string) => {
-  return language === 'fr' ? fr : enUS
-}
-
-// Utility function to format payment frequency for display
-const getFrequencyDisplay = (frequency: string, language: string) => {
-  const frequencies = {
-    en: {
-      monthly: 'Monthly',
-      quarterly: 'Quarterly',
-      biannual: 'Bi-annual', 
-      annual: 'Annual',
-      custom: 'Custom'
-    },
-    fr: {
-      monthly: 'Mensuel',
-      quarterly: 'Trimestriel',
-      biannual: 'Semestriel',
-      annual: 'Annuel',
-      custom: 'Personnalisé'
-    }
-  }
-  
-  return frequencies[language as keyof typeof frequencies]?.[frequency as keyof typeof frequencies.en] || frequency
+function appOrigin(): string {
+  return (process.env.NEXT_PUBLIC_APP_URL || "https://www.deltalytix.app").replace(
+    /\/$/,
+    "",
+  )
 }
 
 // Utility function to calculate next payment date based on frequency
@@ -108,7 +91,7 @@ export async function GET(req: Request) {
           select: {
             id: true,
             email: true,
-            language: true
+            language: true,
           }
         }
       }
@@ -149,41 +132,62 @@ export async function GET(req: Request) {
       }
     })
 
+    const userEmails = [...userAccountsMap.keys()]
+    const newsletters = userEmails.length
+      ? await prisma.newsletter.findMany({
+          where: { email: { in: userEmails } },
+          select: { email: true, firstName: true },
+        })
+      : []
+    const firstNameByEmail = new Map(
+      newsletters.map((row) => [row.email, row.firstName]),
+    )
+    const origin = appOrigin()
+    const dashboardUrl = `${origin}/dashboard`
+
     // Send emails to each user
     for (const [userEmail, userAccounts] of userAccountsMap) {
       try {
         const user = userAccounts[0].user!
         const userLanguage = user.language || 'en'
-        const locale = getDateLocale(userLanguage)
+        const userFirstName = resolveRenewalNoticeFirstName(
+          firstNameByEmail.get(userEmail),
+        )
         
         // If user has multiple accounts expiring, send one email with all accounts
         // For simplicity, we'll send separate emails for each account
         for (const account of userAccounts) {
           try {
             const daysUntilRenewal = account.renewalNotice!
-            const nextPaymentDate = format(account.nextPaymentDate!, 'PPP', { locale })
+            const nextPaymentDate = account.nextPaymentDate!.toISOString()
             const accountName = account.number || `Account ${account.id}`
             const propFirmName = account.propfirm || 'Unknown Prop Firm'
             const frequency = account.paymentFrequency || 'monthly'
+            const copy = buildRenewalNoticeCopy({
+              language: userLanguage,
+              firstName: userFirstName,
+              propFirmName,
+              daysUntilRenewal,
+            })
             
-            const unsubscribeUrl = `${process.env.NEXT_PUBLIC_APP_URL}/settings/notifications`
+            const unsubscribeUrl = `${origin}/settings/notifications`
 
             const { data, error } = await resend.emails.send({
               from: 'Deltalytix Renewals <renewals@eu.updates.deltalytix.app>',
               to: userEmail,
-              subject: userLanguage === 'fr' 
-                ? `Renouvellement prochain - ${accountName}`
-                : `Upcoming Renewal - ${accountName}`,
+              subject: copy.subject,
               react: RenewalNoticeEmail({
-                userFirstName: user.email.split('@')[0],
+                userFirstName,
                 userEmail: userEmail,
                 accountName: accountName,
                 propFirmName: propFirmName,
-                nextPaymentDate: nextPaymentDate,
+                nextPaymentDate,
                 daysUntilRenewal: daysUntilRenewal,
                 paymentFrequency: frequency,
                 language: userLanguage,
-                unsubscribeUrl: unsubscribeUrl
+                unsubscribeUrl: unsubscribeUrl,
+                changeReminderUrl: dashboardUrl,
+                turnOffNoticeUrl: dashboardUrl,
               }),
               replyTo: 'hugo.demenez@deltalytix.app',
               headers: {

--- a/components/emails/renewal-notice.test.tsx
+++ b/components/emails/renewal-notice.test.tsx
@@ -2,24 +2,131 @@ import { render } from "@react-email/render";
 import { describe, expect, it } from "vitest";
 import RenewalNoticeEmail from "./renewal-notice";
 
-describe("RenewalNoticeEmail", () => {
-  it("renders the renewal content instead of an empty React shell", async () => {
+const paperProps = {
+  userFirstName: "Hugo",
+  userEmail: "hugo@example.com",
+  accountName: "LOCAL-SIM-001",
+  propFirmName: "Apex",
+  nextPaymentDate: "2026-09-12",
+  daysUntilRenewal: 7,
+  paymentFrequency: "monthly",
+  unsubscribeUrl: "https://www.deltalytix.app/settings/notifications",
+  now: "2026-09-05",
+} as const;
+
+describe("RenewalNoticeEmail Paper lock", () => {
+  it("renders EN chrome, copy, greeting, and calendar rules", async () => {
     const html = await render(
       RenewalNoticeEmail({
-        userFirstName: "Hugo",
-        userEmail: "hugo@example.com",
-        accountName: "TFDRA_5044AU8",
-        propFirmName: "Test Prop Firm",
-        nextPaymentDate: "July 20, 2026",
-        daysUntilRenewal: 1,
-        paymentFrequency: "monthly",
+        ...paperProps,
         language: "en",
-        unsubscribeUrl: "https://deltalytix.app/settings/notifications",
       }),
     );
 
-    expect(html).toContain("Account Renewal Notice");
-    expect(html).toContain("TFDRA_5044AU8");
+    expect(html).toContain("Hi Hugo,");
+    expect(html).toContain("Apex payment in 7 days.");
+    expect(html).toContain("Account payment");
+    expect(html).toContain("Auto-renew monthly is set at the firm.");
+    expect(html).toContain("Firm");
+    expect(html).toContain("Account");
+    expect(html).toContain("LOCAL-SIM-001");
+    expect(html).toContain("Apex");
+    expect(html).toContain("September");
+    expect(html).toContain("7 days left");
+    expect(html).toContain(
+      "You can change when we remind you, or turn this notice off for this account.",
+    );
+    expect(html).toContain("Change reminder");
+    expect(html).toContain("Turn off this notice");
+    expect(html).toContain("Unsubscribe from renewal notifications");
+    expect(html).toContain("/settings/notifications");
+    expect(html).toContain("/dashboard");
+    expect(html).toContain("Hugo");
+    expect(html).toContain("Deltalytix");
+
+    expect(html).toContain("#F7F7F4");
+    expect(html).toContain("#EFF5EC");
+    expect(html).toContain("#222722");
+    expect(html).toContain("border-radius:12px");
+    expect(html).toContain("border-radius:6px");
+    expect(html).toContain("Geist,Arial,Helvetica,sans-serif");
+    expect(html).toContain('width="22"');
+    expect(html).toContain("deltalytix-mark.png");
+    expect(html).toContain("max-width:100%");
+    expect(html).not.toContain('width="680"');
+    expect(html).not.toContain("max-width:680px");
+    expect(html).not.toContain("max-width:600px");
+
+    expect(html).toContain("day-today");
+    expect(html).toContain("day-payment");
+    expect(html).toContain("day-range");
+
+    expect(html).not.toContain("Manage Account");
+    expect(html).not.toContain("Contact Support");
+    expect(html).not.toContain("Account Renewal Notice");
+    expect(html).not.toContain("Frequency");
+    expect(html).not.toContain("Next Payment");
     expect(html).not.toContain("<template></template>");
+    expect(html).not.toContain("@example.com");
+    expect(html).not.toContain("hugo@");
+  });
+
+  it("renders FR Dumas lock even when Paper frames still show first-draft copy", async () => {
+    const html = await render(
+      RenewalNoticeEmail({
+        ...paperProps,
+        language: "fr",
+      }),
+    );
+
+    expect(html).toContain("Bonjour Hugo,");
+    expect(html).toContain("Paiement Apex dans 7 jours.");
+    expect(html).toContain("Paiement du compte");
+    expect(html).toContain(
+      "Le renouvellement automatique mensuel est réglé auprès de la prop firm.",
+    );
+    expect(html).toContain("Prop firm");
+    expect(html).toContain("Compte");
+    expect(html).toContain("Plus que 7 jours");
+    expect(html).toContain(
+      "Vous pouvez changer le moment du rappel, ou désactiver cet avis pour ce compte.",
+    );
+    expect(html).toContain("Modifier le rappel");
+    expect(html).toContain("Désactiver cet avis");
+    expect(html).toContain("Se désabonner des avis de paiement de compte");
+    expect(html).toContain("Septembre");
+
+    expect(html).not.toContain("chez la firm");
+    expect(html).not.toContain("Avis de Renouvellement");
+    expect(html).not.toContain("Gérer le Compte");
+  });
+
+  it("uses n=1 strings and does not duplicate the due date as a panel row", async () => {
+    const html = await render(
+      RenewalNoticeEmail({
+        ...paperProps,
+        daysUntilRenewal: 1,
+        nextPaymentDate: "2026-09-06",
+        language: "en",
+      }),
+    );
+
+    expect(html).toContain("Apex payment tomorrow.");
+    expect(html).toContain("1 day left");
+    expect(html).not.toContain("September 6, 2026");
+    expect(html).not.toContain("Next Payment Date");
+  });
+
+  it("does not greet with an email local-part", async () => {
+    const html = await render(
+      RenewalNoticeEmail({
+        ...paperProps,
+        userFirstName: "local-sim@deltalytix.local",
+        language: "en",
+      }),
+    );
+
+    expect(html).toContain("Hi Trader,");
+    expect(html).not.toContain("Hi local-sim");
   });
 });

--- a/components/emails/renewal-notice.test.tsx
+++ b/components/emails/renewal-notice.test.tsx
@@ -53,6 +53,8 @@ describe("RenewalNoticeEmail Paper lock", () => {
     expect(html).toContain('width="22"');
     expect(html).toContain("deltalytix-mark.png");
     expect(html).toContain("max-width:100%");
+    expect(html).toContain(".cta-button-link");
+    expect(html).toContain("white-space: normal !important");
     expect(html).not.toContain('width="680"');
     expect(html).not.toContain("max-width:680px");
     expect(html).not.toContain("max-width:600px");

--- a/components/emails/renewal-notice.test.tsx
+++ b/components/emails/renewal-notice.test.tsx
@@ -32,6 +32,8 @@ describe("RenewalNoticeEmail Paper lock", () => {
     expect(html).toContain("LOCAL-SIM-001");
     expect(html).toContain("Apex");
     expect(html).toContain("September");
+    expect(html).toMatch(/calendar-month[^>]*font-weight:400/);
+    expect(html).not.toMatch(/calendar-month[^>]*font-weight:600/);
     expect(html).toContain("7 days left");
     expect(html).toContain(
       "You can change when we remind you, or turn this notice off for this account.",
@@ -97,6 +99,8 @@ describe("RenewalNoticeEmail Paper lock", () => {
     expect(html).toContain("Désactiver cet avis");
     expect(html).toContain("Se désabonner des avis de paiement de compte");
     expect(html).toContain("Septembre");
+    expect(html).not.toContain("September");
+    expect(html).toMatch(/calendar-month[^>]*font-weight:400/);
 
     expect(html).not.toContain("chez la firm");
     expect(html).not.toContain("Avis de Renouvellement");

--- a/components/emails/renewal-notice.tsx
+++ b/components/emails/renewal-notice.tsx
@@ -1,220 +1,829 @@
-import * as React from 'react';
+import * as React from "react";
+import { Head, Html, Preview } from "@react-email/components";
 import {
-  Body,
-  Button,
-  Head,
-  Heading,
-  Hr,
-  Html,
-  Link,
-  Preview,
-  Section,
-  Tailwind,
-  Text,
-} from '@react-email/components';
+  buildRenewalCalendar,
+  buildRenewalNoticeCopy,
+  resolveRenewalCalendarDates,
+  type RenewalCalendarDay,
+} from "@/lib/renewal-notice-copy";
 
-interface RenewalNoticeEmailProps {
+export interface RenewalNoticeEmailProps {
   userFirstName: string;
   userEmail: string;
   accountName: string;
   propFirmName: string;
-  nextPaymentDate: string;
+  nextPaymentDate: string | Date;
   daysUntilRenewal: number;
   paymentFrequency: string;
   language?: string;
   unsubscribeUrl?: string;
+  changeReminderUrl?: string;
+  turnOffNoticeUrl?: string;
+  now?: string | Date;
 }
 
-const translations = {
-  en: {
-    preview: 'Upcoming renewal for your account',
-    greeting: 'Hello',
-    title: 'Account Renewal Notice',
-    intro: 'This is a friendly reminder that your prop firm account renewal is coming up.',
-    accountDetails: 'Account Details',
-    account: 'Account',
-    propFirm: 'Prop Firm',
-    nextPayment: 'Next Payment Date',
-    frequency: 'Payment Frequency',
-    daysRemaining: 'Days Until Renewal',
-    actionTitle: 'What you need to do',
-    actionDescription: 'Please ensure your payment method is up to date and sufficient funds are available.',
-    manageAccountButton: 'Manage Account',
-    contactSupport: 'If you have any questions or need to make changes to your account, please contact our support team.',
-    supportButton: 'Contact Support',
-    autoRenewalNote: 'This account is set to auto-renew. If you want to make changes or cancel, please do so before the renewal date.',
-    bestRegards: 'Best regards',
-    team: 'The Deltalytix Team',
-    unsubscribe: 'Unsubscribe from renewal notifications',
-    frequencies: {
-      monthly: 'Monthly',
-      quarterly: 'Quarterly', 
-      biannual: 'Bi-annual',
-      annual: 'Annual',
-      custom: 'Custom'
-    }
-  },
-  fr: {
-    preview: 'Renouvellement prochain pour votre compte',
-    greeting: 'Bonjour',
-    title: 'Avis de Renouvellement de Compte',
-    intro: 'Ceci est un rappel amical que le renouvellement de votre compte prop firm approche.',
-    accountDetails: 'Détails du Compte',
-    account: 'Compte',
-    propFirm: 'Prop Firm',
-    nextPayment: 'Prochaine Date de Paiement',
-    frequency: 'Fréquence de Paiement',
-    daysRemaining: 'Jours Avant Renouvellement',
-    actionTitle: 'Ce que vous devez faire',
-    actionDescription: 'Veuillez vous assurer que votre méthode de paiement est à jour et que des fonds suffisants sont disponibles.',
-    manageAccountButton: 'Gérer le Compte',
-    contactSupport: 'Si vous avez des questions ou devez apporter des modifications à votre compte, veuillez contacter notre équipe de support.',
-    supportButton: 'Contacter le Support',
-    autoRenewalNote: 'Ce compte est configuré pour se renouveler automatiquement. Si vous souhaitez apporter des modifications ou annuler, veuillez le faire avant la date de renouvellement.',
-    bestRegards: 'Cordialement',
-    team: 'L\'équipe Deltalytix',
-    unsubscribe: 'Se désabonner des notifications de renouvellement',
-    frequencies: {
-      monthly: 'Mensuel',
-      quarterly: 'Trimestriel',
-      biannual: 'Semestriel', 
-      annual: 'Annuel',
-      custom: 'Personnalisé'
-    }
+const FONT = "Geist,Arial,Helvetica,sans-serif";
+const PAGE = "#F7F7F4";
+const INK = "#222722";
+const MUTED = "#5f665f";
+const KICKER = "#8a908a";
+const MINT = "#EFF5EC";
+const WASH = "#E3EDE4";
+const HAIRLINE = "#e6e8e4";
+
+const chromeCss = `
+:root { color-scheme: light dark; supported-color-schemes: light dark; }
+@media only screen and (max-width: 620px) {
+  .email-shell, .email-pad {
+    width: 100% !important;
+    max-width: 100% !important;
   }
-};
+  .renewal-h1 {
+    font-size: 28px !important;
+    line-height: 34px !important;
+  }
+  .meta-label, .meta-value {
+    display: block !important;
+    width: 100% !important;
+    text-align: left !important;
+  }
+  .meta-value {
+    padding-top: 2px !important;
+    padding-bottom: 14px !important;
+  }
+  .cta-primary, .cta-quiet {
+    display: block !important;
+    width: 100% !important;
+  }
+  .cta-primary {
+    padding-bottom: 12px !important;
+  }
+  .cta-quiet {
+    padding-left: 0 !important;
+    padding-top: 4px !important;
+  }
+  .cta-button, .cta-button-link {
+    width: 100% !important;
+    display: block !important;
+    text-align: center !important;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .dm-bg { background-color:#111411 !important; }
+  .dm-heading { color:#f3f6f2 !important; }
+  .dm-text { color:#b8c1b8 !important; }
+  .dm-kicker { color:#8ab89a !important; }
+  .dm-surface-green { background-color:#19231b !important; }
+  .dm-wash { background-color:#243328 !important; }
+  .dm-border { border-color:#343b34 !important; }
+  .dm-button { background-color:#edf2ec !important; }
+  .dm-button-link { color:#151915 !important; }
+  .dm-today { background-color:#edf2ec !important; color:#151915 !important; }
+  .dm-payment { border-color:#edf2ec !important; color:#f3f6f2 !important; }
+}
+[data-ogsc] .dm-bg { background-color:#111411 !important; }
+[data-ogsc] .dm-heading { color:#f3f6f2 !important; }
+[data-ogsc] .dm-text { color:#b8c1b8 !important; }
+[data-ogsc] .dm-kicker { color:#8ab89a !important; }
+[data-ogsc] .dm-surface-green { background-color:#19231b !important; }
+[data-ogsc] .dm-wash { background-color:#243328 !important; }
+[data-ogsc] .dm-border { border-color:#343b34 !important; }
+[data-ogsc] .dm-button { background-color:#edf2ec !important; }
+[data-ogsc] .dm-button-link { color:#151915 !important; }
+[data-ogsc] .dm-today { background-color:#edf2ec !important; color:#151915 !important; }
+[data-ogsc] .dm-payment { border-color:#edf2ec !important; color:#f3f6f2 !important; }
+img.brand-mark-dark { display: none !important; max-height: 0 !important; overflow: hidden !important; }
+@media (prefers-color-scheme: dark) {
+  img.brand-mark-light { display: none !important; max-height: 0 !important; overflow: hidden !important; }
+  img.brand-mark-dark { display: inline-block !important; max-height: none !important; overflow: visible !important; width: 22px !important; height: 22px !important; }
+}
+[data-ogsc] img.brand-mark-light { display: none !important; max-height: 0 !important; overflow: hidden !important; }
+[data-ogsc] img.brand-mark-dark { display: inline-block !important; max-height: none !important; overflow: visible !important; width: 22px !important; height: 22px !important; }
+`;
+
+function appOrigin(): string {
+  return (process.env.NEXT_PUBLIC_APP_URL || "https://www.deltalytix.app").replace(
+    /\/$/,
+    "",
+  );
+}
+
+function Spacer({ height }: { height: number }) {
+  return (
+    <table width="100%" cellPadding={0} cellSpacing={0} border={0} role="presentation">
+      <tbody>
+        <tr>
+          <td
+            height={height}
+            style={{
+              height: `${height}px`,
+              fontSize: "1px",
+              lineHeight: "1px",
+            }}
+          >
+            &nbsp;
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+function BrandMark() {
+  return (
+    <>
+      <img
+        className="brand-mark-light dm-image"
+        src="https://www.deltalytix.app/brand/deltalytix-mark.png"
+        width={22}
+        height={22}
+        border={0}
+        alt="Deltalytix"
+        style={{
+          display: "inline-block",
+          width: "22px",
+          height: "22px",
+          border: 0,
+          outline: "none",
+          textDecoration: "none",
+        }}
+      />
+      <img
+        className="brand-mark-dark dm-image"
+        src="https://www.deltalytix.app/brand/deltalytix-mark-light.png"
+        width={22}
+        height={22}
+        border={0}
+        alt="Deltalytix"
+        style={{
+          display: "none",
+          width: "22px",
+          height: "22px",
+          border: 0,
+          outline: "none",
+          textDecoration: "none",
+        }}
+      />
+    </>
+  );
+}
+
+function DayCell({ cell }: { cell: RenewalCalendarDay }) {
+  const isToday = cell.kind === "today";
+  const isPayment = cell.kind === "payment";
+  const isRange = cell.kind === "range";
+  const className = [
+    "day-cell",
+    isToday ? "day-today" : "",
+    isPayment ? "day-payment" : "",
+    isRange ? "day-range" : "",
+    cell.kind === "empty" ? "day-empty" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const number = cell.day == null ? "" : String(cell.day);
+
+  return (
+    <td
+      className={`${className}${isRange ? " dm-wash" : ""}`}
+      align="center"
+      valign="middle"
+      width="14%"
+      bgcolor={isRange ? WASH : undefined}
+      style={{
+        width: "14.28%",
+        height: "36px",
+        paddingTop: "4px",
+        paddingRight: "2px",
+        paddingBottom: "4px",
+        paddingLeft: "2px",
+        backgroundColor: isRange ? WASH : "transparent",
+        fontFamily: FONT,
+        fontSize: "13px",
+        lineHeight: "20px",
+        color: INK,
+        textAlign: "center",
+      }}
+    >
+      {isToday ? (
+        <span
+          className="dm-today"
+          style={{
+            display: "inline-block",
+            width: "28px",
+            height: "28px",
+            lineHeight: "28px",
+            backgroundColor: INK,
+            color: "#ffffff",
+            borderRadius: "50%",
+            fontWeight: 600,
+            fontFamily: FONT,
+            fontSize: "13px",
+          }}
+        >
+          {number}
+        </span>
+      ) : isPayment ? (
+        <span
+          className="dm-payment"
+          style={{
+            display: "inline-block",
+            width: "26px",
+            height: "26px",
+            lineHeight: "24px",
+            border: `1.5px solid ${INK}`,
+            borderRadius: "50%",
+            color: INK,
+            fontWeight: 500,
+            fontFamily: FONT,
+            fontSize: "13px",
+          }}
+        >
+          {number}
+        </span>
+      ) : (
+        <span
+          className="dm-heading"
+          style={{
+            display: "inline-block",
+            minWidth: "28px",
+            fontFamily: FONT,
+            fontSize: "13px",
+            lineHeight: "28px",
+            color: INK,
+          }}
+        >
+          {number || "\u00a0"}
+        </span>
+      )}
+    </td>
+  );
+}
 
 export default function RenewalNoticeEmail({
   userFirstName,
-  userEmail,
   accountName,
   propFirmName,
   nextPaymentDate,
   daysUntilRenewal,
-  paymentFrequency,
-  language = 'en',
-  unsubscribeUrl
+  language = "en",
+  unsubscribeUrl,
+  changeReminderUrl,
+  turnOffNoticeUrl,
+  now,
 }: RenewalNoticeEmailProps) {
-  const t = translations[language as keyof typeof translations] || translations.en;
-  const dashboardUrl = `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`;
-  const supportUrl = `${process.env.NEXT_PUBLIC_APP_URL}/support`;
+  const t = buildRenewalNoticeCopy({
+    language,
+    firstName: userFirstName,
+    propFirmName,
+    daysUntilRenewal,
+  });
+  const { today, payment } = resolveRenewalCalendarDates({
+    now,
+    nextPaymentDate,
+    daysUntilRenewal,
+  });
+  const calendar = buildRenewalCalendar({
+    language: t.locale,
+    today,
+    payment,
+  });
+  const origin = appOrigin();
+  const reminderUrl = changeReminderUrl || `${origin}/dashboard`;
+  const disableUrl = turnOffNoticeUrl || `${origin}/dashboard`;
+  const unsubUrl = unsubscribeUrl || `${origin}/settings/notifications`;
 
   return (
-    <Html>
-      <Tailwind>
-        <Head />
-        <Preview>{t.preview}</Preview>
-        <Body className="bg-gray-50 font-sans">
-          <Section className="bg-white max-w-[600px] mx-auto rounded-lg shadow-xs">
-            <Section className="px-6 py-8">
-              <Heading className="text-2xl font-bold text-gray-900 mb-6">
-                {t.greeting} {userFirstName},
-              </Heading>
-
-              <Heading className="text-xl font-semibold text-gray-900 mb-4">
-                {t.title}
-              </Heading>
-
-              <Text className="text-gray-800 mb-6 leading-6">
-                {t.intro}
-              </Text>
-
-              {/* Account Details Card */}
-              <Section className="bg-gray-50 rounded-lg p-6 mb-6">
-                <Heading className="text-lg font-semibold text-gray-900 mb-4">
-                  {t.accountDetails}
-                </Heading>
-                
-                <div className="space-y-3">
-                  <div className="flex justify-between">
-                    <Text className="text-gray-600 margin-0">{t.account}:</Text>
-                    <Text className="text-gray-900 font-medium margin-0">{accountName}</Text>
-                  </div>
-                  
-                  <div className="flex justify-between">
-                    <Text className="text-gray-600 margin-0">{t.propFirm}:</Text>
-                    <Text className="text-gray-900 font-medium margin-0">{propFirmName}</Text>
-                  </div>
-                  
-                  <div className="flex justify-between">
-                    <Text className="text-gray-600 margin-0">{t.nextPayment}:</Text>
-                    <Text className="text-gray-900 font-medium margin-0">{nextPaymentDate}</Text>
-                  </div>
-                  
-                  <div className="flex justify-between">
-                    <Text className="text-gray-600 margin-0">{t.frequency}:</Text>
-                    <Text className="text-gray-900 font-medium margin-0">
-                      {t.frequencies[paymentFrequency as keyof typeof t.frequencies] || paymentFrequency}
-                    </Text>
-                  </div>
-                  
-                  <div className="flex justify-between">
-                    <Text className="text-gray-600 margin-0">{t.daysRemaining}:</Text>
-                    <Text className={`font-medium margin-0 ${daysUntilRenewal <= 3 ? 'text-red-600' : 'text-orange-600'}`}>
-                      {daysUntilRenewal} {daysUntilRenewal === 1 ? 'day' : 'days'}
-                    </Text>
-                  </div>
-                </div>
-              </Section>
-
-              {/* Action Section */}
-              <Section className="mb-6">
-                <Heading className="text-lg font-semibold text-gray-900 mb-3">
-                  {t.actionTitle}
-                </Heading>
-                <Text className="text-gray-800 mb-4 leading-6">
-                  {t.actionDescription}
-                </Text>
-                
-                <Button
-                  href={dashboardUrl}
-                  className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-medium text-center block w-fit"
+    <Html lang={t.locale}>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="x-apple-disable-message-reformatting" />
+        <meta name="color-scheme" content="light dark" />
+        <meta name="supported-color-schemes" content="light dark" />
+        <style dangerouslySetInnerHTML={{ __html: chromeCss }} />
+      </Head>
+      <Preview>{t.preview}</Preview>
+      <body
+        className="dm-bg"
+        style={{
+          marginTop: 0,
+          marginRight: 0,
+          marginBottom: 0,
+          marginLeft: 0,
+          backgroundColor: PAGE,
+          fontFamily: FONT,
+        }}
+      >
+        <table
+          className="dm-bg email-shell"
+          width="100%"
+          cellPadding={0}
+          cellSpacing={0}
+          border={0}
+          role="presentation"
+          bgcolor={PAGE}
+          style={{ width: "100%", maxWidth: "100%", backgroundColor: PAGE }}
+        >
+          <tbody>
+            <tr>
+              <td className="dm-bg" align="center" style={{ padding: 0 }} bgcolor={PAGE}>
+                <table
+                  className="dm-bg"
+                  width="100%"
+                  cellPadding={0}
+                  cellSpacing={0}
+                  border={0}
+                  role="presentation"
+                  style={{ width: "100%", maxWidth: "100%" }}
                 >
-                  {t.manageAccountButton}
-                </Button>
-              </Section>
+                  <tbody>
+                    <tr>
+                      <td
+                        className="email-pad"
+                        style={{
+                          paddingTop: "36px",
+                          paddingRight: "12px",
+                          paddingBottom: "40px",
+                          paddingLeft: "12px",
+                        }}
+                      >
+                        <table
+                          width="100%"
+                          cellPadding={0}
+                          cellSpacing={0}
+                          border={0}
+                          role="presentation"
+                        >
+                          <tbody>
+                            <tr>
+                              <td valign="middle" align="left" style={{ paddingBottom: "28px" }}>
+                                <table
+                                  cellPadding={0}
+                                  cellSpacing={0}
+                                  border={0}
+                                  role="presentation"
+                                >
+                                  <tbody>
+                                    <tr>
+                                      <td valign="middle" style={{ paddingRight: "8px" }}>
+                                        <BrandMark />
+                                      </td>
+                                      <td valign="middle">
+                                        <p
+                                          className="dm-heading"
+                                          style={{
+                                            fontFamily: FONT,
+                                            fontSize: "15px",
+                                            lineHeight: "20px",
+                                            color: INK,
+                                            fontWeight: 700,
+                                            margin: 0,
+                                          }}
+                                        >
+                                          Deltalytix
+                                        </p>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                              <td valign="middle" align="right" style={{ paddingBottom: "28px" }}>
+                                <p
+                                  className="dm-kicker dm-text"
+                                  style={{
+                                    fontFamily: FONT,
+                                    fontSize: "13px",
+                                    lineHeight: "20px",
+                                    color: KICKER,
+                                    fontWeight: 400,
+                                    margin: 0,
+                                  }}
+                                >
+                                  {t.kicker}
+                                </p>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
 
-              {/* Auto-renewal Notice */}
-              <Section className="bg-blue-50 rounded-lg p-4 mb-6">
-                <Text className="text-blue-800 margin-0 text-sm leading-5">
-                  ℹ️ {t.autoRenewalNote}
-                </Text>
-              </Section>
+                        <p
+                          className="dm-text"
+                          style={{
+                            fontFamily: FONT,
+                            fontSize: "15px",
+                            lineHeight: "24px",
+                            color: MUTED,
+                            marginTop: 0,
+                            marginBottom: "10px",
+                          }}
+                        >
+                          {t.greeting}
+                        </p>
+                        <h1
+                          className="dm-heading renewal-h1"
+                          style={{
+                            fontFamily: FONT,
+                            fontSize: "32px",
+                            lineHeight: "40px",
+                            fontWeight: 500,
+                            letterSpacing: "-0.03em",
+                            color: INK,
+                            marginTop: 0,
+                            marginBottom: "10px",
+                          }}
+                        >
+                          {t.h1}
+                        </h1>
+                        <p
+                          className="dm-text"
+                          style={{
+                            fontFamily: FONT,
+                            fontSize: "15px",
+                            lineHeight: "24px",
+                            color: MUTED,
+                            marginTop: 0,
+                            marginBottom: 0,
+                          }}
+                        >
+                          {t.lede}
+                        </p>
 
-              {/* Support Section */}
-              <Section className="mb-6">
-                <Text className="text-gray-800 mb-4 leading-6">
-                  {t.contactSupport}
-                </Text>
-                
-                <Button
-                  href={supportUrl}
-                  className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-lg font-medium text-center block w-fit"
-                >
-                  {t.supportButton}
-                </Button>
-              </Section>
+                        <Spacer height={24} />
 
-              <Text className="text-gray-800 mt-8 mb-2">
-                {t.bestRegards},
-              </Text>
-              <Text className="text-gray-800 mb-6">
-                {t.team}
-              </Text>
+                        <table
+                          className="dm-surface-green"
+                          width="100%"
+                          cellPadding={0}
+                          cellSpacing={0}
+                          border={0}
+                          role="presentation"
+                          bgcolor={MINT}
+                          style={{
+                            width: "100%",
+                            backgroundColor: MINT,
+                            borderRadius: "12px",
+                          }}
+                        >
+                          <tbody>
+                            <tr>
+                              <td
+                                className="dm-surface-green"
+                                bgcolor={MINT}
+                                style={{
+                                  backgroundColor: MINT,
+                                  borderRadius: "12px",
+                                  paddingTop: "22px",
+                                  paddingRight: "22px",
+                                  paddingBottom: "22px",
+                                  paddingLeft: "22px",
+                                }}
+                              >
+                                <table
+                                  width="100%"
+                                  cellPadding={0}
+                                  cellSpacing={0}
+                                  border={0}
+                                  role="presentation"
+                                >
+                                  <tbody>
+                                    <tr>
+                                      <td
+                                        className="meta-label dm-text"
+                                        valign="top"
+                                        style={{
+                                          fontFamily: FONT,
+                                          fontSize: "13px",
+                                          lineHeight: "20px",
+                                          color: MUTED,
+                                          paddingBottom: "10px",
+                                        }}
+                                      >
+                                        {t.firmLabel}
+                                      </td>
+                                      <td
+                                        className="meta-value dm-heading"
+                                        valign="top"
+                                        align="right"
+                                        style={{
+                                          fontFamily: FONT,
+                                          fontSize: "15px",
+                                          lineHeight: "20px",
+                                          color: INK,
+                                          fontWeight: 700,
+                                          textAlign: "right",
+                                          paddingBottom: "10px",
+                                        }}
+                                      >
+                                        {propFirmName}
+                                      </td>
+                                    </tr>
+                                    <tr>
+                                      <td
+                                        className="meta-label dm-text"
+                                        valign="top"
+                                        style={{
+                                          fontFamily: FONT,
+                                          fontSize: "13px",
+                                          lineHeight: "20px",
+                                          color: MUTED,
+                                          paddingBottom: "18px",
+                                        }}
+                                      >
+                                        {t.accountLabel}
+                                      </td>
+                                      <td
+                                        className="meta-value dm-heading"
+                                        valign="top"
+                                        align="right"
+                                        style={{
+                                          fontFamily: FONT,
+                                          fontSize: "15px",
+                                          lineHeight: "20px",
+                                          color: INK,
+                                          fontWeight: 700,
+                                          textAlign: "right",
+                                          paddingBottom: "18px",
+                                        }}
+                                      >
+                                        {accountName}
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
 
-              <Hr className="border-gray-200 my-6" />
+                                <p
+                                  className="dm-heading"
+                                  style={{
+                                    fontFamily: FONT,
+                                    fontSize: "13px",
+                                    lineHeight: "20px",
+                                    color: INK,
+                                    fontWeight: 600,
+                                    marginTop: 0,
+                                    marginBottom: "10px",
+                                  }}
+                                >
+                                  {calendar.monthName}
+                                </p>
 
-              {unsubscribeUrl && (
-                <Text className="text-gray-400 text-xs text-center margin-0">
-                  <Link href={unsubscribeUrl} className="text-gray-400 underline">
-                    {t.unsubscribe}
-                  </Link>
-                </Text>
-              )}
-            </Section>
-          </Section>
-        </Body>
-      </Tailwind>
+                                <table
+                                  width="100%"
+                                  cellPadding={0}
+                                  cellSpacing={0}
+                                  border={0}
+                                  role="presentation"
+                                >
+                                  <tbody>
+                                    <tr>
+                                      {calendar.weekdays.map((weekday, index) => (
+                                        <td
+                                          key={`${weekday}-${index}`}
+                                          align="center"
+                                          width="14%"
+                                          style={{
+                                            width: "14.28%",
+                                            fontFamily: FONT,
+                                            fontSize: "12px",
+                                            lineHeight: "18px",
+                                            color: KICKER,
+                                            paddingBottom: "6px",
+                                          }}
+                                        >
+                                          {weekday}
+                                        </td>
+                                      ))}
+                                    </tr>
+                                    {calendar.weeks.map((week, weekIndex) => (
+                                      <tr key={`week-${weekIndex}`}>
+                                        {week.map((cell, dayIndex) => (
+                                          <DayCell
+                                            key={`d-${weekIndex}-${dayIndex}`}
+                                            cell={cell}
+                                          />
+                                        ))}
+                                      </tr>
+                                    ))}
+                                  </tbody>
+                                </table>
+
+                                <p
+                                  className="dm-text"
+                                  style={{
+                                    fontFamily: FONT,
+                                    fontSize: "13px",
+                                    lineHeight: "20px",
+                                    color: MUTED,
+                                    marginTop: "14px",
+                                    marginBottom: 0,
+                                  }}
+                                >
+                                  {t.caption}
+                                </p>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <Spacer height={24} />
+
+                        <p
+                          className="dm-text"
+                          style={{
+                            fontFamily: FONT,
+                            fontSize: "15px",
+                            lineHeight: "24px",
+                            color: MUTED,
+                            marginTop: 0,
+                            marginBottom: 0,
+                          }}
+                        >
+                          {t.quiet}
+                        </p>
+
+                        <Spacer height={22} />
+
+                        <table
+                          className="cta-row"
+                          width="100%"
+                          cellPadding={0}
+                          cellSpacing={0}
+                          border={0}
+                          role="presentation"
+                        >
+                          <tbody>
+                            <tr>
+                              <td
+                                className="cta-primary"
+                                valign="middle"
+                                width="1%"
+                                style={{ width: "1%", whiteSpace: "nowrap" }}
+                              >
+                                <table
+                                  className="cta-button dm-button"
+                                  cellPadding={0}
+                                  cellSpacing={0}
+                                  border={0}
+                                  role="presentation"
+                                  style={{ borderRadius: "6px" }}
+                                >
+                                  <tbody>
+                                    <tr>
+                                      <td
+                                        className="dm-button"
+                                        align="center"
+                                        bgcolor={INK}
+                                        style={{
+                                          backgroundColor: INK,
+                                          borderRadius: "6px",
+                                        }}
+                                      >
+                                        <a
+                                          className="cta-button-link dm-button-link"
+                                          href={reminderUrl}
+                                          style={{
+                                            display: "inline-block",
+                                            fontFamily: FONT,
+                                            fontSize: "14px",
+                                            lineHeight: "20px",
+                                            fontWeight: 700,
+                                            color: "#ffffff",
+                                            textDecoration: "none",
+                                            paddingTop: "12px",
+                                            paddingRight: "18px",
+                                            paddingBottom: "12px",
+                                            paddingLeft: "18px",
+                                            borderRadius: "6px",
+                                          }}
+                                        >
+                                          {t.ctaPrimary}
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                              <td
+                                className="cta-quiet"
+                                valign="middle"
+                                style={{ paddingLeft: "16px" }}
+                              >
+                                <a
+                                  className="dm-text"
+                                  href={disableUrl}
+                                  style={{
+                                    fontFamily: FONT,
+                                    fontSize: "14px",
+                                    lineHeight: "20px",
+                                    color: MUTED,
+                                    textDecoration: "none",
+                                  }}
+                                >
+                                  {t.ctaQuiet}
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <Spacer height={48} />
+
+                        <p
+                          className="dm-heading"
+                          style={{
+                            fontFamily: FONT,
+                            fontSize: "15px",
+                            lineHeight: "24px",
+                            color: INK,
+                            marginTop: 0,
+                            marginBottom: 0,
+                          }}
+                        >
+                          {t.signoffName}
+                        </p>
+                        <p
+                          className="dm-text"
+                          style={{
+                            fontFamily: FONT,
+                            fontSize: "13px",
+                            lineHeight: "20px",
+                            color: MUTED,
+                            marginTop: 0,
+                            marginBottom: "16px",
+                          }}
+                        >
+                          {t.signoffBrand}
+                        </p>
+                        <table
+                          width="100%"
+                          cellPadding={0}
+                          cellSpacing={0}
+                          border={0}
+                          role="presentation"
+                        >
+                          <tbody>
+                            <tr>
+                              <td
+                                className="dm-border"
+                                height={1}
+                                style={{
+                                  borderTop: `1px solid ${HAIRLINE}`,
+                                  fontSize: "1px",
+                                  lineHeight: "1px",
+                                }}
+                              >
+                                &nbsp;
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <p
+                          className="dm-text"
+                          style={{
+                            fontFamily: FONT,
+                            fontSize: "13px",
+                            lineHeight: "20px",
+                            color: KICKER,
+                            marginTop: "16px",
+                            marginBottom: 0,
+                          }}
+                        >
+                          <a
+                            className="dm-text"
+                            href={unsubUrl}
+                            style={{
+                              fontFamily: FONT,
+                              fontSize: "13px",
+                              lineHeight: "20px",
+                              color: KICKER,
+                              textDecoration: "none",
+                            }}
+                          >
+                            {t.unsubscribe}
+                          </a>
+                        </p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </body>
     </Html>
   );
-} 
+}
+
+RenewalNoticeEmail.PreviewProps = {
+  userFirstName: "Hugo",
+  userEmail: "hugo@example.com",
+  accountName: "LOCAL-SIM-001",
+  propFirmName: "Apex",
+  nextPaymentDate: "2026-09-12",
+  daysUntilRenewal: 7,
+  paymentFrequency: "monthly",
+  language: "en",
+  unsubscribeUrl: "https://www.deltalytix.app/settings/notifications",
+  now: "2026-09-05",
+} satisfies RenewalNoticeEmailProps;

--- a/components/emails/renewal-notice.tsx
+++ b/components/emails/renewal-notice.tsx
@@ -57,15 +57,23 @@ const chromeCss = `
   }
   .cta-primary {
     padding-bottom: 12px !important;
+    white-space: normal !important;
   }
   .cta-quiet {
     padding-left: 0 !important;
     padding-top: 4px !important;
   }
-  .cta-button, .cta-button-link {
+  .cta-button {
+    width: 100% !important;
+  }
+  .cta-button td {
+    width: 100% !important;
+  }
+  .cta-button-link {
     width: 100% !important;
     display: block !important;
     text-align: center !important;
+    box-sizing: border-box !important;
   }
 }
 @media (prefers-color-scheme: dark) {

--- a/components/emails/renewal-notice.tsx
+++ b/components/emails/renewal-notice.tsx
@@ -561,13 +561,13 @@ export default function RenewalNoticeEmail({
                                 </table>
 
                                 <p
-                                  className="dm-heading"
+                                  className="dm-text calendar-month"
                                   style={{
                                     fontFamily: FONT,
                                     fontSize: "13px",
                                     lineHeight: "20px",
                                     color: INK,
-                                    fontWeight: 600,
+                                    fontWeight: 400,
                                     marginTop: 0,
                                     marginBottom: "10px",
                                   }}

--- a/lib/renewal-notice-copy.test.ts
+++ b/lib/renewal-notice-copy.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildRenewalCalendar,
+  buildRenewalNoticeCopy,
+  resolveRenewalCalendarDates,
+  resolveRenewalNoticeFirstName,
+} from "./renewal-notice-copy";
+
+describe("renewal notice copy lock", () => {
+  test("EN n=7 uses Paper strings", () => {
+    const t = buildRenewalNoticeCopy({
+      language: "en",
+      firstName: "Hugo",
+      propFirmName: "Apex",
+      daysUntilRenewal: 7,
+    });
+
+    expect(t.kicker).toBe("Account payment");
+    expect(t.greeting).toBe("Hi Hugo,");
+    expect(t.h1).toBe("Apex payment in 7 days.");
+    expect(t.lede).toBe("Auto-renew monthly is set at the firm.");
+    expect(t.firmLabel).toBe("Firm");
+    expect(t.accountLabel).toBe("Account");
+    expect(t.caption).toBe("7 days left");
+    expect(t.quiet).toBe(
+      "You can change when we remind you, or turn this notice off for this account.",
+    );
+    expect(t.ctaPrimary).toBe("Change reminder");
+    expect(t.ctaQuiet).toBe("Turn off this notice");
+    expect(t.unsubscribe).toBe("Unsubscribe from renewal notifications");
+  });
+
+  test("EN n=1 uses tomorrow / 1 day left", () => {
+    const t = buildRenewalNoticeCopy({
+      language: "en",
+      firstName: "Hugo",
+      propFirmName: "Apex",
+      daysUntilRenewal: 1,
+    });
+
+    expect(t.h1).toBe("Apex payment tomorrow.");
+    expect(t.caption).toBe("1 day left");
+  });
+
+  test("FR Dumas lock, including n=1", () => {
+    const week = buildRenewalNoticeCopy({
+      language: "fr",
+      firstName: "Hugo",
+      propFirmName: "Apex",
+      daysUntilRenewal: 7,
+    });
+    const tomorrow = buildRenewalNoticeCopy({
+      language: "fr",
+      firstName: "Hugo",
+      propFirmName: "Apex",
+      daysUntilRenewal: 1,
+    });
+
+    expect(week.kicker).toBe("Paiement du compte");
+    expect(week.greeting).toBe("Bonjour Hugo,");
+    expect(week.h1).toBe("Paiement Apex dans 7 jours.");
+    expect(week.lede).toBe(
+      "Le renouvellement automatique mensuel est réglé auprès de la prop firm.",
+    );
+    expect(week.firmLabel).toBe("Prop firm");
+    expect(week.accountLabel).toBe("Compte");
+    expect(week.caption).toBe("Plus que 7 jours");
+    expect(week.quiet).toBe(
+      "Vous pouvez changer le moment du rappel, ou désactiver cet avis pour ce compte.",
+    );
+    expect(week.ctaPrimary).toBe("Modifier le rappel");
+    expect(week.ctaQuiet).toBe("Désactiver cet avis");
+    expect(week.unsubscribe).toBe("Se désabonner des avis de paiement de compte");
+
+    expect(tomorrow.h1).toBe("Paiement Apex demain.");
+    expect(tomorrow.caption).toBe("Plus qu'un jour.");
+  });
+
+  test("first name ignores email local-parts", () => {
+    expect(resolveRenewalNoticeFirstName("hugo@example.com")).toBe("Trader");
+    expect(resolveRenewalNoticeFirstName("  ")).toBe("Trader");
+    expect(resolveRenewalNoticeFirstName("Hugo")).toBe("Hugo");
+  });
+});
+
+describe("renewal notice calendar", () => {
+  test("September 2026 is Monday-start with today, range, and payment", () => {
+    const calendar = buildRenewalCalendar({
+      language: "en",
+      today: { year: 2026, month: 8, day: 5 },
+      payment: { year: 2026, month: 8, day: 12 },
+    });
+
+    expect(calendar.monthName).toBe("September");
+    expect(calendar.weekdays).toEqual(["M", "T", "W", "T", "F", "S", "S"]);
+    expect(calendar.weeks[0].map((cell) => cell.day)).toEqual([
+      null,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+    ]);
+    expect(calendar.weeks[0][5]?.kind).toBe("today");
+    expect(calendar.weeks[0][6]?.kind).toBe("range");
+    expect(calendar.weeks[1].map((cell) => cell.kind)).toEqual([
+      "range",
+      "range",
+      "range",
+      "range",
+      "range",
+      "payment",
+      "plain",
+    ]);
+  });
+
+  test("ISO payment dates parse as civil dates", () => {
+    const dates = resolveRenewalCalendarDates({
+      now: "2026-09-05T00:00:00.000Z",
+      nextPaymentDate: "2026-09-12T00:00:00.000Z",
+      daysUntilRenewal: 7,
+    });
+
+    expect(dates.today).toEqual({ year: 2026, month: 8, day: 5 });
+    expect(dates.payment).toEqual({ year: 2026, month: 8, day: 12 });
+  });
+});

--- a/lib/renewal-notice-copy.test.ts
+++ b/lib/renewal-notice-copy.test.ts
@@ -115,6 +115,17 @@ describe("renewal notice calendar", () => {
     ]);
   });
 
+  test("FR calendar month is Septembre, not English September", () => {
+    const calendar = buildRenewalCalendar({
+      language: "fr",
+      today: { year: 2026, month: 8, day: 5 },
+      payment: { year: 2026, month: 8, day: 12 },
+    });
+
+    expect(calendar.monthName).toBe("Septembre");
+    expect(calendar.monthName).not.toBe("September");
+  });
+
   test("ISO payment dates parse as civil dates", () => {
     const dates = resolveRenewalCalendarDates({
       now: "2026-09-05T00:00:00.000Z",

--- a/lib/renewal-notice-copy.ts
+++ b/lib/renewal-notice-copy.ts
@@ -1,0 +1,258 @@
+export type RenewalNoticeLocale = "en" | "fr";
+
+export type CivilDate = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+export type RenewalCalendarDayKind = "empty" | "plain" | "today" | "payment" | "range";
+
+export type RenewalCalendarDay = {
+  day: number | null;
+  kind: RenewalCalendarDayKind;
+};
+
+export const RENEWAL_WEEKDAYS = ["M", "T", "W", "T", "F", "S", "S"] as const;
+
+const MONTHS = {
+  en: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
+  fr: [
+    "Janvier",
+    "Février",
+    "Mars",
+    "Avril",
+    "Mai",
+    "Juin",
+    "Juillet",
+    "Août",
+    "Septembre",
+    "Octobre",
+    "Novembre",
+    "Décembre",
+  ],
+} as const;
+
+const copy = {
+  en: {
+    kicker: "Account payment",
+    greeting: (firstName: string) => `Hi ${firstName},`,
+    h1: (firm: string, days: number) =>
+      days === 1 ? `${firm} payment tomorrow.` : `${firm} payment in ${days} days.`,
+    lede: "Auto-renew monthly is set at the firm.",
+    firmLabel: "Firm",
+    accountLabel: "Account",
+    caption: (days: number) => (days === 1 ? "1 day left" : `${days} days left`),
+    quiet:
+      "You can change when we remind you, or turn this notice off for this account.",
+    ctaPrimary: "Change reminder",
+    ctaQuiet: "Turn off this notice",
+    signoffName: "Hugo",
+    signoffBrand: "Deltalytix",
+    unsubscribe: "Unsubscribe from renewal notifications",
+  },
+  fr: {
+    kicker: "Paiement du compte",
+    greeting: (firstName: string) => `Bonjour ${firstName},`,
+    h1: (firm: string, days: number) =>
+      days === 1
+        ? `Paiement ${firm} demain.`
+        : `Paiement ${firm} dans ${days} jours.`,
+    lede: "Le renouvellement automatique mensuel est réglé auprès de la prop firm.",
+    firmLabel: "Prop firm",
+    accountLabel: "Compte",
+    caption: (days: number) =>
+      days === 1 ? "Plus qu'un jour." : `Plus que ${days} jours`,
+    quiet:
+      "Vous pouvez changer le moment du rappel, ou désactiver cet avis pour ce compte.",
+    ctaPrimary: "Modifier le rappel",
+    ctaQuiet: "Désactiver cet avis",
+    signoffName: "Hugo",
+    signoffBrand: "Deltalytix",
+    unsubscribe: "Se désabonner des avis de paiement de compte",
+  },
+} as const;
+
+export function renewalNoticeLocale(language?: string): RenewalNoticeLocale {
+  return language === "fr" ? "fr" : "en";
+}
+
+export function resolveRenewalNoticeFirstName(name?: string | null): string {
+  const trimmed = name?.trim();
+  if (!trimmed) {
+    return "Trader";
+  }
+  if (trimmed.includes("@")) {
+    return "Trader";
+  }
+  return trimmed;
+}
+
+export function buildRenewalNoticeCopy(input: {
+  language?: string;
+  firstName?: string | null;
+  propFirmName: string;
+  daysUntilRenewal: number;
+}) {
+  const locale = renewalNoticeLocale(input.language);
+  const t = copy[locale];
+  const firstName = resolveRenewalNoticeFirstName(input.firstName);
+  const firm = input.propFirmName.trim() || (locale === "fr" ? "prop firm" : "firm");
+  const days = Number.isFinite(input.daysUntilRenewal)
+    ? Math.max(0, Math.round(input.daysUntilRenewal))
+    : 0;
+  const h1 = t.h1(firm, days);
+
+  return {
+    locale,
+    firstName,
+    kicker: t.kicker,
+    greeting: t.greeting(firstName),
+    h1,
+    preview: h1,
+    subject: h1,
+    lede: t.lede,
+    firmLabel: t.firmLabel,
+    accountLabel: t.accountLabel,
+    caption: t.caption(days),
+    quiet: t.quiet,
+    ctaPrimary: t.ctaPrimary,
+    ctaQuiet: t.ctaQuiet,
+    signoffName: t.signoffName,
+    signoffBrand: t.signoffBrand,
+    unsubscribe: t.unsubscribe,
+  };
+}
+
+export function civilToOrdinal(date: CivilDate): number {
+  return Date.UTC(date.year, date.month, date.day);
+}
+
+export function addCivilDays(date: CivilDate, days: number): CivilDate {
+  const next = new Date(date.year, date.month, date.day + days);
+  return {
+    year: next.getFullYear(),
+    month: next.getMonth(),
+    day: next.getDate(),
+  };
+}
+
+export function parseCivilDate(
+  value: Date | string | undefined | null,
+): CivilDate | null {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return {
+      year: value.getFullYear(),
+      month: value.getMonth(),
+      day: value.getDate(),
+    };
+  }
+
+  if (typeof value === "string") {
+    const iso = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (iso) {
+      return {
+        year: Number(iso[1]),
+        month: Number(iso[2]) - 1,
+        day: Number(iso[3]),
+      };
+    }
+
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return {
+        year: parsed.getFullYear(),
+        month: parsed.getMonth(),
+        day: parsed.getDate(),
+      };
+    }
+  }
+
+  return null;
+}
+
+export function buildRenewalCalendar(input: {
+  language?: string;
+  today: CivilDate;
+  payment: CivilDate;
+}) {
+  const locale = renewalNoticeLocale(input.language);
+  const { today, payment } = input;
+  const daysInMonth = new Date(today.year, today.month + 1, 0).getDate();
+  const firstWeekday = new Date(today.year, today.month, 1).getDay();
+  const mondayPad = (firstWeekday + 6) % 7;
+  const todayOrdinal = civilToOrdinal(today);
+  const paymentOrdinal = civilToOrdinal(payment);
+  const rangeStart = Math.min(todayOrdinal, paymentOrdinal);
+  const rangeEnd = Math.max(todayOrdinal, paymentOrdinal);
+
+  const cells: RenewalCalendarDay[] = [];
+  for (let i = 0; i < mondayPad; i += 1) {
+    cells.push({ day: null, kind: "empty" });
+  }
+
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const cell: CivilDate = { year: today.year, month: today.month, day };
+    const ordinal = civilToOrdinal(cell);
+    const isToday = ordinal === todayOrdinal;
+    const isPayment = ordinal === paymentOrdinal;
+
+    let kind: RenewalCalendarDayKind = "plain";
+    if (isToday) {
+      kind = "today";
+    } else if (isPayment) {
+      kind = "payment";
+    } else if (ordinal > rangeStart && ordinal < rangeEnd) {
+      kind = "range";
+    }
+
+    cells.push({ day, kind });
+  }
+
+  while (cells.length % 7 !== 0) {
+    cells.push({ day: null, kind: "empty" });
+  }
+
+  const weeks: RenewalCalendarDay[][] = [];
+  for (let i = 0; i < cells.length; i += 7) {
+    weeks.push(cells.slice(i, i + 7));
+  }
+
+  return {
+    monthName: MONTHS[locale][today.month],
+    weekdays: RENEWAL_WEEKDAYS,
+    weeks,
+  };
+}
+
+export function resolveRenewalCalendarDates(input: {
+  now?: Date | string;
+  nextPaymentDate?: Date | string;
+  daysUntilRenewal: number;
+}) {
+  const today =
+    parseCivilDate(input.now) ??
+    parseCivilDate(new Date()) ?? {
+      year: 2026,
+      month: 8,
+      day: 1,
+    };
+  const payment =
+    parseCivilDate(input.nextPaymentDate) ??
+    addCivilDays(today, input.daysUntilRenewal);
+
+  return { today, payment };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restyles the Resend renewal notice (`components/emails/renewal-notice.tsx`, cron `GET /api/cron/renewal-notice`, from `renewals@eu.updates.deltalytix.app`) to match Paper frames **Email / Renewal notice** and **Email / Avis de paiement** (680 + 390).

This is a **prop-firm account payment** alert, not a Deltalytix subscription renewal.

## Chrome
- Geist, page `#F7F7F4`, 22px nib, primary CTA `#222722` radius 6, mint panel `#EFF5EC` radius 12
- Fluid `100%` width (no 680 lock)
- 680: primary + quiet CTA side by side; 390: primary full-width, quiet text under

## Layout
brand + kicker → `Hi {firstName},` → h1 → lede → mint panel (Firm/Account + calendar) → quiet line → CTAs → Hugo / Deltalytix → unsub

## Calendar
Monday-start current month. Filled `#222722` = today. Outline = payment day. Mint wash on days between. Caption under the grid. Date is not duplicated as a next-due row.

**Tess QA:** month label is regular weight (not bold) at every locale/width. FR month string is `Septembre` from the email locale (Paper FR frames will move from English September → Septembre).

## Copy
Locked EN (Shake) and FR (Dumas, including strings Paper frames 3–4 still show as first-draft). Greeting uses Newsletter first name, not the email local-part.

## Contract
Cron still passes locale, firm, account, days, payment date, and CTA/unsub URLs. Change-reminder and turn-off both keep `/dashboard` (account configurator). Unsub path stays `/settings/notifications`.

## Tests
- `lib/renewal-notice-copy.test.ts`
- `components/emails/renewal-notice.test.tsx`
- `bun run typecheck` clean

EN 680 (regular September):

![English 680 calendar month regular weight](https://cursor.com/artifacts/c/art-7d30cd3b-93a1-4a10-bc08-4c91e74176e3)

EN 390:

![English 390 calendar month regular weight](https://cursor.com/artifacts/c/art-c709eb19-a936-41e9-8a55-3927fb0141b2)

FR 680 (Septembre):

![French 680 calendar month Septembre regular weight](https://cursor.com/artifacts/c/art-a967a973-cb66-45e9-8ae3-3869002f049b)

FR 390:

![French 390 calendar month Septembre regular weight](https://cursor.com/artifacts/c/art-9c6bf5e1-9cd1-4c09-8554-1cdfd5561b56)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b481d40a-677f-4658-b07e-08a25422beb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b481d40a-677f-4658-b07e-08a25422beb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

