### PR TITLE
Map dashboard widgets to data-honest chart encodings

### DIFF
--- a/app/[locale]/dashboard/components/charts/chart-conclusions.ts
+++ b/app/[locale]/dashboard/components/charts/chart-conclusions.ts
@@ -1,0 +1,62 @@
+import { peakIndex } from "./chart-glance"
+
+export type EmptyConclusion = { kind: "empty" }
+
+export type DailyPnlConclusion =
+  | EmptyConclusion
+  | { kind: "greenDays"; green: number; total: number }
+  | { kind: "redDays"; red: number; total: number }
+
+export function dailyPnlConclusion(values: number[]): DailyPnlConclusion {
+  if (values.length === 0) return { kind: "empty" }
+  const green = values.filter((value) => value > 0).length
+  const red = values.filter((value) => value < 0).length
+  if (green >= red) {
+    return { kind: "greenDays", green, total: values.length }
+  }
+  return { kind: "redDays", red, total: values.length }
+}
+
+export type NamedValueConclusion =
+  | EmptyConclusion
+  | { kind: "best"; label: string }
+  | { kind: "worst"; label: string }
+
+export function namedSignedConclusion(
+  items: Array<{ label: string; value: number }>,
+): NamedValueConclusion {
+  const active = items.filter((item) => item.value !== 0)
+  if (active.length === 0) return { kind: "empty" }
+
+  const strongest = peakIndex(active, (item) => item.value, "max")
+  const weakest = peakIndex(active, (item) => item.value, "min")
+  const best = active[strongest]
+  const worst = active[weakest]
+
+  if (Math.abs(best.value) >= Math.abs(worst.value)) {
+    return { kind: "best", label: best.label }
+  }
+  return { kind: "worst", label: worst.label }
+}
+
+export type CountPeakConclusion =
+  | EmptyConclusion
+  | { kind: "peak"; label: string }
+
+export function countPeakConclusion(
+  items: Array<{ label: string; count: number }>,
+): CountPeakConclusion {
+  const active = items.filter((item) => item.count > 0)
+  if (active.length === 0) return { kind: "empty" }
+  const index = peakIndex(active, (item) => item.count, "max")
+  return { kind: "peak", label: active[index].label }
+}
+
+export type ShareConclusion =
+  | EmptyConclusion
+  | { kind: "share"; percent: number }
+
+export function shareConclusion(part: number, whole: number): ShareConclusion {
+  if (whole <= 0) return { kind: "empty" }
+  return { kind: "share", percent: Math.round((part / whole) * 100) }
+}

--- a/app/[locale]/dashboard/components/charts/chart-glance-bar.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-glance-bar.tsx
@@ -1,7 +1,12 @@
 "use client"
 
 import { Rectangle } from "recharts"
-import { chartBarRadius } from "./chart-glance"
+import {
+  CHART_BAR_CAP,
+  type ChartBarLayout,
+  chartBarRadius,
+  normalizeBarRect,
+} from "./chart-glance"
 
 interface GlanceBarProps {
   x?: number
@@ -10,6 +15,7 @@ interface GlanceBarProps {
   height?: number
   fill?: string
   value?: number | string
+  layout?: ChartBarLayout
 }
 
 export function GlanceBar({
@@ -19,17 +25,28 @@ export function GlanceBar({
   height = 0,
   fill,
   value,
+  layout = "vertical",
 }: GlanceBarProps) {
   const numeric = typeof value === "number" ? value : Number(value ?? 0)
+  const signed =
+    Number.isFinite(numeric) && numeric !== 0
+      ? numeric
+      : layout === "horizontal"
+        ? width
+        : height
+  const rect = normalizeBarRect(x, y, width, height)
+  const cap = Math.min(CHART_BAR_CAP, rect.width / 2, rect.height / 2)
 
   return (
     <Rectangle
-      x={x}
-      y={y}
-      width={width}
-      height={height}
+      x={rect.x}
+      y={rect.y}
+      width={rect.width}
+      height={rect.height}
       fill={fill}
-      radius={chartBarRadius(Number.isFinite(numeric) ? numeric : 0)}
+      radius={chartBarRadius(signed, layout).map((corner) =>
+        corner === 0 ? 0 : cap,
+      ) as [number, number, number, number]}
     />
   )
 }

--- a/app/[locale]/dashboard/components/charts/chart-glance-bar.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-glance-bar.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { Rectangle } from "recharts"
+import { chartBarRadius } from "./chart-glance"
+
+interface GlanceBarProps {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  fill?: string
+  value?: number | string
+}
+
+export function GlanceBar({
+  x = 0,
+  y = 0,
+  width = 0,
+  height = 0,
+  fill,
+  value,
+}: GlanceBarProps) {
+  const numeric = typeof value === "number" ? value : Number(value ?? 0)
+
+  return (
+    <Rectangle
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      fill={fill}
+      radius={chartBarRadius(Number.isFinite(numeric) ? numeric : 0)}
+    />
+  )
+}

--- a/app/[locale]/dashboard/components/charts/chart-glance.test.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.test.ts
@@ -5,9 +5,12 @@ import {
   filterBarOpacity,
   honestPositiveDomain,
   honestSignedDomain,
+  normalizeBarRect,
   peakIndex,
   signedFill,
 } from "./chart-glance"
+import { expandUnitDots, shouldPackUnitField } from "./chart-unit-field"
+import { canDrawUnitHistogram } from "./chart-unit-histogram"
 import {
   countPeakConclusion,
   dailyPnlConclusion,
@@ -22,6 +25,85 @@ describe("chartBarRadius", () => {
 
   it("rounds the outer end of a negative bar", () => {
     expect(chartBarRadius(-4)).toEqual([0, 0, 8, 8])
+  })
+
+  it("rounds the outer end of a horizontal negative bar", () => {
+    expect(chartBarRadius(-4, "horizontal")).toEqual([8, 0, 0, 8])
+  })
+
+  it("rounds the outer end of a horizontal positive bar", () => {
+    expect(chartBarRadius(12, "horizontal")).toEqual([0, 8, 8, 0])
+  })
+})
+
+describe("normalizeBarRect", () => {
+  it("keeps a positive-height rect in place", () => {
+    expect(normalizeBarRect(10, 20, 8, 40)).toEqual({
+      x: 10,
+      y: 20,
+      width: 8,
+      height: 40,
+    })
+  })
+
+  it("flips a negative-height rect so y is the visual top", () => {
+    expect(normalizeBarRect(10, 80, 8, -40)).toEqual({
+      x: 10,
+      y: 40,
+      width: 8,
+      height: 40,
+    })
+  })
+
+  it("flips a negative-width rect so x is the visual left", () => {
+    expect(normalizeBarRect(80, 20, -40, 8)).toEqual({
+      x: 40,
+      y: 20,
+      width: 40,
+      height: 8,
+    })
+  })
+})
+
+describe("expandUnitDots", () => {
+  it("emits one dot per record", () => {
+    expect(
+      expandUnitDots(
+        [
+          { key: "win", label: "Win", color: "green", count: 2 },
+          { key: "loss", label: "Loss", color: "red", count: 1 },
+        ],
+        "record",
+      ),
+    ).toHaveLength(3)
+  })
+
+  it("packs percent mode to 100 dots", () => {
+    const dots = expandUnitDots(
+      [
+        { key: "win", label: "Win", color: "green", count: 3 },
+        { key: "loss", label: "Loss", color: "red", count: 1 },
+      ],
+      "percent",
+    )
+    expect(dots).toHaveLength(100)
+    expect(dots.filter((dot) => dot.key.startsWith("win-"))).toHaveLength(75)
+    expect(dots.filter((dot) => dot.key.startsWith("loss-"))).toHaveLength(25)
+  })
+})
+
+describe("shouldPackUnitField", () => {
+  it("packs only dense trade counts", () => {
+    expect(shouldPackUnitField(120)).toBe(false)
+    expect(shouldPackUnitField(121)).toBe(true)
+  })
+})
+
+describe("canDrawUnitHistogram", () => {
+  it("rejects a histogram that would crush the dots", () => {
+    expect(canDrawUnitHistogram([2, 4, 3])).toBe(true)
+    expect(canDrawUnitHistogram(Array.from({ length: 20 }, () => 2))).toBe(false)
+    expect(canDrawUnitHistogram([80])).toBe(false)
   })
 })
 

--- a/app/[locale]/dashboard/components/charts/chart-glance.test.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+import {
+  chartBarRadius,
+  chartMaxBarSize,
+  filterBarOpacity,
+  honestPositiveDomain,
+  honestSignedDomain,
+  peakIndex,
+  signedFill,
+} from "./chart-glance"
+import {
+  countPeakConclusion,
+  dailyPnlConclusion,
+  namedSignedConclusion,
+  shareConclusion,
+} from "./chart-conclusions"
+
+describe("chartBarRadius", () => {
+  it("rounds the outer end of a positive bar", () => {
+    expect(chartBarRadius(12)).toEqual([8, 8, 0, 0])
+  })
+
+  it("rounds the outer end of a negative bar", () => {
+    expect(chartBarRadius(-4)).toEqual([0, 0, 8, 8])
+  })
+})
+
+describe("honestSignedDomain", () => {
+  it("keeps zero on the axis", () => {
+    expect(honestSignedDomain([40, -10])).toEqual([-14, 44])
+  })
+
+  it("does not start a positive series above zero", () => {
+    const [, max] = honestSignedDomain([10, 20])
+    expect(honestSignedDomain([10, 20])[0]).toBe(0)
+    expect(max).toBeGreaterThan(20)
+  })
+})
+
+describe("honestPositiveDomain", () => {
+  it("starts at zero", () => {
+    expect(honestPositiveDomain([4, 8])[0]).toBe(0)
+  })
+})
+
+describe("signedFill", () => {
+  it("maps sign to win/loss tokens", () => {
+    expect(signedFill(1)).toContain("chart-win")
+    expect(signedFill(-1)).toContain("chart-loss")
+  })
+})
+
+describe("filterBarOpacity", () => {
+  it("dims inactive bars only when a filter is on", () => {
+    expect(filterBarOpacity(false, false)).toBe(1)
+    expect(filterBarOpacity(false, true)).toBe(0.35)
+    expect(filterBarOpacity(true, true)).toBe(1)
+  })
+})
+
+describe("chartMaxBarSize", () => {
+  it("uses chunkier Glance bars on medium widgets", () => {
+    expect(chartMaxBarSize("medium")).toBeGreaterThan(chartMaxBarSize("small"))
+  })
+})
+
+describe("dailyPnlConclusion", () => {
+  it("reports the majority color", () => {
+    expect(dailyPnlConclusion([10, 4, -2])).toEqual({
+      kind: "greenDays",
+      green: 2,
+      total: 3,
+    })
+    expect(dailyPnlConclusion([-3, -1, 2])).toEqual({
+      kind: "redDays",
+      red: 2,
+      total: 3,
+    })
+  })
+})
+
+describe("namedSignedConclusion", () => {
+  it("picks the larger absolute swing", () => {
+    expect(
+      namedSignedConclusion([
+        { label: "Mon", value: 20 },
+        { label: "Wed", value: -80 },
+      ]),
+    ).toEqual({ kind: "worst", label: "Wed" })
+  })
+})
+
+describe("countPeakConclusion", () => {
+  it("names the busiest bucket", () => {
+    expect(
+      countPeakConclusion([
+        { label: "2", count: 1 },
+        { label: "4", count: 9 },
+      ]),
+    ).toEqual({ kind: "peak", label: "4" })
+  })
+})
+
+describe("shareConclusion", () => {
+  it("rounds the part of the whole", () => {
+    expect(shareConclusion(18, 100)).toEqual({ kind: "share", percent: 18 })
+  })
+})
+
+describe("peakIndex", () => {
+  it("returns -1 for an empty list", () => {
+    expect(peakIndex([], (value: number) => value)).toBe(-1)
+  })
+})

--- a/app/[locale]/dashboard/components/charts/chart-glance.test.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.test.ts
@@ -9,7 +9,11 @@ import {
   peakIndex,
   signedFill,
 } from "./chart-glance"
-import { expandUnitDots, shouldPackUnitField } from "./chart-unit-field"
+import {
+  expandUnitDots,
+  pickUnitFieldGrid,
+  shouldPackUnitField,
+} from "./chart-unit-field"
 import { canDrawUnitHistogram } from "./chart-unit-histogram"
 import {
   countPeakConclusion,
@@ -96,6 +100,18 @@ describe("shouldPackUnitField", () => {
   it("packs only dense trade counts", () => {
     expect(shouldPackUnitField(120)).toBe(false)
     expect(shouldPackUnitField(121)).toBe(true)
+  })
+})
+
+describe("pickUnitFieldGrid", () => {
+  it("keeps a square field on a 10 by 10 waffle", () => {
+    expect(pickUnitFieldGrid(200, 200, 100)).toEqual({ columns: 10, rows: 10 })
+  })
+
+  it("adds columns on a wide card so cells stay close to square", () => {
+    const grid = pickUnitFieldGrid(320, 160, 100)
+    expect(grid.columns).toBeGreaterThan(grid.rows)
+    expect(grid.columns * grid.rows).toBeGreaterThanOrEqual(100)
   })
 })
 

--- a/app/[locale]/dashboard/components/charts/chart-glance.test.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.test.ts
@@ -14,6 +14,7 @@ import {
   pickUnitFieldGrid,
   shouldPackUnitField,
 } from "./chart-unit-field"
+import { sharePercents } from "./chart-share-split"
 import { canDrawUnitHistogram } from "./chart-unit-histogram"
 import {
   countPeakConclusion,
@@ -112,6 +113,16 @@ describe("pickUnitFieldGrid", () => {
     const grid = pickUnitFieldGrid(320, 160, 100)
     expect(grid.columns).toBeGreaterThan(grid.rows)
     expect(grid.columns * grid.rows).toBeGreaterThanOrEqual(100)
+  })
+})
+
+describe("sharePercents", () => {
+  it("splits a whole into rounded percents", () => {
+    const parts = sharePercents([
+      { key: "win", label: "Win", color: "green", count: 2 },
+      { key: "loss", label: "Loss", color: "red", count: 1 },
+    ])
+    expect(parts.map((part) => part.percent)).toEqual([67, 33])
   })
 })
 

--- a/app/[locale]/dashboard/components/charts/chart-glance.test.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { CHART_WIDGET_KINDS } from "./chart-widget-kind"
 import {
   chartBarRadius,
   chartMaxBarSize,
@@ -219,5 +220,18 @@ describe("shareConclusion", () => {
 describe("peakIndex", () => {
   it("returns -1 for an empty list", () => {
     expect(peakIndex([], (value: number) => value)).toBe(-1)
+  })
+})
+
+describe("chart widget kinds", () => {
+  it("keeps one family per encoding", () => {
+    expect(CHART_WIDGET_KINDS).toEqual([
+      "series",
+      "share",
+      "category",
+      "duration",
+      "ticks",
+      "metric",
+    ])
   })
 })

--- a/app/[locale]/dashboard/components/charts/chart-glance.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.ts
@@ -1,0 +1,108 @@
+import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
+
+/**
+ * Glance-family defaults for dashboard chart widgets.
+ *
+ * Mapped from lieflat-charts catalog shapes (dashboard context → Glance):
+ * daily / weekday / hour / side / instrument P&L → G10 diverging bars
+ * equity → G18 draw-in + counter
+ * tick histogram → F1 rung bars (bins as categories)
+ * win/loss/BE and P/L-vs-fees → F4 tick donut
+ *
+ * Visual rules stay on Paper tokens. Length still encodes value, axes stay
+ * unbroken, fills stay solid, and bar caps round on the outer end.
+ */
+
+export const CHART_WIN = "hsl(var(--chart-win))"
+export const CHART_LOSS = "hsl(var(--chart-loss))"
+export const CHART_LINE_STROKE = 2
+export const CHART_BAR_CAP = 8
+export const CHART_TOOLTIP_CLASS = "rounded-lg border bg-background p-2"
+export const CHART_TOOLTIP_WRAPPER = { zIndex: 1000 } as const
+
+export const CHART_GRID_PROPS = {
+  vertical: false,
+  stroke: "hsl(var(--border))",
+  strokeOpacity: 0.45,
+} as const
+
+export const CHART_ZERO_LINE_PROPS = {
+  stroke: "hsl(var(--muted-foreground))",
+  strokeOpacity: 0.45,
+} as const
+
+export function chartMaxBarSize(size: WidgetSize = "medium") {
+  return size === "small" ? 28 : 52
+}
+
+export function chartBarRadius(
+  value: number,
+): [number, number, number, number] {
+  return value >= 0
+    ? [CHART_BAR_CAP, CHART_BAR_CAP, 0, 0]
+    : [0, 0, CHART_BAR_CAP, CHART_BAR_CAP]
+}
+
+export function chartTickStyle(size: WidgetSize = "medium") {
+  return {
+    fontSize: size === "small" ? 9 : 11,
+    fill: "currentColor",
+    fontWeight: 600,
+  }
+}
+
+export function chartTooltipFontSize(size: WidgetSize = "medium") {
+  return size === "small" ? "10px" : "12px"
+}
+
+export function signedFill(value: number) {
+  if (value > 0) return CHART_WIN
+  if (value < 0) return CHART_LOSS
+  return "hsl(var(--muted-foreground))"
+}
+
+export function unsignedFill() {
+  return "hsl(var(--chart-2))"
+}
+
+export function filterBarOpacity(isActive: boolean, hasFilter: boolean) {
+  if (!hasFilter) return 1
+  return isActive ? 1 : 0.35
+}
+
+export function honestSignedDomain(values: number[]): [number, number] {
+  if (values.length === 0) {
+    return [0, 0]
+  }
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const pad = Math.max(Math.abs(min), Math.abs(max)) * 0.1
+  return [Math.min(min - pad, 0), Math.max(max + pad, 0)]
+}
+
+export function honestPositiveDomain(values: number[]): [number, number] {
+  if (values.length === 0) {
+    return [0, 1]
+  }
+
+  const max = Math.max(0, ...values)
+  return [0, max === 0 ? 1 : max * 1.1]
+}
+
+export function peakIndex<T>(
+  items: T[],
+  valueOf: (item: T) => number,
+  prefer: "max" | "min" = "max",
+) {
+  if (items.length === 0) return -1
+  let best = 0
+  for (let i = 1; i < items.length; i++) {
+    const current = valueOf(items[i])
+    const winner = valueOf(items[best])
+    if (prefer === "max" ? current > winner : current < winner) {
+      best = i
+    }
+  }
+  return best
+}

--- a/app/[locale]/dashboard/components/charts/chart-glance.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.ts
@@ -1,16 +1,15 @@
 import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
 
 /**
- * Glance-family defaults for dashboard chart widgets.
+ * Chart encodings for dashboard widgets, mapped from lieflat-charts
+ * data shapes. Implementations are original React/SVG on Paper tokens.
  *
- * Mapped from lieflat-charts catalog shapes (dashboard context → Glance):
- * daily / weekday / hour / side / instrument P&L → G10 diverging bars
- * equity → G18 draw-in + counter
- * tick histogram → F1 rung bars (bins as categories)
- * win/loss/BE and P/L-vs-fees → F4 tick donut
- *
- * Visual rules stay on Paper tokens. Length still encodes value, axes stay
- * unbroken, fills stay solid, and bar caps round on the outer end.
+ * trade / commission share → L14 / G4 unit field (one dot = one trade or 1%)
+ * daily P/L sequence → L3 barcode lollipop (stem = day, cap = net)
+ * weekday / side → G10 / F5 horizontal diverging bars
+ * tick histogram → F1 countable stacks (one dot = one trade)
+ * hourly / instrument P/L → G10 vertical diverging bars
+ * equity → G18 counter + line
  */
 
 export const CHART_WIN = "hsl(var(--chart-win))"
@@ -26,6 +25,12 @@ export const CHART_GRID_PROPS = {
   strokeOpacity: 0.45,
 } as const
 
+export const CHART_GRID_PROPS_HORIZONTAL = {
+  horizontal: false,
+  stroke: "hsl(var(--border))",
+  strokeOpacity: 0.45,
+} as const
+
 export const CHART_ZERO_LINE_PROPS = {
   stroke: "hsl(var(--muted-foreground))",
   strokeOpacity: 0.45,
@@ -35,12 +40,35 @@ export function chartMaxBarSize(size: WidgetSize = "medium") {
   return size === "small" ? 28 : 52
 }
 
+export type ChartBarLayout = "vertical" | "horizontal"
+
+export function normalizeBarRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) {
+  return {
+    x: width < 0 ? x + width : x,
+    y: height < 0 ? y + height : y,
+    width: Math.abs(width),
+    height: Math.abs(height),
+  }
+}
+
 export function chartBarRadius(
   value: number,
+  layout: ChartBarLayout = "vertical",
 ): [number, number, number, number] {
-  return value >= 0
-    ? [CHART_BAR_CAP, CHART_BAR_CAP, 0, 0]
-    : [0, 0, CHART_BAR_CAP, CHART_BAR_CAP]
+  const negative = value < 0
+  if (layout === "horizontal") {
+    return negative
+      ? [CHART_BAR_CAP, 0, 0, CHART_BAR_CAP]
+      : [0, CHART_BAR_CAP, CHART_BAR_CAP, 0]
+  }
+  return negative
+    ? [0, 0, CHART_BAR_CAP, CHART_BAR_CAP]
+    : [CHART_BAR_CAP, CHART_BAR_CAP, 0, 0]
 }
 
 export function chartTickStyle(size: WidgetSize = "medium") {

--- a/app/[locale]/dashboard/components/charts/chart-glance.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.ts
@@ -4,7 +4,7 @@ import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
  * Chart encodings for dashboard widgets, mapped from lieflat-charts
  * data shapes. Implementations are original React/SVG on Paper tokens.
  *
- * trade / commission share → L14 / G4 unit field (one dot = one trade or 1%)
+ * trade / commission share → L14 / G4 unit field (one dot = 1%, fills the card)
  * daily P/L sequence → L3 barcode lollipop (stem = day, cap = net)
  * weekday / side → G10 / F5 horizontal diverging bars
  * tick histogram → F1 countable stacks (one dot = one trade)

--- a/app/[locale]/dashboard/components/charts/chart-glance.ts
+++ b/app/[locale]/dashboard/components/charts/chart-glance.ts
@@ -4,7 +4,7 @@ import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
  * Chart encodings for dashboard widgets, mapped from lieflat-charts
  * data shapes. Implementations are original React/SVG on Paper tokens.
  *
- * trade / commission share → L14 / G4 unit field (one dot = 1%, fills the card)
+ * trade / commission share → one number + one stacked bar (part of the whole)
  * daily P/L sequence → L3 barcode lollipop (stem = day, cap = net)
  * weekday / side → G10 / F5 horizontal diverging bars
  * tick histogram → F1 countable stacks (one dot = one trade)

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -19,6 +19,14 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
+import {
+  CHART_BAR_CAP,
+  CHART_GRID_PROPS,
+  CHART_LINE_STROKE,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  honestSignedDomain,
+} from "./chart-glance";
 
 const MUTED_BAR_FILL = "hsl(var(--muted-foreground) / 0.35)";
 const DEFAULT_LOADING_LABEL = "Loading chart data...";
@@ -85,13 +93,7 @@ export function getAxisDimensions(
 }
 
 export function getSignedDomain(values: number[]) {
-  if (values.length === 0) {
-    return [0, 0] as [number, number];
-  }
-
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  return [Math.min(min * 1.1, 0), Math.max(max * 1.1, 0)] as [number, number];
+  return honestSignedDomain(values);
 }
 
 interface ChartAxisSkeletonOverlayProps {
@@ -177,7 +179,7 @@ export function BarChartLoadingSkeleton({
   const { xAxisHeight } = getAxisDimensions(size, yAxisWidth);
   const values = data.map((row) => Number(row[yDataKey]));
   const yDomain = domain ?? getSignedDomain(values);
-  const barSize = maxBarSize ?? (size === "small" ? 25 : 40);
+  const barSize = maxBarSize ?? chartMaxBarSize(size);
 
   return (
     <ChartLoadingContainer
@@ -193,10 +195,7 @@ export function BarChartLoadingSkeleton({
       />
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={data} margin={margin}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            className="text-border dark:opacity-[0.12] opacity-[0.2]"
-          />
+          <CartesianGrid {...CHART_GRID_PROPS} />
           <XAxis
             dataKey={xDataKey}
             tickLine={false}
@@ -214,11 +213,11 @@ export function BarChartLoadingSkeleton({
             domain={yDomain}
           />
           {showReferenceLine ? (
-            <ReferenceLine y={0} stroke="hsl(var(--border))" />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
           ) : null}
           <Bar
             dataKey={yDataKey}
-            radius={[3, 3, 0, 0]}
+            radius={[CHART_BAR_CAP, CHART_BAR_CAP, 0, 0]}
             maxBarSize={barSize}
             className="transition-none"
             fill={MUTED_BAR_FILL}
@@ -266,10 +265,7 @@ export function LineChartLoadingSkeleton({
       />
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data} margin={margin}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            className="text-border dark:opacity-[0.12] opacity-[0.2]"
-          />
+          <CartesianGrid {...CHART_GRID_PROPS} />
           <XAxis
             dataKey={xDataKey}
             tickLine={false}
@@ -286,18 +282,13 @@ export function LineChartLoadingSkeleton({
             tick={false}
           />
           {showReferenceLine ? (
-            <ReferenceLine
-              y={0}
-              stroke="hsl(var(--muted-foreground))"
-              strokeDasharray="3 3"
-              strokeOpacity={0.5}
-            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
           ) : null}
           <Line
             type="monotone"
             dataKey={yDataKey}
             stroke={MUTED_BAR_FILL}
-            strokeWidth={2}
+            strokeWidth={CHART_LINE_STROKE}
             dot={false}
             className="transition-none"
           />
@@ -401,10 +392,7 @@ export function ComposedChartLoadingSkeleton({
       />
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart data={data} margin={margin}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            className="text-border dark:opacity-[0.12] opacity-[0.2]"
-          />
+          <CartesianGrid {...CHART_GRID_PROPS} />
           <XAxis
             dataKey={xDataKey}
             tickLine={false}
@@ -419,10 +407,10 @@ export function ComposedChartLoadingSkeleton({
             tickMargin={4}
             tick={false}
           />
-          <ReferenceLine y={0} stroke="hsl(var(--border))" />
+          <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
           <Bar
             dataKey={barDataKey}
-            radius={[3, 3, 0, 0]}
+            radius={[CHART_BAR_CAP, CHART_BAR_CAP, 0, 0]}
             maxBarSize={size === "small" ? 20 : 30}
             className="transition-none"
             fill={MUTED_BAR_FILL}
@@ -435,7 +423,7 @@ export function ComposedChartLoadingSkeleton({
             type="stepAfter"
             dataKey={lineDataKey}
             stroke={MUTED_BAR_FILL}
-            strokeWidth={2}
+            strokeWidth={CHART_LINE_STROKE}
             dot={false}
             className="transition-none"
           />

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -22,8 +22,11 @@ import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import {
   CHART_BAR_CAP,
   CHART_GRID_PROPS,
+  CHART_GRID_PROPS_HORIZONTAL,
   CHART_LINE_STROKE,
   CHART_ZERO_LINE_PROPS,
+  type ChartBarLayout,
+  chartBarRadius,
   chartMaxBarSize,
   honestSignedDomain,
 } from "./chart-glance";
@@ -55,7 +58,7 @@ function ChartLoadingContainer({
   );
 }
 
-export type ChartMarginVariant = "default" | "hourly" | "calendar";
+export type ChartMarginVariant = "default" | "hourly" | "calendar" | "horizontal";
 
 export function getChartMargins(
   size: WidgetSize = "medium",
@@ -65,6 +68,12 @@ export function getChartMargins(
     return size === "small"
       ? { left: 0, right: 4, top: 4, bottom: 20 }
       : { left: 0, right: 8, top: 8, bottom: 24 };
+  }
+
+  if (variant === "horizontal") {
+    return size === "small"
+      ? { left: 0, right: 8, top: 4, bottom: 4 }
+      : { left: 4, right: 12, top: 8, bottom: 8 };
   }
 
   if (variant === "calendar") {
@@ -160,6 +169,7 @@ interface BarChartLoadingSkeletonProps {
   domain?: [number, number];
   xTickCount?: number;
   loadingLabel?: string;
+  layout?: ChartBarLayout;
 }
 
 export function BarChartLoadingSkeleton({
@@ -174,12 +184,19 @@ export function BarChartLoadingSkeleton({
   domain,
   xTickCount = 6,
   loadingLabel,
+  layout = "vertical",
 }: BarChartLoadingSkeletonProps) {
-  const margin = getChartMargins(size, marginVariant);
+  const margin = getChartMargins(
+    size,
+    marginVariant === "default" && layout === "horizontal"
+      ? "horizontal"
+      : marginVariant,
+  );
   const { xAxisHeight } = getAxisDimensions(size, yAxisWidth);
   const values = data.map((row) => Number(row[yDataKey]));
   const yDomain = domain ?? getSignedDomain(values);
   const barSize = maxBarSize ?? chartMaxBarSize(size);
+  const horizontal = layout === "horizontal";
 
   return (
     <ChartLoadingContainer
@@ -194,30 +211,62 @@ export function BarChartLoadingSkeleton({
         xTickCount={xTickCount}
       />
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data} margin={margin}>
-          <CartesianGrid {...CHART_GRID_PROPS} />
-          <XAxis
-            dataKey={xDataKey}
-            tickLine={false}
-            axisLine={false}
-            height={xAxisHeight}
-            tick={false}
-            minTickGap={size === "small" ? 30 : 50}
+        <BarChart
+          data={data}
+          margin={margin}
+          layout={horizontal ? "vertical" : "horizontal"}
+        >
+          <CartesianGrid
+            {...(horizontal ? CHART_GRID_PROPS_HORIZONTAL : CHART_GRID_PROPS)}
           />
-          <YAxis
-            tickLine={false}
-            axisLine={false}
-            width={yAxisWidth}
-            tickMargin={4}
-            tick={false}
-            domain={yDomain}
-          />
+          {horizontal ? (
+            <>
+              <XAxis
+                type="number"
+                tickLine={false}
+                axisLine={false}
+                height={xAxisHeight}
+                tick={false}
+                domain={yDomain}
+              />
+              <YAxis
+                type="category"
+                dataKey={xDataKey}
+                tickLine={false}
+                axisLine={false}
+                width={yAxisWidth}
+                tick={false}
+              />
+            </>
+          ) : (
+            <>
+              <XAxis
+                dataKey={xDataKey}
+                tickLine={false}
+                axisLine={false}
+                height={xAxisHeight}
+                tick={false}
+                minTickGap={size === "small" ? 30 : 50}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={yAxisWidth}
+                tickMargin={4}
+                tick={false}
+                domain={yDomain}
+              />
+            </>
+          )}
           {showReferenceLine ? (
-            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <ReferenceLine
+              {...(horizontal ? { x: 0 } : { y: 0 })}
+              {...CHART_ZERO_LINE_PROPS}
+            />
           ) : null}
           <Bar
             dataKey={yDataKey}
-            radius={[CHART_BAR_CAP, CHART_BAR_CAP, 0, 0]}
+            radius={chartBarRadius(1, layout)}
             maxBarSize={barSize}
             className="transition-none"
             fill={MUTED_BAR_FILL}
@@ -301,6 +350,39 @@ export function LineChartLoadingSkeleton({
 interface DonutChartLoadingSkeletonProps {
   size?: WidgetSize;
   loadingLabel?: string;
+}
+
+export function UnitFieldLoadingSkeleton({
+  size = "medium",
+  loadingLabel,
+}: DonutChartLoadingSkeletonProps) {
+  const compact = size === "small";
+  const columns = 10;
+  const rows = compact ? 6 : 10;
+
+  return (
+    <ChartLoadingContainer
+      loadingLabel={loadingLabel}
+      className="flex animate-pulse flex-col items-center justify-center gap-3"
+    >
+      <div
+        className="grid gap-1.5"
+        style={{
+          gridTemplateColumns: `repeat(${columns}, ${compact ? "0.55rem" : "0.7rem"})`,
+        }}
+      >
+        {Array.from({ length: columns * rows }).map((_, i) => (
+          <span
+            key={`unit-skeleton-${i}`}
+            className={cn(
+              "rounded-full bg-muted-foreground/30",
+              compact ? "size-2" : "size-2.5",
+            )}
+          />
+        ))}
+      </div>
+    </ChartLoadingContainer>
+  );
 }
 
 export function DonutChartLoadingSkeleton({

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -356,28 +356,27 @@ export function UnitFieldLoadingSkeleton({
   size = "medium",
   loadingLabel,
 }: DonutChartLoadingSkeletonProps) {
-  const compact = size === "small";
-  const columns = 10;
-  const rows = compact ? 6 : 10;
+  const compact = size === "small" || size === "tiny";
 
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="flex animate-pulse flex-col items-center justify-center gap-3"
+      className="flex h-full min-h-0 animate-pulse flex-col"
     >
       <div
-        className="grid gap-1.5"
+        className={cn(
+          "grid h-full min-h-0 w-full",
+          compact ? "gap-1" : "gap-1.5",
+        )}
         style={{
-          gridTemplateColumns: `repeat(${columns}, ${compact ? "0.55rem" : "0.7rem"})`,
+          gridTemplateColumns: "repeat(10, minmax(0, 1fr))",
+          gridTemplateRows: "repeat(10, minmax(0, 1fr))",
         }}
       >
-        {Array.from({ length: columns * rows }).map((_, i) => (
+        {Array.from({ length: 100 }).map((_, i) => (
           <span
             key={`unit-skeleton-${i}`}
-            className={cn(
-              "rounded-full bg-muted-foreground/30",
-              compact ? "size-2" : "size-2.5",
-            )}
+            className="min-h-0 min-w-0 rounded-full bg-muted-foreground/25"
           />
         ))}
       </div>

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -361,16 +361,16 @@ export function ShareSplitLoadingSkeleton({
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="flex h-full min-h-0 animate-pulse flex-col gap-3"
+      className="grid h-full min-h-0 animate-pulse grid-rows-[auto_minmax(0,1fr)] gap-3"
     >
-      <div className="shrink-0 space-y-2">
+      <div className="space-y-2">
         <Skeleton className={cn(compact ? "h-8 w-16" : "h-10 w-20")} />
         <Skeleton className={cn(compact ? "h-3 w-36" : "h-4 w-44")} />
         <Skeleton className={cn("w-full rounded-full", compact ? "h-2" : "h-2.5")} />
       </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <div className="grid min-h-0 grid-rows-3 gap-2">
         {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={`share-row-${i}`} className="min-h-0 flex-1 rounded-lg" />
+          <Skeleton key={`share-row-${i}`} className="min-h-0 rounded-lg" />
         ))}
       </div>
     </ChartLoadingContainer>

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -352,7 +352,7 @@ interface DonutChartLoadingSkeletonProps {
   loadingLabel?: string;
 }
 
-export function UnitFieldLoadingSkeleton({
+export function ShareSplitLoadingSkeleton({
   size = "medium",
   loadingLabel,
 }: DonutChartLoadingSkeletonProps) {
@@ -361,27 +361,23 @@ export function UnitFieldLoadingSkeleton({
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="flex h-full min-h-0 animate-pulse flex-col"
+      className="flex h-full min-h-0 animate-pulse flex-col justify-center gap-5"
     >
-      <div
-        className={cn(
-          "grid h-full min-h-0 w-full",
-          compact ? "gap-1" : "gap-1.5",
-        )}
-        style={{
-          gridTemplateColumns: "repeat(10, minmax(0, 1fr))",
-          gridTemplateRows: "repeat(10, minmax(0, 1fr))",
-        }}
-      >
-        {Array.from({ length: 100 }).map((_, i) => (
-          <span
-            key={`unit-skeleton-${i}`}
-            className="min-h-0 min-w-0 rounded-full bg-muted-foreground/25"
-          />
-        ))}
+      <div className="space-y-2">
+        <Skeleton className={cn(compact ? "h-8 w-16" : "h-12 w-24")} />
+        <Skeleton className={cn(compact ? "h-3 w-36" : "h-4 w-48")} />
+      </div>
+      <Skeleton className={cn("w-full rounded-full", compact ? "h-2.5" : "h-3")} />
+      <div className="flex gap-4">
+        <Skeleton className={cn(compact ? "h-3 w-20" : "h-3.5 w-24")} />
+        <Skeleton className={cn(compact ? "h-3 w-20" : "h-3.5 w-24")} />
       </div>
     </ChartLoadingContainer>
   );
+}
+
+export function UnitFieldLoadingSkeleton(props: DonutChartLoadingSkeletonProps) {
+  return <ShareSplitLoadingSkeleton {...props} />;
 }
 
 export function DonutChartLoadingSkeleton({

--- a/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-loading-skeleton.tsx
@@ -361,16 +361,17 @@ export function ShareSplitLoadingSkeleton({
   return (
     <ChartLoadingContainer
       loadingLabel={loadingLabel}
-      className="flex h-full min-h-0 animate-pulse flex-col justify-center gap-5"
+      className="flex h-full min-h-0 animate-pulse flex-col gap-3"
     >
-      <div className="space-y-2">
-        <Skeleton className={cn(compact ? "h-8 w-16" : "h-12 w-24")} />
-        <Skeleton className={cn(compact ? "h-3 w-36" : "h-4 w-48")} />
+      <div className="shrink-0 space-y-2">
+        <Skeleton className={cn(compact ? "h-8 w-16" : "h-10 w-20")} />
+        <Skeleton className={cn(compact ? "h-3 w-36" : "h-4 w-44")} />
+        <Skeleton className={cn("w-full rounded-full", compact ? "h-2" : "h-2.5")} />
       </div>
-      <Skeleton className={cn("w-full rounded-full", compact ? "h-2.5" : "h-3")} />
-      <div className="flex gap-4">
-        <Skeleton className={cn(compact ? "h-3 w-20" : "h-3.5 w-24")} />
-        <Skeleton className={cn(compact ? "h-3 w-20" : "h-3.5 w-24")} />
+      <div className="flex min-h-0 flex-1 flex-col gap-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={`share-row-${i}`} className="min-h-0 flex-1 rounded-lg" />
+        ))}
       </div>
     </ChartLoadingContainer>
   );

--- a/app/[locale]/dashboard/components/charts/chart-lollipop-bar.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-lollipop-bar.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { normalizeBarRect } from "./chart-glance"
+
+interface LollipopBarProps {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  fill?: string
+  value?: number | string
+}
+
+export function LollipopBar({
+  x = 0,
+  y = 0,
+  width = 0,
+  height = 0,
+  fill,
+  value,
+}: LollipopBarProps) {
+  const numeric = typeof value === "number" ? value : Number(value ?? 0)
+  const rect = normalizeBarRect(x, y, width, height)
+  if (rect.height === 0 || rect.width === 0) {
+    return null
+  }
+
+  const negative = (Number.isFinite(numeric) ? numeric : height) < 0
+  const cx = rect.x + rect.width / 2
+  const tipY = negative ? rect.y + rect.height : rect.y
+  const baseY = negative ? rect.y : rect.y + rect.height
+  const radius = Math.min(4.5, Math.max(2.5, rect.width / 3))
+
+  return (
+    <g>
+      <line
+        x1={cx}
+        y1={baseY}
+        x2={cx}
+        y2={tipY}
+        stroke={fill}
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+      <circle cx={cx} cy={tipY} r={radius} fill={fill} />
+    </g>
+  )
+}

--- a/app/[locale]/dashboard/components/charts/chart-share-split.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-share-split.tsx
@@ -50,15 +50,16 @@ export function ShareSplit({
   size?: WidgetSize
 }) {
   const compact = size === "small" || size === "tiny"
-  const parts = sharePercents(groups).filter((part) => part.percent > 0)
+  const parts = sharePercents(groups)
+  const trackParts = parts.filter((part) => part.percent > 0)
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col justify-center gap-5">
-      <div className="min-w-0">
+    <div className="flex h-full min-h-0 w-full flex-col gap-3">
+      <div className="shrink-0">
         <p
           className={cn(
             "font-semibold tracking-[-0.04em] tabular-nums text-foreground",
-            compact ? "text-3xl" : "text-5xl",
+            compact ? "text-3xl" : "text-4xl",
           )}
         >
           {headline}
@@ -71,44 +72,81 @@ export function ShareSplit({
         >
           {caption}
         </p>
-      </div>
-      <div
-        role="img"
-        aria-label={label}
-        className={cn(
-          "flex w-full overflow-hidden rounded-full bg-muted",
-          compact ? "h-2.5" : "h-3",
-        )}
-      >
-        {parts.map((part) => (
-          <span
-            key={part.key}
-            title={`${part.label} · ${part.percent}%`}
-            className="min-w-0"
-            style={{
-              flexGrow: part.percent,
-              backgroundColor: part.color,
-            }}
-          />
-        ))}
-      </div>
-      <ul
-        className={cn(
-          "flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground",
-          compact ? "text-[10px]" : "text-[11px]",
-        )}
-      >
-        {groups
-          .filter((group) => group.count > 0)
-          .map((group) => (
-            <li key={group.key} className="flex items-center gap-1.5">
-              <span
-                className="size-2 shrink-0 rounded-full"
-                style={{ backgroundColor: group.color }}
-              />
-              <span className="leading-none">{group.label}</span>
-            </li>
+        <div
+          role="img"
+          aria-label={label}
+          className={cn(
+            "mt-3 flex w-full overflow-hidden rounded-full bg-muted",
+            compact ? "h-2" : "h-2.5",
+          )}
+        >
+          {trackParts.map((part) => (
+            <span
+              key={part.key}
+              title={`${part.label} · ${part.percent}%`}
+              className="min-w-0"
+              style={{
+                flexGrow: part.percent,
+                backgroundColor: part.color,
+              }}
+            />
           ))}
+        </div>
+      </div>
+      <ul className="flex min-h-0 flex-1 flex-col gap-2">
+        {parts.map((part) => (
+          <li
+            key={part.key}
+            className={cn(
+              "flex min-h-0 min-w-0 flex-1 flex-col justify-center rounded-lg bg-muted/40",
+              compact ? "gap-1 px-2.5 py-1.5" : "gap-1.5 px-3 py-2",
+            )}
+          >
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
+                <span
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: part.color }}
+                />
+                <span
+                  className={cn(
+                    "truncate",
+                    compact ? "text-[11px]" : "text-sm",
+                  )}
+                >
+                  {part.label}
+                </span>
+              </span>
+              <span
+                className={cn(
+                  "shrink-0 font-semibold tabular-nums text-foreground",
+                  compact ? "text-sm" : "text-base",
+                )}
+              >
+                {part.percent}%
+              </span>
+            </div>
+            {part.detail ? (
+              <p
+                className={cn(
+                  "truncate tabular-nums text-muted-foreground",
+                  compact ? "text-[10px]" : "text-xs",
+                )}
+              >
+                {part.detail}
+              </p>
+            ) : null}
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <span
+                className="block h-full rounded-full"
+                style={{
+                  width: `${part.percent}%`,
+                  backgroundColor: part.color,
+                }}
+              />
+            </div>
+          </li>
+        ))}
       </ul>
     </div>
   )

--- a/app/[locale]/dashboard/components/charts/chart-share-split.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-share-split.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
+import type { UnitFieldGroup } from "./chart-unit-field"
+
+export interface ShareSplitPart extends UnitFieldGroup {
+  percent: number
+}
+
+export function sharePercents(groups: UnitFieldGroup[]): ShareSplitPart[] {
+  const total = groups.reduce((sum, group) => sum + Math.max(0, group.count), 0)
+  if (total <= 0) {
+    return groups.map((group) => ({ ...group, percent: 0 }))
+  }
+
+  const raw = groups.map((group) => ({
+    group,
+    exact: (Math.max(0, group.count) / total) * 100,
+  }))
+  const percents = raw.map((row) => Math.floor(row.exact))
+  let remaining = 100 - percents.reduce((sum, value) => sum + value, 0)
+  const order = raw
+    .map((row, index) => ({
+      index,
+      frac: row.exact - Math.floor(row.exact),
+      count: row.group.count,
+    }))
+    .filter((row) => row.count > 0)
+    .sort((a, b) => b.frac - a.frac)
+
+  for (let i = 0; i < remaining && order.length > 0; i++) {
+    percents[order[i % order.length].index] += 1
+  }
+
+  return groups.map((group, index) => ({ ...group, percent: percents[index] }))
+}
+
+export function ShareSplit({
+  groups,
+  headline,
+  caption,
+  label,
+  size = "medium",
+}: {
+  groups: UnitFieldGroup[]
+  headline: string
+  caption: string
+  label: string
+  size?: WidgetSize
+}) {
+  const compact = size === "small" || size === "tiny"
+  const parts = sharePercents(groups).filter((part) => part.percent > 0)
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col justify-center gap-5">
+      <div className="min-w-0">
+        <p
+          className={cn(
+            "font-semibold tracking-[-0.04em] tabular-nums text-foreground",
+            compact ? "text-3xl" : "text-5xl",
+          )}
+        >
+          {headline}
+        </p>
+        <p
+          className={cn(
+            "mt-1 text-muted-foreground",
+            compact ? "text-xs" : "text-sm",
+          )}
+        >
+          {caption}
+        </p>
+      </div>
+      <div
+        role="img"
+        aria-label={label}
+        className={cn(
+          "flex w-full overflow-hidden rounded-full bg-muted",
+          compact ? "h-2.5" : "h-3",
+        )}
+      >
+        {parts.map((part) => (
+          <span
+            key={part.key}
+            title={`${part.label} · ${part.percent}%`}
+            className="min-w-0"
+            style={{
+              flexGrow: part.percent,
+              backgroundColor: part.color,
+            }}
+          />
+        ))}
+      </div>
+      <ul
+        className={cn(
+          "flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground",
+          compact ? "text-[10px]" : "text-[11px]",
+        )}
+      >
+        {groups
+          .filter((group) => group.count > 0)
+          .map((group) => (
+            <li key={group.key} className="flex items-center gap-1.5">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: group.color }}
+              />
+              <span className="leading-none">{group.label}</span>
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/charts/chart-share-split.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-share-split.tsx
@@ -54,8 +54,8 @@ export function ShareSplit({
   const trackParts = parts.filter((part) => part.percent > 0)
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col gap-3">
-      <div className="shrink-0">
+    <div className="grid h-full min-h-0 w-full grid-rows-[auto_minmax(0,1fr)] gap-3">
+      <div className="min-w-0">
         <p
           className={cn(
             "font-semibold tracking-[-0.04em] tabular-nums text-foreground",
@@ -93,12 +93,17 @@ export function ShareSplit({
           ))}
         </div>
       </div>
-      <ul className="flex min-h-0 flex-1 flex-col gap-2">
+      <div
+        className="grid min-h-0 gap-2"
+        style={{
+          gridTemplateRows: `repeat(${Math.max(parts.length, 1)}, minmax(0, 1fr))`,
+        }}
+      >
         {parts.map((part) => (
-          <li
+          <div
             key={part.key}
             className={cn(
-              "flex min-h-0 min-w-0 flex-1 flex-col justify-center rounded-lg bg-muted/40",
+              "flex min-h-0 min-w-0 flex-col justify-center rounded-lg bg-muted/40",
               compact ? "gap-1 px-2.5 py-1.5" : "gap-1.5 px-3 py-2",
             )}
           >
@@ -145,9 +150,9 @@ export function ShareSplit({
                 }}
               />
             </div>
-          </li>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   )
 }

--- a/app/[locale]/dashboard/components/charts/chart-share-split.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-share-split.tsx
@@ -103,11 +103,11 @@ export function ShareSplit({
           <div
             key={part.key}
             className={cn(
-              "flex min-h-0 min-w-0 flex-col justify-center rounded-lg bg-muted/40",
+              "flex min-h-0 min-w-0 flex-col rounded-lg bg-muted/40",
               compact ? "gap-1 px-2.5 py-1.5" : "gap-1.5 px-3 py-2",
             )}
           >
-            <div className="flex items-baseline justify-between gap-3">
+            <div className="flex shrink-0 items-baseline justify-between gap-3">
               <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
                 <span
                   className="size-2 shrink-0 rounded-full"
@@ -122,28 +122,30 @@ export function ShareSplit({
                   {part.label}
                 </span>
               </span>
-              <span
-                className={cn(
-                  "shrink-0 font-semibold tabular-nums text-foreground",
-                  compact ? "text-sm" : "text-base",
-                )}
-              >
-                {part.percent}%
+              <span className="flex shrink-0 items-baseline gap-2">
+                {part.detail ? (
+                  <span
+                    className={cn(
+                      "tabular-nums text-muted-foreground",
+                      compact ? "text-[10px]" : "text-xs",
+                    )}
+                  >
+                    {part.detail}
+                  </span>
+                ) : null}
+                <span
+                  className={cn(
+                    "font-semibold tabular-nums text-foreground",
+                    compact ? "text-sm" : "text-base",
+                  )}
+                >
+                  {part.percent}%
+                </span>
               </span>
             </div>
-            {part.detail ? (
-              <p
-                className={cn(
-                  "truncate tabular-nums text-muted-foreground",
-                  compact ? "text-[10px]" : "text-xs",
-                )}
-              >
-                {part.detail}
-              </p>
-            ) : null}
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div className="min-h-2 w-full flex-1 overflow-hidden rounded-md bg-muted">
               <span
-                className="block h-full rounded-full"
+                className="block h-full rounded-md"
                 style={{
                   width: `${part.percent}%`,
                   backgroundColor: part.color,

--- a/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
+
+export const UNIT_FIELD_RECORD_LIMIT = 120
+
+export interface UnitFieldGroup {
+  key: string
+  label: string
+  color: string
+  count: number
+}
+
+export interface UnitDot {
+  key: string
+  color: string
+  label: string
+}
+
+export function expandUnitDots(
+  groups: UnitFieldGroup[],
+  mode: "record" | "percent",
+): UnitDot[] {
+  if (mode === "percent") {
+    const total = groups.reduce((sum, group) => sum + group.count, 0)
+    if (total <= 0) return []
+
+    const raw = groups.map((group) => ({
+      group,
+      exact: (group.count / total) * 100,
+    }))
+    const dots = raw.map((row) => Math.floor(row.exact))
+    let remaining = 100 - dots.reduce((sum, value) => sum + value, 0)
+    const order = raw
+      .map((row, index) => ({ index, frac: row.exact - Math.floor(row.exact) }))
+      .sort((a, b) => b.frac - a.frac)
+
+    for (let i = 0; i < remaining; i++) {
+      dots[order[i % order.length].index] += 1
+    }
+
+    return dots.flatMap((count, index) =>
+      Array.from({ length: Math.max(0, count) }, (_, i) => ({
+        key: `${raw[index].group.key}-${i}`,
+        color: raw[index].group.color,
+        label: raw[index].group.label,
+      })),
+    )
+  }
+
+  return groups.flatMap((group) =>
+    Array.from({ length: Math.max(0, Math.round(group.count)) }, (_, i) => ({
+      key: `${group.key}-${i}`,
+      color: group.color,
+      label: group.label,
+    })),
+  )
+}
+
+export function shouldPackUnitField(total: number) {
+  return total > UNIT_FIELD_RECORD_LIMIT
+}
+
+export function UnitDotField({
+  groups,
+  mode = "record",
+  label,
+  size = "medium",
+}: {
+  groups: UnitFieldGroup[]
+  mode?: "record" | "percent"
+  label: string
+  size?: WidgetSize
+}) {
+  const dots = expandUnitDots(groups, mode)
+  const compact = size === "small"
+  const columns = mode === "percent" || dots.length > 40 ? 10 : 8
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      <div
+        role="img"
+        aria-label={label}
+        className="grid min-h-0 flex-1 content-center justify-center gap-1.5"
+        style={{
+          gridTemplateColumns: `repeat(${columns}, ${compact ? "0.55rem" : "0.7rem"})`,
+        }}
+      >
+        {dots.map((dot) => (
+          <span
+            key={dot.key}
+            title={dot.label}
+            className={cn("rounded-full", compact ? "size-2" : "size-2.5")}
+            style={{ backgroundColor: dot.color }}
+          />
+        ))}
+      </div>
+      <ul
+        className={cn(
+          "flex flex-wrap justify-center gap-x-3 gap-y-1 text-muted-foreground",
+          compact ? "text-[10px]" : "text-[11px]",
+        )}
+      >
+        {groups
+          .filter((group) => group.count > 0)
+          .map((group) => (
+            <li key={group.key} className="flex items-center gap-1.5">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: group.color }}
+              />
+              <span className="leading-none">{group.label}</span>
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
@@ -95,11 +95,10 @@ function useFilledUnitGrid(count: number) {
     if (!node) return
 
     const update = () => {
-      const next = pickUnitFieldGrid(
-        node.clientWidth,
-        node.clientHeight,
-        count,
-      )
+      const width = node.clientWidth
+      const height = node.clientHeight
+      if (width < 8 || height < 8) return
+      const next = pickUnitFieldGrid(width, height, count)
       setGrid((current) =>
         current.columns === next.columns && current.rows === next.rows
           ? current
@@ -108,9 +107,13 @@ function useFilledUnitGrid(count: number) {
     }
 
     update()
+    const frame = window.requestAnimationFrame(update)
     const observer = new ResizeObserver(update)
     observer.observe(node)
-    return () => observer.disconnect()
+    return () => {
+      window.cancelAnimationFrame(frame)
+      observer.disconnect()
+    }
   }, [count])
 
   return { ref, ...grid }
@@ -171,8 +174,8 @@ export function UnitDotField({
   )
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-2">
-      <div ref={ref} className="min-h-0 flex-1">
+    <div className="flex h-full min-h-0 w-full flex-col gap-2">
+      <div ref={ref} className="min-h-0 min-w-0 w-full flex-1">
         <UnitFieldGrid
           dots={dots}
           columns={columns}

--- a/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import * as React from "react"
 import { cn } from "@/lib/utils"
 import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
 
 export const UNIT_FIELD_RECORD_LIMIT = 120
+export const UNIT_FIELD_PERCENT_DOTS = 100
 
 export interface UnitFieldGroup {
   key: string
@@ -28,10 +30,11 @@ export function expandUnitDots(
 
     const raw = groups.map((group) => ({
       group,
-      exact: (group.count / total) * 100,
+      exact: (group.count / total) * UNIT_FIELD_PERCENT_DOTS,
     }))
     const dots = raw.map((row) => Math.floor(row.exact))
-    let remaining = 100 - dots.reduce((sum, value) => sum + value, 0)
+    let remaining =
+      UNIT_FIELD_PERCENT_DOTS - dots.reduce((sum, value) => sum + value, 0)
     const order = raw
       .map((row, index) => ({ index, frac: row.exact - Math.floor(row.exact) }))
       .sort((a, b) => b.frac - a.frac)
@@ -62,9 +65,97 @@ export function shouldPackUnitField(total: number) {
   return total > UNIT_FIELD_RECORD_LIMIT
 }
 
+export function pickUnitFieldGrid(
+  width: number,
+  height: number,
+  count = UNIT_FIELD_PERCENT_DOTS,
+): { columns: number; rows: number } {
+  const safeCount = Math.max(1, count)
+  if (width <= 0 || height <= 0) {
+    return { columns: 10, rows: Math.ceil(safeCount / 10) }
+  }
+
+  const ratio = width / height
+  const columns = Math.min(
+    20,
+    Math.max(4, Math.round(Math.sqrt(safeCount * ratio))),
+  )
+  return { columns, rows: Math.ceil(safeCount / columns) }
+}
+
+function useFilledUnitGrid(count: number) {
+  const ref = React.useRef<HTMLDivElement>(null)
+  const [grid, setGrid] = React.useState({
+    columns: 10,
+    rows: Math.ceil(Math.max(count, 1) / 10),
+  })
+
+  React.useLayoutEffect(() => {
+    const node = ref.current
+    if (!node) return
+
+    const update = () => {
+      const next = pickUnitFieldGrid(
+        node.clientWidth,
+        node.clientHeight,
+        count,
+      )
+      setGrid((current) =>
+        current.columns === next.columns && current.rows === next.rows
+          ? current
+          : next,
+      )
+    }
+
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [count])
+
+  return { ref, ...grid }
+}
+
+export function UnitFieldGrid({
+  dots,
+  columns,
+  rows,
+  size = "medium",
+  label,
+}: {
+  dots: Array<{ key: string; color: string; label?: string }>
+  columns: number
+  rows: number
+  size?: WidgetSize
+  label?: string
+}) {
+  const compact = size === "small" || size === "tiny"
+
+  return (
+    <div
+      role={label ? "img" : undefined}
+      aria-label={label}
+      className={cn("grid h-full min-h-0 w-full", compact ? "gap-1" : "gap-1.5")}
+      style={{
+        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+        gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`,
+      }}
+    >
+      {dots.map((dot) => (
+        <span
+          key={dot.key}
+          title={dot.label}
+          className="min-h-0 min-w-0 rounded-full"
+          style={{ backgroundColor: dot.color }}
+        />
+      ))}
+    </div>
+  )
+}
+
 export function UnitDotField({
   groups,
-  mode = "record",
+  mode = "percent",
   label,
   size = "medium",
 }: {
@@ -74,31 +165,25 @@ export function UnitDotField({
   size?: WidgetSize
 }) {
   const dots = expandUnitDots(groups, mode)
-  const compact = size === "small"
-  const columns = mode === "percent" || dots.length > 40 ? 10 : 8
+  const compact = size === "small" || size === "tiny"
+  const { ref, columns, rows } = useFilledUnitGrid(
+    dots.length || UNIT_FIELD_PERCENT_DOTS,
+  )
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3">
-      <div
-        role="img"
-        aria-label={label}
-        className="grid min-h-0 flex-1 content-center justify-center gap-1.5"
-        style={{
-          gridTemplateColumns: `repeat(${columns}, ${compact ? "0.55rem" : "0.7rem"})`,
-        }}
-      >
-        {dots.map((dot) => (
-          <span
-            key={dot.key}
-            title={dot.label}
-            className={cn("rounded-full", compact ? "size-2" : "size-2.5")}
-            style={{ backgroundColor: dot.color }}
-          />
-        ))}
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <div ref={ref} className="min-h-0 flex-1">
+        <UnitFieldGrid
+          dots={dots}
+          columns={columns}
+          rows={rows}
+          size={size}
+          label={label}
+        />
       </div>
       <ul
         className={cn(
-          "flex flex-wrap justify-center gap-x-3 gap-y-1 text-muted-foreground",
+          "flex shrink-0 flex-wrap justify-center gap-x-3 gap-y-1 text-muted-foreground",
           compact ? "text-[10px]" : "text-[11px]",
         )}
       >

--- a/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-unit-field.tsx
@@ -12,6 +12,7 @@ export interface UnitFieldGroup {
   label: string
   color: string
   count: number
+  detail?: string
 }
 
 export interface UnitDot {

--- a/app/[locale]/dashboard/components/charts/chart-unit-histogram.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-unit-histogram.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
+import {
+  CHART_LOSS,
+  CHART_WIN,
+  filterBarOpacity,
+  unsignedFill,
+} from "./chart-glance"
+
+export interface UnitHistogramBucket {
+  key: string
+  label: string
+  count: number
+  signed?: number
+}
+
+export function canDrawUnitHistogram(counts: number[]) {
+  if (counts.length === 0) return false
+  const total = counts.reduce((sum, count) => sum + count, 0)
+  const peak = Math.max(0, ...counts)
+  return counts.length <= 16 && peak <= 24 && total <= 150
+}
+
+function bucketFill(signed: number) {
+  if (signed > 0) return CHART_WIN
+  if (signed < 0) return CHART_LOSS
+  return unsignedFill()
+}
+
+export function UnitHistogram({
+  buckets,
+  size = "medium",
+  activeKey,
+  hasFilter = false,
+  onSelect,
+  label,
+}: {
+  buckets: UnitHistogramBucket[]
+  size?: WidgetSize
+  activeKey?: string | null
+  hasFilter?: boolean
+  onSelect?: (key: string) => void
+  label: string
+}) {
+  const compact = size === "small"
+  const peak = Math.max(1, ...buckets.map((bucket) => bucket.count))
+
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className="flex h-full min-h-0 items-stretch justify-center gap-1 overflow-hidden px-1"
+    >
+      {buckets.map((bucket) => {
+        const signed =
+          bucket.signed ?? Number.parseInt(bucket.key.replace("+", ""), 10)
+        const color = bucketFill(Number.isFinite(signed) ? signed : 0)
+        const blanks = Math.max(0, peak - bucket.count)
+
+        return (
+          <button
+            key={bucket.key}
+            type="button"
+            title={`${bucket.label}: ${bucket.count}`}
+            onClick={() => onSelect?.(bucket.key)}
+            className="flex h-full min-w-0 flex-1 flex-col items-center gap-1"
+          >
+            <div
+              className="grid min-h-0 w-full flex-1 gap-px"
+              style={{ gridTemplateRows: `repeat(${peak}, minmax(0, 1fr))` }}
+            >
+              {Array.from({ length: blanks }, (_, i) => (
+                <span key={`blank-${i}`} />
+              ))}
+              {Array.from({ length: bucket.count }, (_, i) => (
+                <span
+                  key={`dot-${i}`}
+                  className="mx-auto w-[70%] max-w-3 rounded-[1px]"
+                  style={{
+                    backgroundColor: color,
+                    opacity: filterBarOpacity(
+                      activeKey === bucket.key,
+                      hasFilter,
+                    ),
+                  }}
+                />
+              ))}
+            </div>
+            <span
+              className={cn(
+                "shrink-0 text-center font-semibold text-foreground",
+                compact ? "text-[9px]" : "text-[11px]",
+              )}
+            >
+              {bucket.label}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { InfoBubble } from "@/components/ui/info-bubble"
+import { cn } from "@/lib/utils"
+import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
+
+interface ChartWidgetFrameProps {
+  size?: WidgetSize
+  title: string
+  subtitle?: string
+  description: ReactNode
+  actions?: ReactNode
+  children: ReactNode
+  contentInteractive?: boolean
+  onContentClick?: () => void
+  titleClassName?: string
+}
+
+export function ChartWidgetFrame({
+  size = "medium",
+  title,
+  subtitle,
+  description,
+  actions,
+  children,
+  contentInteractive = false,
+  onContentClick,
+  titleClassName,
+}: ChartWidgetFrameProps) {
+  const compact = size === "small"
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader
+        className={cn(
+          "flex shrink-0 flex-col items-stretch space-y-0 border-b",
+          compact ? "p-2" : "p-3 sm:p-4",
+        )}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <CardTitle
+                className={cn(
+                  "line-clamp-1 font-semibold tracking-[-0.02em]",
+                  compact ? "text-sm" : "text-base",
+                  titleClassName,
+                )}
+              >
+                {title}
+              </CardTitle>
+              <InfoBubble
+                side="top"
+                iconClassName={cn(compact ? "size-3.5" : "size-4")}
+              >
+                {typeof description === "string" ? <p>{description}</p> : description}
+              </InfoBubble>
+            </div>
+            {subtitle ? (
+              <p
+                className={cn(
+                  "mt-0.5 line-clamp-2 text-muted-foreground",
+                  compact ? "text-[10px] leading-tight" : "text-xs",
+                )}
+              >
+                {subtitle}
+              </p>
+            ) : null}
+          </div>
+          {actions ? (
+            <div className="flex shrink-0 items-center gap-2">{actions}</div>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent
+        className={cn("min-h-0 flex-1", compact ? "p-1" : "p-2 sm:p-4")}
+      >
+        <div
+          className={cn("h-full w-full", contentInteractive && "cursor-pointer")}
+          onClick={onContentClick}
+        >
+          {children}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
@@ -74,15 +74,11 @@ export function ChartWidgetFrame({
           ) : null}
         </div>
       </CardHeader>
-      <CardContent
-        className={cn(
-          "flex min-h-0 flex-1 flex-col",
-          compact ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
+      <CardContent className="relative min-h-0 flex-1 p-0">
         <div
           className={cn(
-            "min-h-0 w-full flex-1",
+            "absolute inset-0",
+            compact ? "p-1" : "p-2 sm:p-4",
             contentInteractive && "cursor-pointer",
           )}
           onClick={onContentClick}

--- a/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
@@ -36,11 +36,14 @@ export function ChartWidgetMasthead({
       <div className="flex min-w-0 flex-1 items-start gap-2">
         <ChartWidgetKindMark kind={kind} compact={compact} />
         <div className="min-w-0 flex-1">
-          {compact ? null : (
-            <p className="mb-0.5 truncate text-[11px] font-medium leading-none text-muted-foreground">
-              {eyebrow}
-            </p>
-          )}
+          <p
+            className={cn(
+              "mb-0.5 truncate font-medium leading-none text-muted-foreground",
+              compact ? "text-[10px]" : "text-[11px]",
+            )}
+          >
+            {eyebrow}
+          </p>
           <div className="flex items-center gap-1.5">
             <CardTitle
               className={cn(

--- a/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
@@ -75,10 +75,16 @@ export function ChartWidgetFrame({
         </div>
       </CardHeader>
       <CardContent
-        className={cn("min-h-0 flex-1", compact ? "p-1" : "p-2 sm:p-4")}
+        className={cn(
+          "flex min-h-0 flex-1 flex-col",
+          compact ? "p-1" : "p-2 sm:p-4",
+        )}
       >
         <div
-          className={cn("h-full w-full", contentInteractive && "cursor-pointer")}
+          className={cn(
+            "min-h-0 w-full flex-1",
+            contentInteractive && "cursor-pointer",
+          )}
           onClick={onContentClick}
         >
           {children}

--- a/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-widget-frame.tsx
@@ -5,9 +5,82 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { InfoBubble } from "@/components/ui/info-bubble"
 import { cn } from "@/lib/utils"
 import type { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard"
+import {
+  ChartWidgetKindMark,
+  type ChartWidgetKind,
+} from "./chart-widget-kind"
+
+interface ChartWidgetMastheadProps {
+  kind: ChartWidgetKind
+  eyebrow: string
+  title: string
+  subtitle?: string
+  description: ReactNode
+  actions?: ReactNode
+  compact?: boolean
+  titleClassName?: string
+}
+
+export function ChartWidgetMasthead({
+  kind,
+  eyebrow,
+  title,
+  subtitle,
+  description,
+  actions,
+  compact = false,
+  titleClassName,
+}: ChartWidgetMastheadProps) {
+  return (
+    <div className="flex items-start justify-between gap-2">
+      <div className="flex min-w-0 flex-1 items-start gap-2">
+        <ChartWidgetKindMark kind={kind} compact={compact} />
+        <div className="min-w-0 flex-1">
+          {compact ? null : (
+            <p className="mb-0.5 truncate text-[11px] font-medium leading-none text-muted-foreground">
+              {eyebrow}
+            </p>
+          )}
+          <div className="flex items-center gap-1.5">
+            <CardTitle
+              className={cn(
+                "line-clamp-1 font-semibold tracking-[-0.02em]",
+                compact ? "text-sm" : "text-base",
+                titleClassName,
+              )}
+            >
+              {title}
+            </CardTitle>
+            <InfoBubble
+              side="top"
+              iconClassName={cn(compact ? "size-3.5" : "size-4")}
+            >
+              {typeof description === "string" ? <p>{description}</p> : description}
+            </InfoBubble>
+          </div>
+          {subtitle ? (
+            <p
+              className={cn(
+                "mt-0.5 line-clamp-2 text-muted-foreground",
+                compact ? "text-[10px] leading-tight" : "text-xs",
+              )}
+            >
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {actions ? (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      ) : null}
+    </div>
+  )
+}
 
 interface ChartWidgetFrameProps {
   size?: WidgetSize
+  kind: ChartWidgetKind
+  eyebrow: string
   title: string
   subtitle?: string
   description: ReactNode
@@ -20,6 +93,8 @@ interface ChartWidgetFrameProps {
 
 export function ChartWidgetFrame({
   size = "medium",
+  kind,
+  eyebrow,
   title,
   subtitle,
   description,
@@ -32,47 +107,26 @@ export function ChartWidgetFrame({
   const compact = size === "small"
 
   return (
-    <Card className="flex h-full flex-col">
+    <Card
+      data-widget-kind={kind}
+      className="flex h-full flex-col overflow-hidden"
+    >
       <CardHeader
         className={cn(
-          "flex shrink-0 flex-col items-stretch space-y-0 border-b",
+          "flex shrink-0 flex-col items-stretch space-y-0 border-b bg-muted/40",
           compact ? "p-2" : "p-3 sm:p-4",
         )}
       >
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1.5">
-              <CardTitle
-                className={cn(
-                  "line-clamp-1 font-semibold tracking-[-0.02em]",
-                  compact ? "text-sm" : "text-base",
-                  titleClassName,
-                )}
-              >
-                {title}
-              </CardTitle>
-              <InfoBubble
-                side="top"
-                iconClassName={cn(compact ? "size-3.5" : "size-4")}
-              >
-                {typeof description === "string" ? <p>{description}</p> : description}
-              </InfoBubble>
-            </div>
-            {subtitle ? (
-              <p
-                className={cn(
-                  "mt-0.5 line-clamp-2 text-muted-foreground",
-                  compact ? "text-[10px] leading-tight" : "text-xs",
-                )}
-              >
-                {subtitle}
-              </p>
-            ) : null}
-          </div>
-          {actions ? (
-            <div className="flex shrink-0 items-center gap-2">{actions}</div>
-          ) : null}
-        </div>
+        <ChartWidgetMasthead
+          kind={kind}
+          eyebrow={eyebrow}
+          title={title}
+          subtitle={subtitle}
+          description={description}
+          actions={actions}
+          compact={compact}
+          titleClassName={titleClassName}
+        />
       </CardHeader>
       <CardContent className="relative min-h-0 flex-1 p-0">
         <div

--- a/app/[locale]/dashboard/components/charts/chart-widget-kind.tsx
+++ b/app/[locale]/dashboard/components/charts/chart-widget-kind.tsx
@@ -1,0 +1,177 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+export const CHART_WIDGET_KINDS = [
+  "series",
+  "share",
+  "category",
+  "duration",
+  "ticks",
+  "metric",
+] as const
+
+export type ChartWidgetKind = (typeof CHART_WIDGET_KINDS)[number]
+
+function KindSvg({
+  className,
+  children,
+}: {
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden
+      className={className}
+    >
+      {children}
+    </svg>
+  )
+}
+
+function SeriesKindIcon({ className }: { className?: string }) {
+  return (
+    <KindSvg className={className}>
+      <path
+        d="M4 13.5V8"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle cx="4" cy="6.5" r="1.5" fill="currentColor" />
+      <path
+        d="M8 13.5V6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle cx="8" cy="4.5" r="1.5" fill="currentColor" />
+      <path
+        d="M12 13.5V10"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle cx="12" cy="8.5" r="1.5" fill="currentColor" />
+    </KindSvg>
+  )
+}
+
+function ShareKindIcon({ className }: { className?: string }) {
+  return (
+    <KindSvg className={className}>
+      <rect x="3" y="4" width="10" height="3.2" rx="1.2" fill="currentColor" />
+      <rect
+        x="3"
+        y="8.6"
+        width="10"
+        height="3.2"
+        rx="1.2"
+        fill="currentColor"
+        opacity="0.4"
+      />
+    </KindSvg>
+  )
+}
+
+function CategoryKindIcon({ className }: { className?: string }) {
+  return (
+    <KindSvg className={className}>
+      <path
+        d="M8 3.5V12.5"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        opacity="0.35"
+      />
+      <rect x="3" y="4.4" width="5" height="2.2" rx="1.1" fill="currentColor" />
+      <rect x="8" y="9.4" width="5" height="2.2" rx="1.1" fill="currentColor" />
+    </KindSvg>
+  )
+}
+
+function DurationKindIcon({ className }: { className?: string }) {
+  return (
+    <KindSvg className={className}>
+      <rect x="3" y="8" width="2.5" height="5" rx="1.2" fill="currentColor" />
+      <rect x="6.75" y="4.5" width="2.5" height="8.5" rx="1.2" fill="currentColor" />
+      <rect x="10.5" y="6.5" width="2.5" height="6.5" rx="1.2" fill="currentColor" />
+    </KindSvg>
+  )
+}
+
+function TicksKindIcon({ className }: { className?: string }) {
+  return (
+    <KindSvg className={className}>
+      <circle cx="4.5" cy="5" r="1.35" fill="currentColor" />
+      <circle cx="8" cy="5" r="1.35" fill="currentColor" />
+      <circle cx="11.5" cy="5" r="1.35" fill="currentColor" />
+      <circle cx="4.5" cy="11" r="1.35" fill="currentColor" opacity="0.4" />
+      <circle cx="8" cy="11" r="1.35" fill="currentColor" />
+      <circle cx="11.5" cy="11" r="1.35" fill="currentColor" opacity="0.4" />
+    </KindSvg>
+  )
+}
+
+function MetricKindIcon({ className }: { className?: string }) {
+  return (
+    <KindSvg className={className}>
+      <rect x="3.5" y="4" width="9" height="2.1" rx="1.05" fill="currentColor" />
+      <rect
+        x="3.5"
+        y="7.45"
+        width="6.5"
+        height="2.1"
+        rx="1.05"
+        fill="currentColor"
+        opacity="0.45"
+      />
+      <rect
+        x="3.5"
+        y="10.9"
+        width="4.2"
+        height="2.1"
+        rx="1.05"
+        fill="currentColor"
+        opacity="0.25"
+      />
+    </KindSvg>
+  )
+}
+
+const KIND_ICONS: Record<
+  ChartWidgetKind,
+  (props: { className?: string }) => JSX.Element
+> = {
+  series: SeriesKindIcon,
+  share: ShareKindIcon,
+  category: CategoryKindIcon,
+  duration: DurationKindIcon,
+  ticks: TicksKindIcon,
+  metric: MetricKindIcon,
+}
+
+export function ChartWidgetKindMark({
+  kind,
+  compact = false,
+}: {
+  kind: ChartWidgetKind
+  compact?: boolean
+}) {
+  const Icon = KIND_ICONS[kind]
+
+  return (
+    <span
+      aria-hidden
+      data-widget-kind={kind}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-md bg-foreground/[0.06] text-foreground",
+        compact ? "size-6" : "size-7",
+      )}
+    >
+      <Icon className={compact ? "size-3.5" : "size-4"} />
+    </span>
+  )
+}

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -10,30 +10,24 @@ import {
   Legend,
   Label,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
-import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton";
+import { shareConclusion } from "./chart-conclusions";
+import {
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  chartTooltipFontSize,
+} from "./chart-glance";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface CommissionsPnLChartProps {
   size?: WidgetSize;
 }
 
-
-const chartConfig = {
-  pnl: {
-    label: "Net P/L",
-    color: "hsl(var(--chart-win))",
-  },
-  commissions: {
-    label: "Commissions",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
+const PNL_COLOR = "hsl(var(--chart-win))";
+const COMMISSIONS_COLOR = "hsl(var(--chart-loss))";
 
 const formatCurrency = (value: number) =>
   value.toLocaleString("en-US", { style: "currency", currency: "USD" });
@@ -44,8 +38,7 @@ export default function CommissionsPnLChart({
   const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
 
-
-  const chartData = React.useMemo(() => {
+  const { chartData, conclusion } = React.useMemo(() => {
     const totalPnL = trades.reduce((sum, trade) => sum + trade.pnl, 0);
     const totalCommissions = trades.reduce(
       (sum, trade) => sum + trade.commission,
@@ -54,28 +47,35 @@ export default function CommissionsPnLChart({
     const total = Math.abs(totalPnL) + Math.abs(totalCommissions);
     const pnlPercent = total > 0 ? Number(((Math.abs(totalPnL) / total) * 100).toFixed(2)) : 0;
     const commPercent = total > 0 ? Number(((Math.abs(totalCommissions) / total) * 100).toFixed(2)) : 0;
-    return [
-      {
-        name: t("commissions.legend.netPnl"),
-        value: pnlPercent,
-        color: chartConfig.pnl.color,
-        raw: totalPnL,
-      },
-      {
-        name: t("commissions.legend.commissions"),
-        value: commPercent,
-        color: chartConfig.commissions.color,
-        raw: totalCommissions,
-      },
-    ];
+    return {
+      chartData: [
+        {
+          name: t("commissions.legend.netPnl"),
+          value: pnlPercent,
+          color: PNL_COLOR,
+          raw: totalPnL,
+        },
+        {
+          name: t("commissions.legend.commissions"),
+          value: commPercent,
+          color: COMMISSIONS_COLOR,
+          raw: totalCommissions,
+        },
+      ],
+      conclusion: shareConclusion(Math.abs(totalCommissions), total),
+    };
   }, [trades, t]);
 
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("commissions.subtitle.empty")
+      : t("commissions.subtitle.share", { percent: conclusion.percent });
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: any }> }) => {
     if (active && payload && payload.length) {
       const data = payload[0].payload;
       return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
+        <div className={CHART_TOOLTIP_CLASS}>
           <div className="grid gap-2">
             <div className="flex flex-col">
               <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -105,129 +105,97 @@ export default function CommissionsPnLChart({
     return null;
   };
 
-
   const renderColorfulLegendText = (value: string, entry: any) => {
     return <span className="text-xs text-muted-foreground">{value}</span>;
   };
-
 
   // Pie radii for consistency with trade-distribution
   const getInnerRadius = () => (size === 'small' ? '60%' : '65%');
   const getOuterRadius = () => (size === 'small' ? '80%' : '85%');
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
+    <ChartWidgetFrame
+      size={size}
+      title={t("commissions.title")}
+      subtitle={subtitle}
+      description={t("commissions.tooltip.description")}
+    >
+      {isLoading ? (
+        <DonutChartLoadingSkeleton size={size} />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="45%"
+              innerRadius={getInnerRadius()}
+              outerRadius={getOuterRadius()}
+              paddingAngle={2}
+              dataKey="value"
+              nameKey="name"
+              startAngle={90}
+              endAngle={-270}
+              stroke="hsl(var(--background))"
+              strokeWidth={1}
             >
-              {t("commissions.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === 'small' ? "size-3.5" : "size-4")}
-            >
-              <p>{t("commissions.tooltip.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === 'small' ? "p-1" : "p-2 sm:p-4"
-        )}
-      >
-        <div className="w-full h-full">
-          {isLoading ? (
-            <DonutChartLoadingSkeleton size={size} />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="45%"
-                innerRadius={getInnerRadius()}
-                outerRadius={getOuterRadius()}
-                paddingAngle={2}
-                dataKey="value"
-                nameKey="name"
-                startAngle={90}
-                endAngle={-270}
-                stroke="hsl(var(--background))"
-                strokeWidth={1}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={entry.color}
-                    className="transition-opacity duration-300 ease-out hover:opacity-80 dark:brightness-90"
-                  />
-                ))}
-                {/* Centered percentage labels */}
-                <Label
-                  position="center"
-                  content={(props: any) => {
-                    if (!props.viewBox) return null;
-                    const viewBox = props.viewBox;
-                    if (!viewBox.cx || !viewBox.cy) return null;
-                    const cx = viewBox.cx;
-                    const cy = viewBox.cy;
-                    const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1);
-                    return chartData.map((entry, index) => {
-                      const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
-                      const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
-                      const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
-                      return (
-                        <text
-                          key={index}
-                          x={x}
-                          y={y}
-                          textAnchor="middle"
-                          dominantBaseline="middle"
-                          className="fill-muted-foreground font-medium translate-y-2"
-                          style={{ fontSize: size === 'small' ? '10px' : '12px' }}
-                        >
-                          {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
-                        </text>
-                      );
-                    });
-                  }}
+              {chartData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={entry.color}
                 />
-              </Pie>
-              <Legend
-                verticalAlign="bottom"
-                align="center"
-                iconSize={8}
-                iconType="circle"
-                formatter={renderColorfulLegendText}
-                wrapperStyle={{
-                  paddingTop: size === 'small' ? 0 : 16
+              ))}
+              {/* Centered percentage labels */}
+              <Label
+                position="center"
+                content={(props: any) => {
+                  if (!props.viewBox) return null;
+                  const viewBox = props.viewBox;
+                  if (!viewBox.cx || !viewBox.cy) return null;
+                  const cx = viewBox.cx;
+                  const cy = viewBox.cy;
+                  const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1);
+                  return chartData.map((entry, index) => {
+                    const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
+                    const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
+                    const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
+                    return (
+                      <text
+                        key={index}
+                        x={x}
+                        y={y}
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        className="fill-muted-foreground font-medium translate-y-2"
+                        style={{ fontSize: size === 'small' ? '10px' : '12px' }}
+                      >
+                        {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
+                      </text>
+                    );
+                  });
                 }}
               />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === 'small' ? '10px' : '12px',
-                  zIndex: 1000
-                }}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+            </Pie>
+            <Legend
+              verticalAlign="bottom"
+              align="center"
+              iconSize={8}
+              iconType="circle"
+              formatter={renderColorfulLegendText}
+              wrapperStyle={{
+                paddingTop: size === 'small' ? 0 : 16
+              }}
+            />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -1,26 +1,13 @@
 "use client";
 
 import * as React from "react";
-import {
-  PieChart,
-  Pie,
-  Cell,
-  ResponsiveContainer,
-  Tooltip,
-  Legend,
-  Label,
-} from "recharts";
 import { useData } from "@/context/data-provider";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
-import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton";
+import { UnitFieldLoadingSkeleton } from "./chart-loading-skeleton";
 import { shareConclusion } from "./chart-conclusions";
-import {
-  CHART_TOOLTIP_CLASS,
-  CHART_TOOLTIP_WRAPPER,
-  chartTooltipFontSize,
-} from "./chart-glance";
 import { ChartWidgetFrame } from "./chart-widget-frame";
+import { UnitDotField } from "./chart-unit-field";
 
 interface CommissionsPnLChartProps {
   size?: WidgetSize;
@@ -29,37 +16,32 @@ interface CommissionsPnLChartProps {
 const PNL_COLOR = "hsl(var(--chart-win))";
 const COMMISSIONS_COLOR = "hsl(var(--chart-loss))";
 
-const formatCurrency = (value: number) =>
-  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
-
 export default function CommissionsPnLChart({
   size = "medium",
 }: CommissionsPnLChartProps) {
   const { formattedTrades: trades, isLoading } = useData();
   const t = useI18n();
 
-  const { chartData, conclusion } = React.useMemo(() => {
+  const { groups, conclusion } = React.useMemo(() => {
     const totalPnL = trades.reduce((sum, trade) => sum + trade.pnl, 0);
     const totalCommissions = trades.reduce(
       (sum, trade) => sum + trade.commission,
       0,
     );
     const total = Math.abs(totalPnL) + Math.abs(totalCommissions);
-    const pnlPercent = total > 0 ? Number(((Math.abs(totalPnL) / total) * 100).toFixed(2)) : 0;
-    const commPercent = total > 0 ? Number(((Math.abs(totalCommissions) / total) * 100).toFixed(2)) : 0;
     return {
-      chartData: [
+      groups: [
         {
-          name: t("commissions.legend.netPnl"),
-          value: pnlPercent,
+          key: "pnl",
+          label: t("commissions.legend.netPnl"),
           color: PNL_COLOR,
-          raw: totalPnL,
+          count: Math.abs(totalPnL),
         },
         {
-          name: t("commissions.legend.commissions"),
-          value: commPercent,
+          key: "commissions",
+          label: t("commissions.legend.commissions"),
           color: COMMISSIONS_COLOR,
-          raw: totalCommissions,
+          count: Math.abs(totalCommissions),
         },
       ],
       conclusion: shareConclusion(Math.abs(totalCommissions), total),
@@ -71,48 +53,6 @@ export default function CommissionsPnLChart({
       ? t("commissions.subtitle.empty")
       : t("commissions.subtitle.share", { percent: conclusion.percent });
 
-  const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: any }> }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      return (
-        <div className={CHART_TOOLTIP_CLASS}>
-          <div className="grid gap-2">
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("commissions.tooltip.type")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.name}
-              </span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("commissions.tooltip.amount")}
-              </span>
-              <span className="font-bold">{formatCurrency(data.raw)}</span>
-            </div>
-            <div className="flex flex-col">
-              <span className="text-[0.70rem] uppercase text-muted-foreground">
-                {t("commissions.tooltip.percentage")}
-              </span>
-              <span className="font-bold text-muted-foreground">
-                {data.value.toFixed(2)}%</span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-    return null;
-  };
-
-  const renderColorfulLegendText = (value: string, entry: any) => {
-    return <span className="text-xs text-muted-foreground">{value}</span>;
-  };
-
-  // Pie radii for consistency with trade-distribution
-  const getInnerRadius = () => (size === 'small' ? '60%' : '65%');
-  const getOuterRadius = () => (size === 'small' ? '80%' : '85%');
-
   return (
     <ChartWidgetFrame
       size={size}
@@ -121,80 +61,14 @@ export default function CommissionsPnLChart({
       description={t("commissions.tooltip.description")}
     >
       {isLoading ? (
-        <DonutChartLoadingSkeleton size={size} />
+        <UnitFieldLoadingSkeleton size={size} />
       ) : (
-        <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-            <Pie
-              data={chartData}
-              cx="50%"
-              cy="45%"
-              innerRadius={getInnerRadius()}
-              outerRadius={getOuterRadius()}
-              paddingAngle={2}
-              dataKey="value"
-              nameKey="name"
-              startAngle={90}
-              endAngle={-270}
-              stroke="hsl(var(--background))"
-              strokeWidth={1}
-            >
-              {chartData.map((entry, index) => (
-                <Cell
-                  key={`cell-${index}`}
-                  fill={entry.color}
-                />
-              ))}
-              {/* Centered percentage labels */}
-              <Label
-                position="center"
-                content={(props: any) => {
-                  if (!props.viewBox) return null;
-                  const viewBox = props.viewBox;
-                  if (!viewBox.cx || !viewBox.cy) return null;
-                  const cx = viewBox.cx;
-                  const cy = viewBox.cy;
-                  const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1);
-                  return chartData.map((entry, index) => {
-                    const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
-                    const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
-                    const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
-                    return (
-                      <text
-                        key={index}
-                        x={x}
-                        y={y}
-                        textAnchor="middle"
-                        dominantBaseline="middle"
-                        className="fill-muted-foreground font-medium translate-y-2"
-                        style={{ fontSize: size === 'small' ? '10px' : '12px' }}
-                      >
-                        {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
-                      </text>
-                    );
-                  });
-                }}
-              />
-            </Pie>
-            <Legend
-              verticalAlign="bottom"
-              align="center"
-              iconSize={8}
-              iconType="circle"
-              formatter={renderColorfulLegendText}
-              wrapperStyle={{
-                paddingTop: size === 'small' ? 0 : 16
-              }}
-            />
-            <Tooltip
-              content={<CustomTooltip />}
-              wrapperStyle={{
-                fontSize: chartTooltipFontSize(size),
-                ...CHART_TOOLTIP_WRAPPER,
-              }}
-            />
-          </PieChart>
-        </ResponsiveContainer>
+        <UnitDotField
+          groups={groups}
+          mode="percent"
+          label={subtitle}
+          size={size}
+        />
       )}
     </ChartWidgetFrame>
   );

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -16,6 +16,9 @@ interface CommissionsPnLChartProps {
 const PNL_COLOR = "hsl(var(--chart-win))";
 const COMMISSIONS_COLOR = "hsl(var(--chart-loss))";
 
+const formatCurrency = (value: number) =>
+  value.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
 export default function CommissionsPnLChart({
   size = "medium",
 }: CommissionsPnLChartProps) {
@@ -34,12 +37,14 @@ export default function CommissionsPnLChart({
         {
           key: "pnl",
           label: t("commissions.legend.netPnl"),
+          detail: formatCurrency(totalPnL),
           color: PNL_COLOR,
           count: Math.abs(totalPnL),
         },
         {
           key: "commissions",
           label: t("commissions.legend.commissions"),
+          detail: formatCurrency(totalCommissions),
           color: COMMISSIONS_COLOR,
           count: Math.abs(totalCommissions),
         },

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -4,10 +4,10 @@ import * as React from "react";
 import { useData } from "@/context/data-provider";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
-import { UnitFieldLoadingSkeleton } from "./chart-loading-skeleton";
+import { ShareSplitLoadingSkeleton } from "./chart-loading-skeleton";
 import { shareConclusion } from "./chart-conclusions";
 import { ChartWidgetFrame } from "./chart-widget-frame";
-import { UnitDotField } from "./chart-unit-field";
+import { ShareSplit } from "./chart-share-split";
 
 interface CommissionsPnLChartProps {
   size?: WidgetSize;
@@ -48,10 +48,11 @@ export default function CommissionsPnLChart({
     };
   }, [trades, t]);
 
+  const percent = conclusion.kind === "empty" ? 0 : conclusion.percent;
   const subtitle =
     conclusion.kind === "empty"
       ? t("commissions.subtitle.empty")
-      : t("commissions.subtitle.share", { percent: conclusion.percent });
+      : t("commissions.subtitle.share", { percent });
 
   return (
     <ChartWidgetFrame
@@ -61,11 +62,12 @@ export default function CommissionsPnLChart({
       description={t("commissions.tooltip.description")}
     >
       {isLoading ? (
-        <UnitFieldLoadingSkeleton size={size} />
+        <ShareSplitLoadingSkeleton size={size} />
       ) : (
-        <UnitDotField
+        <ShareSplit
           groups={groups}
-          mode="percent"
+          headline={conclusion.kind === "empty" ? "—" : `${percent}%`}
+          caption={t("commissions.caption.share")}
           label={subtitle}
           size={size}
         />

--- a/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/commissions-pnl.tsx
@@ -62,6 +62,8 @@ export default function CommissionsPnLChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="share"
+      eyebrow={t("commissions.eyebrow")}
       title={t("commissions.title")}
       subtitle={subtitle}
       description={t("commissions.tooltip.description")}

--- a/app/[locale]/dashboard/components/charts/equity-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/equity-chart.tsx
@@ -48,6 +48,13 @@ import {
   LineChartLoadingSkeleton,
   LOADING_MOCK_EQUITY,
 } from "./chart-loading-skeleton";
+import {
+  CHART_GRID_PROPS,
+  CHART_LINE_STROKE,
+  CHART_TOOLTIP_CLASS,
+  CHART_ZERO_LINE_PROPS,
+  chartTickStyle,
+} from "./chart-glance";
 import { usePathname } from "next/navigation";
 
 interface EquityChartProps {
@@ -273,7 +280,7 @@ const OptimizedTooltip = React.memo(
     // In shared view, show simplified tooltip without payouts/resets
     if (isSharedView) {
       return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
+        <div className={CHART_TOOLTIP_CLASS}>
           <div className="grid gap-2">
             <div className="flex flex-col">
               <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -327,7 +334,7 @@ const OptimizedTooltip = React.memo(
 
     // Only show tooltip in grouped mode
     return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
+      <div className={CHART_TOOLTIP_CLASS}>
         <div className="grid gap-2">
           <div className="flex flex-col">
             <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -910,7 +917,7 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
         <Line
           type="monotone"
           dataKey="equity"
-          strokeWidth={2}
+          strokeWidth={CHART_LINE_STROKE}
           dot={renderDot}
           isAnimationActive={false}
           activeDot={{ r: 3, style: { fill: "hsl(var(--chart-2))" } }}
@@ -959,7 +966,7 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
           key={accountNumber}
           type="linear" // Linear is faster than monotone
           dataKey={`equity_${accountNumber}`}
-          strokeWidth={1.5} // Thinner lines for better performance
+          strokeWidth={CHART_LINE_STROKE}
           dot={renderDot}
           isAnimationActive={false}
           activeDot={renderClosestActiveDot}
@@ -985,19 +992,24 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
     <Card className="h-full flex flex-col">
       <CardHeader
         className={cn(
-          "flex h-11 shrink-0 flex-col items-stretch space-y-0 border-b",
+          "flex min-h-11 shrink-0 flex-col items-stretch space-y-0 border-b",
           size === "small" ? "p-2" : "px-3 py-2.5"
         )}
       >
         <div className="flex items-center justify-between h-full">
           <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1 text-xs font-semibold tracking-[-0.02em]"
-              )}
-            >
-              {t("equity.title")}
-            </CardTitle>
+            <div className="min-w-0">
+              <CardTitle
+                className={cn(
+                  "line-clamp-1 text-xs font-semibold tracking-[-0.02em]"
+                )}
+              >
+                {t("equity.title")}
+              </CardTitle>
+              <p className="mt-0.5 line-clamp-1 text-[10px] text-muted-foreground">
+                {t("equity.subtitle")}
+              </p>
+            </div>
             <InfoBubble
               side="top"
               iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
@@ -1078,20 +1090,14 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
                       setPointerValue(null);
                     }}
                   >
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                    />
+                    <CartesianGrid {...CHART_GRID_PROPS} />
                     <XAxis
                       dataKey="date"
                       tickLine={false}
                       axisLine={false}
                       height={size === "small" ? 20 : 24}
                       tickMargin={size === "small" ? 4 : 8}
-                      tick={{
-                        fontSize: size === "small" ? 9 : 11,
-                        fill: "currentColor",
-                      }}
+                      tick={chartTickStyle(size)}
                       tickFormatter={(value) =>
                         format(new Date(value), "MMM d", { locale: dateLocale })
                       }
@@ -1101,18 +1107,10 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
                       axisLine={false}
                       width={60}
                       tickMargin={4}
-                      tick={{
-                        fontSize: size === "small" ? 9 : 11,
-                        fill: "currentColor",
-                      }}
+                      tick={chartTickStyle(size)}
                       tickFormatter={formatCurrency}
                     />
-                    <ReferenceLine
-                      y={0}
-                      stroke="hsl(var(--muted-foreground))"
-                      strokeDasharray="3 3"
-                      strokeOpacity={0.5}
-                    />
+                    <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
                     <ChartTooltip
                       content={({
                         active,

--- a/app/[locale]/dashboard/components/charts/equity-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/equity-chart.tsx
@@ -23,7 +23,7 @@ import { fr, enUS } from "date-fns/locale";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 import {
   ChartConfig,
@@ -48,6 +48,7 @@ import {
   LineChartLoadingSkeleton,
   LOADING_MOCK_EQUITY,
 } from "./chart-loading-skeleton";
+import { ChartWidgetMasthead } from "./chart-widget-frame";
 import {
   CHART_GRID_PROPS,
   CHART_LINE_STROKE,
@@ -989,48 +990,39 @@ export default function EquityChart({ size = "medium" }: EquityChartProps) {
   }, [isSharedView, showIndividual, chartData]);
 
   return (
-    <Card className="h-full flex flex-col">
+    <Card
+      data-widget-kind="series"
+      className="flex h-full flex-col overflow-hidden"
+    >
       <CardHeader
         className={cn(
-          "flex min-h-11 shrink-0 flex-col items-stretch space-y-0 border-b",
-          size === "small" ? "p-2" : "px-3 py-2.5"
+          "flex shrink-0 flex-col items-stretch space-y-0 border-b bg-muted/40",
+          size === "small" ? "p-2" : "p-3 sm:p-4"
         )}
       >
-        <div className="flex items-center justify-between h-full">
-          <div className="flex items-center gap-1.5">
-            <div className="min-w-0">
-              <CardTitle
-                className={cn(
-                  "line-clamp-1 text-xs font-semibold tracking-[-0.02em]"
-                )}
-              >
-                {t("equity.title")}
-              </CardTitle>
-              <p className="mt-0.5 line-clamp-1 text-[10px] text-muted-foreground">
-                {t("equity.subtitle")}
-              </p>
-            </div>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("equity.description")}</p>
-            </InfoBubble>
-          </div>
-          {!isSharedView && !isTeamView && (
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="view-mode"
-                checked={showIndividual}
-                onCheckedChange={setShowIndividualConfig}
-                className="shrink-0"
-              />
-              <Label htmlFor="view-mode" className="text-sm">
-                {t("equity.toggle.individual")}
-              </Label>
-            </div>
-          )}
-        </div>
+        <ChartWidgetMasthead
+          kind="series"
+          eyebrow={t("equity.eyebrow")}
+          title={t("equity.title")}
+          subtitle={t("equity.subtitle")}
+          description={t("equity.description")}
+          compact={size === "small"}
+          actions={
+            !isSharedView && !isTeamView ? (
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="view-mode"
+                  checked={showIndividual}
+                  onCheckedChange={setShowIndividualConfig}
+                  className="shrink-0"
+                />
+                <Label htmlFor="view-mode" className="text-sm">
+                  {t("equity.toggle.individual")}
+                </Label>
+              </div>
+            ) : undefined
+          }
+        />
       </CardHeader>
       <CardContent
         className={cn(

--- a/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
@@ -10,21 +10,33 @@ import {
   Cell,
   Tooltip,
   ResponsiveContainer,
+  ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig, ChartContainer } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
-import { cn } from "@/lib/utils";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { useI18n, useCurrentLocale } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import { fr, enUS } from "date-fns/locale";
 import { useUserStore } from "@/store/user-store";
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_DATE_PNL,
 } from "./chart-loading-skeleton";
+import { dailyPnlConclusion } from "./chart-conclusions";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  honestSignedDomain,
+  signedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface PNLChartProps {
   size?: WidgetSize;
@@ -45,13 +57,6 @@ interface TooltipProps {
   label?: string;
 }
 
-const chartConfig = {
-  pnl: {
-    label: "Daily P/L",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
-
 const formatCurrency = (value: number) => {
   const absValue = Math.abs(value);
   if (absValue >= 1000000) {
@@ -63,10 +68,7 @@ const formatCurrency = (value: number) => {
   return `${value < 0 ? "-" : ""}$${absValue.toFixed(0)}`;
 };
 
-const positiveColor = "hsl(var(--chart-2))"; // Green color
-const negativeColor = "hsl(var(--chart-loss))"; // Orangish color
-
-const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
+const CustomTooltip = ({ active, payload }: TooltipProps) => {
   const t = useI18n();
   const locale = useCurrentLocale();
   const { timezone } = useUserStore();
@@ -76,7 +78,7 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps) => {
     const data = payload[0].payload;
     const date = new Date(data.date + "T00:00:00Z");
     return (
-      <div className="bg-background p-2 border rounded shadow-xs">
+      <div className={CHART_TOOLTIP_CLASS}>
         <p className="font-semibold">
           {formatInTimeZone(date, timezone, "MMM d, yyyy", {
             locale: dateLocale,
@@ -121,138 +123,78 @@ export default function PNLChart({ size = "medium" }: PNLChartProps) {
     [calendarData],
   );
 
-  const maxPnL = Math.max(...chartData.map((d) => d.pnl));
-  const minPnL = Math.min(...chartData.map((d) => d.pnl));
-
-  const getChartHeight = () => {
-    switch (size) {
-      case "small":
-        return "h-[140px]";
-      case "medium":
-        return "h-[200px]";
-      case "large":
-        return "h-[240px]";
-      default:
-        return "h-[200px]";
-    }
-  };
-
-  const getChartMargins = () => {
-    switch (size) {
-      case "small":
-        return { left: 10, right: 4, top: 4, bottom: 20 };
-      case "medium":
-        return { left: 10, right: 8, top: 8, bottom: 24 };
-      case "large":
-        return { left: 10, right: 12, top: 12, bottom: 28 };
-      default:
-        return { left: 10, right: 8, top: 8, bottom: 24 };
-    }
-  };
+  const conclusion = dailyPnlConclusion(chartData.map((point) => point.pnl));
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("pnl.subtitle.empty")
+      : conclusion.kind === "greenDays"
+        ? t("pnl.subtitle.greenDays", conclusion)
+        : t("pnl.subtitle.redDays", conclusion);
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnl.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnl.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_DATE_PNL}
-              xDataKey="date"
-              yDataKey="pnl"
-              marginVariant="default"
+    <ChartWidgetFrame
+      size={size}
+      title={t("pnl.title")}
+      subtitle={subtitle}
+      description={t("pnl.description")}
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_DATE_PNL}
+          xDataKey="date"
+          yDataKey="pnl"
+          marginVariant="default"
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={getChartMargins(size)}>
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
+              minTickGap={size === "small" ? 30 : 50}
+              tickFormatter={(value) => {
+                const date = new Date(value + "T00:00:00Z");
+                return formatInTimeZone(date, timezone, "MMM d", {
+                  locale: dateLocale,
+                });
+              }}
             />
-          ) : (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={chartData} margin={getChartMargins()}>
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  minTickGap={size === "small" ? 30 : 50}
-                  tickFormatter={(value) => {
-                    const date = new Date(value + "T00:00:00Z");
-                    return formatInTimeZone(date, timezone, "MMM d", {
-                      locale: dateLocale,
-                    });
-                  }}
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="pnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={entry.pnl >= 0 ? positiveColor : negativeColor}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={60}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatCurrency}
+              domain={honestSignedDomain(chartData.map((point) => point.pnl))}
+            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="pnl"
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
+            >
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={signedFill(entry.pnl)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
@@ -35,7 +35,7 @@ import {
   honestSignedDomain,
   signedFill,
 } from "./chart-glance";
-import { GlanceBar } from "./chart-glance-bar";
+import { LollipopBar } from "./chart-lollipop-bar";
 import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface PNLChartProps {
@@ -185,7 +185,7 @@ export default function PNLChart({ size = "medium" }: PNLChartProps) {
             <Bar
               dataKey="pnl"
               maxBarSize={chartMaxBarSize(size)}
-              shape={<GlanceBar />}
+              shape={<LollipopBar />}
               className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
               {chartData.map((entry, index) => (

--- a/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-bar-chart.tsx
@@ -134,6 +134,8 @@ export default function PNLChart({ size = "medium" }: PNLChartProps) {
   return (
     <ChartWidgetFrame
       size={size}
+      kind="series"
+      eyebrow={t("pnl.eyebrow")}
       title={t("pnl.title")}
       subtitle={subtitle}
       description={t("pnl.description")}

--- a/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
@@ -22,7 +22,7 @@ import {
   LOADING_MOCK_SIDE_PNL,
 } from "./chart-loading-skeleton";
 import {
-  CHART_GRID_PROPS,
+  CHART_GRID_PROPS_HORIZONTAL,
   CHART_TOOLTIP_CLASS,
   CHART_TOOLTIP_WRAPPER,
   CHART_ZERO_LINE_PROPS,
@@ -181,29 +181,37 @@ export default function PnLBySideChart({
           yDataKey="pnl"
           showReferenceLine
           xTickCount={2}
+          yAxisWidth={size === "small" ? 40 : 56}
+          layout="horizontal"
         />
       ) : (
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={chartData} margin={getChartMargins(size)}>
-            <CartesianGrid {...CHART_GRID_PROPS} />
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={getChartMargins(size, "horizontal")}
+          >
+            <CartesianGrid {...CHART_GRID_PROPS_HORIZONTAL} />
             <XAxis
-              dataKey="side"
+              type="number"
               tickLine={false}
               axisLine={false}
               height={size === "small" ? 20 : 24}
               tickMargin={size === "small" ? 4 : 8}
               tick={chartTickStyle(size)}
-            />
-            <YAxis
-              tickLine={false}
-              axisLine={false}
-              width={60}
-              tickMargin={4}
-              tick={chartTickStyle(size)}
               tickFormatter={formatCurrency}
               domain={honestSignedDomain(chartData.map((entry) => entry.pnl))}
             />
-            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <YAxis
+              type="category"
+              dataKey="side"
+              tickLine={false}
+              axisLine={false}
+              width={size === "small" ? 40 : 56}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+            />
+            <ReferenceLine x={0} {...CHART_ZERO_LINE_PROPS} />
             <Tooltip
               content={<CustomTooltip />}
               wrapperStyle={{
@@ -214,7 +222,7 @@ export default function PnLBySideChart({
             <Bar
               dataKey="pnl"
               maxBarSize={chartMaxBarSize(size)}
-              shape={<GlanceBar />}
+              shape={<GlanceBar layout="horizontal" />}
               className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
               {chartData.map((entry, index) => (

--- a/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
@@ -12,29 +12,33 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
-import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { Switch } from "@/components/ui/switch";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_SIDE_PNL,
 } from "./chart-loading-skeleton";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  honestSignedDomain,
+  peakIndex,
+  signedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface PnLBySideChartProps {
   size?: WidgetSize;
 }
-
-const chartConfig = {
-  pnl: {
-    label: "P/L",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
 
 const formatCurrency = (value: number) =>
   value.toLocaleString("en-US", { style: "currency", currency: "USD" });
@@ -44,7 +48,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
+      <div className={CHART_TOOLTIP_CLASS}>
         <div className="grid gap-2">
           <div className="flex flex-col">
             <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -133,138 +137,93 @@ export default function PnLBySideChart({
     ];
   }, [trades, showAverage]);
 
-  const maxPnL = Math.max(...chartData.map((d) => d.pnl));
-  const minPnL = Math.min(...chartData.map((d) => d.pnl));
-  const absMax = Math.max(Math.abs(maxPnL), Math.abs(minPnL));
-
-  const getColor = (value: number) => {
-    const ratio = Math.abs(value / absMax);
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-4";
-    const intensity = Math.max(0.2, ratio);
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
+  const hasTrades = chartData.some((entry) => entry.tradeCount > 0);
+  const leaderIndex = peakIndex(chartData, (entry) => entry.pnl);
+  const subtitle = !hasTrades
+    ? t("pnlBySide.subtitle.empty")
+    : t("pnlBySide.subtitle.best", {
+        label: chartData[leaderIndex]?.side ?? "Long",
+        mode: showAverage
+          ? t("pnlBySide.mode.average")
+          : t("pnlBySide.mode.total"),
+      });
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnlBySide.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlBySide.description")}</p>
-            </InfoBubble>
-          </div>
-          <div className="flex items-center gap-2">
-            <span
-              className={cn(
-                "text-muted-foreground",
-                size === "small" ? "text-xs" : "text-sm",
-              )}
-            >
-              {t("pnlBySide.toggle.showAverage")}
-            </span>
-            <Switch
-              checked={showAverage}
-              onCheckedChange={setShowAverage}
-              className="data-[state=checked]:bg-primary"
-            />
-          </div>
+    <ChartWidgetFrame
+      size={size}
+      title={t("pnlBySide.title")}
+      subtitle={subtitle}
+      description={t("pnlBySide.description")}
+      actions={
+        <div className="flex items-center gap-2">
+          <span
+            className={
+              size === "small"
+                ? "text-xs text-muted-foreground"
+                : "text-sm text-muted-foreground"
+            }
+          >
+            {t("pnlBySide.toggle.showAverage")}
+          </span>
+          <Switch
+            checked={showAverage}
+            onCheckedChange={setShowAverage}
+            className="data-[state=checked]:bg-primary"
+          />
         </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_SIDE_PNL}
-              xDataKey="side"
-              yDataKey="pnl"
-              showReferenceLine
-              xTickCount={2}
+      }
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_SIDE_PNL}
+          xDataKey="side"
+          yDataKey="pnl"
+          showReferenceLine
+          xTickCount={2}
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={getChartMargins(size)}>
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="side"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
             />
-          ) : (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                margin={
-                  size === "small"
-                    ? { left: 10, right: 4, top: 4, bottom: 20 }
-                    : { left: 10, right: 8, top: 8, bottom: 24 }
-                }
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                />
-                <XAxis
-                  dataKey="side"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                  domain={[
-                    Math.min(minPnL * 1.1, 0),
-                    Math.max(maxPnL * 1.1, 0),
-                  ]}
-                />
-                <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="pnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={getColor(entry.pnl)} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={60}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatCurrency}
+              domain={honestSignedDomain(chartData.map((entry) => entry.pnl))}
+            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="pnl"
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
+            >
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={signedFill(entry.pnl)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-by-side.tsx
@@ -151,6 +151,8 @@ export default function PnLBySideChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="category"
+      eyebrow={t("pnlBySide.eyebrow")}
       title={t("pnlBySide.title")}
       subtitle={subtitle}
       description={t("pnlBySide.description")}

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
@@ -12,12 +12,9 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import {
   Select,
   SelectContent,
@@ -32,18 +29,25 @@ import { formatInTimeZone } from "date-fns-tz";
 import { fr, enUS } from "date-fns/locale";
 import { useUserStore } from "@/store/user-store";
 import { useCurrentLocale } from "@/locales/client";
-import { Button } from "@/components/ui/button";
+import { getChartMargins } from "./chart-loading-skeleton";
+import { dailyPnlConclusion } from "./chart-conclusions";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  honestSignedDomain,
+  signedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface PnLPerContractDailyChartProps {
   size?: WidgetSize;
 }
-
-const chartConfig = {
-  pnl: {
-    label: "Avg Net P/L per Contract",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
 
 const formatCurrency = (value: number) =>
   value.toLocaleString("en-US", { style: "currency", currency: "USD" });
@@ -53,7 +57,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
+      <div className={CHART_TOOLTIP_CLASS}>
         <div className="grid gap-2">
           <div className="flex flex-col">
             <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -183,528 +187,469 @@ export default function PnLPerContractDailyChart({
       .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   }, [trades, config.selectedInstrument, timezone]);
 
-  const maxPnL = Math.max(...chartData.map((d) => d.averagePnl));
-  const minPnL = Math.min(...chartData.map((d) => d.averagePnl));
-  const absMax = Math.max(Math.abs(maxPnL), Math.abs(minPnL));
-
-  const getColor = (value: number) => {
-    const ratio = Math.abs(value / absMax);
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-loss";
-    const intensity = Math.max(0.2, ratio);
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
+  const conclusion = dailyPnlConclusion(
+    chartData.map((entry) => entry.averagePnl),
+  );
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("pnlPerContractDaily.subtitle.empty")
+      : conclusion.kind === "greenDays"
+        ? t("pnlPerContractDaily.subtitle.greenDays", conclusion)
+        : t("pnlPerContractDaily.subtitle.redDays", conclusion);
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnlPerContractDaily.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlPerContractDaily.description")}</p>
-            </InfoBubble>
-          </div>
-          <div className="flex items-center gap-2">
-            <Select
-              value={config.selectedInstrument}
-              onValueChange={setSelectedInstrument}
-            >
-              <SelectTrigger
-                className={cn(
-                  "w-[120px]",
-                  size === "small" ? "h-7 text-xs" : "h-8 text-sm",
-                )}
+    <ChartWidgetFrame
+      size={size}
+      title={t("pnlPerContractDaily.title")}
+      subtitle={subtitle}
+      description={t("pnlPerContractDaily.description")}
+      actions={
+        <Select
+          value={config.selectedInstrument}
+          onValueChange={setSelectedInstrument}
+        >
+          <SelectTrigger
+            className={cn(
+              "w-[120px]",
+              size === "small" ? "h-7 text-xs" : "h-8 text-sm",
+            )}
+          >
+            <SelectValue
+              placeholder={t("pnlPerContractDaily.selectInstrument")}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {availableInstruments.map((instrument) => (
+              <SelectItem key={instrument} value={instrument}>
+                {instrument}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      }
+    >
+      {isLoading ? (
+        (() => {
+          const loadingMockData = [
+            {
+              date: "2024-12-02",
+              averagePnl: 12.444999999999999,
+              totalPnl: 99.55999999999999,
+              tradeCount: 8,
+              winCount: 2,
+              totalContracts: 8,
+            },
+            {
+              date: "2024-12-03",
+              averagePnl: 59.32,
+              totalPnl: 237.28,
+              tradeCount: 4,
+              winCount: 4,
+              totalContracts: 4,
+            },
+            {
+              date: "2024-12-11",
+              averagePnl: 28.069999999999997,
+              totalPnl: 224.55999999999997,
+              tradeCount: 8,
+              winCount: 4,
+              totalContracts: 8,
+            },
+            {
+              date: "2024-12-16",
+              averagePnl: -34.43,
+              totalPnl: -68.86,
+              tradeCount: 2,
+              winCount: 0,
+              totalContracts: 2,
+            },
+            {
+              date: "2024-12-17",
+              averagePnl: -3.18,
+              totalPnl: -6.36,
+              tradeCount: 2,
+              winCount: 0,
+              totalContracts: 2,
+            },
+            {
+              date: "2024-12-19",
+              averagePnl: 48.90333333333333,
+              totalPnl: 293.41999999999996,
+              tradeCount: 6,
+              winCount: 4,
+              totalContracts: 6,
+            },
+            {
+              date: "2024-12-20",
+              averagePnl: 17.653333333333332,
+              totalPnl: 105.92,
+              tradeCount: 6,
+              winCount: 2,
+              totalContracts: 6,
+            },
+            {
+              date: "2025-01-06",
+              averagePnl: 59.32,
+              totalPnl: 237.28,
+              tradeCount: 3,
+              winCount: 3,
+              totalContracts: 4,
+            },
+            {
+              date: "2025-01-07",
+              averagePnl: 74.94500000000001,
+              totalPnl: 599.5600000000001,
+              tradeCount: 6,
+              winCount: 6,
+              totalContracts: 8,
+            },
+            {
+              date: "2025-01-14",
+              averagePnl: 28.07,
+              totalPnl: 224.56,
+              tradeCount: 6,
+              winCount: 3,
+              totalContracts: 8,
+            },
+            {
+              date: "2025-01-15",
+              averagePnl: -3.18,
+              totalPnl: -12.72,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 4,
+            },
+            {
+              date: "2025-01-21",
+              averagePnl: 28.07,
+              totalPnl: 224.56,
+              tradeCount: 6,
+              winCount: 3,
+              totalContracts: 8,
+            },
+            {
+              date: "2025-01-22",
+              averagePnl: 59.32,
+              totalPnl: 474.56,
+              tradeCount: 6,
+              winCount: 6,
+              totalContracts: 8,
+            },
+            {
+              date: "2025-01-23",
+              averagePnl: 74.945,
+              totalPnl: 599.56,
+              tradeCount: 6,
+              winCount: 6,
+              totalContracts: 8,
+            },
+            {
+              date: "2025-01-24",
+              averagePnl: -34.43000000000001,
+              totalPnl: -413.1600000000001,
+              tradeCount: 9,
+              winCount: 0,
+              totalContracts: 12,
+            },
+            {
+              date: "2025-01-28",
+              averagePnl: -3.18,
+              totalPnl: -38.160000000000004,
+              tradeCount: 9,
+              winCount: 0,
+              totalContracts: 12,
+            },
+            {
+              date: "2025-01-31",
+              averagePnl: 59.32,
+              totalPnl: 237.28,
+              tradeCount: 3,
+              winCount: 3,
+              totalContracts: 4,
+            },
+            {
+              date: "2025-02-20",
+              averagePnl: 59.32000000000001,
+              totalPnl: 593.2,
+              tradeCount: 6,
+              winCount: 6,
+              totalContracts: 10,
+            },
+            {
+              date: "2025-02-25",
+              averagePnl: 59.32000000000001,
+              totalPnl: 296.6,
+              tradeCount: 3,
+              winCount: 3,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-02-27",
+              averagePnl: -96.93,
+              totalPnl: -484.65000000000003,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-03-12",
+              averagePnl: 21.82,
+              totalPnl: 109.1,
+              tradeCount: 3,
+              winCount: 2,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-03-18",
+              averagePnl: -3.1799999999999997,
+              totalPnl: -15.899999999999999,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-03-19",
+              averagePnl: -3.1799999999999997,
+              totalPnl: -15.899999999999999,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-03-20",
+              averagePnl: -65.67999999999999,
+              totalPnl: -328.4,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-03-21",
+              averagePnl: -34.43,
+              totalPnl: -172.15,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-04-22",
+              averagePnl: 17.65333333333333,
+              totalPnl: 264.79999999999995,
+              tradeCount: 9,
+              winCount: 3,
+              totalContracts: 15,
+            },
+            {
+              date: "2025-04-23",
+              averagePnl: 59.32000000000001,
+              totalPnl: 296.6,
+              tradeCount: 3,
+              winCount: 3,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-04-24",
+              averagePnl: -3.1799999999999997,
+              totalPnl: -47.699999999999996,
+              tradeCount: 9,
+              winCount: 0,
+              totalContracts: 15,
+            },
+            {
+              date: "2025-04-29",
+              averagePnl: -34.42999999999999,
+              totalPnl: -344.29999999999995,
+              tradeCount: 6,
+              winCount: 0,
+              totalContracts: 10,
+            },
+            {
+              date: "2025-05-08",
+              averagePnl: 59.32000000000001,
+              totalPnl: 296.6,
+              tradeCount: 3,
+              winCount: 3,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-05-15",
+              averagePnl: 59.32000000000001,
+              totalPnl: 296.6,
+              tradeCount: 3,
+              winCount: 3,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-05-19",
+              averagePnl: -34.43,
+              totalPnl: -172.15,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 5,
+            },
+            {
+              date: "2025-05-22",
+              averagePnl: 28.07,
+              totalPnl: 280.7,
+              tradeCount: 6,
+              winCount: 3,
+              totalContracts: 10,
+            },
+            {
+              date: "2025-06-03",
+              averagePnl: -34.43,
+              totalPnl: -344.3,
+              tradeCount: 6,
+              winCount: 0,
+              totalContracts: 10,
+            },
+            {
+              date: "2025-06-04",
+              averagePnl: -3.1799999999999997,
+              totalPnl: -15.899999999999999,
+              tradeCount: 3,
+              winCount: 0,
+              totalContracts: 5,
+            },
+          ];
+          const margin = getChartMargins(size);
+          const yAxisWidth = 60;
+          const xAxisHeight = size === "small" ? 20 : 24;
+          return (
+            <div className={cn("w-full h-full animate-pulse relative")}>
+              {/* Axis tick skeletons */}
+              <div
+                className="pointer-events-none absolute flex flex-col justify-between pr-2"
+                style={{
+                  left: `${margin.left}px`,
+                  top: `${margin.top}px`,
+                  bottom: `${margin.bottom + xAxisHeight}px`,
+                  width: `${yAxisWidth}px`,
+                }}
               >
-                <SelectValue
-                  placeholder={t("pnlPerContractDaily.selectInstrument")}
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {availableInstruments.map((instrument) => (
-                  <SelectItem key={instrument} value={instrument}>
-                    {instrument}
-                  </SelectItem>
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton key={i} className="h-3 w-10" />
                 ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            (() => {
-              const loadingMockData = [
-                {
-                  date: "2024-12-02",
-                  averagePnl: 12.444999999999999,
-                  totalPnl: 99.55999999999999,
-                  tradeCount: 8,
-                  winCount: 2,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2024-12-03",
-                  averagePnl: 59.32,
-                  totalPnl: 237.28,
-                  tradeCount: 4,
-                  winCount: 4,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2024-12-11",
-                  averagePnl: 28.069999999999997,
-                  totalPnl: 224.55999999999997,
-                  tradeCount: 8,
-                  winCount: 4,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2024-12-16",
-                  averagePnl: -34.43,
-                  totalPnl: -68.86,
-                  tradeCount: 2,
-                  winCount: 0,
-                  totalContracts: 2,
-                },
-                {
-                  date: "2024-12-17",
-                  averagePnl: -3.18,
-                  totalPnl: -6.36,
-                  tradeCount: 2,
-                  winCount: 0,
-                  totalContracts: 2,
-                },
-                {
-                  date: "2024-12-19",
-                  averagePnl: 48.90333333333333,
-                  totalPnl: 293.41999999999996,
-                  tradeCount: 6,
-                  winCount: 4,
-                  totalContracts: 6,
-                },
-                {
-                  date: "2024-12-20",
-                  averagePnl: 17.653333333333332,
-                  totalPnl: 105.92,
-                  tradeCount: 6,
-                  winCount: 2,
-                  totalContracts: 6,
-                },
-                {
-                  date: "2025-01-06",
-                  averagePnl: 59.32,
-                  totalPnl: 237.28,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2025-01-07",
-                  averagePnl: 74.94500000000001,
-                  totalPnl: 599.5600000000001,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-14",
-                  averagePnl: 28.07,
-                  totalPnl: 224.56,
-                  tradeCount: 6,
-                  winCount: 3,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-15",
-                  averagePnl: -3.18,
-                  totalPnl: -12.72,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2025-01-21",
-                  averagePnl: 28.07,
-                  totalPnl: 224.56,
-                  tradeCount: 6,
-                  winCount: 3,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-22",
-                  averagePnl: 59.32,
-                  totalPnl: 474.56,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-23",
-                  averagePnl: 74.945,
-                  totalPnl: 599.56,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 8,
-                },
-                {
-                  date: "2025-01-24",
-                  averagePnl: -34.43000000000001,
-                  totalPnl: -413.1600000000001,
-                  tradeCount: 9,
-                  winCount: 0,
-                  totalContracts: 12,
-                },
-                {
-                  date: "2025-01-28",
-                  averagePnl: -3.18,
-                  totalPnl: -38.160000000000004,
-                  tradeCount: 9,
-                  winCount: 0,
-                  totalContracts: 12,
-                },
-                {
-                  date: "2025-01-31",
-                  averagePnl: 59.32,
-                  totalPnl: 237.28,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 4,
-                },
-                {
-                  date: "2025-02-20",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 593.2,
-                  tradeCount: 6,
-                  winCount: 6,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-02-25",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-02-27",
-                  averagePnl: -96.93,
-                  totalPnl: -484.65000000000003,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-12",
-                  averagePnl: 21.82,
-                  totalPnl: 109.1,
-                  tradeCount: 3,
-                  winCount: 2,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-18",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -15.899999999999999,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-19",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -15.899999999999999,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-20",
-                  averagePnl: -65.67999999999999,
-                  totalPnl: -328.4,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-03-21",
-                  averagePnl: -34.43,
-                  totalPnl: -172.15,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-04-22",
-                  averagePnl: 17.65333333333333,
-                  totalPnl: 264.79999999999995,
-                  tradeCount: 9,
-                  winCount: 3,
-                  totalContracts: 15,
-                },
-                {
-                  date: "2025-04-23",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-04-24",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -47.699999999999996,
-                  tradeCount: 9,
-                  winCount: 0,
-                  totalContracts: 15,
-                },
-                {
-                  date: "2025-04-29",
-                  averagePnl: -34.42999999999999,
-                  totalPnl: -344.29999999999995,
-                  tradeCount: 6,
-                  winCount: 0,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-05-08",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-05-15",
-                  averagePnl: 59.32000000000001,
-                  totalPnl: 296.6,
-                  tradeCount: 3,
-                  winCount: 3,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-05-19",
-                  averagePnl: -34.43,
-                  totalPnl: -172.15,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-                {
-                  date: "2025-05-22",
-                  averagePnl: 28.07,
-                  totalPnl: 280.7,
-                  tradeCount: 6,
-                  winCount: 3,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-06-03",
-                  averagePnl: -34.43,
-                  totalPnl: -344.3,
-                  tradeCount: 6,
-                  winCount: 0,
-                  totalContracts: 10,
-                },
-                {
-                  date: "2025-06-04",
-                  averagePnl: -3.1799999999999997,
-                  totalPnl: -15.899999999999999,
-                  tradeCount: 3,
-                  winCount: 0,
-                  totalContracts: 5,
-                },
-              ];
-              const maxP = Math.max(
-                ...loadingMockData.map((d) => d.averagePnl),
-              );
-              const minP = Math.min(
-                ...loadingMockData.map((d) => d.averagePnl),
-              );
-              const domainMin = Math.min(minP * 1.1, 0);
-              const domainMax = Math.max(maxP * 1.1, 0);
-              const margin =
-                size === "small"
-                  ? { left: 10, right: 4, top: 4, bottom: 20 }
-                  : { left: 10, right: 8, top: 8, bottom: 24 };
-              const yAxisWidth = 60;
-              const xAxisHeight = size === "small" ? 20 : 24;
-              return (
-                <div className={cn("w-full h-full animate-pulse relative")}>
-                  {/* Axis tick skeletons */}
-                  <div
-                    className="pointer-events-none absolute flex flex-col justify-between pr-2"
-                    style={{
-                      left: `${margin.left}px`,
-                      top: `${margin.top}px`,
-                      bottom: `${margin.bottom + xAxisHeight}px`,
-                      width: `${yAxisWidth}px`,
-                    }}
-                  >
-                    {Array.from({ length: 5 }).map((_, i) => (
-                      <Skeleton key={i} className="h-3 w-10" />
-                    ))}
-                  </div>
-                  <div
-                    className="pointer-events-none absolute flex items-center justify-between"
-                    style={{
-                      left: `${margin.left + yAxisWidth}px`,
-                      right: `${margin.right}px`,
-                      bottom: `${margin.bottom}px`,
-                      height: `${xAxisHeight}px`,
-                    }}
-                  >
-                    {Array.from({ length: 6 }).map((_, i) => (
-                      <Skeleton
-                        key={i}
-                        className={cn(
-                          size === "small" ? "h-3 w-8" : "h-3.5 w-10",
-                        )}
-                      />
-                    ))}
-                  </div>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={loadingMockData} margin={margin}>
-                      <CartesianGrid
-                        strokeDasharray="3 3"
-                        className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                      />
-                      <XAxis
-                        dataKey="date"
-                        tickLine={false}
-                        axisLine={false}
-                        height={size === "small" ? 20 : 24}
-                        tick={false}
-                        minTickGap={size === "small" ? 30 : 50}
-                      />
-                      <YAxis
-                        tickLine={false}
-                        axisLine={false}
-                        width={60}
-                        tickMargin={4}
-                        tick={false}
-                        domain={[domainMin, domainMax]}
-                      />
-                      <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                      <Bar
-                        dataKey="averagePnl"
-                        radius={[3, 3, 0, 0]}
-                        maxBarSize={size === "small" ? 25 : 40}
-                        className="transition-none"
-                        fill="hsl(var(--muted-foreground) / 0.35)"
-                      >
-                        {loadingMockData.map((_, index) => (
-                          <Cell
-                            key={`skeleton-cell-${index}`}
-                            fill="hsl(var(--muted-foreground) / 0.35)"
-                          />
-                        ))}
-                      </Bar>
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              );
-            })()
-          ) : chartData.length > 0 ? (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                margin={
-                  size === "small"
-                    ? { left: 10, right: 4, top: 4, bottom: 20 }
-                    : { left: 10, right: 8, top: 8, bottom: 24 }
-                }
+              </div>
+              <div
+                className="pointer-events-none absolute flex items-center justify-between"
+                style={{
+                  left: `${margin.left + yAxisWidth}px`,
+                  right: `${margin.right}px`,
+                  bottom: `${margin.bottom}px`,
+                  height: `${xAxisHeight}px`,
+                }}
               >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
-                />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  minTickGap={size === "small" ? 30 : 50}
-                  tickFormatter={(value) => {
-                    const date = new Date(value);
-                    return formatInTimeZone(date, timezone, "MMM d", {
-                      locale: dateLocale,
-                    });
-                  }}
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                  domain={[
-                    Math.min(minPnL * 1.1, 0),
-                    Math.max(maxPnL * 1.1, 0),
-                  ]}
-                />
-                <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="averagePnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={getColor(entry.averagePnl)}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              {config.selectedInstrument
-                ? t("pnlPerContractDaily.noData")
-                : t("pnlPerContractDaily.selectInstrument")}
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <Skeleton
+                    key={i}
+                    className={cn(
+                      size === "small" ? "h-3 w-8" : "h-3.5 w-10",
+                    )}
+                  />
+                ))}
+              </div>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={loadingMockData} margin={margin}>
+                  <CartesianGrid {...CHART_GRID_PROPS} />
+                  <XAxis
+                    dataKey="date"
+                    tickLine={false}
+                    axisLine={false}
+                    height={size === "small" ? 20 : 24}
+                    tick={false}
+                    minTickGap={size === "small" ? 30 : 50}
+                  />
+                  <YAxis
+                    tickLine={false}
+                    axisLine={false}
+                    width={60}
+                    tickMargin={4}
+                    tick={false}
+                    domain={honestSignedDomain(
+                      loadingMockData.map((d) => d.averagePnl),
+                    )}
+                  />
+                  <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+                  <Bar
+                    dataKey="averagePnl"
+                    maxBarSize={chartMaxBarSize(size)}
+                    shape={<GlanceBar />}
+                    className="transition-none"
+                    fill="hsl(var(--muted-foreground) / 0.35)"
+                  >
+                    {loadingMockData.map((_, index) => (
+                      <Cell
+                        key={`skeleton-cell-${index}`}
+                        fill="hsl(var(--muted-foreground) / 0.35)"
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
             </div>
-          )}
+          );
+        })()
+      ) : chartData.length > 0 ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={getChartMargins(size)}>
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
+              minTickGap={size === "small" ? 30 : 50}
+              tickFormatter={(value) => {
+                const date = new Date(value);
+                return formatInTimeZone(date, timezone, "MMM d", {
+                  locale: dateLocale,
+                });
+              }}
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={60}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatCurrency}
+              domain={honestSignedDomain(
+                chartData.map((entry) => entry.averagePnl),
+              )}
+            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="averagePnl"
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
+            >
+              {chartData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={signedFill(entry.averagePnl)}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex items-center justify-center h-full text-muted-foreground">
+          {config.selectedInstrument
+            ? t("pnlPerContractDaily.noData")
+            : t("pnlPerContractDaily.selectInstrument")}
         </div>
-      </CardContent>
-    </Card>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
@@ -42,7 +42,7 @@ import {
   honestSignedDomain,
   signedFill,
 } from "./chart-glance";
-import { GlanceBar } from "./chart-glance-bar";
+import { LollipopBar } from "./chart-lollipop-bar";
 import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface PnLPerContractDailyChartProps {
@@ -574,7 +574,7 @@ export default function PnLPerContractDailyChart({
                   <Bar
                     dataKey="averagePnl"
                     maxBarSize={chartMaxBarSize(size)}
-                    shape={<GlanceBar />}
+                    shape={<LollipopBar />}
                     className="transition-none"
                     fill="hsl(var(--muted-foreground) / 0.35)"
                   >
@@ -631,7 +631,7 @@ export default function PnLPerContractDailyChart({
             <Bar
               dataKey="averagePnl"
               maxBarSize={chartMaxBarSize(size)}
-              shape={<GlanceBar />}
+              shape={<LollipopBar />}
               className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
               {chartData.map((entry, index) => (

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract-daily.tsx
@@ -200,6 +200,8 @@ export default function PnLPerContractDailyChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="series"
+      eyebrow={t("pnlPerContractDaily.eyebrow")}
       title={t("pnlPerContractDaily.title")}
       subtitle={subtitle}
       description={t("pnlPerContractDaily.description")}

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
@@ -12,28 +12,32 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
-import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_AVERAGE_PNL,
 } from "./chart-loading-skeleton";
+import { namedSignedConclusion } from "./chart-conclusions";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  honestSignedDomain,
+  signedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface PnLPerContractChartProps {
   size?: WidgetSize;
 }
-
-const chartConfig = {
-  pnl: {
-    label: "Avg P/L per Contract",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
 
 const formatCurrency = (value: number) =>
   value.toLocaleString("en-US", { style: "currency", currency: "USD" });
@@ -43,7 +47,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
+      <div className={CHART_TOOLTIP_CLASS}>
         <div className="grid gap-2">
           <div className="flex flex-col">
             <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -138,127 +142,83 @@ export default function PnLPerContractChart({
       .sort((a, b) => b.averagePnl - a.averagePnl); // Sort by average PnL descending
   }, [trades]);
 
-  const maxPnL = Math.max(...chartData.map((d) => d.averagePnl));
-  const minPnL = Math.min(...chartData.map((d) => d.averagePnl));
-  const absMax = Math.max(Math.abs(maxPnL), Math.abs(minPnL));
-
-  const getColor = (value: number) => {
-    const ratio = Math.abs(value / absMax);
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-4";
-    const intensity = Math.max(0.2, ratio);
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
+  const conclusion = namedSignedConclusion(
+    chartData.map((entry) => ({
+      label: entry.instrument,
+      value: entry.averagePnl,
+    })),
+  );
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("pnlPerContract.subtitle.empty")
+      : t(`pnlPerContract.subtitle.${conclusion.kind}`, {
+          label: conclusion.label,
+        });
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnlPerContract.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlPerContract.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_AVERAGE_PNL}
-              xDataKey="instrument"
-              yDataKey="averagePnl"
-              showReferenceLine
+    <ChartWidgetFrame
+      size={size}
+      title={t("pnlPerContract.title")}
+      subtitle={subtitle}
+      description={t("pnlPerContract.description")}
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_AVERAGE_PNL}
+          xDataKey="instrument"
+          yDataKey="averagePnl"
+          showReferenceLine
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={getChartMargins(size)}>
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="instrument"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
+              angle={-45}
+              textAnchor="end"
             />
-          ) : (
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                margin={
-                  size === "small"
-                    ? { left: 10, right: 4, top: 4, bottom: 20 }
-                    : { left: 10, right: 8, top: 8, bottom: 24 }
-                }
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  className="text-border dark:opacity-[0.12] opacity-[0.2]"
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={60}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatCurrency}
+              domain={honestSignedDomain(
+                chartData.map((entry) => entry.averagePnl),
+              )}
+            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="averagePnl"
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
+            >
+              {chartData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={signedFill(entry.averagePnl)}
                 />
-                <XAxis
-                  dataKey="instrument"
-                  tickLine={false}
-                  axisLine={false}
-                  height={size === "small" ? 20 : 24}
-                  tickMargin={size === "small" ? 4 : 8}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  angle={size === "small" ? -45 : -45}
-                  textAnchor="end"
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={60}
-                  tickMargin={4}
-                  tick={{
-                    fontSize: size === "small" ? 9 : 11,
-                    fill: "currentColor",
-                  }}
-                  tickFormatter={formatCurrency}
-                  domain={[
-                    Math.min(minPnL * 1.1, 0),
-                    Math.max(maxPnL * 1.1, 0),
-                  ]}
-                />
-                <ReferenceLine y={0} stroke="hsl(var(--border))" />
-                <Tooltip
-                  content={<CustomTooltip />}
-                  wrapperStyle={{
-                    fontSize: size === "small" ? "10px" : "12px",
-                    zIndex: 1000,
-                  }}
-                />
-                <Bar
-                  dataKey="averagePnl"
-                  radius={[3, 3, 0, 0]}
-                  maxBarSize={size === "small" ? 25 : 40}
-                  className="transition-opacity duration-300 ease-out"
-                >
-                  {chartData.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={getColor(entry.averagePnl)}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-per-contract.tsx
@@ -158,6 +158,8 @@ export default function PnLPerContractChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="category"
+      eyebrow={t("pnlPerContract.eyebrow")}
       title={t("pnlPerContract.title")}
       subtitle={subtitle}
       description={t("pnlPerContract.description")}

--- a/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
@@ -10,13 +10,10 @@ import {
   Tooltip,
   Cell,
   ResponsiveContainer,
+  ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { Trade } from "@/prisma/generated/prisma/browser";
-import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
@@ -24,19 +21,28 @@ import { Button } from "@/components/ui/button";
 import { useUserStore } from "../../../../../store/user-store";
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_HOURLY,
 } from "./chart-loading-skeleton";
+import { namedSignedConclusion } from "./chart-conclusions";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  filterBarOpacity,
+  honestSignedDomain,
+  signedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface TimeOfDayTradeChartProps {
   size?: WidgetSize;
 }
-
-const chartConfig = {
-  avgPnl: {
-    label: "Average P/L",
-    color: "hsl(var(--chart-loss))",
-  },
-} satisfies ChartConfig;
 
 const formatCurrency = (value: number) =>
   value.toLocaleString("en-US", { style: "currency", currency: "USD" });
@@ -67,19 +73,16 @@ export default function TimeOfDayTradeChart({
     const hourlyData: { [hour: string]: { totalPnl: number; count: number } } =
       {};
 
-    // Initialize hourly data for all 24 hours
     for (let i = 0; i < 24; i++) {
       hourlyData[i.toString()] = { totalPnl: 0, count: 0 };
     }
 
-    // Sum up PNL and count trades for each hour in user's timezone
     trades.forEach((trade: Trade) => {
       const hour = formatInTimeZone(new Date(trade.entryDate), timezone, "H");
       hourlyData[hour].totalPnl += trade.pnl;
       hourlyData[hour].count++;
     });
 
-    // Convert to array format for Recharts and calculate average PNL
     return Object.entries(hourlyData)
       .map(([hour, data]) => ({
         hour: parseInt(hour),
@@ -89,14 +92,16 @@ export default function TimeOfDayTradeChart({
       .sort((a, b) => a.hour - b.hour);
   }, [trades, timezone]);
 
-  const maxTradeCount = Math.max(...chartData.map((data) => data.tradeCount));
-  const maxPnL = Math.max(...chartData.map((data) => data.avgPnl));
-  const minPnL = Math.min(...chartData.map((data) => data.avgPnl));
-
-  const getColor = (count: number) => {
-    const intensity = Math.max(0.2, count / maxTradeCount);
-    return `hsl(var(--chart-4) / ${intensity})`;
-  };
+  const conclusion = namedSignedConclusion(
+    chartData.map((entry) => ({
+      label: String(entry.hour),
+      value: entry.avgPnl,
+    })),
+  );
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("pnlTime.subtitle.empty")
+      : t(`pnlTime.subtitle.${conclusion.kind}`, { label: conclusion.label });
 
   const CustomTooltip = ({ active, payload, label }: any) => {
     React.useEffect(() => {
@@ -110,7 +115,7 @@ export default function TimeOfDayTradeChart({
     if (active && payload && payload.length) {
       const data = payload[0].payload;
       return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
+        <div className={CHART_TOOLTIP_CLASS}>
           <div className="grid gap-2">
             <div className="flex flex-col">
               <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -144,136 +149,94 @@ export default function TimeOfDayTradeChart({
     return null;
   };
 
+  const hasFilter = hourFilter.hour !== null;
+
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === "small" ? "p-2 h-10" : "p-3 sm:p-4 h-14",
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("pnlTime.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("pnlTime.description")}</p>
-            </InfoBubble>
-          </div>
-          {hourFilter.hour !== null && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 px-2 lg:px-3"
-              onClick={() => setHourFilter({ hour: null })}
-            >
-              {t("pnlTime.clearFilter")}
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className="w-full h-full cursor-pointer" onClick={handleClick}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_HOURLY}
-              xDataKey="hour"
-              yDataKey="avgPnl"
-              marginVariant="hourly"
-              yAxisWidth={45}
-              xTickCount={8}
-            />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
+    <ChartWidgetFrame
+      size={size}
+      title={t("pnlTime.title")}
+      subtitle={subtitle}
+      description={t("pnlTime.description")}
+      contentInteractive
+      onContentClick={handleClick}
+      actions={
+        hasFilter ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 lg:px-3"
+            onClick={() => setHourFilter({ hour: null })}
+          >
+            {t("pnlTime.clearFilter")}
+          </Button>
+        ) : null
+      }
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_HOURLY}
+          xDataKey="hour"
+          yDataKey="avgPnl"
+          marginVariant="hourly"
+          yAxisWidth={45}
+          xTickCount={8}
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={getChartMargins(size, "hourly")}>
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="hour"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
+              tickFormatter={(value) => `${value}h`}
+              ticks={
                 size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
+                  ? [0, 6, 12, 18]
+                  : [0, 3, 6, 9, 12, 15, 18, 21]
               }
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={45}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatCurrency}
+              domain={honestSignedDomain(chartData.map((entry) => entry.avgPnl))}
+            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="avgPnl"
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="hour"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={(value) => `${value}h`}
-                ticks={
-                  size === "small"
-                    ? [0, 6, 12, 18]
-                    : [0, 3, 6, 9, 12, 15, 18, 21]
-                }
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatCurrency}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="avgPnl"
-                fill={chartConfig.avgPnl.color}
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={hourFilter.hour !== null ? 0.3 : 1}
-              >
-                {chartData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.hour}`}
-                    fill={getColor(entry.tradeCount)}
-                    opacity={
-                      hourFilter.hour === entry.hour
-                        ? 1
-                        : hourFilter.hour !== null
-                          ? 0.3
-                          : 1
-                    }
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+              {chartData.map((entry) => (
+                <Cell
+                  key={`cell-${entry.hour}`}
+                  fill={signedFill(entry.avgPnl)}
+                  opacity={filterBarOpacity(
+                    hourFilter.hour === entry.hour,
+                    hasFilter,
+                  )}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
+++ b/app/[locale]/dashboard/components/charts/pnl-time-bar-chart.tsx
@@ -154,6 +154,8 @@ export default function TimeOfDayTradeChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="category"
+      eyebrow={t("pnlTime.eyebrow")}
       title={t("pnlTime.title")}
       subtitle={subtitle}
       description={t("pnlTime.description")}

--- a/app/[locale]/dashboard/components/charts/tick-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/tick-distribution.tsx
@@ -11,19 +11,30 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
-import { cn } from "@/lib/utils";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { useI18n } from "@/locales/client";
 import { Button } from "@/components/ui/button";
 import { useTickDetailsStore } from "@/store/tick-details-store";
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_TICKS,
 } from "./chart-loading-skeleton";
+import { countPeakConclusion } from "./chart-conclusions";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  filterBarOpacity,
+  honestPositiveDomain,
+  unsignedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface TickDistributionProps {
   size?: WidgetSize;
@@ -42,19 +53,12 @@ interface TooltipProps {
   label?: string;
 }
 
-const chartConfig = {
-  count: {
-    label: "Count",
-    color: "hsl(var(--chart-7))",
-  },
-} satisfies ChartConfig;
-
 const CustomTooltip = ({ active, payload }: TooltipProps) => {
   const t = useI18n();
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
+      <div className={CHART_TOOLTIP_CLASS}>
         <div className="grid gap-2">
           <div className="flex flex-col">
             <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -147,153 +151,120 @@ export default function TickDistributionChart({
     }
   };
 
+  const conclusion = countPeakConclusion(
+    chartData.map((entry) => ({ label: entry.ticks, count: entry.count })),
+  );
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("tickDistribution.subtitle.empty")
+      : t("tickDistribution.subtitle.peak", { label: conclusion.label });
+  const hasFilter = Boolean(tickFilter.value);
+
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === "small" ? "p-2 h-10" : "p-3 sm:p-4 h-14",
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("tickDistribution.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("tickDistribution.description")}</p>
-            </InfoBubble>
-          </div>
-          {tickFilter.value && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 px-2 lg:px-3"
-              onClick={() => setTickFilter({ value: null })}
-            >
-              {t("tickDistribution.clearFilter")}
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_TICKS}
-              xDataKey="ticks"
-              yDataKey="count"
-              yAxisWidth={45}
-              showReferenceLine={false}
-              domain={[
-                0,
-                Math.max(...LOADING_MOCK_TICKS.map((d) => d.count)) * 1.1,
-              ]}
+    <ChartWidgetFrame
+      size={size}
+      title={t("tickDistribution.title")}
+      subtitle={subtitle}
+      description={t("tickDistribution.description")}
+      actions={
+        hasFilter ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 lg:px-3"
+            onClick={() => setTickFilter({ value: null })}
+          >
+            {t("tickDistribution.clearFilter")}
+          </Button>
+        ) : null
+      }
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_TICKS}
+          xDataKey="ticks"
+          yDataKey="count"
+          yAxisWidth={45}
+          showReferenceLine={false}
+          domain={honestPositiveDomain(LOADING_MOCK_TICKS.map((d) => d.count))}
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            margin={getChartMargins(size, "hourly")}
+            onClick={(e) =>
+              e?.activePayload && handleBarClick(e.activePayload[0].payload)
+            }
+          >
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="ticks"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={(props) => {
+                const { x, y, payload } = props;
+                return (
+                  <g transform={`translate(${x},${y})`}>
+                    <text
+                      x={0}
+                      y={0}
+                      dy={size === "small" ? 8 : 4}
+                      textAnchor={size === "small" ? "end" : "middle"}
+                      fill="currentColor"
+                      fontSize={size === "small" ? 9 : 11}
+                      fontWeight={600}
+                      transform={
+                        size === "small" ? "rotate(-45)" : "rotate(0)"
+                      }
+                    >
+                      {payload.value}
+                    </text>
+                  </g>
+                );
+              }}
+              interval="preserveStartEnd"
+              allowDataOverflow={true}
             />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
-              onClick={(e) =>
-                e?.activePayload && handleBarClick(e.activePayload[0].payload)
-              }
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={45}
+              tickMargin={4}
+              tickFormatter={formatCount}
+              tick={chartTickStyle(size)}
+              domain={honestPositiveDomain(chartData.map((entry) => entry.count))}
+            />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="count"
+              fill={unsignedFill()}
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="ticks"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={(props) => {
-                  const { x, y, payload } = props;
-                  return (
-                    <g transform={`translate(${x},${y})`}>
-                      <text
-                        x={0}
-                        y={0}
-                        dy={size === "small" ? 8 : 4}
-                        textAnchor={size === "small" ? "end" : "middle"}
-                        fill="currentColor"
-                        fontSize={size === "small" ? 9 : 11}
-                        transform={
-                          size === "small" ? "rotate(-45)" : "rotate(0)"
-                        }
-                      >
-                        {payload.value}
-                      </text>
-                    </g>
-                  );
-                }}
-                interval="preserveStartEnd"
-                allowDataOverflow={true}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tickFormatter={formatCount}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="count"
-                fill={chartConfig.count.color}
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={tickFilter.value ? 0.3 : 1}
-              >
-                {chartData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.ticks}`}
-                    opacity={
-                      tickFilter.value === entry.ticks
-                        ? 1
-                        : tickFilter.value
-                          ? 0.3
-                          : 1
-                    }
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+              {chartData.map((entry) => (
+                <Cell
+                  key={`cell-${entry.ticks}`}
+                  opacity={filterBarOpacity(
+                    tickFilter.value === entry.ticks,
+                    hasFilter,
+                  )}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/tick-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/tick-distribution.tsx
@@ -34,6 +34,10 @@ import {
   unsignedFill,
 } from "./chart-glance";
 import { GlanceBar } from "./chart-glance-bar";
+import {
+  canDrawUnitHistogram,
+  UnitHistogram,
+} from "./chart-unit-histogram";
 import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface TickDistributionProps {
@@ -154,10 +158,16 @@ export default function TickDistributionChart({
   const conclusion = countPeakConclusion(
     chartData.map((entry) => ({ label: entry.ticks, count: entry.count })),
   );
+  const useStacks = canDrawUnitHistogram(chartData.map((entry) => entry.count));
   const subtitle =
     conclusion.kind === "empty"
       ? t("tickDistribution.subtitle.empty")
-      : t("tickDistribution.subtitle.peak", { label: conclusion.label });
+      : t(
+          useStacks
+            ? "tickDistribution.subtitle.peakStacks"
+            : "tickDistribution.subtitle.peak",
+          { label: conclusion.label },
+        );
   const hasFilter = Boolean(tickFilter.value);
 
   return (
@@ -190,6 +200,21 @@ export default function TickDistributionChart({
           domain={honestPositiveDomain(LOADING_MOCK_TICKS.map((d) => d.count))}
         />
       ) : (
+        useStacks ? (
+          <UnitHistogram
+            size={size}
+            label={subtitle}
+            activeKey={tickFilter.value}
+            hasFilter={hasFilter}
+            onSelect={(key) => handleBarClick({ ticks: key })}
+            buckets={chartData.map((entry) => ({
+              key: entry.ticks,
+              label: entry.ticks,
+              count: entry.count,
+              signed: Number(entry.ticks.replace("+", "")),
+            }))}
+          />
+        ) : (
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={chartData}
@@ -264,6 +289,7 @@ export default function TickDistributionChart({
             </Bar>
           </BarChart>
         </ResponsiveContainer>
+        )
       )}
     </ChartWidgetFrame>
   );

--- a/app/[locale]/dashboard/components/charts/tick-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/tick-distribution.tsx
@@ -173,6 +173,8 @@ export default function TickDistributionChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="ticks"
+      eyebrow={t("tickDistribution.eyebrow")}
       title={t("tickDistribution.title")}
       subtitle={subtitle}
       description={t("tickDistribution.description")}

--- a/app/[locale]/dashboard/components/charts/time-in-position.tsx
+++ b/app/[locale]/dashboard/components/charts/time-in-position.tsx
@@ -11,30 +11,33 @@ import {
   Cell,
   ResponsiveContainer,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
 import { Trade } from "@/prisma/generated/prisma/browser";
-import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import { formatInTimeZone } from "date-fns-tz";
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_HOURLY_TIME,
 } from "./chart-loading-skeleton";
+import { countPeakConclusion } from "./chart-conclusions";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  honestPositiveDomain,
+  unsignedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
 interface TimeInPositionChartProps {
   size?: WidgetSize;
 }
-
-const chartConfig = {
-  avgTimeInPosition: {
-    label: "Average Time in Position",
-    color: "hsl(var(--chart-7))",
-  },
-} satisfies ChartConfig;
 
 const formatTime = (minutes: number) => {
   const hours = Math.floor(minutes / 60);
@@ -77,18 +80,22 @@ export default function TimeInPositionChart({
       .sort((a, b) => a.hour - b.hour);
   }, [trades]);
 
-  const maxTradeCount = Math.max(...chartData.map((data) => data.tradeCount));
-
-  const getColor = (count: number) => {
-    const intensity = Math.max(0.2, count / maxTradeCount);
-    return `hsl(var(--chart-8) / ${intensity})`;
-  };
+  const conclusion = countPeakConclusion(
+    chartData.map((entry) => ({
+      label: String(entry.hour),
+      count: entry.avgTimeInPosition,
+    })),
+  );
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("timeInPosition.subtitle.empty")
+      : t("timeInPosition.subtitle.peak", { label: conclusion.label });
 
   const CustomTooltip = ({ active, payload, label }: any) => {
     if (active && payload && payload.length) {
       const data = payload[0].payload;
       return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
+        <div className={CHART_TOOLTIP_CLASS}>
           <div className="grid gap-2">
             <div className="flex flex-col">
               <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -125,116 +132,75 @@ export default function TimeInPositionChart({
   };
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-col items-stretch space-y-0 border-b shrink-0",
-          size === "small" ? "p-2" : "p-3 sm:p-4",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("timeInPosition.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("timeInPosition.description")}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className={cn("w-full h-full")}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_HOURLY_TIME}
-              xDataKey="hour"
-              yDataKey="avgTimeInPosition"
-              marginVariant="hourly"
-              yAxisWidth={45}
-              xTickCount={8}
-            />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
+    <ChartWidgetFrame
+      size={size}
+      title={t("timeInPosition.title")}
+      subtitle={subtitle}
+      description={t("timeInPosition.description")}
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_HOURLY_TIME}
+          xDataKey="hour"
+          yDataKey="avgTimeInPosition"
+          marginVariant="hourly"
+          yAxisWidth={45}
+          xTickCount={8}
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            margin={getChartMargins(size, "hourly")}
+          >
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="hour"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
+              tickFormatter={(value) => `${value}h`}
+              ticks={
                 size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
+                  ? [0, 6, 12, 18]
+                  : [0, 3, 6, 9, 12, 15, 18, 21]
               }
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={45}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatTime}
+              domain={honestPositiveDomain(
+                chartData.map((entry) => entry.avgTimeInPosition),
+              )}
+            />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="avgTimeInPosition"
+              fill={unsignedFill()}
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="hour"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={(value) => `${value}h`}
-                ticks={
-                  size === "small"
-                    ? [0, 6, 12, 18]
-                    : [0, 3, 6, 9, 12, 15, 18, 21]
-                }
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatTime}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="avgTimeInPosition"
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-              >
-                {chartData.map((entry, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={getColor(entry.tradeCount)}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={unsignedFill()} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/time-in-position.tsx
+++ b/app/[locale]/dashboard/components/charts/time-in-position.tsx
@@ -134,6 +134,8 @@ export default function TimeInPositionChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="duration"
+      eyebrow={t("timeInPosition.eyebrow")}
       title={t("timeInPosition.title")}
       subtitle={subtitle}
       description={t("timeInPosition.description")}

--- a/app/[locale]/dashboard/components/charts/time-range-performance.tsx
+++ b/app/[locale]/dashboard/components/charts/time-range-performance.tsx
@@ -1,21 +1,33 @@
 "use client"
 
 import * as React from "react"
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, ReferenceLine } from "recharts"
 import { useData } from "@/context/data-provider"
-import { cn } from "@/lib/utils"
-import { InfoBubble } from "@/components/ui/info-bubble"
 import { WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
 import { useI18n } from "@/locales/client"
 import { Trade } from "@/prisma/generated/prisma/browser"
 import { Button } from "@/components/ui/button"
-import { ChartConfig } from "@/components/ui/chart"
 import { getTimeRangeKey } from "@/lib/time-range"
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_TIME_RANGE,
 } from "./chart-loading-skeleton"
+import { namedSignedConclusion } from "./chart-conclusions"
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  filterBarOpacity,
+  honestSignedDomain,
+  signedFill,
+} from "./chart-glance"
+import { GlanceBar } from "./chart-glance-bar"
+import { ChartWidgetFrame } from "./chart-widget-frame"
 
 interface TimeRangePerformanceChartProps {
   size?: WidgetSize
@@ -40,13 +52,6 @@ function getColorByWinRate(winRate: number): string {
   if (winRate === 0) return "hsl(var(--muted-foreground))"
   return winRate >= 50 ? "hsl(var(--chart-win))" : "hsl(var(--chart-loss))"
 }
-
-const chartConfig = {
-  avgPnl: {
-    label: "Average PnL",
-    color: "hsl(var(--chart-1))",
-  },
-} satisfies ChartConfig
 
 export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRangePerformanceChartProps) {
   const { formattedTrades: trades, timeRange, setTimeRange, isLoading } = useData()
@@ -89,10 +94,22 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
         avgPnl: data.totalTrades > 0 ? data.totalPnl / data.totalTrades : 0,
         winRate,
         trades: data.totalTrades,
-        color: getColorByWinRate(winRate)
       }
     })
   }, [trades])
+
+  const conclusion = namedSignedConclusion(
+    chartData.map((entry) => ({
+      label: getTimeRangeLabel(entry.range),
+      value: entry.avgPnl,
+    })),
+  )
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("timeRangePerformance.subtitle.empty")
+      : t(`timeRangePerformance.subtitle.${conclusion.kind}`, {
+          label: conclusion.label,
+        })
 
   const handleClick = React.useCallback(() => {
     if (!activeRange) return
@@ -115,16 +132,15 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
     if (active && payload && payload.length) {
       const data = payload[0].payload
       return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
+        <div className={CHART_TOOLTIP_CLASS}>
           <div className="grid gap-2">
             <div className="flex flex-col">
               <span className="text-[0.70rem] uppercase text-muted-foreground">
                 {t('timeRangePerformance.tooltip.timeRange')}
               </span>
-              <span className={cn(
-                "font-bold",
-                timeRange.range === data.range ? "text-primary" : "text-muted-foreground"
-              )}>
+              <span className={
+                timeRange.range === data.range ? "font-bold text-primary" : "font-bold text-muted-foreground"
+              }>
                 {getTimeRangeLabel(label)}
               </span>
             </div>
@@ -140,7 +156,7 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
               <span className="text-[0.70rem] uppercase text-muted-foreground">
                 {t('timeRangePerformance.tooltip.winRate')}
               </span>
-              <span className="font-bold" style={{ color: data.color }}>
+              <span className="font-bold" style={{ color: getColorByWinRate(data.winRate) }}>
                 {data.winRate.toFixed(1)}%
               </span>
             </div>
@@ -162,141 +178,109 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
     return null
   }
 
+  const hasFilter = Boolean(timeRange.range)
+
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader 
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle 
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
-            >
-              {t('timeRangePerformance.title')}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === 'small' ? "size-3.5" : "size-4")}
-            >
-              <p>{t('timeRangePerformance.description')}</p>
-            </InfoBubble>
-          </div>
-          {timeRange.range && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 px-2 lg:px-3"
-              onClick={() => setTimeRange({ range: null })}
-            >
-              {t('timeRangePerformance.clearFilter')}
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent 
-        className={cn(
-          "flex-1 min-h-0",
-          size === 'small' ? "p-1" : "p-2 sm:p-4"
-        )}
-      >
-        <div 
-          className="w-full h-full cursor-pointer" 
-          onClick={handleClick}
-        >
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_TIME_RANGE}
-              xDataKey="range"
-              yDataKey="avgPnl"
-              yAxisWidth={45}
-              showReferenceLine
+    <ChartWidgetFrame
+      size={size}
+      title={t('timeRangePerformance.title')}
+      subtitle={subtitle}
+      description={t('timeRangePerformance.description')}
+      contentInteractive
+      onContentClick={handleClick}
+      actions={
+        hasFilter ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 lg:px-3"
+            onClick={() => setTimeRange({ range: null })}
+          >
+            {t('timeRangePerformance.clearFilter')}
+          </Button>
+        ) : null
+      }
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_TIME_RANGE}
+          xDataKey="range"
+          yDataKey="avgPnl"
+          yAxisWidth={45}
+          showReferenceLine
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            margin={getChartMargins(size, "hourly")}
+          >
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="range"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={(props) => {
+                const { x, y, payload } = props;
+                return (
+                  <g transform={`translate(${x},${y})`}>
+                    <text
+                      x={0}
+                      y={0}
+                      dy={size === 'small' ? 8 : 4}
+                      textAnchor={size === 'small' ? 'end' : 'middle'}
+                      fill="currentColor"
+                      fontSize={size === 'small' ? 9 : 11}
+                      fontWeight={600}
+                      transform={size === 'small' ? 'rotate(-45)' : 'rotate(0)'}
+                    >
+                      {getTimeRangeLabel(payload.value)}
+                    </text>
+                  </g>
+                );
+              }}
+              interval="preserveStartEnd"
+              allowDataOverflow={true}
             />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={
-                size === 'small'
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={45}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              domain={honestSignedDomain(chartData.map((entry) => entry.avgPnl))}
+            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <Tooltip 
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="avgPnl"
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
-              <CartesianGrid 
-                strokeDasharray="3 3" 
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="range"
-                tickLine={false}
-                axisLine={false}
-                height={size === 'small' ? 20 : 24}
-                tickMargin={size === 'small' ? 4 : 8}
-                tick={(props) => {
-                  const { x, y, payload } = props;
-                  return (
-                    <g transform={`translate(${x},${y})`}>
-                      <text
-                        x={0}
-                        y={0}
-                        dy={size === 'small' ? 8 : 4}
-                        textAnchor={size === 'small' ? 'end' : 'middle'}
-                        fill="currentColor"
-                        fontSize={size === 'small' ? 9 : 11}
-                        transform={size === 'small' ? 'rotate(-45)' : 'rotate(0)'}
-                      >
-                        {getTimeRangeLabel(payload.value)}
-                      </text>
-                    </g>
-                  );
-                }}
-                interval="preserveStartEnd"
-                allowDataOverflow={true}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{ 
-                  fontSize: size === 'small' ? 9 : 11,
-                  fill: 'currentColor'
-                }}
-              />
-              <Tooltip 
-                content={<CustomTooltip />}
-                wrapperStyle={{ 
-                  fontSize: size === 'small' ? '10px' : '12px',
-                  zIndex: 1000
-                }} 
-              />
-              <Bar
-                dataKey="avgPnl"
-                fill={chartConfig.avgPnl.color}
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === 'small' ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={timeRange.range ? 0.3 : 1}
-              >
-                {chartData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.range}`}
-                    fill={entry.color}
-                    opacity={timeRange.range === entry.range ? 1 : (timeRange.range ? 0.3 : 1)}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+              {chartData.map((entry) => (
+                <Cell
+                  key={`cell-${entry.range}`}
+                  fill={signedFill(entry.avgPnl)}
+                  opacity={filterBarOpacity(
+                    timeRange.range === entry.range,
+                    hasFilter,
+                  )}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   )
 }

--- a/app/[locale]/dashboard/components/charts/time-range-performance.tsx
+++ b/app/[locale]/dashboard/components/charts/time-range-performance.tsx
@@ -183,6 +183,8 @@ export default function TimeRangePerformanceChart({ size = 'medium' }: TimeRange
   return (
     <ChartWidgetFrame
       size={size}
+      kind="duration"
+      eyebrow={t('timeRangePerformance.eyebrow')}
       title={t('timeRangePerformance.title')}
       subtitle={subtitle}
       description={t('timeRangePerformance.description')}

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -4,13 +4,17 @@ import * as React from "react"
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend, Label } from "recharts"
 import type { Props } from 'recharts/types/component/Label'
 import type { PolarViewBox } from 'recharts/types/util/types'
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useData } from "@/context/data-provider"
-import { cn } from "@/lib/utils"
 import { WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
-import { InfoBubble } from "@/components/ui/info-bubble"
 import { useI18n } from "@/locales/client"
 import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton"
+import { shareConclusion } from "./chart-conclusions"
+import {
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  chartTooltipFontSize,
+} from "./chart-glance"
+import { ChartWidgetFrame } from "./chart-widget-frame"
 
 interface TradeDistributionProps {
   size?: WidgetSize
@@ -35,7 +39,7 @@ const CustomTooltip = ({ active, payload }: TooltipProps) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (
-      <div className="rounded-lg border bg-background p-2 shadow-xs">
+      <div className={CHART_TOOLTIP_CLASS}>
         <div className="grid gap-2">
           <div className="flex flex-col">
             <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -76,126 +80,102 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
     ]
   }, [nbWin, nbLoss, nbBe, nbTrades, t])
 
+  const conclusion = shareConclusion(nbWin, nbTrades)
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("tradeDistribution.subtitle.empty")
+      : t("tradeDistribution.subtitle.share", { percent: conclusion.percent })
+
   const renderColorfulLegendText = (value: string, entry: any) => {
     return <span className="text-xs text-muted-foreground">{value}</span>;
   }
 
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader 
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === 'small' ? "p-2 h-10" : "p-3 sm:p-4 h-14"
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle 
-              className={cn(
-                "line-clamp-1",
-                size === 'small' ? "text-sm" : "text-base"
-              )}
+    <ChartWidgetFrame
+      size={size}
+      title={t('tradeDistribution.title')}
+      subtitle={subtitle}
+      description={t('tradeDistribution.description')}
+    >
+      {isLoading ? (
+        <DonutChartLoadingSkeleton size={size} />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="45%"
+              innerRadius={size === 'small' ? "60%" : "65%"}
+              outerRadius={size === 'small' ? "80%" : "85%"}
+              paddingAngle={2}
+              dataKey="value"
+              startAngle={90}
+              endAngle={-270}
+              stroke="hsl(var(--background))"
+              strokeWidth={1}
             >
-              {t('tradeDistribution.title')}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === 'small' ? "size-3.5" : "size-4")}
-            >
-              <p>{t('tradeDistribution.description')}</p>
-            </InfoBubble>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent 
-        className={cn(
-          "flex-1 min-h-0",
-          size === 'small' ? "p-1" : "p-2 sm:p-4"
-        )}
-      >
-        <div className="w-full h-full">
-          {isLoading ? (
-            <DonutChartLoadingSkeleton size={size} />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="45%"
-                innerRadius={size === 'small' ? "60%" : "65%"}
-                outerRadius={size === 'small' ? "80%" : "85%"}
-                paddingAngle={2}
-                dataKey="value"
-                startAngle={90}
-                endAngle={-270}
-                stroke="hsl(var(--background))"
-                strokeWidth={1}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell 
-                    key={`cell-${index}`} 
-                    fill={entry.color}
-                    className="transition-opacity duration-300 ease-out hover:opacity-80 dark:brightness-90"
-                  />
-                ))}
-                <Label
-                  position="center"
-                  content={(props: Props) => {
-                    if (!props.viewBox) return null;
-                    const viewBox = props.viewBox as PolarViewBox;
-                    if (!viewBox.cx || !viewBox.cy) return null;
-                    const cx = viewBox.cx;
-                    const cy = viewBox.cy;
-
-                    // Use a percentage of the distance from center to edge for label positioning
-                    const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1); // Position labels at 95% or 100% of available space
-
-                    return chartData.map((entry, index) => {
-                      const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
-                      const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
-                      const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
-                      return (
-                        <text
-                          key={index}
-                          x={x}
-                          y={y}
-                          textAnchor="middle"
-                          dominantBaseline="middle"
-                          className="fill-muted-foreground font-medium translate-y-2"
-                          style={{ 
-                            fontSize: size === 'small' ? '10px' : '12px'
-                          }}
-                        >
-                          {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
-                        </text>
-                      );
-                    });
-                  }}
+              {chartData.map((entry, index) => (
+                <Cell 
+                  key={`cell-${index}`} 
+                  fill={entry.color}
                 />
-              </Pie>
-              <Legend 
-                verticalAlign="bottom"
-                align="center"
-                iconSize={8}
-                iconType="circle"
-                formatter={renderColorfulLegendText}
-                wrapperStyle={{
-                  paddingTop: size === 'small' ? 0 : 16
+              ))}
+              <Label
+                position="center"
+                content={(props: Props) => {
+                  if (!props.viewBox) return null;
+                  const viewBox = props.viewBox as PolarViewBox;
+                  if (!viewBox.cx || !viewBox.cy) return null;
+                  const cx = viewBox.cx;
+                  const cy = viewBox.cy;
+
+                  // Use a percentage of the distance from center to edge for label positioning
+                  const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1); // Position labels at 95% or 100% of available space
+
+                  return chartData.map((entry, index) => {
+                    const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
+                    const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
+                    const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
+                    return (
+                      <text
+                        key={index}
+                        x={x}
+                        y={y}
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        className="fill-muted-foreground font-medium translate-y-2"
+                        style={{ 
+                          fontSize: size === 'small' ? '10px' : '12px'
+                        }}
+                      >
+                        {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
+                      </text>
+                    );
+                  });
                 }}
               />
-              <Tooltip 
-                content={<CustomTooltip />}
-                wrapperStyle={{ 
-                  fontSize: size === 'small' ? '10px' : '12px',
-                  zIndex: 1000
-                }} 
-              />
-            </PieChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+            </Pie>
+            <Legend 
+              verticalAlign="bottom"
+              align="center"
+              iconSize={8}
+              iconType="circle"
+              formatter={renderColorfulLegendText}
+              wrapperStyle={{
+                paddingTop: size === 'small' ? 0 : 16
+              }}
+            />
+            <Tooltip 
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   )
 }

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -1,94 +1,57 @@
 "use client"
 
 import * as React from "react"
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend, Label } from "recharts"
-import type { Props } from 'recharts/types/component/Label'
-import type { PolarViewBox } from 'recharts/types/util/types'
 import { useData } from "@/context/data-provider"
 import { WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
 import { useI18n } from "@/locales/client"
-import { DonutChartLoadingSkeleton } from "./chart-loading-skeleton"
+import { UnitFieldLoadingSkeleton } from "./chart-loading-skeleton"
 import { shareConclusion } from "./chart-conclusions"
-import {
-  CHART_TOOLTIP_CLASS,
-  CHART_TOOLTIP_WRAPPER,
-  chartTooltipFontSize,
-} from "./chart-glance"
 import { ChartWidgetFrame } from "./chart-widget-frame"
+import {
+  shouldPackUnitField,
+  UnitDotField,
+} from "./chart-unit-field"
 
 interface TradeDistributionProps {
   size?: WidgetSize
 }
 
-interface ChartDataPoint {
-  name: string;
-  value: number;
-  color: string;
-  count: number;
-}
-
-interface TooltipProps {
-  active?: boolean;
-  payload?: Array<{
-    payload: ChartDataPoint;
-  }>;
-}
-
-const CustomTooltip = ({ active, payload }: TooltipProps) => {
-  const t = useI18n()
-  if (active && payload && payload.length) {
-    const data = payload[0].payload;
-    return (
-      <div className={CHART_TOOLTIP_CLASS}>
-        <div className="grid gap-2">
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t('tradeDistribution.tooltip.type')}
-            </span>
-            <span className="font-bold text-muted-foreground">
-              {data.name}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-[0.70rem] uppercase text-muted-foreground">
-              {t('tradeDistribution.tooltip.percentage')}
-            </span>
-            <span className="font-bold">
-              {data.value.toFixed(2)}%
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-  return null;
-};
-
 export default function TradeDistributionChart({ size = 'medium' }: TradeDistributionProps) {
   const { statistics: { nbWin, nbLoss, nbBe, nbTrades }, isLoading } = useData()
   const t = useI18n()
+  const packed = shouldPackUnitField(nbTrades)
 
-  const chartData = React.useMemo(() => {
-    const winRate = Number((nbWin / nbTrades * 100).toFixed(2))
-    const lossRate = Number((nbLoss / nbTrades * 100).toFixed(2))
-    const beRate = Number((nbBe / nbTrades * 100).toFixed(2))
-
-    return [
-      { name: t('tradeDistribution.winWithCount', { count: nbWin, total: nbTrades }), value: winRate, color: 'hsl(var(--chart-win))', count: nbWin },
-      { name: t('tradeDistribution.breakevenWithCount', { count: nbBe, total: nbTrades }), value: beRate, color: 'hsl(var(--muted-foreground))', count: nbBe },
-      { name: t('tradeDistribution.lossWithCount', { count: nbLoss, total: nbTrades }), value: lossRate, color: 'hsl(var(--chart-loss))', count: nbLoss }
-    ]
-  }, [nbWin, nbLoss, nbBe, nbTrades, t])
+  const groups = React.useMemo(() => [
+    {
+      key: "win",
+      label: t('tradeDistribution.winWithCount', { count: nbWin, total: nbTrades }),
+      color: 'hsl(var(--chart-win))',
+      count: nbWin,
+    },
+    {
+      key: "breakeven",
+      label: t('tradeDistribution.breakevenWithCount', { count: nbBe, total: nbTrades }),
+      color: 'hsl(var(--muted-foreground))',
+      count: nbBe,
+    },
+    {
+      key: "loss",
+      label: t('tradeDistribution.lossWithCount', { count: nbLoss, total: nbTrades }),
+      color: 'hsl(var(--chart-loss))',
+      count: nbLoss,
+    },
+  ], [nbWin, nbLoss, nbBe, nbTrades, t])
 
   const conclusion = shareConclusion(nbWin, nbTrades)
   const subtitle =
     conclusion.kind === "empty"
       ? t("tradeDistribution.subtitle.empty")
-      : t("tradeDistribution.subtitle.share", { percent: conclusion.percent })
-
-  const renderColorfulLegendText = (value: string, entry: any) => {
-    return <span className="text-xs text-muted-foreground">{value}</span>;
-  }
+      : t(
+          packed
+            ? "tradeDistribution.subtitle.sharePacked"
+            : "tradeDistribution.subtitle.share",
+          { percent: conclusion.percent },
+        )
 
   return (
     <ChartWidgetFrame
@@ -98,83 +61,14 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
       description={t('tradeDistribution.description')}
     >
       {isLoading ? (
-        <DonutChartLoadingSkeleton size={size} />
+        <UnitFieldLoadingSkeleton size={size} />
       ) : (
-        <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-            <Pie
-              data={chartData}
-              cx="50%"
-              cy="45%"
-              innerRadius={size === 'small' ? "60%" : "65%"}
-              outerRadius={size === 'small' ? "80%" : "85%"}
-              paddingAngle={2}
-              dataKey="value"
-              startAngle={90}
-              endAngle={-270}
-              stroke="hsl(var(--background))"
-              strokeWidth={1}
-            >
-              {chartData.map((entry, index) => (
-                <Cell 
-                  key={`cell-${index}`} 
-                  fill={entry.color}
-                />
-              ))}
-              <Label
-                position="center"
-                content={(props: Props) => {
-                  if (!props.viewBox) return null;
-                  const viewBox = props.viewBox as PolarViewBox;
-                  if (!viewBox.cx || !viewBox.cy) return null;
-                  const cx = viewBox.cx;
-                  const cy = viewBox.cy;
-
-                  // Use a percentage of the distance from center to edge for label positioning
-                  const labelRadius = Math.min(cx, cy) * (size === 'small' ? 0.95 : 1.1); // Position labels at 95% or 100% of available space
-
-                  return chartData.map((entry, index) => {
-                    const angle = -90 + (360 * (entry.value / 100) / 2) + (360 * chartData.slice(0, index).reduce((acc, curr) => acc + curr.value, 0) / 100);
-                    const x = cx + labelRadius * Math.cos((angle * Math.PI) / 180);
-                    const y = cy + labelRadius * Math.sin((angle * Math.PI) / 180);
-                    return (
-                      <text
-                        key={index}
-                        x={x}
-                        y={y}
-                        textAnchor="middle"
-                        dominantBaseline="middle"
-                        className="fill-muted-foreground font-medium translate-y-2"
-                        style={{ 
-                          fontSize: size === 'small' ? '10px' : '12px'
-                        }}
-                      >
-                        {entry.value > 5 ? `${Math.round(entry.value)}%` : ''}
-                      </text>
-                    );
-                  });
-                }}
-              />
-            </Pie>
-            <Legend 
-              verticalAlign="bottom"
-              align="center"
-              iconSize={8}
-              iconType="circle"
-              formatter={renderColorfulLegendText}
-              wrapperStyle={{
-                paddingTop: size === 'small' ? 0 : 16
-              }}
-            />
-            <Tooltip 
-              content={<CustomTooltip />}
-              wrapperStyle={{
-                fontSize: chartTooltipFontSize(size),
-                ...CHART_TOOLTIP_WRAPPER,
-              }}
-            />
-          </PieChart>
-        </ResponsiveContainer>
+        <UnitDotField
+          groups={groups}
+          mode={packed ? "percent" : "record"}
+          label={subtitle}
+          size={size}
+        />
       )}
     </ChartWidgetFrame>
   )

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -4,10 +4,10 @@ import * as React from "react"
 import { useData } from "@/context/data-provider"
 import { WidgetSize } from '@/app/[locale]/dashboard/types/dashboard'
 import { useI18n } from "@/locales/client"
-import { UnitFieldLoadingSkeleton } from "./chart-loading-skeleton"
+import { ShareSplitLoadingSkeleton } from "./chart-loading-skeleton"
 import { shareConclusion } from "./chart-conclusions"
 import { ChartWidgetFrame } from "./chart-widget-frame"
-import { UnitDotField } from "./chart-unit-field"
+import { ShareSplit } from "./chart-share-split"
 
 interface TradeDistributionProps {
   size?: WidgetSize
@@ -39,10 +39,11 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
   ], [nbWin, nbLoss, nbBe, nbTrades, t])
 
   const conclusion = shareConclusion(nbWin, nbTrades)
+  const percent = conclusion.kind === "empty" ? 0 : conclusion.percent
   const subtitle =
     conclusion.kind === "empty"
       ? t("tradeDistribution.subtitle.empty")
-      : t("tradeDistribution.subtitle.share", { percent: conclusion.percent })
+      : t("tradeDistribution.subtitle.share", { percent })
 
   return (
     <ChartWidgetFrame
@@ -52,11 +53,12 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
       description={t('tradeDistribution.description')}
     >
       {isLoading ? (
-        <UnitFieldLoadingSkeleton size={size} />
+        <ShareSplitLoadingSkeleton size={size} />
       ) : (
-        <UnitDotField
+        <ShareSplit
           groups={groups}
-          mode="percent"
+          headline={conclusion.kind === "empty" ? "—" : `${percent}%`}
+          caption={t("tradeDistribution.caption.winners")}
           label={subtitle}
           size={size}
         />

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -7,10 +7,7 @@ import { useI18n } from "@/locales/client"
 import { UnitFieldLoadingSkeleton } from "./chart-loading-skeleton"
 import { shareConclusion } from "./chart-conclusions"
 import { ChartWidgetFrame } from "./chart-widget-frame"
-import {
-  shouldPackUnitField,
-  UnitDotField,
-} from "./chart-unit-field"
+import { UnitDotField } from "./chart-unit-field"
 
 interface TradeDistributionProps {
   size?: WidgetSize
@@ -19,7 +16,6 @@ interface TradeDistributionProps {
 export default function TradeDistributionChart({ size = 'medium' }: TradeDistributionProps) {
   const { statistics: { nbWin, nbLoss, nbBe, nbTrades }, isLoading } = useData()
   const t = useI18n()
-  const packed = shouldPackUnitField(nbTrades)
 
   const groups = React.useMemo(() => [
     {
@@ -46,12 +42,7 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
   const subtitle =
     conclusion.kind === "empty"
       ? t("tradeDistribution.subtitle.empty")
-      : t(
-          packed
-            ? "tradeDistribution.subtitle.sharePacked"
-            : "tradeDistribution.subtitle.share",
-          { percent: conclusion.percent },
-        )
+      : t("tradeDistribution.subtitle.share", { percent: conclusion.percent })
 
   return (
     <ChartWidgetFrame
@@ -65,7 +56,7 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
       ) : (
         <UnitDotField
           groups={groups}
-          mode={packed ? "percent" : "record"}
+          mode="percent"
           label={subtitle}
           size={size}
         />

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -20,19 +20,22 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
   const groups = React.useMemo(() => [
     {
       key: "win",
-      label: t('tradeDistribution.winWithCount', { count: nbWin, total: nbTrades }),
+      label: t('tradeDistribution.win'),
+      detail: t('tradeDistribution.detail.count', { count: nbWin, total: nbTrades }),
       color: 'hsl(var(--chart-win))',
       count: nbWin,
     },
     {
       key: "breakeven",
-      label: t('tradeDistribution.breakevenWithCount', { count: nbBe, total: nbTrades }),
+      label: t('tradeDistribution.breakeven'),
+      detail: t('tradeDistribution.detail.count', { count: nbBe, total: nbTrades }),
       color: 'hsl(var(--muted-foreground))',
       count: nbBe,
     },
     {
       key: "loss",
-      label: t('tradeDistribution.lossWithCount', { count: nbLoss, total: nbTrades }),
+      label: t('tradeDistribution.loss'),
+      detail: t('tradeDistribution.detail.count', { count: nbLoss, total: nbTrades }),
       color: 'hsl(var(--chart-loss))',
       count: nbLoss,
     },

--- a/app/[locale]/dashboard/components/charts/trade-distribution.tsx
+++ b/app/[locale]/dashboard/components/charts/trade-distribution.tsx
@@ -51,6 +51,8 @@ export default function TradeDistributionChart({ size = 'medium' }: TradeDistrib
   return (
     <ChartWidgetFrame
       size={size}
+      kind="share"
+      eyebrow={t('tradeDistribution.eyebrow')}
       title={t('tradeDistribution.title')}
       subtitle={subtitle}
       description={t('tradeDistribution.description')}

--- a/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
@@ -10,22 +10,35 @@ import {
   Tooltip,
   Cell,
   ResponsiveContainer,
+  ReferenceLine,
 } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartConfig } from "@/components/ui/chart";
 import { useData } from "@/context/data-provider";
-import { cn } from "@/lib/utils";
-import { InfoBubble } from "@/components/ui/info-bubble";
 import { WidgetSize } from "@/app/[locale]/dashboard/types/dashboard";
 import { useI18n } from "@/locales/client";
 import { translateWeekdayPnL } from "@/lib/translation-utils";
 import { Button } from "@/components/ui/button";
 import {
   BarChartLoadingSkeleton,
+  getChartMargins,
   LOADING_MOCK_WEEKDAY,
 } from "./chart-loading-skeleton";
+import { namedSignedConclusion } from "./chart-conclusions";
+import {
+  CHART_GRID_PROPS,
+  CHART_TOOLTIP_CLASS,
+  CHART_TOOLTIP_WRAPPER,
+  CHART_ZERO_LINE_PROPS,
+  chartMaxBarSize,
+  chartTickStyle,
+  chartTooltipFontSize,
+  filterBarOpacity,
+  honestSignedDomain,
+  signedFill,
+} from "./chart-glance";
+import { GlanceBar } from "./chart-glance-bar";
+import { ChartWidgetFrame } from "./chart-widget-frame";
 
-const daysOfWeek = [0, 1, 2, 3, 4, 5, 6]; // Sunday = 0, Saturday = 6
+const daysOfWeek = [0, 1, 2, 3, 4, 5, 6];
 
 interface WeekdayPNLChartProps {
   size?: WidgetSize;
@@ -34,37 +47,13 @@ interface WeekdayPNLChartProps {
 const formatCurrency = (value: number) =>
   value.toLocaleString("en-US", { style: "currency", currency: "USD" });
 
-const chartConfig = {
-  pnl: {
-    label: "PnL",
-    color: "hsl(var(--chart-1))",
-  },
-} satisfies ChartConfig;
-
 export default function WeekdayPNLChart({
   size = "medium",
 }: WeekdayPNLChartProps) {
   const { calendarData, weekdayFilter, setWeekdayFilter, isLoading } =
     useData();
-  const [darkMode, setDarkMode] = React.useState(false);
   const [activeDay, setActiveDay] = React.useState<number | null>(null);
   const t = useI18n();
-
-  React.useEffect(() => {
-    const isDarkMode = document.documentElement.classList.contains("dark");
-    setDarkMode(isDarkMode);
-
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.attributeName === "class") {
-          setDarkMode(document.documentElement.classList.contains("dark"));
-        }
-      });
-    });
-
-    observer.observe(document.documentElement, { attributes: true });
-    return () => observer.disconnect();
-  }, []);
 
   const weekdayData = React.useMemo(() => {
     const weekdayTotals = daysOfWeek.reduce(
@@ -91,31 +80,28 @@ export default function WeekdayPNLChart({
     }));
   }, [calendarData]);
 
-  const maxPnL = Math.max(...weekdayData.map((d) => d.pnl));
-  const minPnL = Math.min(...weekdayData.map((d) => d.pnl));
-
-  const getColor = (value: number) => {
-    const ratio = Math.abs((value - minPnL) / (maxPnL - minPnL));
-    const baseColorVar = value >= 0 ? "--chart-win" : "--chart-loss";
-    const intensity = darkMode
-      ? Math.max(0.3, ratio) // Higher minimum intensity in dark mode
-      : Math.max(0.2, ratio); // Lower minimum intensity in light mode
-    return `hsl(var(${baseColorVar}) / ${intensity})`;
-  };
+  const conclusion = namedSignedConclusion(
+    weekdayData.map((entry) => ({
+      label: translateWeekdayPnL(t, entry.day),
+      value: entry.pnl,
+    })),
+  );
+  const subtitle =
+    conclusion.kind === "empty"
+      ? t("weekdayPnl.subtitle.empty")
+      : t(`weekdayPnl.subtitle.${conclusion.kind}`, { label: conclusion.label });
 
   const handleClick = React.useCallback(() => {
     if (activeDay === null) return;
     const currentDays = weekdayFilter.days || [];
     if (currentDays.includes(activeDay)) {
-      // Remove day from filter
-      setWeekdayFilter({ days: currentDays.filter(d => d !== activeDay) });
+      setWeekdayFilter({ days: currentDays.filter((d) => d !== activeDay) });
     } else {
-      // Add day to filter
       setWeekdayFilter({ days: [...currentDays, activeDay] });
     }
   }, [activeDay, weekdayFilter.days, setWeekdayFilter]);
 
-  const CustomTooltip = ({ active, payload, label }: any) => {
+  const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: (typeof weekdayData)[number] }> }) => {
     React.useEffect(() => {
       if (active && payload && payload.length) {
         setActiveDay(payload[0].payload.day);
@@ -127,7 +113,7 @@ export default function WeekdayPNLChart({
     if (active && payload && payload.length) {
       const data = payload[0].payload;
       return (
-        <div className="rounded-lg border bg-background p-2 shadow-xs">
+        <div className={CHART_TOOLTIP_CLASS}>
           <div className="grid gap-2">
             <div className="flex flex-col">
               <span className="text-[0.70rem] uppercase text-muted-foreground">
@@ -161,129 +147,91 @@ export default function WeekdayPNLChart({
     return null;
   };
 
+  const hasFilter = Boolean(weekdayFilter.days && weekdayFilter.days.length > 0);
+
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader
-        className={cn(
-          "flex flex-row items-center justify-between space-y-0 border-b shrink-0",
-          size === "small" ? "p-2 h-10" : "p-3 sm:p-4 h-14",
-        )}
-      >
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            <CardTitle
-              className={cn(
-                "line-clamp-1",
-                size === "small" ? "text-sm" : "text-base",
-              )}
-            >
-              {t("weekdayPnl.title")}
-            </CardTitle>
-            <InfoBubble
-              side="top"
-              iconClassName={cn(size === "small" ? "size-3.5" : "size-4")}
-            >
-              <p>{t("weekdayPnl.description")}</p>
-            </InfoBubble>
-          </div>
-          {weekdayFilter.days && weekdayFilter.days.length > 0 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 px-2 lg:px-3"
-              onClick={() => setWeekdayFilter({ days: [] })}
-            >
-              {t("weekdayPnl.clearFilter")}
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent
-        className={cn(
-          "flex-1 min-h-0",
-          size === "small" ? "p-1" : "p-2 sm:p-4",
-        )}
-      >
-        <div className="w-full h-full cursor-pointer" onClick={handleClick}>
-          {isLoading ? (
-            <BarChartLoadingSkeleton
-              size={size}
-              data={LOADING_MOCK_WEEKDAY}
-              xDataKey="day"
-              yDataKey="pnl"
-              yAxisWidth={45}
-              xTickCount={7}
+    <ChartWidgetFrame
+      size={size}
+      title={t("weekdayPnl.title")}
+      subtitle={subtitle}
+      description={t("weekdayPnl.description")}
+      contentInteractive
+      onContentClick={handleClick}
+      actions={
+        hasFilter ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 lg:px-3"
+            onClick={() => setWeekdayFilter({ days: [] })}
+          >
+            {t("weekdayPnl.clearFilter")}
+          </Button>
+        ) : null
+      }
+    >
+      {isLoading ? (
+        <BarChartLoadingSkeleton
+          size={size}
+          data={LOADING_MOCK_WEEKDAY}
+          xDataKey="day"
+          yDataKey="pnl"
+          yAxisWidth={45}
+          xTickCount={7}
+        />
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={weekdayData} margin={getChartMargins(size, "hourly")}>
+            <CartesianGrid {...CHART_GRID_PROPS} />
+            <XAxis
+              dataKey="day"
+              tickLine={false}
+              axisLine={false}
+              height={size === "small" ? 20 : 24}
+              tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
+              tickFormatter={(value) => {
+                const dayName = translateWeekdayPnL(t, value);
+                return size === "small" ? dayName.slice(0, 3) : dayName;
+              }}
             />
-          ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={weekdayData}
-              margin={
-                size === "small"
-                  ? { left: 0, right: 4, top: 4, bottom: 20 }
-                  : { left: 0, right: 8, top: 8, bottom: 24 }
-              }
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={45}
+              tickMargin={4}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatCurrency}
+              domain={honestSignedDomain(weekdayData.map((entry) => entry.pnl))}
+            />
+            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <Tooltip
+              content={<CustomTooltip />}
+              wrapperStyle={{
+                fontSize: chartTooltipFontSize(size),
+                ...CHART_TOOLTIP_WRAPPER,
+              }}
+            />
+            <Bar
+              dataKey="pnl"
+              maxBarSize={chartMaxBarSize(size)}
+              shape={<GlanceBar />}
+              className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                className="text-border dark:opacity-[0.12] opacity-[0.2]"
-              />
-              <XAxis
-                dataKey="day"
-                tickLine={false}
-                axisLine={false}
-                height={size === "small" ? 20 : 24}
-                tickMargin={size === "small" ? 4 : 8}
-                tick={{
-                  fontSize: size === "small" ? 9 : 11,
-                  fill: "currentColor",
-                }}
-                tickFormatter={(value) => {
-                  const dayName = translateWeekdayPnL(t, value);
-                  return size === "small" ? dayName.slice(0, 3) : dayName;
-                }}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={45}
-                tickMargin={4}
-                tick={{
-                  fontSize: 8,
-                  fill: "currentColor",
-                }}
-                tickFormatter={formatCurrency}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                wrapperStyle={{
-                  fontSize: size === "small" ? "10px" : "12px",
-                  zIndex: 1000,
-                }}
-              />
-              <Bar
-                dataKey="pnl"
-                radius={[3, 3, 0, 0]}
-                maxBarSize={size === "small" ? 25 : 40}
-                className="transition-opacity duration-300 ease-out"
-                opacity={weekdayFilter.days && weekdayFilter.days.length > 0 ? 0.3 : 1}
-              >
-                {weekdayData.map((entry) => (
-                  <Cell
-                    key={`cell-${entry.day}`}
-                    fill={getColor(entry.pnl)}
-                    className={cn(
-                      "transition-[opacity,filter,box-shadow] duration-300 ease-out",
-                      weekdayFilter.days && weekdayFilter.days.includes(entry.day) && "ring-2 ring-primary ring-offset-2"
-                    )}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+              {weekdayData.map((entry) => (
+                <Cell
+                  key={`cell-${entry.day}`}
+                  fill={signedFill(entry.pnl)}
+                  opacity={filterBarOpacity(
+                    Boolean(weekdayFilter.days?.includes(entry.day)),
+                    hasFilter,
+                  )}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartWidgetFrame>
   );
 }

--- a/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
@@ -24,7 +24,7 @@ import {
 } from "./chart-loading-skeleton";
 import { namedSignedConclusion } from "./chart-conclusions";
 import {
-  CHART_GRID_PROPS,
+  CHART_GRID_PROPS_HORIZONTAL,
   CHART_TOOLTIP_CLASS,
   CHART_TOOLTIP_WRAPPER,
   CHART_ZERO_LINE_PROPS,
@@ -176,35 +176,43 @@ export default function WeekdayPNLChart({
           data={LOADING_MOCK_WEEKDAY}
           xDataKey="day"
           yDataKey="pnl"
-          yAxisWidth={45}
+          yAxisWidth={size === "small" ? 36 : 72}
           xTickCount={7}
+          layout="horizontal"
+          showReferenceLine
         />
       ) : (
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={weekdayData} margin={getChartMargins(size, "hourly")}>
-            <CartesianGrid {...CHART_GRID_PROPS} />
+          <BarChart
+            data={weekdayData}
+            layout="vertical"
+            margin={getChartMargins(size, "horizontal")}
+          >
+            <CartesianGrid {...CHART_GRID_PROPS_HORIZONTAL} />
             <XAxis
-              dataKey="day"
+              type="number"
               tickLine={false}
               axisLine={false}
               height={size === "small" ? 20 : 24}
               tickMargin={size === "small" ? 4 : 8}
+              tick={chartTickStyle(size)}
+              tickFormatter={formatCurrency}
+              domain={honestSignedDomain(weekdayData.map((entry) => entry.pnl))}
+            />
+            <YAxis
+              type="category"
+              dataKey="day"
+              tickLine={false}
+              axisLine={false}
+              width={size === "small" ? 36 : 72}
+              tickMargin={4}
               tick={chartTickStyle(size)}
               tickFormatter={(value) => {
                 const dayName = translateWeekdayPnL(t, value);
                 return size === "small" ? dayName.slice(0, 3) : dayName;
               }}
             />
-            <YAxis
-              tickLine={false}
-              axisLine={false}
-              width={45}
-              tickMargin={4}
-              tick={chartTickStyle(size)}
-              tickFormatter={formatCurrency}
-              domain={honestSignedDomain(weekdayData.map((entry) => entry.pnl))}
-            />
-            <ReferenceLine y={0} {...CHART_ZERO_LINE_PROPS} />
+            <ReferenceLine x={0} {...CHART_ZERO_LINE_PROPS} />
             <Tooltip
               content={<CustomTooltip />}
               wrapperStyle={{
@@ -215,7 +223,7 @@ export default function WeekdayPNLChart({
             <Bar
               dataKey="pnl"
               maxBarSize={chartMaxBarSize(size)}
-              shape={<GlanceBar />}
+              shape={<GlanceBar layout="horizontal" />}
               className="motion-reduce:transition-none transition-opacity duration-300 ease-out"
             >
               {weekdayData.map((entry) => (

--- a/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
+++ b/app/[locale]/dashboard/components/charts/weekday-pnl.tsx
@@ -152,6 +152,8 @@ export default function WeekdayPNLChart({
   return (
     <ChartWidgetFrame
       size={size}
+      kind="category"
+      eyebrow={t("weekdayPnl.eyebrow")}
       title={t("weekdayPnl.title")}
       subtitle={subtitle}
       description={t("weekdayPnl.description")}

--- a/app/[locale]/dashboard/components/statistics/kpi-card.tsx
+++ b/app/[locale]/dashboard/components/statistics/kpi-card.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { Card } from '@/components/ui/card'
 import { InfoBubble } from '@/components/ui/info-bubble'
 import { cn } from '@/lib/utils'
+import { ChartWidgetKindMark } from '../charts/chart-widget-kind'
 
 export function KpiCard({
   title,
@@ -15,9 +16,10 @@ export function KpiCard({
   valueClassName?: string
 }) {
   return (
-    <Card className="h-full">
+    <Card data-widget-kind="metric" className="h-full overflow-hidden">
       <div className="flex h-full flex-col items-start justify-center gap-2 px-3 py-2.5">
-        <div className="flex min-w-0 items-center gap-1.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <ChartWidgetKindMark kind="metric" compact />
           <span className="truncate text-xs font-medium leading-tight tracking-[-0.02em] text-[#686D67] dark:text-muted-foreground">
             {title}
           </span>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1139,6 +1139,8 @@ export default {
   "commissions.title": "P/L vs Commissions",
   "commissions.tooltip.description":
     "Distribution of net profit/loss versus commissions paid",
+  "commissions.subtitle.empty": "No commission split in this range",
+  "commissions.subtitle.share": "Commissions take {percent}% of the absolute split · slice = share",
   "commissions.tooltip.type": "Type",
   "commissions.tooltip.amount": "Amount",
   "commissions.tooltip.percentage": "Percentage",
@@ -1154,6 +1156,7 @@ export default {
   equity: {
     title: "Equity",
     description: "Track your equity over time",
+    subtitle: "Line = cumulative equity · selected accounts",
     loading: "Loading chart data...",
     toggle: {
       individual: "Individual",
@@ -1203,6 +1206,9 @@ export default {
   },
   "pnl.title": "Daily Profit/Loss",
   "pnl.description": "Showing daily P/L over time",
+  "pnl.subtitle.empty": "No closed days in this range",
+  "pnl.subtitle.greenDays": "{green} of {total} days finished green · bar = daily net",
+  "pnl.subtitle.redDays": "{red} of {total} days finished red · bar = daily net",
   "pnl.tooltip.date": "Date",
   "pnl.tooltip.pnl": "P/L",
   "pnl.tooltip.longTrades": "Long Trades",
@@ -1210,6 +1216,10 @@ export default {
   "pnlBySide.title": "P/L by Side",
   "pnlBySide.description":
     "Profit/loss comparison between long and short trades",
+  "pnlBySide.subtitle.empty": "No long or short trades in this range",
+  "pnlBySide.subtitle.best": "{label}s are ahead · bar = {mode}",
+  "pnlBySide.mode.average": "average P/L",
+  "pnlBySide.mode.total": "total P/L",
   "pnlBySide.tooltip.side": "Side",
   "pnlBySide.tooltip.averageTotal": "Average P/L",
   "pnlBySide.tooltip.winRate": "Win Rate",
@@ -1220,6 +1230,9 @@ export default {
   "pnlPerContract.title": "Avg Net P/L per Contract",
   "pnlPerContract.description":
     "Average net profit/loss per contract by trading instrument (after commissions)",
+  "pnlPerContract.subtitle.empty": "No instrument averages yet",
+  "pnlPerContract.subtitle.best": "{label} leads per contract · bar = average net",
+  "pnlPerContract.subtitle.worst": "{label} lags per contract · bar = average net",
   "pnlPerContract.tooltip.instrument": "Instrument",
   "pnlPerContract.tooltip.averagePnl": "Avg Net P/L per Contract",
   "pnlPerContract.tooltip.totalPnl": "Total Net P/L",
@@ -1232,6 +1245,9 @@ export default {
   "pnlPerContractDaily.title": "Daily Avg Net P/L per contract",
   "pnlPerContractDaily.description":
     "Average net profit/loss per contract per day for selected instrument (after commissions)",
+  "pnlPerContractDaily.subtitle.empty": "No daily averages for this instrument",
+  "pnlPerContractDaily.subtitle.greenDays": "{green} of {total} days finished green · bar = daily average net",
+  "pnlPerContractDaily.subtitle.redDays": "{red} of {total} days finished red · bar = daily average net",
   "pnlPerContractDaily.selectInstrument": "Select Instrument",
   "pnlPerContractDaily.noData": "No data available for selected instrument",
   "pnlPerContractDaily.tooltip.date": "Date",
@@ -1243,6 +1259,9 @@ export default {
   "pnlPerContractDaily.tooltip.contracts": "contracts",
   "pnlTime.title": "Average P/L by Hour",
   "pnlTime.description": "Average profit/loss for each hour of the day",
+  "pnlTime.subtitle.empty": "No hourly averages yet",
+  "pnlTime.subtitle.best": "Most of the edge sits at {label}:00 · bar = average P/L",
+  "pnlTime.subtitle.worst": "{label}:00 is the weakest hour · bar = average P/L",
   "pnlTime.tooltip.time": "Time",
   "pnlTime.tooltip.averagePnl": "Average P/L",
   "pnlTime.tooltip.trades": "Trades",
@@ -1252,6 +1271,10 @@ export default {
   tickDistribution: {
     title: "Tick Distribution",
     description: "Distribution of trades by tick value (PnL per contract)",
+    subtitle: {
+      empty: "No tick counts in this range",
+      peak: "Most trades close at {label} ticks · bar = trade count",
+    },
     tooltip: {
       ticks: "ticks",
       tick: "tick",
@@ -1265,6 +1288,8 @@ export default {
   "timeInPosition.title": "Average Time in Position",
   "timeInPosition.description":
     "Average time in position for each hour of the day",
+  "timeInPosition.subtitle.empty": "No holding-time averages yet",
+  "timeInPosition.subtitle.peak": "Longest holds start at {label}:00 · bar = average duration",
   "timeInPosition.tooltip.time": "Time",
   "timeInPosition.tooltip.averageDuration": "Average Duration",
   "timeInPosition.tooltip.trades": "Trades",
@@ -1272,6 +1297,9 @@ export default {
   "timeInPosition.tooltip.trades_plural": "trades",
   "weekdayPnl.title": "Average P/L by Day",
   "weekdayPnl.description": "Average profit/loss for each day of the week",
+  "weekdayPnl.subtitle.empty": "No weekday averages yet",
+  "weekdayPnl.subtitle.best": "{label} is the strongest day · bar = average P/L",
+  "weekdayPnl.subtitle.worst": "{label} is the weakest day · bar = average P/L",
   "weekdayPnl.tooltip.day": "Day",
   "weekdayPnl.tooltip.averagePnl": "Average P/L",
   "weekdayPnl.tooltip.trades": "Trades",
@@ -1649,6 +1677,10 @@ export default {
   tradeDistribution: {
     title: "Trade Distribution",
     description: "Distribution of winning, losing, and breakeven trades",
+    subtitle: {
+      empty: "No closed trades in this range",
+      share: "{percent}% of trades are winners · slice = share",
+    },
     win: "Winning trades",
     loss: "Losing trades",
     breakeven: "Breakeven trades",
@@ -1856,6 +1888,11 @@ export default {
     title: "Time Range Performance",
     description:
       "Average P&L and win rate distribution across different holding times",
+    subtitle: {
+      empty: "No holding-time averages yet",
+      best: "{label} holds the best average · bar = average P/L",
+      worst: "{label} holds the weakest average · bar = average P/L",
+    },
     tooltip: {
       timeRange: "Time Range",
       avgPnl: "Average P&L",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1140,7 +1140,7 @@ export default {
   "commissions.tooltip.description":
     "Distribution of net profit/loss versus commissions paid",
   "commissions.subtitle.empty": "No commission split in this range",
-  "commissions.subtitle.share": "Commissions take {percent}% of the absolute split · slice = share",
+  "commissions.subtitle.share": "Commissions take {percent}% of the absolute split · one dot = one percent",
   "commissions.tooltip.type": "Type",
   "commissions.tooltip.amount": "Amount",
   "commissions.tooltip.percentage": "Percentage",
@@ -1207,8 +1207,8 @@ export default {
   "pnl.title": "Daily Profit/Loss",
   "pnl.description": "Showing daily P/L over time",
   "pnl.subtitle.empty": "No closed days in this range",
-  "pnl.subtitle.greenDays": "{green} of {total} days finished green · bar = daily net",
-  "pnl.subtitle.redDays": "{red} of {total} days finished red · bar = daily net",
+  "pnl.subtitle.greenDays": "{green} of {total} days finished green · stem = day · cap = daily net",
+  "pnl.subtitle.redDays": "{red} of {total} days finished red · stem = day · cap = daily net",
   "pnl.tooltip.date": "Date",
   "pnl.tooltip.pnl": "P/L",
   "pnl.tooltip.longTrades": "Long Trades",
@@ -1217,7 +1217,7 @@ export default {
   "pnlBySide.description":
     "Profit/loss comparison between long and short trades",
   "pnlBySide.subtitle.empty": "No long or short trades in this range",
-  "pnlBySide.subtitle.best": "{label}s are ahead · bar = {mode}",
+  "pnlBySide.subtitle.best": "{label}s are ahead · bar = {mode}, diverging from zero",
   "pnlBySide.mode.average": "average P/L",
   "pnlBySide.mode.total": "total P/L",
   "pnlBySide.tooltip.side": "Side",
@@ -1246,8 +1246,8 @@ export default {
   "pnlPerContractDaily.description":
     "Average net profit/loss per contract per day for selected instrument (after commissions)",
   "pnlPerContractDaily.subtitle.empty": "No daily averages for this instrument",
-  "pnlPerContractDaily.subtitle.greenDays": "{green} of {total} days finished green · bar = daily average net",
-  "pnlPerContractDaily.subtitle.redDays": "{red} of {total} days finished red · bar = daily average net",
+  "pnlPerContractDaily.subtitle.greenDays": "{green} of {total} days finished green · stem = day · cap = daily average net",
+  "pnlPerContractDaily.subtitle.redDays": "{red} of {total} days finished red · stem = day · cap = daily average net",
   "pnlPerContractDaily.selectInstrument": "Select Instrument",
   "pnlPerContractDaily.noData": "No data available for selected instrument",
   "pnlPerContractDaily.tooltip.date": "Date",
@@ -1274,6 +1274,7 @@ export default {
     subtitle: {
       empty: "No tick counts in this range",
       peak: "Most trades close at {label} ticks · bar = trade count",
+      peakStacks: "Most trades close at {label} ticks · one stack = one tick · one dot = one trade",
     },
     tooltip: {
       ticks: "ticks",
@@ -1298,8 +1299,8 @@ export default {
   "weekdayPnl.title": "Average P/L by Day",
   "weekdayPnl.description": "Average profit/loss for each day of the week",
   "weekdayPnl.subtitle.empty": "No weekday averages yet",
-  "weekdayPnl.subtitle.best": "{label} is the strongest day · bar = average P/L",
-  "weekdayPnl.subtitle.worst": "{label} is the weakest day · bar = average P/L",
+  "weekdayPnl.subtitle.best": "{label} is the strongest day · bar = average P/L, diverging from zero",
+  "weekdayPnl.subtitle.worst": "{label} is the weakest day · bar = average P/L, diverging from zero",
   "weekdayPnl.tooltip.day": "Day",
   "weekdayPnl.tooltip.averagePnl": "Average P/L",
   "weekdayPnl.tooltip.trades": "Trades",
@@ -1679,7 +1680,8 @@ export default {
     description: "Distribution of winning, losing, and breakeven trades",
     subtitle: {
       empty: "No closed trades in this range",
-      share: "{percent}% of trades are winners · slice = share",
+      share: "{percent}% of trades are winners · one dot = one trade",
+      sharePacked: "{percent}% of trades are winners · one dot = one percent",
     },
     win: "Winning trades",
     loss: "Losing trades",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1140,7 +1140,8 @@ export default {
   "commissions.tooltip.description":
     "Distribution of net profit/loss versus commissions paid",
   "commissions.subtitle.empty": "No commission split in this range",
-  "commissions.subtitle.share": "Commissions take {percent}% of the absolute split · one dot = one percent",
+  "commissions.subtitle.share": "Commissions take {percent}% of the split",
+  "commissions.caption.share": "of the absolute split",
   "commissions.tooltip.type": "Type",
   "commissions.tooltip.amount": "Amount",
   "commissions.tooltip.percentage": "Percentage",
@@ -1680,8 +1681,11 @@ export default {
     description: "Distribution of winning, losing, and breakeven trades",
     subtitle: {
       empty: "No closed trades in this range",
-      share: "{percent}% of trades are winners · one dot = one percent",
-      sharePacked: "{percent}% of trades are winners · one dot = one percent",
+      share: "{percent}% of trades are winners",
+      sharePacked: "{percent}% of trades are winners",
+    },
+    caption: {
+      winners: "of trades are winners",
     },
     win: "Winning trades",
     loss: "Losing trades",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1687,6 +1687,9 @@ export default {
     caption: {
       winners: "of trades are winners",
     },
+    detail: {
+      count: "{count} of {total}",
+    },
     win: "Winning trades",
     loss: "Losing trades",
     breakeven: "Breakeven trades",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1680,7 +1680,7 @@ export default {
     description: "Distribution of winning, losing, and breakeven trades",
     subtitle: {
       empty: "No closed trades in this range",
-      share: "{percent}% of trades are winners · one dot = one trade",
+      share: "{percent}% of trades are winners · one dot = one percent",
       sharePacked: "{percent}% of trades are winners · one dot = one percent",
     },
     win: "Winning trades",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1136,6 +1136,7 @@ export default {
   "calendar.charts.equityVariation": "Equity Variation",
   "calendar.charts.dailyPnlDistribution": "Daily P&L Distribution",
   "calendar.charts.totalPnlAfterComm": "Total P&L (after commissions)",
+  "commissions.eyebrow": "Cost vs result",
   "commissions.title": "P/L vs Commissions",
   "commissions.tooltip.description":
     "Distribution of net profit/loss versus commissions paid",
@@ -1155,6 +1156,7 @@ export default {
   "contracts.tooltip.numberOfTrades": "Number of Trades",
   "contracts.axis.contracts": "Contracts",
   equity: {
+    eyebrow: "Running total",
     title: "Equity",
     description: "Track your equity over time",
     subtitle: "Line = cumulative equity · selected accounts",
@@ -1205,6 +1207,7 @@ export default {
       maxAccountsInfo: "At most {max} accounts can be charted at once",
     },
   },
+  "pnl.eyebrow": "Each session",
   "pnl.title": "Daily Profit/Loss",
   "pnl.description": "Showing daily P/L over time",
   "pnl.subtitle.empty": "No closed days in this range",
@@ -1214,6 +1217,7 @@ export default {
   "pnl.tooltip.pnl": "P/L",
   "pnl.tooltip.longTrades": "Long Trades",
   "pnl.tooltip.shortTrades": "Short Trades",
+  "pnlBySide.eyebrow": "Long vs short",
   "pnlBySide.title": "P/L by Side",
   "pnlBySide.description":
     "Profit/loss comparison between long and short trades",
@@ -1228,6 +1232,7 @@ export default {
   "pnlBySide.tooltip.wins": "win",
   "pnlBySide.tooltip.wins_plural": "wins",
   "pnlBySide.toggle.showAverage": "Show Average",
+  "pnlPerContract.eyebrow": "By instrument",
   "pnlPerContract.title": "Avg Net P/L per Contract",
   "pnlPerContract.description":
     "Average net profit/loss per contract by trading instrument (after commissions)",
@@ -1243,6 +1248,7 @@ export default {
   "pnlPerContract.tooltip.wins_plural": "wins",
   "pnlPerContract.tooltip.totalContracts": "Total Contracts",
   "pnlPerContract.tooltip.contracts": "contracts",
+  "pnlPerContractDaily.eyebrow": "Per contract",
   "pnlPerContractDaily.title": "Daily Avg Net P/L per contract",
   "pnlPerContractDaily.description":
     "Average net profit/loss per contract per day for selected instrument (after commissions)",
@@ -1258,6 +1264,7 @@ export default {
   "pnlPerContractDaily.tooltip.trades": "Trades",
   "pnlPerContractDaily.tooltip.totalContracts": "Total contracts",
   "pnlPerContractDaily.tooltip.contracts": "contracts",
+  "pnlTime.eyebrow": "By hour",
   "pnlTime.title": "Average P/L by Hour",
   "pnlTime.description": "Average profit/loss for each hour of the day",
   "pnlTime.subtitle.empty": "No hourly averages yet",
@@ -1270,6 +1277,7 @@ export default {
   "pnlTime.tooltip.trades_plural": "trades",
   "pnlTime.clearFilter": "Clear Filter",
   tickDistribution: {
+    eyebrow: "By tick size",
     title: "Tick Distribution",
     description: "Distribution of trades by tick value (PnL per contract)",
     subtitle: {
@@ -1287,6 +1295,7 @@ export default {
     },
     clearFilter: "Clear filter",
   },
+  "timeInPosition.eyebrow": "Hold time",
   "timeInPosition.title": "Average Time in Position",
   "timeInPosition.description":
     "Average time in position for each hour of the day",
@@ -1297,6 +1306,7 @@ export default {
   "timeInPosition.tooltip.trades": "Trades",
   "timeInPosition.tooltip.trade": "trade",
   "timeInPosition.tooltip.trades_plural": "trades",
+  "weekdayPnl.eyebrow": "By weekday",
   "weekdayPnl.title": "Average P/L by Day",
   "weekdayPnl.description": "Average profit/loss for each day of the week",
   "weekdayPnl.subtitle.empty": "No weekday averages yet",
@@ -1677,6 +1687,7 @@ export default {
   "toolbar.resetSettings": "Reset to Default",
   "toolbar.contextMenu": "Right-click for options",
   tradeDistribution: {
+    eyebrow: "Winners and losers",
     title: "Trade Distribution",
     description: "Distribution of winning, losing, and breakeven trades",
     subtitle: {
@@ -1894,6 +1905,7 @@ export default {
     noCredentials: "No credentials",
   },
   timeRangePerformance: {
+    eyebrow: "Session window",
     title: "Time Range Performance",
     description:
       "Average P&L and win rate distribution across different holding times",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1120,6 +1120,8 @@ export default {
   "commissions.title": "P&L vs Commissions",
   "commissions.tooltip.description":
     "Distribution des profits/pertes nets par rapport aux commissions payées",
+  "commissions.subtitle.empty": "Aucune répartition de commissions sur cette période",
+  "commissions.subtitle.share": "Les commissions prennent {percent}% de la répartition absolue · part = part du total",
   "commissions.tooltip.type": "Type",
   "commissions.tooltip.amount": "Montant",
   "commissions.tooltip.percentage": "Pourcentage",
@@ -1135,6 +1137,7 @@ export default {
   equity: {
     title: "Profits",
     description: "Suivez l'évolution de vos profits dans le temps",
+    subtitle: "Ligne = profits cumulés · comptes sélectionnés",
     loading: "Chargement des données du graphique...",
     toggle: {
       individual: "Individuel",
@@ -1222,6 +1225,10 @@ export default {
   tradeDistribution: {
     title: "Distribution des trades",
     description: "Répartition des trades gagnants, perdants et à l'équilibre",
+    subtitle: {
+      empty: "Aucun trade clôturé sur cette période",
+      share: "{percent}% des trades sont gagnants · part = part du total",
+    },
     win: "Trades gagnants",
     loss: "Trades perdants",
     breakeven: "Trades à l'équilibre",
@@ -1658,6 +1665,9 @@ export default {
   },
   "pnl.title": "Profits et Pertes Quotidiens",
   "pnl.description": "Affichage des P&L quotidiens dans le temps",
+  "pnl.subtitle.empty": "Aucun jour clôturé sur cette période",
+  "pnl.subtitle.greenDays": "{green} jours sur {total} se terminent dans le vert · barre = net quotidien",
+  "pnl.subtitle.redDays": "{red} jours sur {total} se terminent dans le rouge · barre = net quotidien",
   "pnl.tooltip.date": "Date",
   "pnl.tooltip.pnl": "P&L",
   "pnl.tooltip.longTrades": "Trades Long",
@@ -1665,6 +1675,10 @@ export default {
   "pnlBySide.title": "P&L par Direction",
   "pnlBySide.description":
     "Comparaison des profits et pertes entre les trades long et short",
+  "pnlBySide.subtitle.empty": "Aucun trade long ou short sur cette période",
+  "pnlBySide.subtitle.best": "Les {label}s sont devant · barre = {mode}",
+  "pnlBySide.mode.average": "P&L moyen",
+  "pnlBySide.mode.total": "P&L total",
   "pnlBySide.tooltip.side": "Direction",
   "pnlBySide.tooltip.averageTotal": "P&L Moyen",
   "pnlBySide.tooltip.winRate": "Taux de Réussite",
@@ -1675,6 +1689,9 @@ export default {
   "pnlPerContract.title": "P&L Net Moyen par Contrat",
   "pnlPerContract.description":
     "Profit/perte net moyen par contrat par instrument de trading (après commissions)",
+  "pnlPerContract.subtitle.empty": "Aucune moyenne par instrument pour l'instant",
+  "pnlPerContract.subtitle.best": "{label} mène par contrat · barre = net moyen",
+  "pnlPerContract.subtitle.worst": "{label} est à la traîne par contrat · barre = net moyen",
   "pnlPerContract.tooltip.instrument": "Instrument",
   "pnlPerContract.tooltip.averagePnl": "P&L Net Moyen par Contrat",
   "pnlPerContract.tooltip.totalPnl": "P&L Net Total",
@@ -1687,6 +1704,9 @@ export default {
   "pnlPerContractDaily.title": "P&L Net moyen par contrat par jour",
   "pnlPerContractDaily.description":
     "Profit/perte net moyen par contrat par jour pour l'instrument sélectionné (après commissions)",
+  "pnlPerContractDaily.subtitle.empty": "Aucune moyenne quotidienne pour cet instrument",
+  "pnlPerContractDaily.subtitle.greenDays": "{green} jours sur {total} se terminent dans le vert · barre = net moyen quotidien",
+  "pnlPerContractDaily.subtitle.redDays": "{red} jours sur {total} se terminent dans le rouge · barre = net moyen quotidien",
   "pnlPerContractDaily.selectInstrument": "Sélectionner l'instrument",
   "pnlPerContractDaily.noData":
     "Aucune donnée disponible pour l'instrument sélectionné",
@@ -1700,6 +1720,9 @@ export default {
   "pnlTime.title": "P&L moyen par heure",
   "pnlTime.description":
     "Profits et pertes moyens pour chaque heure de la journée",
+  "pnlTime.subtitle.empty": "Aucune moyenne horaire pour l'instant",
+  "pnlTime.subtitle.best": "L'avantage se concentre à {label} h · barre = P&L moyen",
+  "pnlTime.subtitle.worst": "{label} h est l'heure la plus faible · barre = P&L moyen",
   "pnlTime.tooltip.time": "Heure",
   "pnlTime.tooltip.averagePnl": "P&L Moyen",
   "pnlTime.tooltip.trades": "Trades",
@@ -1881,9 +1904,13 @@ export default {
   "tickDistribution.tooltip.trade": "trade",
   "tickDistribution.tooltip.trades_plural": "trades",
   "tickDistribution.clearFilter": "Effacer le filtre",
+  "tickDistribution.subtitle.empty": "Aucun décompte de ticks sur cette période",
+  "tickDistribution.subtitle.peak": "La plupart des trades se referment à {label} ticks · barre = nombre de trades",
   "timeInPosition.title": "Temps Moyen en Position",
   "timeInPosition.description":
     "Temps moyen en position pour chaque heure de la journée",
+  "timeInPosition.subtitle.empty": "Aucune moyenne de durée pour l'instant",
+  "timeInPosition.subtitle.peak": "Les plus longues positions commencent à {label} h · barre = durée moyenne",
   "timeInPosition.tooltip.time": "Heure",
   "timeInPosition.tooltip.averageDuration": "Durée Moyenne",
   "timeInPosition.tooltip.trades": "Trades",
@@ -1892,6 +1919,9 @@ export default {
   "weekdayPnl.title": "P&L Moyen par Jour",
   "weekdayPnl.description":
     "Profits et pertes moyens pour chaque jour de la semaine",
+  "weekdayPnl.subtitle.empty": "Aucune moyenne par jour pour l'instant",
+  "weekdayPnl.subtitle.best": "{label} est le jour le plus fort · barre = P&L moyen",
+  "weekdayPnl.subtitle.worst": "{label} est le jour le plus faible · barre = P&L moyen",
   "weekdayPnl.tooltip.day": "Jour",
   "weekdayPnl.tooltip.averagePnl": "P&L Moyen",
   "weekdayPnl.tooltip.trades": "Trades",
@@ -1971,6 +2001,11 @@ export default {
     title: "Performance par Durée",
     description:
       "Distribution du P&L moyen et du taux de réussite selon les durées de trades",
+    subtitle: {
+      empty: "Aucune moyenne par durée pour l'instant",
+      best: "{label} a la meilleure moyenne · barre = P&L moyen",
+      worst: "{label} a la moyenne la plus faible · barre = P&L moyen",
+    },
     tooltip: {
       timeRange: "Durée",
       avgPnl: "P&L Moyen",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1121,7 +1121,7 @@ export default {
   "commissions.tooltip.description":
     "Distribution des profits/pertes nets par rapport aux commissions payées",
   "commissions.subtitle.empty": "Aucune répartition de commissions sur cette période",
-  "commissions.subtitle.share": "Les commissions prennent {percent}% de la répartition absolue · part = part du total",
+  "commissions.subtitle.share": "Les commissions prennent {percent}% de la répartition absolue · un point = un pour cent",
   "commissions.tooltip.type": "Type",
   "commissions.tooltip.amount": "Montant",
   "commissions.tooltip.percentage": "Pourcentage",
@@ -1227,7 +1227,8 @@ export default {
     description: "Répartition des trades gagnants, perdants et à l'équilibre",
     subtitle: {
       empty: "Aucun trade clôturé sur cette période",
-      share: "{percent}% des trades sont gagnants · part = part du total",
+      share: "{percent}% des trades sont gagnants · un point = un trade",
+      sharePacked: "{percent}% des trades sont gagnants · un point = un pour cent",
     },
     win: "Trades gagnants",
     loss: "Trades perdants",
@@ -1666,8 +1667,8 @@ export default {
   "pnl.title": "Profits et Pertes Quotidiens",
   "pnl.description": "Affichage des P&L quotidiens dans le temps",
   "pnl.subtitle.empty": "Aucun jour clôturé sur cette période",
-  "pnl.subtitle.greenDays": "{green} jours sur {total} se terminent dans le vert · barre = net quotidien",
-  "pnl.subtitle.redDays": "{red} jours sur {total} se terminent dans le rouge · barre = net quotidien",
+  "pnl.subtitle.greenDays": "{green} jours sur {total} se terminent dans le vert · tige = jour · tête = net quotidien",
+  "pnl.subtitle.redDays": "{red} jours sur {total} se terminent dans le rouge · tige = jour · tête = net quotidien",
   "pnl.tooltip.date": "Date",
   "pnl.tooltip.pnl": "P&L",
   "pnl.tooltip.longTrades": "Trades Long",
@@ -1676,7 +1677,7 @@ export default {
   "pnlBySide.description":
     "Comparaison des profits et pertes entre les trades long et short",
   "pnlBySide.subtitle.empty": "Aucun trade long ou short sur cette période",
-  "pnlBySide.subtitle.best": "Les {label}s sont devant · barre = {mode}",
+  "pnlBySide.subtitle.best": "Les {label}s sont devant · barre = {mode}, divergente depuis zéro",
   "pnlBySide.mode.average": "P&L moyen",
   "pnlBySide.mode.total": "P&L total",
   "pnlBySide.tooltip.side": "Direction",
@@ -1705,8 +1706,8 @@ export default {
   "pnlPerContractDaily.description":
     "Profit/perte net moyen par contrat par jour pour l'instrument sélectionné (après commissions)",
   "pnlPerContractDaily.subtitle.empty": "Aucune moyenne quotidienne pour cet instrument",
-  "pnlPerContractDaily.subtitle.greenDays": "{green} jours sur {total} se terminent dans le vert · barre = net moyen quotidien",
-  "pnlPerContractDaily.subtitle.redDays": "{red} jours sur {total} se terminent dans le rouge · barre = net moyen quotidien",
+  "pnlPerContractDaily.subtitle.greenDays": "{green} jours sur {total} se terminent dans le vert · tige = jour · tête = net moyen quotidien",
+  "pnlPerContractDaily.subtitle.redDays": "{red} jours sur {total} se terminent dans le rouge · tige = jour · tête = net moyen quotidien",
   "pnlPerContractDaily.selectInstrument": "Sélectionner l'instrument",
   "pnlPerContractDaily.noData":
     "Aucune donnée disponible pour l'instrument sélectionné",
@@ -1906,6 +1907,7 @@ export default {
   "tickDistribution.clearFilter": "Effacer le filtre",
   "tickDistribution.subtitle.empty": "Aucun décompte de ticks sur cette période",
   "tickDistribution.subtitle.peak": "La plupart des trades se referment à {label} ticks · barre = nombre de trades",
+  "tickDistribution.subtitle.peakStacks": "La plupart des trades se referment à {label} ticks · une pile = un tick · un point = un trade",
   "timeInPosition.title": "Temps Moyen en Position",
   "timeInPosition.description":
     "Temps moyen en position pour chaque heure de la journée",
@@ -1920,8 +1922,8 @@ export default {
   "weekdayPnl.description":
     "Profits et pertes moyens pour chaque jour de la semaine",
   "weekdayPnl.subtitle.empty": "Aucune moyenne par jour pour l'instant",
-  "weekdayPnl.subtitle.best": "{label} est le jour le plus fort · barre = P&L moyen",
-  "weekdayPnl.subtitle.worst": "{label} est le jour le plus faible · barre = P&L moyen",
+  "weekdayPnl.subtitle.best": "{label} est le jour le plus fort · barre = P&L moyen, divergente depuis zéro",
+  "weekdayPnl.subtitle.worst": "{label} est le jour le plus faible · barre = P&L moyen, divergente depuis zéro",
   "weekdayPnl.tooltip.day": "Jour",
   "weekdayPnl.tooltip.averagePnl": "P&L Moyen",
   "weekdayPnl.tooltip.trades": "Trades",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1117,6 +1117,7 @@ export default {
   "calendar.charts.equityVariation": "Variation des profits",
   "calendar.charts.dailyPnlDistribution": "Distribution du P&L journalier",
   "calendar.charts.totalPnlAfterComm": "P&L total (après commissions)",
+  "commissions.eyebrow": "Coût vs résultat",
   "commissions.title": "P&L vs Commissions",
   "commissions.tooltip.description":
     "Distribution des profits/pertes nets par rapport aux commissions payées",
@@ -1136,6 +1137,7 @@ export default {
   "contracts.tooltip.numberOfTrades": "Nombre de Trades",
   "contracts.axis.contracts": "Contrats",
   equity: {
+    eyebrow: "Cumul",
     title: "Profits",
     description: "Suivez l'évolution de vos profits dans le temps",
     subtitle: "Ligne = profits cumulés · comptes sélectionnés",
@@ -1224,6 +1226,7 @@ export default {
   "toolbar.resetSettings": "Réinitialiser par défaut",
   "toolbar.contextMenu": "Clic droit pour les options",
   tradeDistribution: {
+    eyebrow: "Gagnants et perdants",
     title: "Distribution des trades",
     description: "Répartition des trades gagnants, perdants et à l'équilibre",
     subtitle: {
@@ -1671,6 +1674,7 @@ export default {
         "Répartition de vos trades entre gagnants, à l'équilibre et perdants. Cette métrique vous aide à comprendre votre taux de réussite global et votre cohérence dans le trading.",
     },
   },
+  "pnl.eyebrow": "Chaque séance",
   "pnl.title": "Profits et Pertes Quotidiens",
   "pnl.description": "Affichage des P&L quotidiens dans le temps",
   "pnl.subtitle.empty": "Aucun jour clôturé sur cette période",
@@ -1680,6 +1684,7 @@ export default {
   "pnl.tooltip.pnl": "P&L",
   "pnl.tooltip.longTrades": "Trades Long",
   "pnl.tooltip.shortTrades": "Trades Short",
+  "pnlBySide.eyebrow": "Long vs short",
   "pnlBySide.title": "P&L par Direction",
   "pnlBySide.description":
     "Comparaison des profits et pertes entre les trades long et short",
@@ -1694,6 +1699,7 @@ export default {
   "pnlBySide.tooltip.wins": "gain",
   "pnlBySide.tooltip.wins_plural": "gains",
   "pnlBySide.toggle.showAverage": "Afficher la Moyenne",
+  "pnlPerContract.eyebrow": "Par instrument",
   "pnlPerContract.title": "P&L Net Moyen par Contrat",
   "pnlPerContract.description":
     "Profit/perte net moyen par contrat par instrument de trading (après commissions)",
@@ -1709,6 +1715,7 @@ export default {
   "pnlPerContract.tooltip.wins_plural": "gains",
   "pnlPerContract.tooltip.totalContracts": "Total des Contrats",
   "pnlPerContract.tooltip.contracts": "contrats",
+  "pnlPerContractDaily.eyebrow": "Par contrat",
   "pnlPerContractDaily.title": "P&L Net moyen par contrat par jour",
   "pnlPerContractDaily.description":
     "Profit/perte net moyen par contrat par jour pour l'instrument sélectionné (après commissions)",
@@ -1725,6 +1732,7 @@ export default {
   "pnlPerContractDaily.tooltip.trades": "Trades",
   "pnlPerContractDaily.tooltip.totalContracts": "Total des contrats",
   "pnlPerContractDaily.tooltip.contracts": "contrats",
+  "pnlTime.eyebrow": "Par heure",
   "pnlTime.title": "P&L moyen par heure",
   "pnlTime.description":
     "Profits et pertes moyens pour chaque heure de la journée",
@@ -1902,6 +1910,7 @@ export default {
       invalidTimeFormat: "Format d'heure invalide",
     },
   },
+  "tickDistribution.eyebrow": "Par tick",
   "tickDistribution.title": "Distribution des ticks",
   "tickDistribution.description":
     "Visualisez la distribution de vos trades par ticks",
@@ -1915,6 +1924,7 @@ export default {
   "tickDistribution.subtitle.empty": "Aucun décompte de ticks sur cette période",
   "tickDistribution.subtitle.peak": "La plupart des trades se referment à {label} ticks · barre = nombre de trades",
   "tickDistribution.subtitle.peakStacks": "La plupart des trades se referment à {label} ticks · une pile = un tick · un point = un trade",
+  "timeInPosition.eyebrow": "Durée de détention",
   "timeInPosition.title": "Temps Moyen en Position",
   "timeInPosition.description":
     "Temps moyen en position pour chaque heure de la journée",
@@ -1925,6 +1935,7 @@ export default {
   "timeInPosition.tooltip.trades": "Trades",
   "timeInPosition.tooltip.trade": "trade",
   "timeInPosition.tooltip.trades_plural": "trades",
+  "weekdayPnl.eyebrow": "Par jour",
   "weekdayPnl.title": "P&L Moyen par Jour",
   "weekdayPnl.description":
     "Profits et pertes moyens pour chaque jour de la semaine",
@@ -2007,6 +2018,7 @@ export default {
   "dataManagement.validate": "Valider",
   "dataManagement.validating": "Validation...",
   timeRangePerformance: {
+    eyebrow: "Fenêtre de séance",
     title: "Performance par Durée",
     description:
       "Distribution du P&L moyen et du taux de réussite selon les durées de trades",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1234,6 +1234,9 @@ export default {
     caption: {
       winners: "des trades sont gagnants",
     },
+    detail: {
+      count: "{count} sur {total}",
+    },
     win: "Trades gagnants",
     loss: "Trades perdants",
     breakeven: "Trades à l'équilibre",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1227,7 +1227,7 @@ export default {
     description: "Répartition des trades gagnants, perdants et à l'équilibre",
     subtitle: {
       empty: "Aucun trade clôturé sur cette période",
-      share: "{percent}% des trades sont gagnants · un point = un trade",
+      share: "{percent}% des trades sont gagnants · un point = un pour cent",
       sharePacked: "{percent}% des trades sont gagnants · un point = un pour cent",
     },
     win: "Trades gagnants",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -1121,7 +1121,8 @@ export default {
   "commissions.tooltip.description":
     "Distribution des profits/pertes nets par rapport aux commissions payées",
   "commissions.subtitle.empty": "Aucune répartition de commissions sur cette période",
-  "commissions.subtitle.share": "Les commissions prennent {percent}% de la répartition absolue · un point = un pour cent",
+  "commissions.subtitle.share": "Les commissions prennent {percent}% de la répartition",
+  "commissions.caption.share": "de la répartition absolue",
   "commissions.tooltip.type": "Type",
   "commissions.tooltip.amount": "Montant",
   "commissions.tooltip.percentage": "Pourcentage",
@@ -1227,8 +1228,11 @@ export default {
     description: "Répartition des trades gagnants, perdants et à l'équilibre",
     subtitle: {
       empty: "Aucun trade clôturé sur cette période",
-      share: "{percent}% des trades sont gagnants · un point = un pour cent",
-      sharePacked: "{percent}% des trades sont gagnants · un point = un pour cent",
+      share: "{percent}% des trades sont gagnants",
+      sharePacked: "{percent}% des trades sont gagnants",
+    },
+    caption: {
+      winners: "des trades sont gagnants",
     },
     win: "Trades gagnants",
     loss: "Trades perdants",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The first pass restyled existing Recharts bars and pies with Glance chrome. That missed the point of the lieflat-charts skill: pick an encoding that matches each widget’s data, then draw it originally on Paper tokens (the skill is PolyForm Noncommercial, so nothing is vendored).

## What each widget uses now

- **Daily P/L** and **daily per-contract**: lollipop (stem = day, cap = net)
- **Trade distribution** and **commissions vs P/L**: one large percent and a single stacked share bar (a 100-dot waffle was too loud)
- **Weekday P/L** and **P/L by side**: horizontal bars that diverge from zero
- **Tick distribution**: countable stacks (one stack = one tick, one dot = one trade), falling back to bars when the field would crush
- **Hourly / instrument / time-range / time-in-position**: signed vertical capsule bars
- **Equity**: unchanged line + counter

## Negative bars

Recharts often hands a negative height to the bar shape. Capsule radius is now applied after the rect is normalized to top-left + positive size, so the rounded end sits at the **outer** tip (bottom when the value is negative; left when a horizontal bar is negative).

## License

Original React/SVG on Paper `chart-win` / `chart-loss`. No lieflat HTML, SVG, templates, or tokens.

![Share widgets as a large percent and one stacked bar](https://cursor.com/artifacts/c/art-fc37a5fc-9d79-46a7-a68a-0740ea803d30)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06b09-2946-7c27-8b3a-f40f90505368?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06b09-2946-7c27-8b3a-f40f90505368&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

