### PR TITLE
Invalidate trade cache after deleting rows so sync cannot revive them

### DIFF
--- a/server/accounts-delete-trades-cache.test.ts
+++ b/server/accounts-delete-trades-cache.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const accountsSource = fs.readFileSync(
+  path.join(process.cwd(), "server/accounts.ts"),
+  "utf8",
+)
+
+function functionBody(source: string, exportName: string): string {
+  const start = source.indexOf(`export async function ${exportName}`)
+  expect(start, `${exportName} must exist`).toBeGreaterThan(-1)
+  const nextExport = source.indexOf("\nexport ", start + 1)
+  return source.slice(start, nextExport === -1 ? undefined : nextExport)
+}
+
+describe("deleteTradesByIdsAction cache invalidation", () => {
+  it("invalidates the same trade/user tags as sibling account mutations", () => {
+    const deleteBody = functionBody(accountsSource, "deleteTradesByIdsAction")
+    const siblingBody = functionBody(accountsSource, "removeAccountsFromTradesAction")
+
+    expect(deleteBody).toContain("await prisma.trade.deleteMany")
+    expect(deleteBody.indexOf("updateTag(`trades-${userId}`)")).toBeGreaterThan(
+      deleteBody.indexOf("await prisma.trade.deleteMany"),
+    )
+    expect(deleteBody).toContain("updateTag(`user-data-${userId}`)")
+    expect(deleteBody).toContain("revalidateTag(`trades-${userId}`")
+    expect(deleteBody).toContain("revalidateTag(`user-data-${userId}`")
+
+    expect(siblingBody).toContain("updateTag(`trades-${userId}`)")
+    expect(siblingBody).toContain("updateTag(`user-data-${userId}`)")
+  })
+})

--- a/server/accounts.ts
+++ b/server/accounts.ts
@@ -5,7 +5,7 @@ import { PrismaClient, Trade, Payout } from '@/prisma/generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { computeMetricsForAccounts } from '@/lib/account-metrics'
 import { Account } from '@/context/data-provider'
-import { updateTag } from 'next/cache'
+import { revalidateTag, updateTag } from 'next/cache'
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
@@ -188,6 +188,18 @@ export async function deleteTradesByIdsAction(tradeIds: string[]): Promise<void>
       userId: userId
     }
   })
+  // Expire cached trade reads so a later force:false refresh (e.g. Tradovate
+  // sync) does not rehydrate deleted rows from unstable_cache.
+  // Prefer updateTag in a Server Action; it expires AND immediately refreshes
+  // the cache. updateTag throws from some Route Handler contexts, so fall back
+  // to revalidateTag — same pattern as saveTradesAction.
+  try {
+    updateTag(`trades-${userId}`)
+    updateTag(`user-data-${userId}`)
+  } catch {
+    revalidateTag(`trades-${userId}`, { expire: 0 })
+    revalidateTag(`user-data-${userId}`, { expire: 0 })
+  }
 }
 
 export async function setupAccountAction(account: Account): Promise<Account> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Symptom (Discord / Samarkand)

After deleting duplicate trades in the trade table, the deleted rows reappear after syncing or refreshing another account (notably a later Tradovate sync).

## Root cause

`deleteTradesByIdsAction` in `server/accounts.ts` hard-deletes matching rows from Postgres but never invalidates the Next.js trade cache.

`getTradesAction` / `getCachedTrades` in `server/database.ts` serves `unstable_cache` tagged `trades-${userId}` (revalidate ~1h). A later refresh with `force: false` — for example Tradovate sync in `context/tradovate-sync-context.tsx` — rehydrates that stale list, including the deleted rows.

Sibling mutations already expire the tags (`removeAccountsFromTradesAction`, `deleteInstrumentGroupAction`, `saveTradesAction`). Trade-by-id delete was the missing call site.

## Fix

After a successful `deleteMany`, invalidate `trades-${userId}` and `user-data-${userId}`.

- Prefer `updateTag` (Server Action: expire and immediately refresh).
- Fall back to `revalidateTag(..., { expire: 0 })` if `updateTag` throws, matching `saveTradesAction`.

The client delete path stays optimistic. The server-side tag expire is the primary fix so a later `force: false` read misses cache and hits Postgres.

## Out of scope (intentionally)

Tradovate sync ↔ CSV identity / dedupe, import processors, and day-count metrics. Those belong in a separate PR.

## Test plan

- [x] Source-level regression test: `deleteTradesByIdsAction` invalidates the same tags as sibling account mutations (`bun run test -- server/accounts-delete-trades-cache.test.ts`)
- [x] `bun run typecheck` passes
- [x] Dashboard health checks: `/dashboard` authenticated as `local-dashboard-user`; `/authentication?next=dashboard` 307 → `/dashboard`
- [x] Full `bun run test`: 606 passed; 1 pre-existing failure in `lib/mobile-input-zoom.test.ts` (`sync-schedule-picker.tsx` text size) — unrelated to this PR
- [ ] No full Next.js server-action harness (none exists in-repo)
- [ ] Manual follow-up: delete duplicate trades, then sync/refresh another account with `force: false` and confirm deleted rows stay gone

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c86a90cd-cf88-451f-8633-e2013d7eeb85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c86a90cd-cf88-451f-8633-e2013d7eeb85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

