### PR TITLE
Fix Tradovate sync/CSV duplicate fills from mismatched persisted IDs

### DIFF
--- a/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
@@ -5,6 +5,11 @@ import { saveTradesAction } from '@/server/database'
 import { Trade, TickDetails } from '@/prisma/generated/prisma/client'
 import crypto from 'crypto'
 import { generateDeterministicTradeId } from '@/lib/trade-id-utils'
+import {
+  TRADOVATE_TRADE_TAG,
+  tradovateRoundTripFillIds,
+  tradovateSideFromBuyFirst,
+} from '@/lib/tradovate/identity'
 import { getTickDetails } from '@/server/tick-details'
 import { prisma } from '@/lib/prisma'
 import { upsertAccountsForNumbers } from '@/server/connections'
@@ -1353,7 +1358,12 @@ async function buildTradesFromFillPairs(
       
       // If buy happened first, it's a long trade (buy then sell)
       // If sell happened first, it's a short trade (sell then buy)
-      const side = isBuyFirst ? 'Long' : 'Short'
+      const side = tradovateSideFromBuyFirst(isBuyFirst)
+      const { entryId, closeId } = tradovateRoundTripFillIds({
+        buyFillId: fillPair.buyFillId,
+        sellFillId: fillPair.sellFillId,
+        isBuyFirst,
+      })
       
       // Calculate P&L using tick value (more accurate for futures)
       const tickDetail = tickDetails.find(detail => detail.ticker === contractSymbol)
@@ -1423,8 +1433,8 @@ async function buildTradesFromFillPairs(
 
       const tradeData = {
         accountNumber: accountLabel,
-        entryId: isBuyFirst ? `fill_${fillPair.buyFillId}` : `fill_${fillPair.sellFillId}`,
-        closeId: isBuyFirst ? `fill_${fillPair.sellFillId}` : `fill_${fillPair.buyFillId}`,
+        entryId,
+        closeId,
         instrument: contractSymbol,
         entryPrice: entryPrice.toString(),
         closePrice: exitPrice.toString(),
@@ -1439,8 +1449,8 @@ async function buildTradesFromFillPairs(
         id: generateDeterministicTradeId(tradeData),
         accountNumber: accountLabel,
         quantity: fillPair.qty,
-        entryId: isBuyFirst ? `fill_${fillPair.buyFillId}` : `fill_${fillPair.sellFillId}`,
-        closeId: isBuyFirst ? `fill_${fillPair.sellFillId}` : `fill_${fillPair.buyFillId}`,
+        entryId,
+        closeId,
         instrument: contractSymbol,
         entryPrice: entryPrice.toString(),
         closePrice: exitPrice.toString(),
@@ -1451,7 +1461,7 @@ async function buildTradesFromFillPairs(
         userId: userId,
         side: side,
         commission: totalCommission,
-        tags: ['tradovate'],
+        tags: [TRADOVATE_TRADE_TAG],
       })
 
       trades.push(trade)

--- a/app/[locale]/dashboard/components/import/tradovate/tradovate-processor.tsx
+++ b/app/[locale]/dashboard/components/import/tradovate/tradovate-processor.tsx
@@ -10,6 +10,11 @@ import { useTradesStore } from '@/store/trades-store'
 import { generateTradeHash } from '@/lib/utils'
 import { PlatformProcessorProps } from '../config/platforms'
 import { ProcessedTradesPreview } from '../components/processed-trades-preview'
+import {
+  TRADOVATE_TRADE_TAG,
+  tradovateRoundTripFillIds,
+  tradovateSideFromBuyFirst,
+} from '@/lib/tradovate/identity'
 
 const formatPnl = (pnl: string | undefined): { pnl: number, error?: string } => {
     if (typeof pnl !== 'string' || pnl.trim() === '') {
@@ -188,21 +193,32 @@ export default function TradovateProcessor({ headers, csvData, processedTrades, 
                 }
             }
 
-            // If entryDate is after closeDate (which is buy and sell on tradovate then it means it is short)
-            if (item.entryDate && item.closeDate && new Date(item.entryDate) > new Date(item.closeDate)) {
-                item.side = 'short'
-                // For short trades, swap the dates because Tradovate's "boughtTimestamp" 
-                // is actually the sell (entry) and "soldTimestamp" is the buy (exit)
+            // boughtTimestamp/soldTimestamp stay mapped to entry/close until we
+            // know which fill happened first. Shorts sell first.
+            const isBuyFirst = !(
+                item.entryDate &&
+                item.closeDate &&
+                new Date(item.entryDate) > new Date(item.closeDate)
+            )
+            const { entryId, closeId } = tradovateRoundTripFillIds({
+                buyFillId: item.entryId,
+                sellFillId: item.closeId,
+                isBuyFirst,
+            })
+            item.entryId = entryId
+            item.closeId = closeId
+            item.side = tradovateSideFromBuyFirst(isBuyFirst)
+            item.tags = [TRADOVATE_TRADE_TAG]
+
+            if (!isBuyFirst) {
+                // Tradovate's "boughtTimestamp" is the buy (exit) on a short.
                 const tempDate = item.entryDate;
                 item.entryDate = item.closeDate;
                 item.closeDate = tempDate;
 
-                // Swap the buy and sell prices
                 const tempPrice = item.entryPrice;
                 item.entryPrice = item.closePrice;
                 item.closePrice = tempPrice;
-            } else {
-                item.side = 'long'
             }
 
             item.id = generateTradeHash(item as Trade).toString();

--- a/lib/trade-id-utils.test.ts
+++ b/lib/trade-id-utils.test.ts
@@ -3,7 +3,15 @@ import { v5 as uuidv5 } from 'uuid'
 import {
   generatePersistedTradeUUID,
   RITHMIC_PROTOCOL_TRADE_TAG,
+  TRADOVATE_TRADE_TAG,
 } from './trade-id-utils'
+import {
+  normalizeTradeSide,
+  resolveTradovatePersistedId,
+  tradovateFillPairKey,
+  tradovateRoundTripFillIds,
+  tradovateSideFromBuyFirst,
+} from './tradovate/identity'
 
 const TRADE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
 
@@ -65,5 +73,130 @@ describe('generatePersistedTradeUUID', () => {
     const zero = generatePersistedTradeUUID({ ...baseTrade, commission: 0 })
     const charged = generatePersistedTradeUUID({ ...baseTrade, commission: 4.8 })
     expect(zero).not.toBe(charged)
+  })
+})
+
+describe('Tradovate cross-source persisted identity', () => {
+  const userId = 'local-dashboard-user'
+  const accountNumber = 'SAMARKAND-CHALLENGE'
+  const buyFillId = '88451221'
+  const sellFillId = '88451288'
+
+  const syncLong = {
+    userId,
+    accountNumber,
+    instrument: 'MES',
+    entryDate: '2026-03-10T14:35:12.000+00:00',
+    closeDate: '2026-03-10T14:42:15.000+00:00',
+    entryPrice: '5125.25',
+    closePrice: '5130.5',
+    quantity: 2,
+    entryId: `fill_${buyFillId}`,
+    closeId: `fill_${sellFillId}`,
+    timeInPosition: 423,
+    side: 'Long',
+    pnl: 52.5,
+    commission: 3.28,
+    tags: [TRADOVATE_TRADE_TAG],
+  }
+
+  const csvLong = {
+    userId,
+    accountNumber,
+    instrument: 'MES',
+    entryDate: '2026-03-10T09:35:12.000+00:00',
+    closeDate: '2026-03-10T09:42:15.000+00:00',
+    entryPrice: '5125.25',
+    closePrice: '5130.50',
+    quantity: 2,
+    entryId: buyFillId,
+    closeId: sellFillId,
+    timeInPosition: 423,
+    side: 'long',
+    pnl: 50,
+    commission: 0,
+    tags: [TRADOVATE_TRADE_TAG],
+  }
+
+  it('matches live sync and CSV for the same long fill despite prefix, side, pnl, and commission', () => {
+    expect(generatePersistedTradeUUID(syncLong)).toBe(
+      generatePersistedTradeUUID(csvLong),
+    )
+  })
+
+  it('matches live sync and CSV for the same short when fill ids are swapped', () => {
+    const syncShort = {
+      ...syncLong,
+      side: 'Short',
+      entryId: `fill_${sellFillId}`,
+      closeId: `fill_${buyFillId}`,
+      pnl: -12.5,
+      commission: 4.1,
+    }
+    const csvShortUnswapped = {
+      ...csvLong,
+      side: 'short',
+      entryId: buyFillId,
+      closeId: sellFillId,
+      pnl: -10,
+      commission: 2,
+    }
+
+    expect(generatePersistedTradeUUID(syncShort)).toBe(
+      generatePersistedTradeUUID(csvShortUnswapped),
+    )
+  })
+
+  it('builds the same entry/close fill ids from sync-style and CSV-style raw ids', () => {
+    expect(
+      tradovateRoundTripFillIds({
+        buyFillId: `fill_${buyFillId}`,
+        sellFillId: `fill_${sellFillId}`,
+        isBuyFirst: true,
+      }),
+    ).toEqual(
+      tradovateRoundTripFillIds({
+        buyFillId,
+        sellFillId,
+        isBuyFirst: true,
+      }),
+    )
+    expect(tradovateSideFromBuyFirst(true)).toBe('Long')
+    expect(tradovateSideFromBuyFirst(false)).toBe('Short')
+    expect(normalizeTradeSide(tradovateSideFromBuyFirst(true))).toBe(
+      normalizeTradeSide('long'),
+    )
+  })
+
+  it('does not collapse two different fill pairs', () => {
+    expect(
+      generatePersistedTradeUUID({
+        ...syncLong,
+        closeId: 'fill_999',
+      }),
+    ).not.toBe(generatePersistedTradeUUID(syncLong))
+  })
+
+  it('still treats untagged rows as generic imports (commission stays in the hash)', () => {
+    const syncUntagged = { ...syncLong, tags: [] }
+    const csvUntagged = { ...csvLong, tags: [] }
+    expect(generatePersistedTradeUUID(syncUntagged)).not.toBe(
+      generatePersistedTradeUUID(csvUntagged),
+    )
+  })
+
+  it('reuses an already-persisted sync id when CSV fill ids omit the prefix', () => {
+    const existingId = 'already-synced-uuid'
+    expect(
+      resolveTradovatePersistedId(csvLong, [
+        {
+          id: existingId,
+          accountNumber,
+          entryId: syncLong.entryId,
+          closeId: syncLong.closeId,
+        },
+      ]),
+    ).toBe(existingId)
+    expect(tradovateFillPairKey(syncLong)).toBe(tradovateFillPairKey(csvLong))
   })
 })

--- a/lib/trade-id-utils.ts
+++ b/lib/trade-id-utils.ts
@@ -1,7 +1,13 @@
 import crypto from 'crypto'
 import { v5 as uuidv5 } from 'uuid'
+import {
+  isTradovatePersistedTrade,
+  normalizeTradeSide,
+  normalizeTradovateFillId,
+} from '@/lib/tradovate/identity'
 
 export const RITHMIC_PROTOCOL_TRADE_TAG = 'rithmic-protocol'
+export { TRADOVATE_TRADE_TAG } from '@/lib/tradovate/identity'
 
 /** Same DNS namespace used by `saveTradesAction` since Protocol imports began. */
 const TRADE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
@@ -67,11 +73,37 @@ export type PersistedTradeIdentity = {
 }
 
 /**
- * UUID v5 written by `saveTradesAction`. Protocol rows were first stored with
- * `commission: 0`, so the identity hash still uses 0 for that source — otherwise
- * a later Product RMS rate would insert a second row for the same round-trip.
+ * UUID v5 written by `saveTradesAction`.
+ *
+ * Protocol rows were first stored with `commission: 0`, so the identity hash
+ * still uses 0 for that source — otherwise a later Product RMS rate would
+ * insert a second row for the same round-trip.
+ *
+ * Tradovate live sync and weekly movement CSVs describe the same fill with
+ * different wrappers (`fill_` prefix, Long/long) and different fee/PnL math.
+ * Identity is the account + unordered fill pair so `skipDuplicates` can drop
+ * the re-import. Dates, prices, duration, pnl, and commission stay off the
+ * hash — they are the noisy fields between those two sources.
  */
 export function generatePersistedTradeUUID(trade: PersistedTradeIdentity): string {
+  if (isTradovatePersistedTrade(trade)) {
+    const fillA = normalizeTradovateFillId(trade.entryId)
+    const fillB = normalizeTradovateFillId(trade.closeId)
+    const [entryId, closeId] = [fillA, fillB].sort()
+    const tradeSignature = [
+      trade.userId || '',
+      trade.accountNumber || '',
+      trade.instrument || '',
+      (trade.quantity || 0).toString(),
+      entryId,
+      closeId,
+      normalizeTradeSide(trade.side),
+      '0',
+      '0',
+    ].join('|')
+    return uuidv5(tradeSignature, TRADE_NAMESPACE)
+  }
+
   const identityCommission = trade.tags?.includes(RITHMIC_PROTOCOL_TRADE_TAG)
     ? 0
     : (trade.commission || 0)

--- a/lib/tradovate/identity.test.ts
+++ b/lib/tradovate/identity.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeTradovateFillId,
+  normalizeTradeSide,
+  resolveTradovatePersistedId,
+  tradovateFillIdLookupValues,
+  tradovateFillPairKey,
+  tradovateRoundTripFillIds,
+  tradovateSideFromBuyFirst,
+} from './identity'
+
+describe('normalizeTradovateFillId', () => {
+  it('strips an optional fill_ prefix and leaves raw ids alone', () => {
+    expect(normalizeTradovateFillId('fill_88451221')).toBe('88451221')
+    expect(normalizeTradovateFillId('FILL_88451221')).toBe('88451221')
+    expect(normalizeTradovateFillId('88451221')).toBe('88451221')
+    expect(normalizeTradovateFillId('  fill_88451221  ')).toBe('88451221')
+  })
+})
+
+describe('normalizeTradeSide', () => {
+  it('lowercases Long/Short from sync and long/short from CSV', () => {
+    expect(normalizeTradeSide('Long')).toBe('long')
+    expect(normalizeTradeSide('short')).toBe('short')
+    expect(normalizeTradeSide(' Short ')).toBe('short')
+  })
+})
+
+describe('tradovateRoundTripFillIds', () => {
+  it('uses buy then sell for longs and sell then buy for shorts', () => {
+    expect(
+      tradovateRoundTripFillIds({
+        buyFillId: 'fill_1',
+        sellFillId: 2,
+        isBuyFirst: true,
+      }),
+    ).toEqual({ entryId: '1', closeId: '2' })
+    expect(
+      tradovateRoundTripFillIds({
+        buyFillId: 1,
+        sellFillId: 'fill_2',
+        isBuyFirst: false,
+      }),
+    ).toEqual({ entryId: '2', closeId: '1' })
+  })
+})
+
+describe('tradovateFillPairKey', () => {
+  it('is stable across prefix and entry/close swap', () => {
+    expect(
+      tradovateFillPairKey({
+        accountNumber: 'ACC',
+        entryId: 'fill_1',
+        closeId: '2',
+      }),
+    ).toBe(
+      tradovateFillPairKey({
+        accountNumber: 'ACC',
+        entryId: '2',
+        closeId: '1',
+      }),
+    )
+  })
+
+  it('looks up both raw and prefixed fill ids', () => {
+    expect(tradovateFillIdLookupValues('fill_1')).toEqual(['1', 'fill_1'])
+    expect(tradovateSideFromBuyFirst(true)).toBe('Long')
+  })
+})
+
+describe('resolveTradovatePersistedId', () => {
+  it('returns the existing row when the fill pair matches another account format', () => {
+    expect(
+      resolveTradovatePersistedId(
+        { accountNumber: 'ACC', entryId: '1', closeId: '2' },
+        [
+          {
+            id: 'legacy-sync',
+            accountNumber: 'ACC',
+            entryId: 'fill_2',
+            closeId: 'fill_1',
+          },
+        ],
+      ),
+    ).toBe('legacy-sync')
+  })
+
+  it('does not reuse a row from a different account', () => {
+    expect(
+      resolveTradovatePersistedId(
+        { accountNumber: 'ACC-A', entryId: '1', closeId: '2' },
+        [
+          {
+            id: 'other-account',
+            accountNumber: 'ACC-B',
+            entryId: '1',
+            closeId: '2',
+          },
+        ],
+      ),
+    ).toBeUndefined()
+  })
+})

--- a/lib/tradovate/identity.ts
+++ b/lib/tradovate/identity.ts
@@ -1,0 +1,90 @@
+export const TRADOVATE_TRADE_TAG = 'tradovate'
+
+const FILL_PREFIX = /^fill_/i
+
+export function isTradovatePersistedTrade(trade: {
+  tags?: string[] | null
+}): boolean {
+  return trade.tags?.includes(TRADOVATE_TRADE_TAG) === true
+}
+
+/** Strip the optional `fill_` prefix sync historically prepended to fill ids. */
+export function normalizeTradovateFillId(
+  id: string | null | undefined,
+): string {
+  return (id ?? '').trim().replace(FILL_PREFIX, '')
+}
+
+export function normalizeTradeSide(side: string | null | undefined): string {
+  return (side ?? '').trim().toLowerCase()
+}
+
+export function tradovateSideFromBuyFirst(
+  isBuyFirst: boolean,
+): 'Long' | 'Short' {
+  return isBuyFirst ? 'Long' : 'Short'
+}
+
+/**
+ * Entry/close fill ids for a buy/sell pair. Shorts use the sell fill as entry
+ * so sync and CSV store the same ids for the same round-trip.
+ */
+export function tradovateRoundTripFillIds(input: {
+  buyFillId: string | number | null | undefined
+  sellFillId: string | number | null | undefined
+  isBuyFirst: boolean
+}): { entryId: string; closeId: string } {
+  const buy = normalizeTradovateFillId(
+    input.buyFillId == null ? '' : String(input.buyFillId),
+  )
+  const sell = normalizeTradovateFillId(
+    input.sellFillId == null ? '' : String(input.sellFillId),
+  )
+  return input.isBuyFirst
+    ? { entryId: buy, closeId: sell }
+    : { entryId: sell, closeId: buy }
+}
+
+/**
+ * Account + unordered fill pair. Used to reuse an already-persisted row when
+ * the UUID algorithm changes or a CSV row still differs on dates/prices.
+ */
+export function tradovateFillPairKey(trade: {
+  accountNumber?: string | null
+  entryId?: string | null
+  closeId?: string | null
+}): string | null {
+  const a = normalizeTradovateFillId(trade.entryId)
+  const b = normalizeTradovateFillId(trade.closeId)
+  if (!a || !b) return null
+  return `${trade.accountNumber ?? ''}|${[a, b].sort().join('|')}`
+}
+
+export function tradovateFillIdLookupValues(
+  id: string | null | undefined,
+): string[] {
+  const normalized = normalizeTradovateFillId(id)
+  if (!normalized) return []
+  return [normalized, `fill_${normalized}`]
+}
+
+export function resolveTradovatePersistedId(
+  incoming: {
+    accountNumber?: string | null
+    entryId?: string | null
+    closeId?: string | null
+  },
+  existingRows: Array<{
+    id: string
+    accountNumber?: string | null
+    entryId?: string | null
+    closeId?: string | null
+  }>,
+): string | undefined {
+  const incomingKey = tradovateFillPairKey(incoming)
+  if (!incomingKey) return undefined
+  for (const row of existingRows) {
+    if (tradovateFillPairKey(row) === incomingKey) return row.id
+  }
+  return undefined
+}

--- a/server/database.ts
+++ b/server/database.ts
@@ -13,6 +13,11 @@ import {
   generatePersistedTradeUUID,
   RITHMIC_PROTOCOL_TRADE_TAG,
 } from '@/lib/trade-id-utils'
+import {
+  isTradovatePersistedTrade,
+  resolveTradovatePersistedId,
+  tradovateFillIdLookupValues,
+} from '@/lib/tradovate/identity'
 import { isDuplicateTradesOnlySave } from '@/lib/trades/save-trades-outcome'
 import { capturePostHogEvent } from '@/lib/posthog-server'
 
@@ -84,6 +89,42 @@ async function backfillRithmicProtocolCommissions(
   return updates.length
 }
 
+async function assignExistingTradovateIds(
+  userId: string,
+  trades: Trade[],
+): Promise<Trade[]> {
+  const tradovateTrades = trades.filter(isTradovatePersistedTrade)
+  if (tradovateTrades.length === 0) return trades
+
+  const fillCandidates = [
+    ...new Set(
+      tradovateTrades.flatMap((trade) => [
+        ...tradovateFillIdLookupValues(trade.entryId),
+        ...tradovateFillIdLookupValues(trade.closeId),
+      ]),
+    ),
+  ]
+  if (fillCandidates.length === 0) return trades
+
+  const existing = await prisma.trade.findMany({
+    where: {
+      userId,
+      OR: [
+        { entryId: { in: fillCandidates } },
+        { closeId: { in: fillCandidates } },
+      ],
+    },
+    select: { id: true, accountNumber: true, entryId: true, closeId: true },
+  })
+  if (existing.length === 0) return trades
+
+  return trades.map((trade) => {
+    if (!isTradovatePersistedTrade(trade)) return trade
+    const existingId = resolveTradovatePersistedId(trade, existing)
+    return existingId ? { ...trade, id: existingId } : trade
+  })
+}
+
 export async function saveTradesAction(
   data: Trade[],
   options?: { userId?: string; connectionId?: string | null }
@@ -116,7 +157,7 @@ export async function saveTradesAction(
     )
 
     // Clean the data to remove undefined values and ensure all required fields are present
-    const userAssignedTrades = data.map(trade => {
+    const preparedTrades = data.map(trade => {
       const accountId =
         trade.accountId ||
         (trade.accountNumber
@@ -131,6 +172,11 @@ export async function saveTradesAction(
         id: generatePersistedTradeUUID({ ...trade, userId }),
       } as Trade
     })
+
+    const userAssignedTrades = await assignExistingTradovateIds(
+      userId,
+      preparedTrades,
+    )
 
     const result = await prisma.trade.createMany({
       data: userAssignedTrades,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Symptom (Samarkand / Discord)

Synced Tradovate Challenge accounts (current-day live sync). Next morning, weekly movement CSVs were imported. Monday positions appeared twice.

## Root cause

`saveTradesAction` always assigns IDs via `generatePersistedTradeUUID`. Sync and CSV built different fields for the same fill, so the UUIDs differed and `createMany({ skipDuplicates: true })` kept both rows.

Verified mismatches:

- Sync `entryId`/`closeId` used `` `fill_${buyFillId}` `` / `` `fill_${sellFillId}` ``; CSV stored raw buy/sell fill ids
- Sync side `'Long'`/`'Short'` vs CSV `'long'`/`'short'`
- Sync commission/pnl from API fees + tick math vs file values (and user-entered commissions)
- Shorts: sync swapped which fill is entry vs close; CSV swapped dates/prices but not fill ids

Product docs already note that sync is **current trading day only**; CSV can re-import history including that day. Without a semantic cross-source identity, that re-import is a duplicate.

## What this PR changes

- Shared Tradovate identity helpers in `lib/tradovate/identity.ts` (strip optional `fill_` prefix, normalize side, assign entry/close fill ids from the buy/sell pair)
- Live sync and CSV/mouvements import both use those helpers and tag rows `tradovate`
- `generatePersistedTradeUUID` hashes Tradovate trades on **account + unordered fill pair + side**, ignoring dates, prices, duration, pnl, and commission (same spirit as the Rithmic Protocol `commission: 0` special case)
- `saveTradesAction` reuses an already-persisted row when the fill pair matches, so an older sync row (`fill_123`) still dedupes a later CSV (`123`) after the hash change

## Out of scope

- **[#510](https://github.com/hugodemenez/deltalytix/pull/510)** is the separate delete-cache / `deleteTradesByIdsAction` fix. This PR does not touch that path.
- No day-count timezone metric changes.

## Tests

- Cross-source UUID tests for the prefix, side, pnl/commission, and short fill-id swap mismatches
- Existing Protocol / generic commission identity tests unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-267f6825-a8eb-461f-87f8-d10b4df8a3c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-267f6825-a8eb-461f-87f8-d10b4df8a3c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

