### PR TITLE
Tryable dashboard: footer Sync, stacked account balance

### DIFF
--- a/app/[locale]/dashboard/components/connections-strip-account-row.tsx
+++ b/app/[locale]/dashboard/components/connections-strip-account-row.tsx
@@ -1,12 +1,18 @@
 'use client'
 
-import { useEffect, useRef, useState, type SyntheticEvent } from 'react'
-import { Check, Eye, EyeOff, Loader2, Pencil, Trash2 } from 'lucide-react'
+import type { SyntheticEvent } from 'react'
+import { Check, Eye, EyeOff, Loader2, Trash2 } from 'lucide-react'
 import { useI18n } from '@/locales/client'
 import { cn } from '@/lib/utils'
 import { CommandItem } from '@/components/ui/command'
+import { useUserStore } from '@/store/user-store'
 import type { ConnectionsPageAccount } from '@/app/[locale]/dashboard/connections/types'
-import { accountDisplayName, isMaskedAccount } from './connections-strip-items'
+import {
+  accountDisplayName,
+  formatStripBalance,
+  isMaskedAccount,
+  journaledAccountBalance,
+} from './connections-strip-items'
 
 function stopRowActivation(event: SyntheticEvent) {
   event.stopPropagation()
@@ -27,7 +33,6 @@ export function ConnectionsStripAccountRow({
   deleting,
   onSelect,
   onMask,
-  onRename,
   onRequestDelete,
 }: {
   account: ConnectionsPageAccount
@@ -38,63 +43,25 @@ export function ConnectionsStripAccountRow({
   deleting: boolean
   onSelect: (accountNumber: string) => void
   onMask: (account: ConnectionsPageAccount, masked: boolean) => void
-  onRename: (
-    account: ConnectionsPageAccount,
-    nextName: string
-  ) => Promise<boolean>
   onRequestDelete: (account: ConnectionsPageAccount) => void
 }) {
   const t = useI18n()
-  const inputRef = useRef<HTMLInputElement>(null)
-  const submitLockRef = useRef(false)
   const displayName = accountDisplayName(account)
-  const [isRenaming, setIsRenaming] = useState(false)
-  const [renameValue, setRenameValue] = useState(displayName ?? '')
-  const [renaming, setRenaming] = useState(false)
-  const masked = isMaskedAccount(account, hiddenGroupId)
   const title = displayName ?? account.number
-
-  useEffect(() => {
-    if (!isRenaming) setRenameValue(displayName ?? '')
-  }, [displayName, isRenaming])
-
-  useEffect(() => {
-    if (!isRenaming) return
-    const frame = requestAnimationFrame(() => {
-      inputRef.current?.focus()
-      inputRef.current?.select()
-    })
-    return () => cancelAnimationFrame(frame)
-  }, [isRenaming])
-
-  const cancelRename = () => {
-    setIsRenaming(false)
-    setRenameValue(displayName ?? '')
-  }
-
-  const submitRename = async () => {
-    if (submitLockRef.current) return
-    const nextName = renameValue.trim()
-    if (nextName === (displayName ?? '')) {
-      cancelRename()
-      return
-    }
-    submitLockRef.current = true
-    setRenaming(true)
-    const ok = await onRename(account, nextName)
-    setRenaming(false)
-    submitLockRef.current = false
-    if (ok) setIsRenaming(false)
-    else inputRef.current?.focus()
-  }
+  const masked = isMaskedAccount(account, hiddenGroupId)
+  const storeAccount = useUserStore((state) =>
+    state.accounts.find(
+      (item) => item.id === account.id || item.number === account.number
+    )
+  )
+  const balance = journaledAccountBalance(storeAccount)
+  const formattedBalance =
+    balance == null ? null : formatStripBalance(balance)
 
   return (
     <CommandItem
       value={`${displayName ?? ''} ${account.number}`}
-      onSelect={() => {
-        if (isRenaming) return
-        onSelect(account.number)
-      }}
+      onSelect={() => onSelect(account.number)}
       className="items-center gap-2 rounded-[3px] px-3 py-2"
     >
       <span
@@ -103,61 +70,23 @@ export function ConnectionsStripAccountRow({
           masked && 'text-[#686D67] opacity-60 dark:text-muted-foreground'
         )}
       >
-        <input
-          ref={inputRef}
-          type="text"
-          autoComplete="off"
-          spellCheck={false}
-          value={isRenaming ? renameValue : title}
-          readOnly={!isRenaming}
-          tabIndex={isRenaming ? 0 : -1}
-          aria-label={t('connections.strip.rename')}
-          aria-hidden={!isRenaming}
-          disabled={renaming}
-          onChange={(event) => {
-            if (isRenaming) setRenameValue(event.target.value)
-          }}
-          onClick={(event) => {
-            if (isRenaming) stopRowActivation(event)
-          }}
-          onPointerDown={(event) => {
-            if (isRenaming) stopRowActivation(event)
-          }}
-          onKeyDown={(event) => {
-            if (!isRenaming) return
-            event.stopPropagation()
-            if (event.key === 'Enter') {
-              event.preventDefault()
-              void submitRename()
-            }
-            if (event.key === 'Escape') {
-              event.preventDefault()
-              cancelRename()
-            }
-          }}
-          onBlur={() => {
-            if (isRenaming && !renaming) void submitRename()
-          }}
+        <span
           className={cn(
-            'box-border h-7 w-full min-w-0 truncate rounded-[3px] border bg-transparent px-1.5 text-base font-medium leading-7 outline-none sm:text-sm',
-            isRenaming
-              ? 'border-[#E5E5E5] bg-white text-[#171917] focus-visible:ring-2 focus-visible:ring-[#181A18] dark:border-border dark:bg-background dark:text-foreground dark:focus-visible:ring-white'
-              : 'border-transparent',
-            !isRenaming &&
-              (masked
-                ? 'text-[#686D67] dark:text-muted-foreground'
-                : 'text-[#171917] dark:text-foreground')
+            'block h-7 truncate px-1.5 text-base font-medium leading-7 sm:text-sm',
+            masked
+              ? 'text-[#686D67] dark:text-muted-foreground'
+              : 'text-[#171917] dark:text-foreground'
           )}
-        />
+        >
+          {title}
+        </span>
         <span
           className={cn(
             'mt-0.5 block h-4 truncate px-1.5 text-xs leading-4',
-            masked
-              ? 'text-[#686D67] dark:text-muted-foreground'
-              : 'text-[#686D67] dark:text-muted-foreground'
+            'text-[#686D67] dark:text-muted-foreground'
           )}
         >
-          {displayName || isRenaming ? account.number : '\u00a0'}
+          {displayName ? account.number : '\u00a0'}
         </span>
       </span>
 
@@ -206,78 +135,58 @@ export function ConnectionsStripAccountRow({
           </span>
         </button>
         <div className={cn('flex items-center gap-0.5', masked && 'opacity-60')}>
-        <button
-          type="button"
-          className={cn(
-            iconButtonClass,
-            'text-[#686D67] hover:bg-[#F5F5F5] dark:text-muted-foreground dark:hover:bg-muted/50',
-            masked
-              ? 'hover:text-[#686D67] dark:hover:text-muted-foreground'
-              : 'hover:text-[#171917] dark:hover:text-foreground'
-          )}
-          aria-label={
-            isRenaming
-              ? t('connections.strip.saveName')
-              : t('connections.strip.rename')
-          }
-          disabled={renaming}
-          onMouseDown={(event) => {
-            if (isRenaming) event.preventDefault()
-          }}
-          onClick={() => {
-            if (isRenaming) {
-              void submitRename()
-              return
-            }
-            setIsRenaming(true)
-            setRenameValue(displayName ?? '')
-          }}
-        >
-          {renaming ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-          ) : isRenaming ? (
-            <Check className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+          {formattedBalance ? (
+            <span
+              className={cn(
+                'min-w-0 max-w-[6.5rem] truncate px-1.5 text-xs tabular-nums',
+                masked
+                  ? 'text-[#686D67] dark:text-muted-foreground'
+                  : 'text-[#171917] dark:text-foreground'
+              )}
+              aria-label={t('connections.strip.balance', {
+                amount: formattedBalance,
+              })}
+            >
+              {formattedBalance}
+            </span>
+          ) : null}
+          {canDelete ? (
+            <button
+              type="button"
+              className={cn(
+                iconButtonClass,
+                'text-[#686D67] dark:text-muted-foreground',
+                masked
+                  ? 'hover:bg-[#F5F5F5] hover:text-[#686D67] dark:hover:bg-muted/50 dark:hover:text-muted-foreground'
+                  : 'hover:bg-[#F5F5F5] hover:text-red-600 dark:hover:bg-muted/50 dark:hover:text-red-400'
+              )}
+              aria-label={t('connections.strip.deleteAccount', {
+                account: displayName ?? account.number,
+              })}
+              disabled={deleting}
+              onClick={() => onRequestDelete(account)}
+            >
+              {deleting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+              )}
+            </button>
+          ) : null}
+          {selected ? (
+            <Check
+              className={cn(
+                'h-4 w-4 shrink-0',
+                masked
+                  ? 'text-[#686D67] dark:text-muted-foreground'
+                  : 'text-[#171917] dark:text-foreground'
+              )}
+              strokeWidth={2}
+              aria-hidden
+            />
           ) : (
-            <Pencil className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+            <span className="inline-block h-4 w-4 shrink-0" aria-hidden />
           )}
-        </button>
-        {canDelete ? (
-          <button
-            type="button"
-            className={cn(
-              iconButtonClass,
-              'text-[#686D67] dark:text-muted-foreground',
-              masked
-                ? 'hover:bg-[#F5F5F5] hover:text-[#686D67] dark:hover:bg-muted/50 dark:hover:text-muted-foreground'
-                : 'hover:bg-[#F5F5F5] hover:text-red-600 dark:hover:bg-muted/50 dark:hover:text-red-400'
-            )}
-            aria-label={t('connections.strip.deleteAccount', {
-              account: displayName ?? account.number,
-            })}
-            disabled={deleting}
-            onClick={() => onRequestDelete(account)}
-          >
-            {deleting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-            ) : (
-              <Trash2 className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
-            )}
-          </button>
-        ) : null}
-        {selected ? (
-          <Check
-            className={cn(
-              'h-4 w-4 shrink-0',
-              masked
-                ? 'text-[#686D67] dark:text-muted-foreground'
-                : 'text-[#171917] dark:text-foreground'
-            )}
-            strokeWidth={2}
-            aria-hidden
-          />
-        ) : (
-          <span className="inline-block h-4 w-4 shrink-0" aria-hidden />
-        )}
         </div>
       </div>
     </CommandItem>

--- a/app/[locale]/dashboard/components/connections-strip-account-row.tsx
+++ b/app/[locale]/dashboard/components/connections-strip-account-row.tsx
@@ -8,7 +8,6 @@ import { CommandItem } from '@/components/ui/command'
 import { useUserStore } from '@/store/user-store'
 import type { ConnectionsPageAccount } from '@/app/[locale]/dashboard/connections/types'
 import {
-  accountDisplayName,
   formatStripBalance,
   isMaskedAccount,
   journaledAccountBalance,
@@ -46,8 +45,6 @@ export function ConnectionsStripAccountRow({
   onRequestDelete: (account: ConnectionsPageAccount) => void
 }) {
   const t = useI18n()
-  const displayName = accountDisplayName(account)
-  const title = displayName ?? account.number
   const masked = isMaskedAccount(account, hiddenGroupId)
   const storeAccount = useUserStore((state) =>
     state.accounts.find(
@@ -60,10 +57,24 @@ export function ConnectionsStripAccountRow({
 
   return (
     <CommandItem
-      value={`${displayName ?? ''} ${account.number}`}
+      value={`${account.number} ${account.propfirm ?? ''}`}
       onSelect={() => onSelect(account.number)}
       className="items-center gap-2 rounded-[3px] px-3 py-2"
     >
+      {selected ? (
+        <Check
+          className={cn(
+            'h-4 w-4 shrink-0',
+            masked
+              ? 'text-[#686D67] dark:text-muted-foreground'
+              : 'text-[#171917] dark:text-foreground'
+          )}
+          strokeWidth={2}
+          aria-hidden
+        />
+      ) : (
+        <span className="inline-block h-4 w-4 shrink-0" aria-hidden />
+      )}
       <span
         className={cn(
           'min-w-0 flex-1',
@@ -72,21 +83,23 @@ export function ConnectionsStripAccountRow({
       >
         <span
           className={cn(
-            'block h-7 truncate px-1.5 text-base font-medium leading-7 sm:text-sm',
+            'block truncate text-base font-medium leading-6 sm:text-sm',
             masked
               ? 'text-[#686D67] dark:text-muted-foreground'
               : 'text-[#171917] dark:text-foreground'
           )}
         >
-          {title}
+          {account.number}
         </span>
         <span
-          className={cn(
-            'mt-0.5 block h-4 truncate px-1.5 text-xs leading-4',
-            'text-[#686D67] dark:text-muted-foreground'
-          )}
+          className="mt-0.5 block truncate text-xs leading-4 text-[#686D67] dark:text-muted-foreground tabular-nums"
+          aria-label={
+            formattedBalance
+              ? t('connections.strip.balance', { amount: formattedBalance })
+              : undefined
+          }
         >
-          {displayName ? account.number : '\u00a0'}
+          {formattedBalance ?? '\u00a0'}
         </span>
       </span>
 
@@ -134,60 +147,29 @@ export function ConnectionsStripAccountRow({
             />
           </span>
         </button>
-        <div className={cn('flex items-center gap-0.5', masked && 'opacity-60')}>
-          {formattedBalance ? (
-            <span
-              className={cn(
-                'min-w-0 max-w-[6.5rem] truncate px-1.5 text-xs tabular-nums',
-                masked
-                  ? 'text-[#686D67] dark:text-muted-foreground'
-                  : 'text-[#171917] dark:text-foreground'
-              )}
-              aria-label={t('connections.strip.balance', {
-                amount: formattedBalance,
-              })}
-            >
-              {formattedBalance}
-            </span>
-          ) : null}
-          {canDelete ? (
-            <button
-              type="button"
-              className={cn(
-                iconButtonClass,
-                'text-[#686D67] dark:text-muted-foreground',
-                masked
-                  ? 'hover:bg-[#F5F5F5] hover:text-[#686D67] dark:hover:bg-muted/50 dark:hover:text-muted-foreground'
-                  : 'hover:bg-[#F5F5F5] hover:text-red-600 dark:hover:bg-muted/50 dark:hover:text-red-400'
-              )}
-              aria-label={t('connections.strip.deleteAccount', {
-                account: displayName ?? account.number,
-              })}
-              disabled={deleting}
-              onClick={() => onRequestDelete(account)}
-            >
-              {deleting ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-              ) : (
-                <Trash2 className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
-              )}
-            </button>
-          ) : null}
-          {selected ? (
-            <Check
-              className={cn(
-                'h-4 w-4 shrink-0',
-                masked
-                  ? 'text-[#686D67] dark:text-muted-foreground'
-                  : 'text-[#171917] dark:text-foreground'
-              )}
-              strokeWidth={2}
-              aria-hidden
-            />
-          ) : (
-            <span className="inline-block h-4 w-4 shrink-0" aria-hidden />
-          )}
-        </div>
+        {canDelete ? (
+          <button
+            type="button"
+            className={cn(
+              iconButtonClass,
+              'text-[#686D67] dark:text-muted-foreground',
+              masked
+                ? 'hover:bg-[#F5F5F5] hover:text-[#686D67] dark:hover:bg-muted/50 dark:hover:text-muted-foreground'
+                : 'hover:bg-[#F5F5F5] hover:text-red-600 dark:hover:bg-muted/50 dark:hover:text-red-400'
+            )}
+            aria-label={t('connections.strip.deleteAccount', {
+              account: account.number,
+            })}
+            disabled={deleting}
+            onClick={() => onRequestDelete(account)}
+          >
+            {deleting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+            ) : (
+              <Trash2 className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+            )}
+          </button>
+        ) : null}
       </div>
     </CommandItem>
   )

--- a/app/[locale]/dashboard/components/connections-strip-items.test.ts
+++ b/app/[locale]/dashboard/components/connections-strip-items.test.ts
@@ -3,6 +3,7 @@ import {
   buildStripItems,
   canSyncStripItem,
   chipAccountCountLabel,
+  chipShowsDesktopSync,
   accountDisplayName,
   formatStripBalance,
   isMaskedAccount,
@@ -272,6 +273,15 @@ describe('strip sync eligibility', () => {
     expect(
       canSyncStripItem({ kind: 'connection', service: 'thor' })
     ).toBe(false)
+  })
+
+  it('shows Sync on the chip only after desktop is confirmed', () => {
+    const tradovate = { kind: 'connection' as const, service: 'tradovate' }
+    const standalone = { kind: 'standalone' as const, service: null }
+    expect(chipShowsDesktopSync(tradovate, false)).toBe(true)
+    expect(chipShowsDesktopSync(tradovate, true)).toBe(false)
+    expect(chipShowsDesktopSync(tradovate, undefined)).toBe(false)
+    expect(chipShowsDesktopSync(standalone, false)).toBe(false)
   })
 })
 

--- a/app/[locale]/dashboard/components/connections-strip-items.test.ts
+++ b/app/[locale]/dashboard/components/connections-strip-items.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildStripItems,
+  canSyncStripItem,
   chipAccountCountLabel,
   accountDisplayName,
+  formatStripBalance,
   isMaskedAccount,
   isStandaloneAccount,
+  isStripSyncableService,
+  journaledAccountBalance,
   mapConnectionsAccounts,
   removeConnectionsAccount,
   restoreMovedAccountGroup,
@@ -35,6 +39,7 @@ function connection(
   return {
     service: 'tradovate',
     status: 'connected',
+    accountId: 'ext',
     loginLabel: null,
     authError: null,
     accounts: [],
@@ -66,6 +71,11 @@ describe('buildStripItems', () => {
     expect(items).toHaveLength(1)
     expect(items[0].displayName).toBe('Tradovate')
     expect(items[0].displayName).not.toContain('DEMENEZ')
+    expect(items[0]).toMatchObject({
+      kind: 'connection',
+      accountId: 'ext',
+      service: 'tradovate',
+    })
   })
 
   it('groups every standalone account onto one Standalone chip', () => {
@@ -241,3 +251,49 @@ describe('restoreMovedAccountGroup', () => {
     expect(restored.groups).toBe(groups)
   })
 })
+
+describe('strip sync eligibility', () => {
+  it('allows hosted broker services and hides CSV / Thor / unknown', () => {
+    expect(isStripSyncableService('rithmic')).toBe(true)
+    expect(isStripSyncableService('rithmic-protocol')).toBe(true)
+    expect(isStripSyncableService('tradovate')).toBe(true)
+    expect(isStripSyncableService('dxfeed')).toBe(true)
+    expect(isStripSyncableService('ibkr')).toBe(true)
+    expect(isStripSyncableService('ig')).toBe(true)
+    expect(isStripSyncableService('thor')).toBe(false)
+    expect(isStripSyncableService(null)).toBe(false)
+    expect(isStripSyncableService('csv')).toBe(false)
+    expect(
+      canSyncStripItem({ kind: 'standalone', service: null })
+    ).toBe(false)
+    expect(
+      canSyncStripItem({ kind: 'connection', service: 'tradovate' })
+    ).toBe(true)
+    expect(
+      canSyncStripItem({ kind: 'connection', service: 'thor' })
+    ).toBe(false)
+  })
+})
+
+describe('journaledAccountBalance', () => {
+  it('prefers computed metrics, then balanceToDate, then startingBalance', () => {
+    expect(
+      journaledAccountBalance({
+        metrics: { currentBalance: 51234.5 },
+        balanceToDate: 100,
+        startingBalance: 50,
+      })
+    ).toBe(51234.5)
+    expect(
+      journaledAccountBalance({
+        balanceToDate: 1200,
+        startingBalance: 1000,
+      })
+    ).toBe(1200)
+    expect(journaledAccountBalance({ startingBalance: 50000 })).toBe(50000)
+    expect(journaledAccountBalance({ startingBalance: null })).toBeNull()
+    expect(journaledAccountBalance(null)).toBeNull()
+    expect(formatStripBalance(51234.5)).toBe('$51234.50')
+  })
+})
+

--- a/app/[locale]/dashboard/components/connections-strip-items.test.ts
+++ b/app/[locale]/dashboard/components/connections-strip-items.test.ts
@@ -3,7 +3,7 @@ import {
   buildStripItems,
   canSyncStripItem,
   chipAccountCountLabel,
-  chipShowsDesktopSync,
+  footerShowsDesktopSync,
   accountDisplayName,
   formatStripBalance,
   isMaskedAccount,
@@ -275,13 +275,13 @@ describe('strip sync eligibility', () => {
     ).toBe(false)
   })
 
-  it('shows Sync on the chip only after desktop is confirmed', () => {
+  it('shows footer Sync only after desktop is confirmed', () => {
     const tradovate = { kind: 'connection' as const, service: 'tradovate' }
     const standalone = { kind: 'standalone' as const, service: null }
-    expect(chipShowsDesktopSync(tradovate, false)).toBe(true)
-    expect(chipShowsDesktopSync(tradovate, true)).toBe(false)
-    expect(chipShowsDesktopSync(tradovate, undefined)).toBe(false)
-    expect(chipShowsDesktopSync(standalone, false)).toBe(false)
+    expect(footerShowsDesktopSync(tradovate, false)).toBe(true)
+    expect(footerShowsDesktopSync(tradovate, true)).toBe(false)
+    expect(footerShowsDesktopSync(tradovate, undefined)).toBe(false)
+    expect(footerShowsDesktopSync(standalone, false)).toBe(false)
   })
 })
 

--- a/app/[locale]/dashboard/components/connections-strip-items.ts
+++ b/app/[locale]/dashboard/components/connections-strip-items.ts
@@ -11,6 +11,8 @@ export type StripItem =
       displayName: string
       status: 'connected' | 'error' | 'offline'
       service: string
+      /** Broker login / OAuth key used by existing broker sync routes. */
+      accountId: string
       accounts: ConnectionsPageAccount[]
     }
   | {
@@ -19,8 +21,47 @@ export type StripItem =
       displayName: string
       status: 'offline'
       service: string | null
+      accountId: null
       accounts: ConnectionsPageAccount[]
     }
+
+/** Hosted brokers that already expose on-demand sync. CSV / Thor / unknown: no. */
+export const STRIP_SYNCABLE_SERVICES = new Set<string>([
+  'rithmic',
+  'rithmic-protocol',
+  'tradovate',
+  'dxfeed',
+  'ibkr',
+  'ig',
+])
+
+export function isStripSyncableService(
+  service: string | null | undefined
+): boolean {
+  return service != null && STRIP_SYNCABLE_SERVICES.has(service)
+}
+
+export function canSyncStripItem(item: Pick<StripItem, 'kind' | 'service'>): boolean {
+  return item.kind === 'connection' && isStripSyncableService(item.service)
+}
+
+/** Journaled/computed balance already attached to dashboard accounts. */
+export function journaledAccountBalance(account: {
+  metrics?: { currentBalance?: number } | null
+  balanceToDate?: number | null
+  startingBalance?: number | null
+} | null | undefined): number | null {
+  if (!account) return null
+  const value =
+    account.metrics?.currentBalance ??
+    account.balanceToDate ??
+    account.startingBalance
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export function formatStripBalance(value: number): string {
+  return `$${value.toFixed(2)}`
+}
 
 /**
  * Strip chips are connections only. Every account without a broker link
@@ -39,6 +80,7 @@ export function buildStripItems(
       displayName: connection.displayName,
       status: connection.status,
       service: connection.service,
+      accountId: connection.accountId || connection.externalId,
       accounts: connection.accounts,
     })
   )
@@ -55,6 +97,7 @@ export function buildStripItems(
       displayName: standaloneLabel,
       status: 'offline',
       service: null,
+      accountId: null,
       accounts: data.standaloneAccounts,
     },
   ]

--- a/app/[locale]/dashboard/components/connections-strip-items.ts
+++ b/app/[locale]/dashboard/components/connections-strip-items.ts
@@ -45,6 +45,19 @@ export function canSyncStripItem(item: Pick<StripItem, 'kind' | 'service'>): boo
   return item.kind === 'connection' && isStripSyncableService(item.service)
 }
 
+/**
+ * Desktop-only: Sync replaces the account-count meta on the chip.
+ * Mobile never shows Sync on the chip (or in the drawer).
+ * `isMobile` is `undefined` until the viewport is measured — treat that as
+ * "not desktop" so a phone never flashes a nested Sync button.
+ */
+export function chipShowsDesktopSync(
+  item: Pick<StripItem, 'kind' | 'service'>,
+  isMobile: boolean | undefined
+): boolean {
+  return isMobile === false && canSyncStripItem(item)
+}
+
 /** Journaled/computed balance already attached to dashboard accounts. */
 export function journaledAccountBalance(account: {
   metrics?: { currentBalance?: number } | null

--- a/app/[locale]/dashboard/components/connections-strip-items.ts
+++ b/app/[locale]/dashboard/components/connections-strip-items.ts
@@ -46,12 +46,11 @@ export function canSyncStripItem(item: Pick<StripItem, 'kind' | 'service'>): boo
 }
 
 /**
- * Desktop-only: Sync replaces the account-count meta on the chip.
- * Mobile never shows Sync on the chip (or in the drawer).
+ * Desktop dropdown footer only. Never on the chip, never in the mobile drawer.
  * `isMobile` is `undefined` until the viewport is measured — treat that as
- * "not desktop" so a phone never flashes a nested Sync button.
+ * "not desktop" so a phone never flashes Sync.
  */
-export function chipShowsDesktopSync(
+export function footerShowsDesktopSync(
   item: Pick<StripItem, 'kind' | 'service'>,
   isMobile: boolean | undefined
 ): boolean {

--- a/app/[locale]/dashboard/components/connections-strip.tsx
+++ b/app/[locale]/dashboard/components/connections-strip.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useState,
   type ButtonHTMLAttributes,
-  type ReactNode,
 } from 'react'
 import Link from 'next/link'
 import { ChevronDown, Loader2, Plus } from 'lucide-react'
@@ -14,7 +13,7 @@ import { toast } from 'sonner'
 import { useI18n } from '@/locales/client'
 import { cn } from '@/lib/utils'
 import { useData } from '@/context/data-provider'
-import { useIsMobile } from '@/hooks/use-mobile'
+import { useIsMobile, useIsMobileLayout } from '@/hooks/use-mobile'
 import { useUserStore } from '@/store/user-store'
 import { useTradesStore } from '@/store/trades-store'
 import { removeAccountsFromTradesAction } from '@/server/accounts'
@@ -59,6 +58,7 @@ import { HIDDEN_GROUP_NAME } from '@/app/[locale]/dashboard/components/filters/a
 import {
   buildStripItems,
   chipAccountCountLabel,
+  chipShowsDesktopSync,
   isStandaloneAccount,
   mapConnectionsAccounts,
   removeConnectionsAccount,
@@ -131,31 +131,18 @@ async function fetchConnectionsPageData(): Promise<ConnectionsPageData> {
   return reviveConnectionsPageData(json)
 }
 
-function ChipFrame({
-  open,
-  className,
-  children,
-}: {
-  open: boolean
-  className?: string
-  children: ReactNode
-}) {
-  return (
-    <div
-      className={cn(
-        'inline-flex h-9 max-w-[22rem] shrink-0 items-center rounded-[4px] border bg-white text-sm tracking-[-0.01em] dark:bg-background',
-        open
-          ? 'border-[#181A18] dark:border-white'
-          : 'border-[#E5E5E5] dark:border-border',
-        className
-      )}
-    >
-      {children}
-    </div>
-  )
+function chipStatusLabel(
+  status: StripItem['status'],
+  t: ReturnType<typeof useI18n>
+) {
+  return status === 'connected'
+    ? t('connections.status.connected')
+    : status === 'error'
+      ? t('connections.status.error')
+      : t('connections.status.offline')
 }
 
-function ChipPickerButton({
+function ChipTrigger({
   item,
   open,
   showChevron = true,
@@ -172,12 +159,7 @@ function ChipPickerButton({
   const meta = chipAccountCountLabel(item.accounts.length, t, {
     numericOnly: numericCount,
   })
-  const statusLabel =
-    item.status === 'connected'
-      ? t('connections.status.connected')
-      : item.status === 'error'
-        ? t('connections.status.error')
-        : t('connections.status.offline')
+  const statusLabel = chipStatusLabel(item.status, t)
 
   return (
     <button
@@ -185,7 +167,10 @@ function ChipPickerButton({
       aria-haspopup="listbox"
       aria-expanded={open}
       className={cn(
-        'inline-flex h-full min-w-0 items-center gap-2 px-3 text-left transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.98] dark:hover:bg-muted/50',
+        'inline-flex h-9 max-w-[16rem] shrink-0 items-center gap-2 rounded-[4px] border bg-white px-3 text-left text-sm tracking-[-0.01em] transition-[background-color,border-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.96] dark:bg-background dark:hover:bg-muted/50',
+        open
+          ? 'border-[#181A18] dark:border-white'
+          : 'border-[#E5E5E5] dark:border-border',
         className
       )}
       {...props}
@@ -321,15 +306,14 @@ function StripSyncButton({
         onSync()
       }}
       className={cn(
-        'inline-flex h-full shrink-0 items-center justify-center gap-1.5 border-l border-[#E5E5E5] px-2.5 text-sm font-medium text-[#171917]',
-        'rounded-r-[3px] transition-[background-color,transform] duration-150',
-        'hover:bg-[#F5F5F5] active:scale-[0.98]',
+        'inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-[3px] px-1.5 text-xs font-medium text-[#171917]',
+        'transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.96]',
         'disabled:pointer-events-none disabled:opacity-40',
-        'dark:border-border dark:text-foreground dark:hover:bg-muted/50'
+        'dark:text-foreground dark:hover:bg-muted/50'
       )}
     >
       {syncing ? (
-        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
       ) : null}
       {t('connections.strip.sync')}
     </button>
@@ -357,10 +341,13 @@ function ConnectionChip({
   onRequestDelete: (account: ConnectionsPageAccount) => void
   onSynced: () => void
 }) {
-  const isMobile = useIsMobile()
+  const t = useI18n()
+  const isMobile = useIsMobileLayout()
   const [open, setOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
   const { canSync, sync, syncing } = useStripConnectionSync(item, onSynced)
+  const showDesktopSync = chipShowsDesktopSync(item, isMobile) && canSync
+  const statusLabel = chipStatusLabel(item.status, t)
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next)
@@ -389,24 +376,16 @@ function ConnectionChip({
     />
   )
 
-  const syncControl = canSync ? (
-    <StripSyncButton syncing={syncing} onSync={() => void sync()} />
-  ) : null
-
-  if (isMobile) {
+  if (isMobile === true) {
     return (
       <>
-        <ChipFrame open={open}>
-          <ChipPickerButton
-            item={item}
-            open={open}
-            showChevron={false}
-            numericCount
-            className={syncControl ? 'rounded-l-[3px]' : 'rounded-[3px]'}
-            onClick={() => setOpen(true)}
-          />
-          {syncControl}
-        </ChipFrame>
+        <ChipTrigger
+          item={item}
+          open={open}
+          showChevron={false}
+          numericCount
+          onClick={() => setOpen(true)}
+        />
         <Drawer
           open={open}
           onOpenChange={handleOpenChange}
@@ -427,15 +406,11 @@ function ConnectionChip({
     )
   }
 
-  return (
-    <ChipFrame open={open}>
+  if (!showDesktopSync) {
+    return (
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
-          <ChipPickerButton
-            item={item}
-            open={open}
-            className={syncControl ? 'rounded-l-[3px]' : 'rounded-[3px]'}
-          />
+          <ChipTrigger item={item} open={open} />
         </PopoverTrigger>
         <PopoverContent
           align="start"
@@ -445,8 +420,66 @@ function ConnectionChip({
           {picker('max-h-[320px]')}
         </PopoverContent>
       </Popover>
-      {syncControl}
-    </ChipFrame>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'inline-flex h-9 max-w-[18rem] shrink-0 items-center rounded-[4px] border bg-white text-sm tracking-[-0.01em] dark:bg-background',
+        open
+          ? 'border-[#181A18] dark:border-white'
+          : 'border-[#E5E5E5] dark:border-border'
+      )}
+    >
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-haspopup="listbox"
+            aria-expanded={open}
+            className="inline-flex h-full min-w-0 items-center gap-2 rounded-l-[3px] pl-3 pr-1 text-left transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.98] dark:hover:bg-muted/50"
+          >
+            <span className="min-w-0 truncate font-medium text-[#171917] dark:text-foreground">
+              {item.displayName}
+            </span>
+            <span
+              className={cn(
+                'h-1.5 w-1.5 shrink-0 rounded-full',
+                item.status === 'connected' && 'bg-[#3E7550]',
+                item.status === 'error' && 'bg-red-500',
+                item.status === 'offline' && 'bg-[#A3A3A3]'
+              )}
+              aria-label={statusLabel}
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={8}
+          className="w-[min(28rem,calc(100vw-2rem))] rounded-[4px] border-[#E5E5E5] bg-white p-0 shadow-md dark:border-border dark:bg-background"
+        >
+          {picker('max-h-[320px]')}
+        </PopoverContent>
+      </Popover>
+      <StripSyncButton syncing={syncing} onSync={() => void sync()} />
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={item.displayName}
+        className="inline-flex h-full items-center rounded-r-[3px] pr-3 pl-1 text-[#686D67] transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.98] dark:text-muted-foreground dark:hover:bg-muted/50"
+        onClick={() => handleOpenChange(true)}
+      >
+        <ChevronDown
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 transition-transform duration-150',
+            open && 'rotate-180'
+          )}
+          aria-hidden
+        />
+      </button>
+    </div>
   )
 }
 

--- a/app/[locale]/dashboard/components/connections-strip.tsx
+++ b/app/[locale]/dashboard/components/connections-strip.tsx
@@ -8,7 +8,7 @@ import {
   type ButtonHTMLAttributes,
 } from 'react'
 import Link from 'next/link'
-import { ChevronDown, Loader2, Plus } from 'lucide-react'
+import { ChevronDown, Loader2, Plus, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { useI18n } from '@/locales/client'
 import { cn } from '@/lib/utils'
@@ -58,7 +58,7 @@ import { HIDDEN_GROUP_NAME } from '@/app/[locale]/dashboard/components/filters/a
 import {
   buildStripItems,
   chipAccountCountLabel,
-  chipShowsDesktopSync,
+  footerShowsDesktopSync,
   isStandaloneAccount,
   mapConnectionsAccounts,
   removeConnectionsAccount,
@@ -218,6 +218,7 @@ function AccountPickerList({
   onMask,
   onRequestDelete,
   listClassName,
+  footerSync,
 }: {
   item: StripItem
   selectedAccounts: string[]
@@ -231,6 +232,7 @@ function AccountPickerList({
   onMask: (account: ConnectionsPageAccount, masked: boolean) => void
   onRequestDelete: (account: ConnectionsPageAccount) => void
   listClassName: string
+  footerSync?: { syncing: boolean; onSync: () => void } | null
 }) {
   const t = useI18n()
   const query = searchTerm.trim().toLowerCase()
@@ -276,14 +278,20 @@ function AccountPickerList({
           ))}
         </CommandGroup>
       </CommandList>
-      <div className="border-t border-[#E5E5E5] dark:border-border">
+      <div className="flex items-center justify-between gap-3 border-t border-[#E5E5E5] px-3 py-2 dark:border-border">
         <Link
           href="/dashboard/connections"
-          className="block px-3 py-2.5 text-sm font-medium text-[#3E7550] transition-colors hover:bg-[#EFF5EC] dark:text-[#9BC4A8] dark:hover:bg-[#243028]"
+          className="min-w-0 truncate text-sm font-medium text-[#3E7550] transition-colors hover:text-[#2F5C3E] dark:text-[#9BC4A8] dark:hover:text-[#B7D4C2]"
           onClick={onClose}
         >
           {t('connections.manageConnection')}
         </Link>
+        {footerSync ? (
+          <StripSyncButton
+            syncing={footerSync.syncing}
+            onSync={footerSync.onSync}
+          />
+        ) : null}
       </div>
     </Command>
   )
@@ -306,15 +314,18 @@ function StripSyncButton({
         onSync()
       }}
       className={cn(
-        'inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-[3px] px-1.5 text-xs font-medium text-[#171917]',
-        'transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.96]',
+        'inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-[4px] border border-[#E5E5E5] bg-white px-2.5 text-sm font-medium text-[#171917]',
+        'transition-[background-color,border-color,transform] duration-150',
+        'hover:bg-[#F5F5F5] active:scale-[0.96]',
         'disabled:pointer-events-none disabled:opacity-40',
-        'dark:text-foreground dark:hover:bg-muted/50'
+        'dark:border-border dark:bg-background dark:text-foreground dark:hover:bg-muted/50'
       )}
     >
       {syncing ? (
-        <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
-      ) : null}
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+      ) : (
+        <RefreshCw className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+      )}
       {t('connections.strip.sync')}
     </button>
   )
@@ -341,13 +352,11 @@ function ConnectionChip({
   onRequestDelete: (account: ConnectionsPageAccount) => void
   onSynced: () => void
 }) {
-  const t = useI18n()
   const isMobile = useIsMobileLayout()
   const [open, setOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
   const { canSync, sync, syncing } = useStripConnectionSync(item, onSynced)
-  const showDesktopSync = chipShowsDesktopSync(item, isMobile) && canSync
-  const statusLabel = chipStatusLabel(item.status, t)
+  const showFooterSync = footerShowsDesktopSync(item, isMobile) && canSync
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next)
@@ -359,7 +368,7 @@ function ConnectionChip({
     onRequestDelete(account)
   }
 
-  const picker = (listClassName: string) => (
+  const picker = (listClassName: string, withFooterSync: boolean) => (
     <AccountPickerList
       item={item}
       selectedAccounts={selectedAccounts}
@@ -373,6 +382,11 @@ function ConnectionChip({
       onMask={onMask}
       onRequestDelete={requestDelete}
       listClassName={listClassName}
+      footerSync={
+        withFooterSync
+          ? { syncing, onSync: () => void sync() }
+          : null
+      }
     />
   )
 
@@ -398,7 +412,8 @@ function ConnectionChip({
               </DrawerTitle>
             </DrawerHeader>
             {picker(
-              'max-h-[min(320px,50svh)] pb-[max(0.5rem,env(safe-area-inset-bottom))]'
+              'max-h-[min(320px,50svh)] pb-[max(0.5rem,env(safe-area-inset-bottom))]',
+              false
             )}
           </DrawerContent>
         </Drawer>
@@ -406,80 +421,19 @@ function ConnectionChip({
     )
   }
 
-  if (!showDesktopSync) {
-    return (
-      <Popover open={open} onOpenChange={handleOpenChange}>
-        <PopoverTrigger asChild>
-          <ChipTrigger item={item} open={open} />
-        </PopoverTrigger>
-        <PopoverContent
-          align="start"
-          sideOffset={8}
-          className="w-[min(28rem,calc(100vw-2rem))] rounded-[4px] border-[#E5E5E5] bg-white p-0 shadow-md dark:border-border dark:bg-background"
-        >
-          {picker('max-h-[320px]')}
-        </PopoverContent>
-      </Popover>
-    )
-  }
-
   return (
-    <div
-      className={cn(
-        'inline-flex h-9 max-w-[18rem] shrink-0 items-center rounded-[4px] border bg-white text-sm tracking-[-0.01em] dark:bg-background',
-        open
-          ? 'border-[#181A18] dark:border-white'
-          : 'border-[#E5E5E5] dark:border-border'
-      )}
-    >
-      <Popover open={open} onOpenChange={handleOpenChange}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            aria-haspopup="listbox"
-            aria-expanded={open}
-            className="inline-flex h-full min-w-0 items-center gap-2 rounded-l-[3px] pl-3 pr-1 text-left transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.98] dark:hover:bg-muted/50"
-          >
-            <span className="min-w-0 truncate font-medium text-[#171917] dark:text-foreground">
-              {item.displayName}
-            </span>
-            <span
-              className={cn(
-                'h-1.5 w-1.5 shrink-0 rounded-full',
-                item.status === 'connected' && 'bg-[#3E7550]',
-                item.status === 'error' && 'bg-red-500',
-                item.status === 'offline' && 'bg-[#A3A3A3]'
-              )}
-              aria-label={statusLabel}
-            />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent
-          align="start"
-          sideOffset={8}
-          className="w-[min(28rem,calc(100vw-2rem))] rounded-[4px] border-[#E5E5E5] bg-white p-0 shadow-md dark:border-border dark:bg-background"
-        >
-          {picker('max-h-[320px]')}
-        </PopoverContent>
-      </Popover>
-      <StripSyncButton syncing={syncing} onSync={() => void sync()} />
-      <button
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-label={item.displayName}
-        className="inline-flex h-full items-center rounded-r-[3px] pr-3 pl-1 text-[#686D67] transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.98] dark:text-muted-foreground dark:hover:bg-muted/50"
-        onClick={() => handleOpenChange(true)}
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <ChipTrigger item={item} open={open} />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={8}
+        className="w-[min(28rem,calc(100vw-2rem))] rounded-[4px] border-[#E5E5E5] bg-white p-0 shadow-md dark:border-border dark:bg-background"
       >
-        <ChevronDown
-          className={cn(
-            'h-3.5 w-3.5 shrink-0 transition-transform duration-150',
-            open && 'rotate-180'
-          )}
-          aria-hidden
-        />
-      </button>
-    </div>
+        {picker('max-h-[320px]', showFooterSync)}
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/app/[locale]/dashboard/components/connections-strip.tsx
+++ b/app/[locale]/dashboard/components/connections-strip.tsx
@@ -6,9 +6,10 @@ import {
   useMemo,
   useState,
   type ButtonHTMLAttributes,
+  type ReactNode,
 } from 'react'
 import Link from 'next/link'
-import { ChevronDown, Plus } from 'lucide-react'
+import { ChevronDown, Loader2, Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import { useI18n } from '@/locales/client'
 import { cn } from '@/lib/utils'
@@ -65,6 +66,7 @@ import {
   type StripItem,
 } from './connections-strip-items'
 import { ConnectionsStripAccountRow } from './connections-strip-account-row'
+import { useStripConnectionSync } from './use-strip-connection-sync'
 
 const SERVICE_SECTIONS: {
   service: ConnectionService
@@ -129,7 +131,31 @@ async function fetchConnectionsPageData(): Promise<ConnectionsPageData> {
   return reviveConnectionsPageData(json)
 }
 
-function ChipTrigger({
+function ChipFrame({
+  open,
+  className,
+  children,
+}: {
+  open: boolean
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <div
+      className={cn(
+        'inline-flex h-9 max-w-[22rem] shrink-0 items-center rounded-[4px] border bg-white text-sm tracking-[-0.01em] dark:bg-background',
+        open
+          ? 'border-[#181A18] dark:border-white'
+          : 'border-[#E5E5E5] dark:border-border',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+function ChipPickerButton({
   item,
   open,
   showChevron = true,
@@ -159,10 +185,7 @@ function ChipTrigger({
       aria-haspopup="listbox"
       aria-expanded={open}
       className={cn(
-        'inline-flex h-9 max-w-[16rem] shrink-0 items-center gap-2 rounded-[4px] border bg-white px-3 text-left text-sm tracking-[-0.01em] transition-[background-color,border-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.96] dark:bg-background dark:hover:bg-muted/50',
-        open
-          ? 'border-[#181A18] dark:border-white'
-          : 'border-[#E5E5E5] dark:border-border',
+        'inline-flex h-full min-w-0 items-center gap-2 px-3 text-left transition-[background-color,transform] duration-150 hover:bg-[#F5F5F5] active:scale-[0.98] dark:hover:bg-muted/50',
         className
       )}
       {...props}
@@ -208,7 +231,6 @@ function AccountPickerList({
   onSelectAccount,
   onClose,
   onMask,
-  onRename,
   onRequestDelete,
   listClassName,
 }: {
@@ -222,10 +244,6 @@ function AccountPickerList({
   onSelectAccount: (accountNumber: string) => void
   onClose: () => void
   onMask: (account: ConnectionsPageAccount, masked: boolean) => void
-  onRename: (
-    account: ConnectionsPageAccount,
-    nextName: string
-  ) => Promise<boolean>
   onRequestDelete: (account: ConnectionsPageAccount) => void
   listClassName: string
 }) {
@@ -268,7 +286,6 @@ function AccountPickerList({
                 onClose()
               }}
               onMask={onMask}
-              onRename={onRename}
               onRequestDelete={onRequestDelete}
             />
           ))}
@@ -287,6 +304,38 @@ function AccountPickerList({
   )
 }
 
+function StripSyncButton({
+  syncing,
+  onSync,
+}: {
+  syncing: boolean
+  onSync: () => void
+}) {
+  const t = useI18n()
+  return (
+    <button
+      type="button"
+      disabled={syncing}
+      onClick={(event) => {
+        event.stopPropagation()
+        onSync()
+      }}
+      className={cn(
+        'inline-flex h-full shrink-0 items-center justify-center gap-1.5 border-l border-[#E5E5E5] px-2.5 text-sm font-medium text-[#171917]',
+        'rounded-r-[3px] transition-[background-color,transform] duration-150',
+        'hover:bg-[#F5F5F5] active:scale-[0.98]',
+        'disabled:pointer-events-none disabled:opacity-40',
+        'dark:border-border dark:text-foreground dark:hover:bg-muted/50'
+      )}
+    >
+      {syncing ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+      ) : null}
+      {t('connections.strip.sync')}
+    </button>
+  )
+}
+
 function ConnectionChip({
   item,
   selectedAccounts,
@@ -295,8 +344,8 @@ function ConnectionChip({
   deletingAccountId,
   onSelectAccount,
   onMask,
-  onRename,
   onRequestDelete,
+  onSynced,
 }: {
   item: StripItem
   selectedAccounts: string[]
@@ -305,15 +354,13 @@ function ConnectionChip({
   deletingAccountId: string | null
   onSelectAccount: (accountNumber: string) => void
   onMask: (account: ConnectionsPageAccount, masked: boolean) => void
-  onRename: (
-    account: ConnectionsPageAccount,
-    nextName: string
-  ) => Promise<boolean>
   onRequestDelete: (account: ConnectionsPageAccount) => void
+  onSynced: () => void
 }) {
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
+  const { canSync, sync, syncing } = useStripConnectionSync(item, onSynced)
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next)
@@ -337,22 +384,29 @@ function ConnectionChip({
       onSelectAccount={onSelectAccount}
       onClose={() => handleOpenChange(false)}
       onMask={onMask}
-      onRename={onRename}
       onRequestDelete={requestDelete}
       listClassName={listClassName}
     />
   )
 
+  const syncControl = canSync ? (
+    <StripSyncButton syncing={syncing} onSync={() => void sync()} />
+  ) : null
+
   if (isMobile) {
     return (
       <>
-        <ChipTrigger
-          item={item}
-          open={open}
-          showChevron={false}
-          numericCount
-          onClick={() => setOpen(true)}
-        />
+        <ChipFrame open={open}>
+          <ChipPickerButton
+            item={item}
+            open={open}
+            showChevron={false}
+            numericCount
+            className={syncControl ? 'rounded-l-[3px]' : 'rounded-[3px]'}
+            onClick={() => setOpen(true)}
+          />
+          {syncControl}
+        </ChipFrame>
         <Drawer
           open={open}
           onOpenChange={handleOpenChange}
@@ -374,18 +428,25 @@ function ConnectionChip({
   }
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <ChipTrigger item={item} open={open} />
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        sideOffset={8}
-        className="w-[min(28rem,calc(100vw-2rem))] rounded-[4px] border-[#E5E5E5] bg-white p-0 shadow-md dark:border-border dark:bg-background"
-      >
-        {picker('max-h-[320px]')}
-      </PopoverContent>
-    </Popover>
+    <ChipFrame open={open}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <ChipPickerButton
+            item={item}
+            open={open}
+            className={syncControl ? 'rounded-l-[3px]' : 'rounded-[3px]'}
+          />
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={8}
+          className="w-[min(28rem,calc(100vw-2rem))] rounded-[4px] border-[#E5E5E5] bg-white p-0 shadow-md dark:border-border dark:bg-background"
+        >
+          {picker('max-h-[320px]')}
+        </PopoverContent>
+      </Popover>
+      {syncControl}
+    </ChipFrame>
   )
 }
 
@@ -468,12 +529,10 @@ export function ConnectionsStrip({ className }: { className?: string }) {
     accountNumbers = [],
     setAccountNumbers,
     saveGroup,
-    saveAccount,
     moveAccountsToGroup,
     refreshTradesOnly,
   } = useData()
   const groups = useUserStore((state) => state.groups)
-  const updateAccount = useUserStore((state) => state.updateAccount)
   const removeAccount = useUserStore((state) => state.removeAccount)
   const setAccounts = useUserStore((state) => state.setAccounts)
   const setGroups = useUserStore((state) => state.setGroups)
@@ -579,38 +638,6 @@ export function ConnectionsStrip({ className }: { className?: string }) {
     [applyAccountPatch, ensureHiddenGroup, moveAccountsToGroup, setAccounts, setGroups, t]
   )
 
-  const onRename = useCallback(
-    async (account: ConnectionsPageAccount, nextName: string) => {
-      const storeAccount = useUserStore
-        .getState()
-        .accounts.find(
-          (item) => item.id === account.id || item.number === account.number
-        )
-      if (!storeAccount) {
-        toast.error(t('connections.strip.renameFailed'))
-        return false
-      }
-      try {
-        await saveAccount({ ...storeAccount, propfirm: nextName })
-        applyAccountPatch(account.id, { propfirm: nextName })
-        updateAccount(account.id, { propfirm: nextName })
-        setGroups(
-          useUserStore.getState().groups.map((group) => ({
-            ...group,
-            accounts: group.accounts.map((item) =>
-              item.id === account.id ? { ...item, propfirm: nextName } : item
-            ),
-          }))
-        )
-        return true
-      } catch {
-        toast.error(t('connections.strip.renameFailed'))
-        return false
-      }
-    },
-    [applyAccountPatch, saveAccount, setGroups, t, updateAccount]
-  )
-
   const onDelete = useCallback(
     async (account: ConnectionsPageAccount) => {
       if (!isStandaloneAccount(account)) return
@@ -675,8 +702,8 @@ export function ConnectionsStrip({ className }: { className?: string }) {
             deletingAccountId={deletingAccountId}
             onSelectAccount={onSelectAccount}
             onMask={onMask}
-            onRename={onRename}
             onRequestDelete={setAccountToDelete}
+            onSynced={() => void load()}
           />
         ))}
         <AddConnectionChip onSelectService={setConnectService} />

--- a/app/[locale]/dashboard/components/use-strip-connection-sync.ts
+++ b/app/[locale]/dashboard/components/use-strip-connection-sync.ts
@@ -1,0 +1,101 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import { useI18n } from '@/locales/client'
+import { useDxFeedSyncContext } from '@/context/dxfeed-sync-context'
+import { useIbkrSyncContext } from '@/context/ibkr-sync-context'
+import { useIgSyncContext } from '@/context/ig-sync-context'
+import { useRithmicProtocolSyncContext } from '@/context/rithmic-protocol-sync-context'
+import { useRithmicSyncContext } from '@/context/rithmic-sync-context'
+import { useTradovateSyncContext } from '@/context/tradovate-sync-context'
+import {
+  canSyncStripItem,
+  type StripItem,
+} from './connections-strip-items'
+
+/**
+ * Reuses the same broker sync contexts and handlers as
+ * `/dashboard/connections`. Does not invent a new backend.
+ */
+export function useStripConnectionSync(item: StripItem, onSynced: () => void) {
+  const t = useI18n()
+  const [localSyncing, setLocalSyncing] = useState(false)
+  const { performSyncForAccount: syncTradovate } = useTradovateSyncContext()
+  const { performSyncForAccount: syncDxFeed } = useDxFeedSyncContext()
+  const { performSyncForAccount: syncIbkr } = useIbkrSyncContext()
+  const { performSyncForCredential: syncRithmic } = useRithmicSyncContext()
+  const {
+    performSyncForAccount: syncRithmicProtocol,
+    isAccountSyncing: isRithmicProtocolSyncing,
+  } = useRithmicProtocolSyncContext()
+  const { performSyncForAccount: syncIg, isAccountSyncing: isIgSyncing } =
+    useIgSyncContext()
+
+  const canSync = canSyncStripItem(item) && Boolean(item.accountId)
+  const contextSyncing =
+    item.kind === 'connection' &&
+    ((item.service === 'rithmic-protocol' &&
+      isRithmicProtocolSyncing(item.accountId)) ||
+      (item.service === 'ig' && isIgSyncing(item.accountId)))
+  const syncing = localSyncing || contextSyncing
+
+  const sync = useCallback(async () => {
+    if (!canSync || !item.accountId || syncing) return
+
+    const usesLocalSyncState =
+      item.service !== 'rithmic-protocol' && item.service !== 'ig'
+    if (usesLocalSyncState) setLocalSyncing(true)
+
+    try {
+      let result: { success?: boolean } | void
+      if (item.service === 'tradovate') {
+        result = await syncTradovate(item.accountId)
+      } else if (item.service === 'dxfeed') {
+        result = await syncDxFeed(item.accountId)
+      } else if (item.service === 'ibkr') {
+        result = await syncIbkr(item.accountId)
+      } else if (item.service === 'rithmic-protocol') {
+        result = await syncRithmicProtocol(item.accountId)
+      } else if (item.service === 'ig') {
+        result = await syncIg(item.accountId)
+      } else if (item.service === 'rithmic') {
+        result = await syncRithmic(item.accountId)
+      } else {
+        toast.message(t('connections.sync.manualOnly'))
+        return
+      }
+
+      if (result && result.success === false) {
+        if (usesLocalSyncState) {
+          toast.error(t('connections.sync.failed'))
+        }
+        return
+      }
+
+      onSynced()
+    } catch (error) {
+      console.error(error)
+      if (usesLocalSyncState) {
+        toast.error(t('connections.sync.failed'))
+      }
+    } finally {
+      if (usesLocalSyncState) setLocalSyncing(false)
+    }
+  }, [
+    canSync,
+    item.accountId,
+    item.service,
+    onSynced,
+    syncDxFeed,
+    syncIbkr,
+    syncIg,
+    syncRithmic,
+    syncRithmicProtocol,
+    syncTradovate,
+    syncing,
+    t,
+  ])
+
+  return { canSync, sync, syncing }
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -155,6 +155,8 @@ export default {
   "connections.strip.unmask": "Unmask",
   "connections.strip.rename": "Rename",
   "connections.strip.saveName": "Save name",
+  "connections.strip.sync": "Sync",
+  "connections.strip.balance": "Balance {amount}",
   "connections.strip.deleteAccount": "Delete {account}",
   "connections.strip.deleteConfirmTitle": "Delete this account?",
   "connections.strip.deleteConfirmDescription":

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -156,6 +156,8 @@ export default {
   "connections.strip.unmask": "Afficher",
   "connections.strip.rename": "Renommer",
   "connections.strip.saveName": "Enregistrer le nom",
+  "connections.strip.sync": "Synchroniser",
+  "connections.strip.balance": "Solde {amount}",
   "connections.strip.deleteAccount": "Supprimer {account}",
   "connections.strip.deleteConfirmTitle": "Supprimer ce compte ?",
   "connections.strip.deleteConfirmDescription":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Exploratory, tryable dashboard PR aligned to Paper on this lock. Can still diverge where Paper is still moving.

## Product lock

1. **Desktop chip** — name · status · N accounts · chevron. No Sync on the chip. The split name|Sync|chevron control is gone.
2. **Desktop dropdown footer** — Manage connection (left) · Sync (right). Sync only for hosted brokers (Rithmic, Tradovate, IBKR, DXFeed, IG, rithmic-protocol). Hidden for CSV / standalone / Thor.
3. **Account rows** — account number only; journaled/computed balance stacked under the number on the left. No Rename. Mask (eye), CSV delete when applicable, and Manage connection stay.
4. **Mobile** — no Sync on the chip, no Sync in the drawer. Chip stays name · status · count.

Out of scope: report inconsistency / chatbox.

## Verification

![Desktop chips: count restored, no Sync on chip](https://cursor.com/artifacts/c/art-a26a7590-3c60-4b8e-8d9b-93cdf8ad8139)
![Desktop Apex-Demo popover: stacked balance, footer Sync](https://cursor.com/artifacts/c/art-45ce8f4d-3e03-4f0f-93b2-2f2f949f1498)
![Desktop Standalone popover: no Sync in footer](https://cursor.com/artifacts/c/art-f62c62ad-53f7-4fc2-b6c5-6f05aaa472b8)
![Mobile chip: name, status, count — no Sync](https://cursor.com/artifacts/c/art-1485a79b-bb83-4c4a-8efa-7928e7bdb754)
![Mobile drawer: no Sync](https://cursor.com/artifacts/c/art-0110127c-d778-4826-a0c9-cce21e5e1598)
<a href="https://cursor.com/agents/bc-28f7553e-d487-419a-bbba-7285bcce8e29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffooter_sync_stacked_balance.mp4"><img src="https://cursor.com/artifacts/c/art-5e41cb06-b1e8-4543-a9af-b04ed9c2d957" alt="footer_sync_stacked_balance.mp4" /></a>

Do not merge until Hugo has tried it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28f7553e-d487-419a-bbba-7285bcce8e29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28f7553e-d487-419a-bbba-7285bcce8e29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

