### PR TITLE
Fix Rithmic Protocol duplicate fills inflating calendar P&L

### DIFF
--- a/lib/rithmic-protocol/README.md
+++ b/lib/rithmic-protocol/README.md
@@ -153,8 +153,13 @@ date to today with `ShowFillHistory` in **serial ≤30-day windows** (Rithmic gu
 `RITHMIC_PROTOCOL_HISTORY_LOOKBACK_DAYS` is only a fallback for legacy connections
 that predate the start-date field.
 
-Same-day fills are also pulled via `ReplayExecutions` (ssboe), because on Test the
-fill/order history date index often lags UTC “today”.
+`ShowFillHistory` is the sync source of truth. Exchange notifications on that
+stream are ignored (same `fill_id`, different `transaction_type` encoding).
+`ReplayExecutions` (last ~2 days, ssboe) runs only when history has no UTC-today
+fills — needed on Test, where the date index often lags “today”. Always-on replay
+plus a composite-field dedupe used to keep both copies and FIFO-join them into
+`fillId-fillId` journal rows (2× qty / PnL). Fills are now keyed on
+`accountId + fill_id`.
 Order-history fallback also requests dates one at a time. When `ShowFillHistory`
 returns empty (rp_code `7 no data`) — common on prop-firm plants such as
 **LucidTrading** — sync still tries order-history dates before giving up. Fill

--- a/lib/rithmic-protocol/README.md
+++ b/lib/rithmic-protocol/README.md
@@ -153,13 +153,14 @@ date to today with `ShowFillHistory` in **serial ≤30-day windows** (Rithmic gu
 `RITHMIC_PROTOCOL_HISTORY_LOOKBACK_DAYS` is only a fallback for legacy connections
 that predate the start-date field.
 
-`ShowFillHistory` is the sync source of truth. Exchange notifications on that
-stream are ignored (same `fill_id`, different `transaction_type` encoding).
-`ReplayExecutions` (last ~2 days, ssboe) runs only when history has no UTC-today
-fills — needed on Test, where the date index often lags “today”. Always-on replay
-plus a composite-field dedupe used to keep both copies and FIFO-join them into
-`fillId-fillId` journal rows (2× qty / PnL). Fills are now keyed on
-`accountId + fill_id`.
+Same-day fills are also pulled via `ReplayExecutions` (ssboe), because on Test the
+fill/order history date index often lags mid-session. History-stream exchange
+notifications are kept (some plants emit fills only that way). `dedupeFills`
+collapses the same `accountId + fill_date + fill_id` — `fill_date` is the exchange
+trade date (rolls ~17:00 CT), not a UTC calendar day; `ssboe` is only a fallback
+when `fill_date` is absent. The old composite-field key (transaction type, ssboe,
+basket) kept history `BUY` and replay enum `1` as two fills, and FIFO joined them
+into `fillId-fillId` journal rows (2× qty / PnL).
 Order-history fallback also requests dates one at a time. When `ShowFillHistory`
 returns empty (rp_code `7 no data`) — common on prop-firm plants such as
 **LucidTrading** — sync still tries order-history dates before giving up. Fill

--- a/lib/rithmic-protocol/client.ts
+++ b/lib/rithmic-protocol/client.ts
@@ -28,6 +28,7 @@ import {
   getRithmicProtocolAppVersion,
   normalizeGatewayUri,
 } from './systems'
+import { dedupeFills, shouldReplayRecentExecutions } from './dedupe-fills'
 
 /** Wall-clock budget for a full PnL snapshot sweep across a user's accounts. */
 const PNL_SNAPSHOT_TOTAL_BUDGET_MS = 30_000
@@ -802,10 +803,11 @@ export class RithmicProtocolClient {
         continue
       }
 
-      // Summary/detail streams may also emit exchange notifications.
+      // Exchange notifications on this stream are the same executions as
+      // ResponseShowFillHistory, but transaction_type is the enum (1/2)
+      // instead of "BUY"/"SELL". Collecting both used to survive the old
+      // composite dedupe and FIFO-join into `fillId-fillId` journal rows.
       if (msg.templateId === RithmicTemplateId.EXCHANGE_ORDER_NOTIFICATION) {
-        const fill = this.decodeExchangeFill(msg.raw, params.accountId)
-        if (fill) fills.push(fill)
         continue
       }
 
@@ -1411,6 +1413,7 @@ export async function fetchFillsForAccounts(params: {
 
       let historyFills = 0
       let usedOrderHistoryFallback = false
+      const accountHistory: RithmicProtocolFill[] = []
       for (const window of windows) {
         try {
           const accountFills = await client.getFillHistory({
@@ -1421,7 +1424,7 @@ export async function fetchFillsForAccounts(params: {
             endDateYyyymmdd: toYyyymmddNumber(window.end),
           })
           historyFills += accountFills.length
-          fills.push(...accountFills)
+          accountHistory.push(...accountFills)
         } catch (error) {
           console.warn(
             `[RITHMIC-PROTOCOL] Fill history failed for ${accountId} (${toYyyymmddString(window.start)}–${toYyyymmddString(window.end)}), falling back to order history`,
@@ -1438,7 +1441,7 @@ export async function fetchFillsForAccounts(params: {
             console.log(
               `[RITHMIC-PROTOCOL] Order-history fallback for ${accountId}: ${fallback.length} fill(s)`,
             )
-            fills.push(...fallback)
+            accountHistory.push(...fallback)
           }
           break
         }
@@ -1457,7 +1460,7 @@ export async function fetchFillsForAccounts(params: {
           console.log(
             `[RITHMIC-PROTOCOL] Empty ShowFillHistory for ${accountId}; order-history fallback: ${fallback.length} fill(s)`,
           )
-          fills.push(...fallback)
+          accountHistory.push(...fallback)
         } catch (error) {
           console.warn(
             `[RITHMIC-PROTOCOL] Order-history fallback failed for ${accountId}`,
@@ -1470,28 +1473,39 @@ export async function fetchFillsForAccounts(params: {
         )
       }
 
-      // Same-day fills on Test often land in ReplayExecutions before ShowFillHistory
-      // publishes the trade date (history dates currently lag behind UTC "today").
-      const finishSsboe = Math.floor(Date.now() / 1000) + 60
-      const startSsboe = finishSsboe - Math.min(lookbackDays, 2) * 24 * 60 * 60
-      try {
-        const replayed = await client.replayExecutions({
-          fcmId,
-          ibId,
-          accountId,
-          startSsboe,
-          finishSsboe,
-        })
-        if (replayed.length > 0) {
-          console.log(
-            `[RITHMIC-PROTOCOL] ReplayExecutions returned ${replayed.length} fill(s) for ${accountId}`,
+      fills.push(...accountHistory)
+
+      // Same-day fills on Test often land in ReplayExecutions before
+      // ShowFillHistory publishes the trade date. Skip when this account's
+      // history already includes UTC today — always-on replay doubled Apex
+      // fills (ticket-18).
+      const todayYmd = toYyyymmddString(end)
+      if (shouldReplayRecentExecutions(accountHistory, todayYmd)) {
+        const finishSsboe = Math.floor(Date.now() / 1000) + 60
+        const startSsboe = finishSsboe - Math.min(lookbackDays, 2) * 24 * 60 * 60
+        try {
+          const replayed = await client.replayExecutions({
+            fcmId,
+            ibId,
+            accountId,
+            startSsboe,
+            finishSsboe,
+          })
+          if (replayed.length > 0) {
+            console.log(
+              `[RITHMIC-PROTOCOL] ReplayExecutions returned ${replayed.length} fill(s) for ${accountId}`,
+            )
+            fills.push(...replayed)
+          }
+        } catch (error) {
+          console.warn(
+            `[RITHMIC-PROTOCOL] ReplayExecutions failed for ${accountId}`,
+            error instanceof Error ? error.message : error,
           )
-          fills.push(...replayed)
         }
-      } catch (error) {
-        console.warn(
-          `[RITHMIC-PROTOCOL] ReplayExecutions failed for ${accountId}`,
-          error instanceof Error ? error.message : error,
+      } else {
+        console.log(
+          `[RITHMIC-PROTOCOL] Skipping ReplayExecutions for ${accountId}; ShowFillHistory already has ${todayYmd}`,
         )
       }
     }
@@ -1512,29 +1526,6 @@ function toYyyymmddNumber(d: Date): number {
 
 function toYyyymmddString(d: Date): string {
   return `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, '0')}${String(d.getUTCDate()).padStart(2, '0')}`
-}
-
-function dedupeFills(fills: RithmicProtocolFill[]): RithmicProtocolFill[] {
-  const seen = new Set<string>()
-  const out: RithmicProtocolFill[] = []
-  for (const fill of fills) {
-    const key = [
-      fill.accountId,
-      fill.basketId ?? '',
-      fill.fillId ?? '',
-      fill.symbol,
-      fill.transactionType,
-      fill.fillPrice,
-      fill.fillSize,
-      fill.ssboe ?? '',
-      fill.fillDate ?? '',
-      fill.fillTime ?? '',
-    ].join('|')
-    if (seen.has(key)) continue
-    seen.add(key)
-    out.push(fill)
-  }
-  return out
 }
 
 function utcCalendarDay(d: Date): Date {

--- a/lib/rithmic-protocol/client.ts
+++ b/lib/rithmic-protocol/client.ts
@@ -28,7 +28,7 @@ import {
   getRithmicProtocolAppVersion,
   normalizeGatewayUri,
 } from './systems'
-import { dedupeFills, shouldReplayRecentExecutions } from './dedupe-fills'
+import { dedupeFills } from './dedupe-fills'
 
 /** Wall-clock budget for a full PnL snapshot sweep across a user's accounts. */
 const PNL_SNAPSHOT_TOTAL_BUDGET_MS = 30_000
@@ -803,11 +803,12 @@ export class RithmicProtocolClient {
         continue
       }
 
-      // Exchange notifications on this stream are the same executions as
-      // ResponseShowFillHistory, but transaction_type is the enum (1/2)
-      // instead of "BUY"/"SELL". Collecting both used to survive the old
-      // composite dedupe and FIFO-join into `fillId-fillId` journal rows.
+      // Some plants emit fills only as exchange notifications on this stream.
+      // Keep them; account + trade-date + fill_id dedupe collapses twins of
+      // ResponseShowFillHistory (string BUY/SELL vs enum 1/2).
       if (msg.templateId === RithmicTemplateId.EXCHANGE_ORDER_NOTIFICATION) {
+        const fill = this.decodeExchangeFill(msg.raw, params.accountId)
+        if (fill) fills.push(fill)
         continue
       }
 
@@ -1413,7 +1414,6 @@ export async function fetchFillsForAccounts(params: {
 
       let historyFills = 0
       let usedOrderHistoryFallback = false
-      const accountHistory: RithmicProtocolFill[] = []
       for (const window of windows) {
         try {
           const accountFills = await client.getFillHistory({
@@ -1424,7 +1424,7 @@ export async function fetchFillsForAccounts(params: {
             endDateYyyymmdd: toYyyymmddNumber(window.end),
           })
           historyFills += accountFills.length
-          accountHistory.push(...accountFills)
+          fills.push(...accountFills)
         } catch (error) {
           console.warn(
             `[RITHMIC-PROTOCOL] Fill history failed for ${accountId} (${toYyyymmddString(window.start)}–${toYyyymmddString(window.end)}), falling back to order history`,
@@ -1441,7 +1441,7 @@ export async function fetchFillsForAccounts(params: {
             console.log(
               `[RITHMIC-PROTOCOL] Order-history fallback for ${accountId}: ${fallback.length} fill(s)`,
             )
-            accountHistory.push(...fallback)
+            fills.push(...fallback)
           }
           break
         }
@@ -1460,7 +1460,7 @@ export async function fetchFillsForAccounts(params: {
           console.log(
             `[RITHMIC-PROTOCOL] Empty ShowFillHistory for ${accountId}; order-history fallback: ${fallback.length} fill(s)`,
           )
-          accountHistory.push(...fallback)
+          fills.push(...fallback)
         } catch (error) {
           console.warn(
             `[RITHMIC-PROTOCOL] Order-history fallback failed for ${accountId}`,
@@ -1473,39 +1473,31 @@ export async function fetchFillsForAccounts(params: {
         )
       }
 
-      fills.push(...accountHistory)
-
-      // Same-day fills on Test often land in ReplayExecutions before
-      // ShowFillHistory publishes the trade date. Skip when this account's
-      // history already includes UTC today — always-on replay doubled Apex
-      // fills (ticket-18).
-      const todayYmd = toYyyymmddString(end)
-      if (shouldReplayRecentExecutions(accountHistory, todayYmd)) {
-        const finishSsboe = Math.floor(Date.now() / 1000) + 60
-        const startSsboe = finishSsboe - Math.min(lookbackDays, 2) * 24 * 60 * 60
-        try {
-          const replayed = await client.replayExecutions({
-            fcmId,
-            ibId,
-            accountId,
-            startSsboe,
-            finishSsboe,
-          })
-          if (replayed.length > 0) {
-            console.log(
-              `[RITHMIC-PROTOCOL] ReplayExecutions returned ${replayed.length} fill(s) for ${accountId}`,
-            )
-            fills.push(...replayed)
-          }
-        } catch (error) {
-          console.warn(
-            `[RITHMIC-PROTOCOL] ReplayExecutions failed for ${accountId}`,
-            error instanceof Error ? error.message : error,
+      // Always replay recent executions. ShowFillHistory can lag mid-session
+      // (Test date index; some plants omit the latest fills). Twins collapse
+      // in dedupeFills — do not skip replay just because history has a
+      // fill_date that looks like "today" (that field is the exchange trade
+      // date, which rolls ~17:00 CT, not UTC midnight).
+      const finishSsboe = Math.floor(Date.now() / 1000) + 60
+      const startSsboe = finishSsboe - Math.min(lookbackDays, 2) * 24 * 60 * 60
+      try {
+        const replayed = await client.replayExecutions({
+          fcmId,
+          ibId,
+          accountId,
+          startSsboe,
+          finishSsboe,
+        })
+        if (replayed.length > 0) {
+          console.log(
+            `[RITHMIC-PROTOCOL] ReplayExecutions returned ${replayed.length} fill(s) for ${accountId}`,
           )
+          fills.push(...replayed)
         }
-      } else {
-        console.log(
-          `[RITHMIC-PROTOCOL] Skipping ReplayExecutions for ${accountId}; ShowFillHistory already has ${todayYmd}`,
+      } catch (error) {
+        console.warn(
+          `[RITHMIC-PROTOCOL] ReplayExecutions failed for ${accountId}`,
+          error instanceof Error ? error.message : error,
         )
       }
     }

--- a/lib/rithmic-protocol/dedupe-fills.test.ts
+++ b/lib/rithmic-protocol/dedupe-fills.test.ts
@@ -3,11 +3,16 @@ import { buildTradesFromRithmicFills } from './fills-to-trades'
 import {
   canonicalRithmicFillId,
   dedupeFills,
-  shouldReplayRecentExecutions,
+  fillDayKey,
+  fillIdentityKey,
 } from './dedupe-fills'
 import type { RithmicProtocolFill } from './types'
 
 const tickBySymbol = new Map([['ES', { tickSize: 0.25, tickValue: 12.5 }]])
+
+/** 2026-09-02 19:30 UTC — still 14:30 CT, same CME session as fillDate. */
+const SEP2_SSBOE = Date.UTC(2026, 8, 2, 19, 30, 0) / 1000
+const SEP2_EXIT_SSBOE = Date.UTC(2026, 8, 2, 19, 40, 0) / 1000
 
 function historyFill(
   overrides: Partial<RithmicProtocolFill> = {},
@@ -21,7 +26,7 @@ function historyFill(
     fillId: '1452840',
     fillDate: '20260902',
     fillTime: '14:30:00',
-    ssboe: 1_725_289_800,
+    ssboe: SEP2_SSBOE,
     ...overrides,
   }
 }
@@ -35,7 +40,6 @@ function replayTwin(
     ...fill,
     transactionType,
     basketId: fill.basketId ?? 'basket-1',
-    fillDate: undefined,
     fillTime: undefined,
     ssboe: (fill.ssboe ?? 0) + 1,
   }
@@ -55,6 +59,27 @@ describe('canonicalRithmicFillId', () => {
   })
 })
 
+describe('fillDayKey', () => {
+  it('prefers fill_date (exchange trade date) over ssboe UTC day', () => {
+    // After ~17:00 CT the session date is already the next day; ssboe can
+    // still be the previous UTC calendar day. Identity must follow fill_date.
+    const evening = historyFill({
+      fillDate: '20260903',
+      ssboe: Date.UTC(2026, 8, 2, 23, 30, 0) / 1000,
+    })
+    expect(fillDayKey(evening)).toBe('20260903')
+    expect(fillIdentityKey(evening)).toBe(
+      'id|PA-APEX-39878-10|20260903|1452840',
+    )
+  })
+
+  it('falls back to ssboe truncated to a UTC day when fill_date is absent', () => {
+    expect(
+      fillDayKey(historyFill({ fillDate: undefined, ssboe: SEP2_SSBOE })),
+    ).toBe('20260902')
+  })
+})
+
 describe('dedupeFills', () => {
   it('keeps one row when the same fill_id arrives from history and replay', () => {
     const history = historyFill({ transactionType: 'BUY' })
@@ -63,6 +88,18 @@ describe('dedupeFills', () => {
     expect(out).toHaveLength(1)
     expect(out[0].fillId).toBe('1452840')
     expect(out[0].transactionType).toBe('BUY')
+  })
+
+  it('collapses a replay twin that only has ssboe on the same trade day', () => {
+    const history = historyFill({ fillDate: '20260902', ssboe: SEP2_SSBOE })
+    const replay = {
+      ...history,
+      transactionType: '1',
+      fillDate: undefined,
+      fillTime: undefined,
+      ssboe: SEP2_SSBOE + 1,
+    }
+    expect(dedupeFills([history, replay])).toHaveLength(1)
   })
 
   it('treats id and id-id as the same fill', () => {
@@ -76,12 +113,24 @@ describe('dedupeFills', () => {
     expect(out[0].fillId).toBe('1452840')
   })
 
-  it('keeps distinct fill ids', () => {
+  it('keeps distinct fill ids on the same day', () => {
     const out = dedupeFills([
       historyFill({ fillId: '1452840', transactionType: 'BUY' }),
       historyFill({ fillId: '1452841', transactionType: 'SELL', fillSize: 1 }),
     ])
     expect(out.map((fill) => fill.fillId)).toEqual(['1452840', '1452841'])
+  })
+
+  it('does not collapse the same fill_id on different trade dates', () => {
+    const day1 = historyFill({ fillId: '1452840', fillDate: '20260902' })
+    const day2 = historyFill({
+      fillId: '1452840',
+      fillDate: '20260903',
+      ssboe: Date.UTC(2026, 8, 3, 19, 30, 0) / 1000,
+    })
+    const out = dedupeFills([day1, day2])
+    expect(out).toHaveLength(2)
+    expect(out.map((fill) => fillDayKey(fill))).toEqual(['20260902', '20260903'])
   })
 
   it('still dedupes exact copies when fill_id is missing', () => {
@@ -91,38 +140,18 @@ describe('dedupeFills', () => {
   })
 })
 
-describe('shouldReplayRecentExecutions', () => {
-  it('skips replay when ShowFillHistory already has UTC today', () => {
-    expect(
-      shouldReplayRecentExecutions(
-        [historyFill({ fillDate: '20260904' })],
-        '20260904',
-      ),
-    ).toBe(false)
-  })
-
-  it('replays when history has older days only (Test same-day lag)', () => {
-    expect(
-      shouldReplayRecentExecutions(
-        [historyFill({ fillDate: '20260902', ssboe: undefined })],
-        '20260904',
-      ),
-    ).toBe(true)
-  })
-})
-
 describe('duplicate fills do not inflate FIFO trades', () => {
   const entry = historyFill({
     fillId: '1452840',
     transactionType: 'BUY',
     fillPrice: 5000,
-    ssboe: 1_725_289_800,
+    ssboe: SEP2_SSBOE,
   })
   const exit = historyFill({
     fillId: '1452900',
     transactionType: 'SELL',
     fillPrice: 5010,
-    ssboe: 1_725_290_400,
+    ssboe: SEP2_EXIT_SSBOE,
   })
 
   function pnlOf(fills: RithmicProtocolFill[]) {
@@ -164,5 +193,45 @@ describe('duplicate fills do not inflate FIFO trades', () => {
     expect(trades[0].closeId).toBe('1452900')
     expect(trades[0].quantity).toBe(1)
     expect(trades[0].pnl).toBe(500)
+  })
+
+  it('FIFO still matches two same-id fills that fall on different trade dates', () => {
+    const day1Entry = historyFill({
+      fillId: '1452840',
+      fillDate: '20260902',
+      transactionType: 'BUY',
+      fillPrice: 5000,
+      ssboe: SEP2_SSBOE,
+    })
+    const day1Exit = historyFill({
+      fillId: '1452900',
+      fillDate: '20260902',
+      transactionType: 'SELL',
+      fillPrice: 5010,
+      ssboe: SEP2_EXIT_SSBOE,
+    })
+    const day2Entry = historyFill({
+      fillId: '1452840',
+      fillDate: '20260903',
+      transactionType: 'BUY',
+      fillPrice: 5000,
+      ssboe: Date.UTC(2026, 8, 3, 19, 30, 0) / 1000,
+    })
+    const day2Exit = historyFill({
+      fillId: '1452900',
+      fillDate: '20260903',
+      transactionType: 'SELL',
+      fillPrice: 5010,
+      ssboe: Date.UTC(2026, 8, 3, 19, 40, 0) / 1000,
+    })
+
+    const { trades } = buildTradesFromRithmicFills(
+      [day1Entry, day1Exit, day2Entry, day2Exit],
+      'user-1',
+      tickBySymbol,
+    )
+    expect(trades).toHaveLength(2)
+    expect(trades.every((trade) => trade.quantity === 1)).toBe(true)
+    expect(trades.every((trade) => trade.pnl === 500)).toBe(true)
   })
 })

--- a/lib/rithmic-protocol/dedupe-fills.test.ts
+++ b/lib/rithmic-protocol/dedupe-fills.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import { buildTradesFromRithmicFills } from './fills-to-trades'
+import {
+  canonicalRithmicFillId,
+  dedupeFills,
+  shouldReplayRecentExecutions,
+} from './dedupe-fills'
+import type { RithmicProtocolFill } from './types'
+
+const tickBySymbol = new Map([['ES', { tickSize: 0.25, tickValue: 12.5 }]])
+
+function historyFill(
+  overrides: Partial<RithmicProtocolFill> = {},
+): RithmicProtocolFill {
+  return {
+    accountId: 'PA-APEX-39878-10',
+    symbol: 'ESH5',
+    transactionType: 'BUY',
+    fillPrice: 5000,
+    fillSize: 1,
+    fillId: '1452840',
+    fillDate: '20260902',
+    fillTime: '14:30:00',
+    ssboe: 1_725_289_800,
+    ...overrides,
+  }
+}
+
+/** Replay / exchange notification: same fill, enum side, different clock fields. */
+function replayTwin(
+  fill: RithmicProtocolFill,
+  transactionType: string,
+): RithmicProtocolFill {
+  return {
+    ...fill,
+    transactionType,
+    basketId: fill.basketId ?? 'basket-1',
+    fillDate: undefined,
+    fillTime: undefined,
+    ssboe: (fill.ssboe ?? 0) + 1,
+  }
+}
+
+describe('canonicalRithmicFillId', () => {
+  it('keeps a plain fill id', () => {
+    expect(canonicalRithmicFillId('1452840')).toBe('1452840')
+  })
+
+  it('collapses a repeated id-id leftover to the single fill id', () => {
+    expect(canonicalRithmicFillId('1452840-1452840')).toBe('1452840')
+  })
+
+  it('does not collapse two distinct hyphenated ids', () => {
+    expect(canonicalRithmicFillId('1452840-1452841')).toBe('1452840-1452841')
+  })
+})
+
+describe('dedupeFills', () => {
+  it('keeps one row when the same fill_id arrives from history and replay', () => {
+    const history = historyFill({ transactionType: 'BUY' })
+    const replay = replayTwin(history, '1')
+    const out = dedupeFills([history, replay])
+    expect(out).toHaveLength(1)
+    expect(out[0].fillId).toBe('1452840')
+    expect(out[0].transactionType).toBe('BUY')
+  })
+
+  it('treats id and id-id as the same fill', () => {
+    const clean = historyFill({ fillId: '1452840' })
+    const doubled = historyFill({
+      fillId: '1452840-1452840',
+      transactionType: '1',
+    })
+    const out = dedupeFills([clean, doubled])
+    expect(out).toHaveLength(1)
+    expect(out[0].fillId).toBe('1452840')
+  })
+
+  it('keeps distinct fill ids', () => {
+    const out = dedupeFills([
+      historyFill({ fillId: '1452840', transactionType: 'BUY' }),
+      historyFill({ fillId: '1452841', transactionType: 'SELL', fillSize: 1 }),
+    ])
+    expect(out.map((fill) => fill.fillId)).toEqual(['1452840', '1452841'])
+  })
+
+  it('still dedupes exact copies when fill_id is missing', () => {
+    const a = historyFill({ fillId: undefined })
+    const b = { ...a }
+    expect(dedupeFills([a, b])).toHaveLength(1)
+  })
+})
+
+describe('shouldReplayRecentExecutions', () => {
+  it('skips replay when ShowFillHistory already has UTC today', () => {
+    expect(
+      shouldReplayRecentExecutions(
+        [historyFill({ fillDate: '20260904' })],
+        '20260904',
+      ),
+    ).toBe(false)
+  })
+
+  it('replays when history has older days only (Test same-day lag)', () => {
+    expect(
+      shouldReplayRecentExecutions(
+        [historyFill({ fillDate: '20260902', ssboe: undefined })],
+        '20260904',
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('duplicate fills do not inflate FIFO trades', () => {
+  const entry = historyFill({
+    fillId: '1452840',
+    transactionType: 'BUY',
+    fillPrice: 5000,
+    ssboe: 1_725_289_800,
+  })
+  const exit = historyFill({
+    fillId: '1452900',
+    transactionType: 'SELL',
+    fillPrice: 5010,
+    ssboe: 1_725_290_400,
+  })
+
+  function pnlOf(fills: RithmicProtocolFill[]) {
+    return buildTradesFromRithmicFills(fills, 'user-1', tickBySymbol)
+  }
+
+  it('matches single-source qty and PnL when the same ids arrive twice', () => {
+    const single = pnlOf([entry, exit])
+    const doubled = pnlOf(
+      dedupeFills([
+        entry,
+        exit,
+        replayTwin(entry, '1'),
+        replayTwin(exit, '2'),
+        { ...entry, fillId: '1452840-1452840', transactionType: '1' },
+        { ...exit, fillId: '1452900-1452900', transactionType: '2' },
+      ]),
+    )
+
+    expect(single.trades).toHaveLength(1)
+    expect(doubled.trades).toHaveLength(1)
+    expect(doubled.trades[0].quantity).toBe(single.trades[0].quantity)
+    expect(doubled.trades[0].pnl).toBe(single.trades[0].pnl)
+    expect(doubled.trades[0].quantity).toBe(1)
+    expect(doubled.trades[0].pnl).toBe(500)
+    expect(doubled.trades[0].entryId).toBe('1452840')
+    expect(doubled.trades[0].closeId).toBe('1452900')
+    expect(single.trades[0].id).toBe(doubled.trades[0].id)
+  })
+
+  it('buildTradesFromRithmicFills itself ignores a second copy of the same fill_id', () => {
+    const { trades } = buildTradesFromRithmicFills(
+      [entry, replayTwin(entry, '1'), exit, replayTwin(exit, '2')],
+      'user-1',
+      tickBySymbol,
+    )
+    expect(trades).toHaveLength(1)
+    expect(trades[0].entryId).toBe('1452840')
+    expect(trades[0].closeId).toBe('1452900')
+    expect(trades[0].quantity).toBe(1)
+    expect(trades[0].pnl).toBe(500)
+  })
+})

--- a/lib/rithmic-protocol/dedupe-fills.ts
+++ b/lib/rithmic-protocol/dedupe-fills.ts
@@ -1,0 +1,89 @@
+import type { RithmicProtocolFill } from './types'
+
+/**
+ * Rithmic `fill_id` is unique per execution on an account.
+ *
+ * FIFO `entryId`/`closeId` join fill ids with `-`. When the same fill is
+ * ingested twice, that produces a doubled journal row (`1452840-1452840`)
+ * with 2× qty / 2× PnL. Collapse that repeated form so history (`1452840`)
+ * and a doubled leftover still map to one fill.
+ */
+export function canonicalRithmicFillId(
+  fillId: string | undefined | null,
+): string | undefined {
+  if (fillId == null) return undefined
+  const trimmed = String(fillId).trim()
+  if (!trimmed) return undefined
+  const parts = trimmed.split('-').filter((part) => part.length > 0)
+  if (parts.length >= 2 && parts.every((part) => part === parts[0])) {
+    return parts[0]
+  }
+  return trimmed
+}
+
+function fillOccursOnUtcYyyymmdd(
+  fill: RithmicProtocolFill,
+  yyyymmdd: string,
+): boolean {
+  if (fill.fillDate) {
+    const date = fill.fillDate.replace(/-/g, '')
+    if (date === yyyymmdd) return true
+  }
+  if (typeof fill.ssboe === 'number' && fill.ssboe > 0) {
+    const at = new Date(fill.ssboe * 1000)
+    const fromSsboe = `${at.getUTCFullYear()}${String(at.getUTCMonth() + 1).padStart(2, '0')}${String(at.getUTCDate()).padStart(2, '0')}`
+    if (fromSsboe === yyyymmdd) return true
+  }
+  return false
+}
+
+/**
+ * ReplayExecutions exists for plants (Rithmic Test) where ShowFillHistory
+ * lags UTC today. On Apex / production, history already has those fills —
+ * always-on replay was a second source of the same `fill_id`.
+ */
+export function shouldReplayRecentExecutions(
+  historyFills: RithmicProtocolFill[],
+  todayUtcYyyymmdd: string,
+): boolean {
+  return !historyFills.some((fill) =>
+    fillOccursOnUtcYyyymmdd(fill, todayUtcYyyymmdd),
+  )
+}
+
+function fillIdentityKey(fill: RithmicProtocolFill): string {
+  const fillId = canonicalRithmicFillId(fill.fillId)
+  if (fillId) {
+    // ShowFillHistory stores transaction_type as a string ("BUY");
+    // ExchangeOrderNotification / ReplayExecutions decode the same field as
+    // enum 1/2. A composite key that includes transactionType, ssboe, or
+    // basketId therefore keeps both copies.
+    return `id|${fill.accountId}|${fillId}`
+  }
+  return [
+    'fields',
+    fill.accountId,
+    fill.basketId ?? '',
+    fill.symbol,
+    fill.transactionType,
+    fill.fillPrice,
+    fill.fillSize,
+    fill.ssboe ?? '',
+    fill.fillDate ?? '',
+    fill.fillTime ?? '',
+  ].join('|')
+}
+
+/** Keep the first row per fill identity (history before replay). */
+export function dedupeFills(fills: RithmicProtocolFill[]): RithmicProtocolFill[] {
+  const seen = new Set<string>()
+  const out: RithmicProtocolFill[] = []
+  for (const fill of fills) {
+    const key = fillIdentityKey(fill)
+    if (seen.has(key)) continue
+    seen.add(key)
+    const fillId = canonicalRithmicFillId(fill.fillId)
+    out.push(fillId && fill.fillId !== fillId ? { ...fill, fillId } : fill)
+  }
+  return out
+}

--- a/lib/rithmic-protocol/dedupe-fills.ts
+++ b/lib/rithmic-protocol/dedupe-fills.ts
@@ -1,7 +1,7 @@
 import type { RithmicProtocolFill } from './types'
 
 /**
- * Rithmic `fill_id` is unique per execution on an account.
+ * Rithmic `fill_id` is unique per execution on an account *for a trade date*.
  *
  * FIFO `entryId`/`closeId` join fill ids with `-`. When the same fill is
  * ingested twice, that produces a doubled journal row (`1452840-1452840`)
@@ -21,44 +21,33 @@ export function canonicalRithmicFillId(
   return trimmed
 }
 
-function fillOccursOnUtcYyyymmdd(
-  fill: RithmicProtocolFill,
-  yyyymmdd: string,
-): boolean {
+/**
+ * Exchange trade date for identity (`fill_date`), not a UTC calendar day.
+ * CME sessions roll ~17:00 CT, so `fill_date` can already be the next session
+ * while `ssboe` is still the previous UTC date. Prefer `fillDate` when the
+ * plant sent it; only fall back to ssboe truncated to a UTC day.
+ */
+export function fillDayKey(fill: RithmicProtocolFill): string {
   if (fill.fillDate) {
     const date = fill.fillDate.replace(/-/g, '')
-    if (date === yyyymmdd) return true
+    if (/^\d{8}$/.test(date)) return date
   }
   if (typeof fill.ssboe === 'number' && fill.ssboe > 0) {
     const at = new Date(fill.ssboe * 1000)
-    const fromSsboe = `${at.getUTCFullYear()}${String(at.getUTCMonth() + 1).padStart(2, '0')}${String(at.getUTCDate()).padStart(2, '0')}`
-    if (fromSsboe === yyyymmdd) return true
+    return `${at.getUTCFullYear()}${String(at.getUTCMonth() + 1).padStart(2, '0')}${String(at.getUTCDate()).padStart(2, '0')}`
   }
-  return false
+  return ''
 }
 
-/**
- * ReplayExecutions exists for plants (Rithmic Test) where ShowFillHistory
- * lags UTC today. On Apex / production, history already has those fills —
- * always-on replay was a second source of the same `fill_id`.
- */
-export function shouldReplayRecentExecutions(
-  historyFills: RithmicProtocolFill[],
-  todayUtcYyyymmdd: string,
-): boolean {
-  return !historyFills.some((fill) =>
-    fillOccursOnUtcYyyymmdd(fill, todayUtcYyyymmdd),
-  )
-}
-
-function fillIdentityKey(fill: RithmicProtocolFill): string {
+export function fillIdentityKey(fill: RithmicProtocolFill): string {
   const fillId = canonicalRithmicFillId(fill.fillId)
   if (fillId) {
     // ShowFillHistory stores transaction_type as a string ("BUY");
     // ExchangeOrderNotification / ReplayExecutions decode the same field as
-    // enum 1/2. A composite key that includes transactionType, ssboe, or
-    // basketId therefore keeps both copies.
-    return `id|${fill.accountId}|${fillId}`
+    // enum 1/2. Do not put those, ssboe, or basketId in the key — they differ
+    // across sources of the same execution. Include trade day so a recycled
+    // fill_id on a later session stays a distinct fill.
+    return `id|${fill.accountId}|${fillDayKey(fill)}|${fillId}`
   }
   return [
     'fields',

--- a/lib/rithmic-protocol/fills-to-trades.test.ts
+++ b/lib/rithmic-protocol/fills-to-trades.test.ts
@@ -86,4 +86,48 @@ describe('buildTradesFromRithmicFills', () => {
       buildTradesFromRithmicFills(fills, 'user-1', tickBySymbol).trades[0].id,
     )
   })
+
+  it('does not join a duplicated fill_id into an id-id trade', () => {
+    const fills: RithmicProtocolFill[] = [
+      {
+        accountId: 'PA-APEX-39878-10',
+        symbol: 'ESH5',
+        transactionType: 'BUY',
+        fillPrice: 5000,
+        fillSize: 1,
+        fillId: '1452840',
+        ssboe: 1_725_289_800,
+      },
+      {
+        accountId: 'PA-APEX-39878-10',
+        symbol: 'ESH5',
+        transactionType: '1',
+        fillPrice: 5000,
+        fillSize: 1,
+        fillId: '1452840-1452840',
+        ssboe: 1_725_289_801,
+      },
+      {
+        accountId: 'PA-APEX-39878-10',
+        symbol: 'ESH5',
+        transactionType: 'SELL',
+        fillPrice: 5010,
+        fillSize: 1,
+        fillId: '1452900',
+        ssboe: 1_725_290_400,
+      },
+    ]
+
+    const { trades } = buildTradesFromRithmicFills(
+      fills,
+      'user-1',
+      new Map([['ES', { tickSize: 0.25, tickValue: 12.5 }]]),
+    )
+
+    expect(trades).toHaveLength(1)
+    expect(trades[0].entryId).toBe('1452840')
+    expect(trades[0].closeId).toBe('1452900')
+    expect(trades[0].quantity).toBe(1)
+    expect(trades[0].pnl).toBe(500)
+  })
 })

--- a/lib/rithmic-protocol/fills-to-trades.ts
+++ b/lib/rithmic-protocol/fills-to-trades.ts
@@ -7,6 +7,7 @@ import {
 import { formatTimestamp } from '@/lib/date-utils'
 import type { RithmicProtocolFill } from './types'
 import { commissionForFillQuantity } from './commission-rates'
+import { canonicalRithmicFillId } from './dedupe-fills'
 
 interface TickSpec {
   tickSize: number
@@ -114,6 +115,7 @@ export function buildTradesFromRithmicFills(
       (a, b) => fillTimestampMs(a) - fillTimestampMs(b),
     )
     const openPositions: Record<string, OpenPosition> = {}
+    const seenFillIds = new Set<string>()
 
     for (const fill of sorted) {
       const instrument = normalizeInstrument(fill.symbol)
@@ -123,8 +125,16 @@ export function buildTradesFromRithmicFills(
 
       const side = fillSide(fill.transactionType)
       const timestampMs = fillTimestampMs(fill)
+      // Same Rithmic fill_id from overlapping sources must not FIFO-join into
+      // `1452840-1452840` (2× qty / PnL). Dedupe at fetch is the primary
+      // guard; this is the last line of defense.
+      const fillId = canonicalRithmicFillId(fill.fillId)
+      if (fillId) {
+        if (seenFillIds.has(fillId)) continue
+        seenFillIds.add(fillId)
+      }
       const orderId =
-        fill.fillId ||
+        fillId ||
         fill.sequenceNumber ||
         `${fill.basketId ?? 'fill'}-${timestampMs}-${quantity}`
 

--- a/lib/rithmic-protocol/fills-to-trades.ts
+++ b/lib/rithmic-protocol/fills-to-trades.ts
@@ -7,7 +7,7 @@ import {
 import { formatTimestamp } from '@/lib/date-utils'
 import type { RithmicProtocolFill } from './types'
 import { commissionForFillQuantity } from './commission-rates'
-import { canonicalRithmicFillId } from './dedupe-fills'
+import { canonicalRithmicFillId, fillDayKey } from './dedupe-fills'
 
 interface TickSpec {
   tickSize: number
@@ -126,12 +126,13 @@ export function buildTradesFromRithmicFills(
       const side = fillSide(fill.transactionType)
       const timestampMs = fillTimestampMs(fill)
       // Same Rithmic fill_id from overlapping sources must not FIFO-join into
-      // `1452840-1452840` (2× qty / PnL). Dedupe at fetch is the primary
-      // guard; this is the last line of defense.
+      // `1452840-1452840` (2× qty / PnL). Key includes trade day so a recycled
+      // fill_id on a later session is still a distinct fill.
       const fillId = canonicalRithmicFillId(fill.fillId)
       if (fillId) {
-        if (seenFillIds.has(fillId)) continue
-        seenFillIds.add(fillId)
+        const seenKey = `${fillDayKey(fill)}|${fillId}`
+        if (seenFillIds.has(seenKey)) continue
+        seenFillIds.add(seenKey)
       }
       const orderId =
         fillId ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Discord ticket-18 / Apex account `PA-APEX-39878-10` (`rithmic-protocol` only): calendar day P&L was ~3× on one Wednesday and ~2× on “today”. Stored trades matched the calendar — this is an **ingest** bug, not display.

Pattern:
- Clean rows: `entryId` like `1452840`
- Doubled rows: `entryId`/`closeId` like `1452840-1452840` (same fill id repeated), 2× qty / 2× PnL
- Different UUIDs, so `saveTradesAction` `skipDuplicates` keeps both. Re-sync does not repair existing rows.

## Root cause

`fetchFillsForAccounts` merged overlapping sources of the same Rithmic execution:

1. `ResponseShowFillHistory` (`transaction_type` string, e.g. `BUY`)
2. `ExchangeOrderNotification` on the ShowFillHistory stream (`transaction_type` enum `1`/`2`)
3. `ReplayExecutions` for the last ~2 days (same exchange-notification shape)

The old `dedupeFills` keyed on a composite that included `transactionType`, `ssboe`, `basketId`, and date/time. History vs replay of the **same `fill_id`** therefore survived as two fills.

`buildTradesFromRithmicFills` FIFO-joins fill ids with `-`, so two copies of `1452840` become `entryId` `1452840-1452840` with 2× quantity and 2× PnL. A later sync that produced the clean id created a **second** UUID, which is the 1× + 2× = 3× Wednesday.

## What changed

Dedupe is the collapse path; overlapping sources stay so we do not silently under-report:

- **`ReplayExecutions` is unconditional** (Test / mid-session history lag).
- **History-stream exchange notifications are kept** (notification-only plants).
- **Identity is `accountId + fill_date + fill_id`.** `fill_date` is the exchange trade date (rolls ~17:00 CT), not a UTC calendar day; `ssboe` is only used when `fill_date` is absent. Recycled `fill_id`s across sessions stay distinct. FIFO’s seen-set uses the same day+id key.
- `id` vs `id-id` leftovers still canonicalize to one fill.

## Review follow-up (`c3459f7f`)

Pair review asked to prefer keep+dedupe over skipping sources. The first revision gated replay on “history already has UTC today” and dropped history-stream notifications. That is reverted. Dedupe key widened from `accountId|fill_id` to include trade day.

## Tests

- Same `fill_id` from history + replay (`BUY` vs `1`) → one fill
- `1452840` vs `1452840-1452840` → one fill
- Same `fill_id` on different `fill_date`s → two fills / two FIFO trades
- `fill_date` wins over ssboe UTC day after the ~17:00 CT session roll
- Duplicated fills through FIFO → one trade matching single-source qty / PnL

```bash
bun run test -- lib/rithmic-protocol --exclude '**/*.e2e.test.ts'
```

## Verify on a Protocol connection

1. Connect / re-sync a Rithmic Protocol account that has same-day fills.
2. Confirm new journal rows use a single fill id per side (`1452840`, not `1452840-1452840`) and day P&L matches the firm statement.
3. On Rithmic Test, a day that is not yet in ShowFillHistory should still appear via ReplayExecutions.

## Follow-up (not in this PR)

Existing doubled rows stay in the DB. Cleanup is a separate, one-off delete of `rithmic-protocol` trades whose `entryId`/`closeId` is `fillId-fillId` for the same fill, after confirming the clean row exists (or re-sync after delete). Do not run that against prod from this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f37ebee2-84f5-4ebc-b881-f83b62dba974?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f37ebee2-84f5-4ebc-b881-f83b62dba974&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

