### PR TITLE
Add Tradovate fee settings and first-sync picker on Connexions

### DIFF
--- a/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/actions.ts
@@ -201,30 +201,11 @@ interface Fill {
   commission: number
 }
 
-import { DEFAULT_INCLUDED_FEE_TYPES, type TradovateIncludedFeeTypes } from './fee-types'
-
-/** Sum fees based on which types are included */
-function getTotalFeeFromFillFee(fee: TradovateFillFee, includedFeeTypes: TradovateIncludedFeeTypes | boolean): number {
-  if (includedFeeTypes === true) {
-    return (
-      Number(fee.commission ?? 0) +
-      Number(fee.exchangeFee ?? 0) +
-      Number(fee.clearingFee ?? 0) +
-      Number(fee.nfaFee ?? 0) +
-      Number(fee.brokerageFee ?? 0) +
-      Number(fee.orderRoutingFee ?? 0)
-    )
-  }
-  const types = typeof includedFeeTypes === 'object' ? includedFeeTypes : { commission: true }
-  let total = 0
-  if (types.commission) total += Number(fee.commission ?? 0)
-  if (types.exchangeFee) total += Number(fee.exchangeFee ?? 0)
-  if (types.clearingFee) total += Number(fee.clearingFee ?? 0)
-  if (types.nfaFee) total += Number(fee.nfaFee ?? 0)
-  if (types.brokerageFee) total += Number(fee.brokerageFee ?? 0)
-  if (types.orderRoutingFee) total += Number(fee.orderRoutingFee ?? 0)
-  return total
-}
+import {
+  DEFAULT_INCLUDED_FEE_TYPES,
+  getTotalFeeFromFillFee,
+  type TradovateIncludedFeeTypes,
+} from './fee-types'
 
 
 interface TradovateTradesResult {
@@ -1630,6 +1611,7 @@ export async function updateTradovateIncludedFeeTypes(
       },
       data: { includedFeeTypes }
     })
+    await invalidateConnectionsPageCache(user.id)
 
     return { success: true }
   } catch (error) {

--- a/app/[locale]/dashboard/components/import/tradovate/sync/fee-types.test.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/fee-types.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ALL_INCLUDED_FEE_TYPES,
+  DEFAULT_INCLUDED_FEE_TYPES,
+  TRADOVATE_FEE_EXAMPLE,
+  TRADOVATE_FEE_EXAMPLE_FILL,
+  TRADOVATE_FEE_TYPE_KEYS,
+  getTotalFeeFromFillFee,
+  includedFeeTypesForExampleChoice,
+  isTradovateFeePreferenceUnset,
+  shouldPromptTradovateFeeExample,
+  shouldShowTradovateFeeSettings,
+  tradovateConnectionRowControls,
+} from './fee-types'
+
+describe('includedFeeTypesForExampleChoice', () => {
+  it('maps commission-only to the default commission line', () => {
+    expect(includedFeeTypesForExampleChoice('commission-only')).toEqual(
+      DEFAULT_INCLUDED_FEE_TYPES
+    )
+    expect(includedFeeTypesForExampleChoice('commission-only').commission).toBe(
+      true
+    )
+    for (const key of TRADOVATE_FEE_TYPE_KEYS) {
+      if (key === 'commission') continue
+      expect(includedFeeTypesForExampleChoice('commission-only')[key]).toBe(
+        false
+      )
+    }
+  })
+
+  it('maps all-fees to every Tradovate fee line', () => {
+    expect(includedFeeTypesForExampleChoice('all-fees')).toEqual(
+      ALL_INCLUDED_FEE_TYPES
+    )
+    for (const key of TRADOVATE_FEE_TYPE_KEYS) {
+      expect(includedFeeTypesForExampleChoice('all-fees')[key]).toBe(true)
+    }
+  })
+
+  it('returns a copy so callers cannot mutate the shared default', () => {
+    const commissionOnly = includedFeeTypesForExampleChoice('commission-only')
+    commissionOnly.exchangeFee = true
+    expect(DEFAULT_INCLUDED_FEE_TYPES.exchangeFee).toBe(false)
+  })
+})
+
+describe('illustrative MNQ ×3 example totals', () => {
+  it('commission-only is $2.34 and all-in is $5.70', () => {
+    expect(
+      getTotalFeeFromFillFee(
+        TRADOVATE_FEE_EXAMPLE_FILL,
+        includedFeeTypesForExampleChoice('commission-only')
+      )
+    ).toBeCloseTo(2.34, 2)
+    expect(
+      getTotalFeeFromFillFee(
+        TRADOVATE_FEE_EXAMPLE_FILL,
+        includedFeeTypesForExampleChoice('all-fees')
+      )
+    ).toBeCloseTo(5.7, 2)
+    expect(TRADOVATE_FEE_EXAMPLE.instrument).toBe('MNQ')
+    expect(TRADOVATE_FEE_EXAMPLE.quantity).toBe(3)
+  })
+})
+
+describe('isTradovateFeePreferenceUnset', () => {
+  it('treats null, undefined, and empty objects as unset', () => {
+    expect(isTradovateFeePreferenceUnset(null)).toBe(true)
+    expect(isTradovateFeePreferenceUnset(undefined)).toBe(true)
+    expect(isTradovateFeePreferenceUnset({})).toBe(true)
+  })
+
+  it('treats an explicit commission-only save as set', () => {
+    expect(isTradovateFeePreferenceUnset(DEFAULT_INCLUDED_FEE_TYPES)).toBe(
+      false
+    )
+    expect(isTradovateFeePreferenceUnset(ALL_INCLUDED_FEE_TYPES)).toBe(false)
+  })
+})
+
+describe('tradovate connection fee settings control', () => {
+  it('is present on Tradovate rows and opens fee config', () => {
+    expect(shouldShowTradovateFeeSettings('tradovate')).toBe(true)
+    expect(tradovateConnectionRowControls('tradovate')).toEqual({
+      showFeeSettings: true,
+      feeSettingsOpens: 'fee-config',
+    })
+  })
+
+  it('is absent on other brokers', () => {
+    for (const service of ['rithmic', 'dxfeed', 'ibkr', 'ig', 'thor']) {
+      expect(shouldShowTradovateFeeSettings(service)).toBe(false)
+      expect(tradovateConnectionRowControls(service)).toEqual({
+        showFeeSettings: false,
+        feeSettingsOpens: null,
+      })
+    }
+  })
+
+  it('prompts the example picker only for Tradovate with unset fees', () => {
+    expect(shouldPromptTradovateFeeExample('tradovate', null)).toBe(true)
+    expect(
+      shouldPromptTradovateFeeExample('tradovate', DEFAULT_INCLUDED_FEE_TYPES)
+    ).toBe(false)
+    expect(shouldPromptTradovateFeeExample('dxfeed', null)).toBe(false)
+  })
+})

--- a/app/[locale]/dashboard/components/import/tradovate/sync/fee-types.ts
+++ b/app/[locale]/dashboard/components/import/tradovate/sync/fee-types.ts
@@ -20,4 +20,104 @@ export const DEFAULT_INCLUDED_FEE_TYPES: Record<TradovateFeeTypeKey, boolean> = 
   orderRoutingFee: false,
 }
 
+/** Every Tradovate fee line that can be rolled into trade commission */
+export const ALL_INCLUDED_FEE_TYPES: Record<TradovateFeeTypeKey, boolean> = {
+  commission: true,
+  exchangeFee: true,
+  clearingFee: true,
+  nfaFee: true,
+  brokerageFee: true,
+  orderRoutingFee: true,
+}
+
 export type TradovateIncludedFeeTypes = Partial<Record<TradovateFeeTypeKey, boolean>>
+
+export type TradovateFeeExampleChoice = 'commission-only' | 'all-fees'
+
+/**
+ * Illustrative 3-contract MNQ round-turn, labeled as an example (not a live quote).
+ * Totals match a real report: commission-only $2.34 vs all-in $5.70.
+ */
+export const TRADOVATE_FEE_EXAMPLE_FILL: Record<TradovateFeeTypeKey, number> = {
+  commission: 2.34,
+  exchangeFee: 1.5,
+  clearingFee: 1.2,
+  nfaFee: 0.06,
+  brokerageFee: 0.42,
+  orderRoutingFee: 0.18,
+}
+
+export const TRADOVATE_FEE_EXAMPLE = {
+  instrument: 'MNQ',
+  quantity: 3,
+  fill: TRADOVATE_FEE_EXAMPLE_FILL,
+} as const
+
+export type TradovateFillFeeAmounts = Partial<
+  Record<TradovateFeeTypeKey, number | null>
+>
+
+/** Sum fill-fee lines that the user asked to include in trade commission. */
+export function getTotalFeeFromFillFee(
+  fee: TradovateFillFeeAmounts,
+  includedFeeTypes: TradovateIncludedFeeTypes | boolean
+): number {
+  if (includedFeeTypes === true) {
+    return TRADOVATE_FEE_TYPE_KEYS.reduce(
+      (total, key) => total + Number(fee[key] ?? 0),
+      0
+    )
+  }
+  const types =
+    typeof includedFeeTypes === 'object' && includedFeeTypes
+      ? includedFeeTypes
+      : { commission: true }
+  let total = 0
+  for (const key of TRADOVATE_FEE_TYPE_KEYS) {
+    if (types[key]) total += Number(fee[key] ?? 0)
+  }
+  return total
+}
+
+export function includedFeeTypesForExampleChoice(
+  choice: TradovateFeeExampleChoice
+): Record<TradovateFeeTypeKey, boolean> {
+  return choice === 'all-fees'
+    ? { ...ALL_INCLUDED_FEE_TYPES }
+    : { ...DEFAULT_INCLUDED_FEE_TYPES }
+}
+
+/**
+ * Never persisted (null/empty) — not “commission-only after the user chose it”.
+ * Dismissing the first-sync picker persists DEFAULT so we do not ask again.
+ */
+export function isTradovateFeePreferenceUnset(value: unknown): boolean {
+  if (value == null) return true
+  if (typeof value !== 'object' || Array.isArray(value)) return true
+  return Object.keys(value as object).length === 0
+}
+
+export function shouldShowTradovateFeeSettings(service: string): boolean {
+  return service === 'tradovate'
+}
+
+export function shouldPromptTradovateFeeExample(
+  service: string,
+  includedFeeTypes: unknown
+): boolean {
+  return (
+    shouldShowTradovateFeeSettings(service) &&
+    isTradovateFeePreferenceUnset(includedFeeTypes)
+  )
+}
+
+/** Connexions row: settings sits next to Synchroniser and opens fee config. */
+export function tradovateConnectionRowControls(service: string): {
+  showFeeSettings: boolean
+  feeSettingsOpens: 'fee-config' | null
+} {
+  if (!shouldShowTradovateFeeSettings(service)) {
+    return { showFeeSettings: false, feeSettingsOpens: null }
+  }
+  return { showFeeSettings: true, feeSettingsOpens: 'fee-config' }
+}

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -356,6 +356,7 @@ function ConnectionRow({
   const { openConnect } = useConnectionsRefresh()
   const tradovateStore = useTradovateSyncStore()
   const {
+    accounts: tradovateAccounts,
     performSyncForAccount: syncTradovate,
     getIncludedFeeTypesForAccount,
     updateIncludedFeeTypesForAccount,
@@ -363,10 +364,25 @@ function ConnectionRow({
   const [feeConfigOpen, setFeeConfigOpen] = useState(false)
   const [feeExampleOpen, setFeeExampleOpen] = useState(false)
   const [savingFees, setSavingFees] = useState(false)
+  const feeExampleShouldSyncRef = useRef(false)
+  const feeExampleOpenedAtRef = useRef(0)
+
+  const openFeeExamplePicker = (shouldSync: boolean) => {
+    feeExampleShouldSyncRef.current = shouldSync
+    feeExampleOpenedAtRef.current = Date.now()
+    window.setTimeout(() => setFeeExampleOpen(true), 50)
+  }
   const showFeeSettings = shouldShowTradovateFeeSettings(connection.service)
+  const tradovateAccount = tradovateAccounts.find(
+    (account) => account.accountId === connection.accountId
+  )
+  const rawIncludedFeeTypes =
+    tradovateAccount !== undefined
+      ? tradovateAccount.includedFeeTypes
+      : connection.includedFeeTypes
   const needsFeeExample = shouldPromptTradovateFeeExample(
     connection.service,
-    connection.includedFeeTypes
+    rawIncludedFeeTypes
   )
   const { performSyncForAccount: syncDxFeed } = useDxFeedSyncContext()
   const { performSyncForAccount: syncIbkr } = useIbkrSyncContext()
@@ -499,7 +515,7 @@ function ConnectionRow({
 
   const requestSync = useCallback(() => {
     if (needsFeeExample) {
-      setFeeExampleOpen(true)
+      openFeeExamplePicker(true)
       return
     }
     void handleSync()
@@ -507,23 +523,32 @@ function ConnectionRow({
 
   const handleFeeExampleChoose = useCallback(
     async (choice: TradovateFeeExampleChoice) => {
+      const shouldSync = feeExampleShouldSyncRef.current
+      feeExampleShouldSyncRef.current = false
       const persisted = await persistTradovateFees(
         includedFeeTypesForExampleChoice(choice)
       )
       setFeeExampleOpen(false)
       if (persisted) {
         toast.success(t('tradovateSync.multiAccount.feeConfigUpdated'))
-        await handleSync()
+        if (shouldSync) await handleSync()
       }
     },
     [handleSync, persistTradovateFees, t]
   )
 
   const handleFeeExampleDismiss = useCallback(async () => {
+    // The opening click can bubble as an outside dismiss. Ignore that.
+    if (Date.now() - feeExampleOpenedAtRef.current < 400) {
+      setFeeExampleOpen(true)
+      return
+    }
+    const shouldSync = feeExampleShouldSyncRef.current
+    feeExampleShouldSyncRef.current = false
     setFeeExampleOpen(false)
     // Fallback: keep commission-only and do not ask again.
     await persistTradovateFees({ ...DEFAULT_INCLUDED_FEE_TYPES })
-    await handleSync()
+    if (shouldSync) await handleSync()
   }, [handleSync, persistTradovateFees])
 
   const handleFeeConfigSave = useCallback(
@@ -639,6 +664,12 @@ function ConnectionRow({
               <button
                 type="button"
                 data-testid="tradovate-fee-settings"
+                data-needs-fee-example={needsFeeExample ? 'true' : 'false'}
+                data-included-fee-types={
+                  rawIncludedFeeTypes == null
+                    ? 'null'
+                    : JSON.stringify(rawIncludedFeeTypes)
+                }
                 className={iconButtonClassName}
                 aria-label={t('tradovateSync.multiAccount.configureFees')}
                 onClick={() => setFeeConfigOpen(true)}
@@ -670,6 +701,19 @@ function ConnectionRow({
               t('connections.neverSynced')
             ),
           })}
+          {needsFeeExample && (
+            <>
+              {' · '}
+              <button
+                type="button"
+                data-testid="tradovate-fee-example-open"
+                className="text-black/55 underline-offset-2 transition-colors duration-150 hover:text-black hover:underline dark:text-white/55 dark:hover:text-white"
+                onClick={() => openFeeExamplePicker(false)}
+              >
+                {t('tradovateSync.multiAccount.feeExample.setFees')}
+              </button>
+            </>
+          )}
           {/* A countdown to the next sync is noise while the connection is
               broken — nothing will sync until it is reconnected. */}
           {canSchedule && !needsReconnect && (
@@ -1049,6 +1093,7 @@ export function ConnectionsPageClient({
     updateIncludedFeeTypesForAccount: updateTradovateFees,
   } = useTradovateSyncContext()
   const [syncAllFeeExampleOpen, setSyncAllFeeExampleOpen] = useState(false)
+  const syncAllFeeExampleOpenedAtRef = useRef(0)
   const {
     loadAccounts: loadDxFeed,
     performSyncForAccount: syncDxFeed,
@@ -1385,7 +1430,8 @@ export function ConnectionsPageClient({
   const handleSyncAll = useCallback(async () => {
     if (syncableConnections.length === 0) return
     if (unsetTradovateConnections.length > 0) {
-      setSyncAllFeeExampleOpen(true)
+      syncAllFeeExampleOpenedAtRef.current = Date.now()
+      window.setTimeout(() => setSyncAllFeeExampleOpen(true), 50)
       return
     }
     await runSyncAll()
@@ -1406,6 +1452,10 @@ export function ConnectionsPageClient({
   )
 
   const handleSyncAllFeeExampleDismiss = useCallback(async () => {
+    if (Date.now() - syncAllFeeExampleOpenedAtRef.current < 400) {
+      setSyncAllFeeExampleOpen(true)
+      return
+    }
     setSyncAllFeeExampleOpen(false)
     await persistFeesForUnsetTradovate({ ...DEFAULT_INCLUDED_FEE_TYPES })
     await load({ quiet: true })

--- a/app/[locale]/dashboard/connections/components/connections-page-client.tsx
+++ b/app/[locale]/dashboard/connections/components/connections-page-client.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { ChevronDown, Loader2, Trash2 } from 'lucide-react'
+import { ChevronDown, Loader2, Settings, Trash2 } from 'lucide-react'
 import { useCurrentLocale, useI18n } from '@/locales/client'
 import { cn } from '@/lib/utils'
 import {
@@ -52,6 +52,15 @@ import { toast } from 'sonner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ServiceMonochromeLogo } from '@/components/monochrome-logo'
 import { useConnectionsRefresh } from './connections-refresh'
+import { TradovateFeeConfigDialog } from './tradovate-fee-config-dialog'
+import { TradovateFeeExamplePicker } from './tradovate-fee-example-picker'
+import {
+  DEFAULT_INCLUDED_FEE_TYPES,
+  includedFeeTypesForExampleChoice,
+  shouldPromptTradovateFeeExample,
+  shouldShowTradovateFeeSettings,
+  type TradovateFeeExampleChoice,
+} from '@/app/[locale]/dashboard/components/import/tradovate/sync/fee-types'
 
 // One shape for every status, so a row does not reflow when a connection breaks.
 const statusActionClassName =
@@ -346,7 +355,19 @@ function ConnectionRow({
   const [nowMs, setNowMs] = useState<number | null>(null)
   const { openConnect } = useConnectionsRefresh()
   const tradovateStore = useTradovateSyncStore()
-  const { performSyncForAccount: syncTradovate } = useTradovateSyncContext()
+  const {
+    performSyncForAccount: syncTradovate,
+    getIncludedFeeTypesForAccount,
+    updateIncludedFeeTypesForAccount,
+  } = useTradovateSyncContext()
+  const [feeConfigOpen, setFeeConfigOpen] = useState(false)
+  const [feeExampleOpen, setFeeExampleOpen] = useState(false)
+  const [savingFees, setSavingFees] = useState(false)
+  const showFeeSettings = shouldShowTradovateFeeSettings(connection.service)
+  const needsFeeExample = shouldPromptTradovateFeeExample(
+    connection.service,
+    connection.includedFeeTypes
+  )
   const { performSyncForAccount: syncDxFeed } = useDxFeedSyncContext()
   const { performSyncForAccount: syncIbkr } = useIbkrSyncContext()
   const {
@@ -408,6 +429,24 @@ function ConnectionRow({
     return () => window.clearInterval(id)
   }, [canSchedule, scheduleMode])
 
+  const persistTradovateFees = useCallback(
+    async (includedFeeTypes: Record<string, boolean>) => {
+      const result = await updateIncludedFeeTypesForAccount(
+        connection.accountId,
+        includedFeeTypes
+      )
+      if (!result.success) {
+        toast.error(
+          result.error || t('tradovateSync.multiAccount.feeConfigUpdateError')
+        )
+        return false
+      }
+      onChanged()
+      return true
+    },
+    [connection.accountId, onChanged, t, updateIncludedFeeTypesForAccount]
+  )
+
   const handleSync = useCallback(async () => {
     const usesLocalSyncState =
       connection.service !== 'rithmic-protocol' && connection.service !== 'ig'
@@ -457,6 +496,51 @@ function ConnectionRow({
     syncTradovate,
     t,
   ])
+
+  const requestSync = useCallback(() => {
+    if (needsFeeExample) {
+      setFeeExampleOpen(true)
+      return
+    }
+    void handleSync()
+  }, [handleSync, needsFeeExample])
+
+  const handleFeeExampleChoose = useCallback(
+    async (choice: TradovateFeeExampleChoice) => {
+      const persisted = await persistTradovateFees(
+        includedFeeTypesForExampleChoice(choice)
+      )
+      setFeeExampleOpen(false)
+      if (persisted) {
+        toast.success(t('tradovateSync.multiAccount.feeConfigUpdated'))
+        await handleSync()
+      }
+    },
+    [handleSync, persistTradovateFees, t]
+  )
+
+  const handleFeeExampleDismiss = useCallback(async () => {
+    setFeeExampleOpen(false)
+    // Fallback: keep commission-only and do not ask again.
+    await persistTradovateFees({ ...DEFAULT_INCLUDED_FEE_TYPES })
+    await handleSync()
+  }, [handleSync, persistTradovateFees])
+
+  const handleFeeConfigSave = useCallback(
+    async (includedFeeTypes: Record<string, boolean>) => {
+      setSavingFees(true)
+      try {
+        const persisted = await persistTradovateFees(includedFeeTypes)
+        if (persisted) {
+          toast.success(t('tradovateSync.multiAccount.feeConfigUpdated'))
+          setFeeConfigOpen(false)
+        }
+      } finally {
+        setSavingFees(false)
+      }
+    },
+    [persistTradovateFees, t]
+  )
 
   const handleReconnect = useCallback(async () => {
     // Tradovate can re-auth in place via OAuth without opening the add sheet.
@@ -548,9 +632,20 @@ function ConnectionRow({
               canSync={canSyncRow}
               syncing={rowSyncing}
               reconnecting={reconnecting}
-              onSync={() => void handleSync()}
+              onSync={() => requestSync()}
               onReconnect={() => void handleReconnect()}
             />
+            {showFeeSettings && (
+              <button
+                type="button"
+                data-testid="tradovate-fee-settings"
+                className={iconButtonClassName}
+                aria-label={t('tradovateSync.multiAccount.configureFees')}
+                onClick={() => setFeeConfigOpen(true)}
+              >
+                <Settings className="h-4 w-4" strokeWidth={1.75} />
+              </button>
+            )}
             <button
               type="button"
               className={iconButtonClassName}
@@ -686,6 +781,25 @@ function ConnectionRow({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {showFeeSettings && (
+        <>
+          <TradovateFeeConfigDialog
+            open={feeConfigOpen}
+            accountLabel={connection.displayName}
+            initialFeeTypes={getIncludedFeeTypesForAccount(connection.accountId)}
+            saving={savingFees}
+            onOpenChange={setFeeConfigOpen}
+            onSave={handleFeeConfigSave}
+          />
+          <TradovateFeeExamplePicker
+            open={feeExampleOpen}
+            onOpenChange={setFeeExampleOpen}
+            onChoose={handleFeeExampleChoose}
+            onDismiss={handleFeeExampleDismiss}
+          />
+        </>
+      )}
 
     </div>
   )
@@ -932,7 +1046,9 @@ export function ConnectionsPageClient({
   const {
     loadAccounts: loadTradovate,
     performSyncForAccount: syncTradovate,
+    updateIncludedFeeTypesForAccount: updateTradovateFees,
   } = useTradovateSyncContext()
+  const [syncAllFeeExampleOpen, setSyncAllFeeExampleOpen] = useState(false)
   const {
     loadAccounts: loadDxFeed,
     performSyncForAccount: syncDxFeed,
@@ -1184,7 +1300,37 @@ export function ConnectionsPageClient({
     [data]
   )
 
-  const handleSyncAll = useCallback(async () => {
+  const unsetTradovateConnections = useMemo(
+    () =>
+      (data?.connections ?? []).filter((connection) =>
+        shouldPromptTradovateFeeExample(
+          connection.service,
+          connection.includedFeeTypes
+        )
+      ),
+    [data]
+  )
+
+  const persistFeesForUnsetTradovate = useCallback(
+    async (includedFeeTypes: Record<string, boolean>) => {
+      let failed = 0
+      for (const connection of unsetTradovateConnections) {
+        const result = await updateTradovateFees(
+          connection.accountId,
+          includedFeeTypes
+        )
+        if (!result.success) failed += 1
+      }
+      if (failed > 0) {
+        toast.error(t('tradovateSync.multiAccount.feeConfigUpdateError'))
+        return false
+      }
+      return true
+    },
+    [t, unsetTradovateConnections, updateTradovateFees]
+  )
+
+  const runSyncAll = useCallback(async () => {
     if (syncableConnections.length === 0) return
 
     setSyncingAll(true)
@@ -1236,6 +1382,36 @@ export function ConnectionsPageClient({
     t,
   ])
 
+  const handleSyncAll = useCallback(async () => {
+    if (syncableConnections.length === 0) return
+    if (unsetTradovateConnections.length > 0) {
+      setSyncAllFeeExampleOpen(true)
+      return
+    }
+    await runSyncAll()
+  }, [runSyncAll, syncableConnections.length, unsetTradovateConnections.length])
+
+  const handleSyncAllFeeExampleChoose = useCallback(
+    async (choice: TradovateFeeExampleChoice) => {
+      const persisted = await persistFeesForUnsetTradovate(
+        includedFeeTypesForExampleChoice(choice)
+      )
+      setSyncAllFeeExampleOpen(false)
+      if (!persisted) return
+      toast.success(t('tradovateSync.multiAccount.feeConfigUpdated'))
+      await load({ quiet: true })
+      await runSyncAll()
+    },
+    [load, persistFeesForUnsetTradovate, runSyncAll, t]
+  )
+
+  const handleSyncAllFeeExampleDismiss = useCallback(async () => {
+    setSyncAllFeeExampleOpen(false)
+    await persistFeesForUnsetTradovate({ ...DEFAULT_INCLUDED_FEE_TYPES })
+    await load({ quiet: true })
+    await runSyncAll()
+  }, [load, persistFeesForUnsetTradovate, runSyncAll])
+
   // Publish the action so the page chrome can render "Sync all" alongside the
   // other header actions (this list streams in behind its own Suspense boundary).
   useEffect(() => {
@@ -1267,6 +1443,13 @@ export function ConnectionsPageClient({
           {t('connections.noConnectionsYet')}
         </p>
       )}
+
+      <TradovateFeeExamplePicker
+        open={syncAllFeeExampleOpen}
+        onOpenChange={setSyncAllFeeExampleOpen}
+        onChoose={handleSyncAllFeeExampleChoose}
+        onDismiss={handleSyncAllFeeExampleDismiss}
+      />
 
       {(data?.standaloneAccounts.length ?? 0) > 0 && (
         <section className="space-y-2">

--- a/app/[locale]/dashboard/connections/components/tradovate-fee-config-dialog.tsx
+++ b/app/[locale]/dashboard/connections/components/tradovate-fee-config-dialog.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useI18n } from '@/locales/client'
+import { translateTradovateFeeType } from '@/lib/translation-utils'
+import { cn } from '@/lib/utils'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import {
+  DEFAULT_INCLUDED_FEE_TYPES,
+  TRADOVATE_FEE_TYPE_KEYS,
+} from '@/app/[locale]/dashboard/components/import/tradovate/sync/fee-types'
+
+const secondaryButtonClassName =
+  'inline-flex h-9 items-center justify-center rounded-sm border border-black/20 px-3 text-sm font-medium transition-[opacity,transform,background-color] duration-150 hover:bg-black/5 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:border-white/20 dark:hover:bg-white/5'
+
+const primaryButtonClassName =
+  'inline-flex h-9 items-center justify-center rounded-sm bg-[oklch(0.22_0.01_95)] px-4 text-sm font-medium text-white transition-[opacity,transform] duration-150 hover:opacity-85 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-40 dark:bg-[oklch(0.94_0.01_95)] dark:text-[oklch(0.17_0_0)]'
+
+export function TradovateFeeConfigDialog({
+  open,
+  accountLabel,
+  initialFeeTypes,
+  saving,
+  onOpenChange,
+  onSave,
+}: {
+  open: boolean
+  accountLabel: string
+  initialFeeTypes: Record<string, boolean>
+  saving?: boolean
+  onOpenChange: (open: boolean) => void
+  onSave: (includedFeeTypes: Record<string, boolean>) => void | Promise<void>
+}) {
+  const t = useI18n()
+  const [feeState, setFeeState] = useState<Record<string, boolean>>(
+    initialFeeTypes
+  )
+
+  useEffect(() => {
+    if (open) {
+      setFeeState({ ...DEFAULT_INCLUDED_FEE_TYPES, ...initialFeeTypes })
+    }
+  }, [open, initialFeeTypes])
+
+  const allSelected = TRADOVATE_FEE_TYPE_KEYS.every((key) => feeState[key])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="rounded-sm border-black/10 dark:border-white/10"
+        data-testid="tradovate-fee-config-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle className="font-normal tracking-tight">
+            {t('tradovateSync.multiAccount.feeConfigTitle', {
+              accountId: accountLabel,
+            })}
+          </DialogTitle>
+          <DialogDescription className="text-black/55 dark:text-white/55">
+            {t('tradovateSync.multiAccount.feesToIncludeDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-x-5 gap-y-3">
+            {TRADOVATE_FEE_TYPE_KEYS.map((key) => (
+              <div key={key} className="flex items-center gap-2">
+                <Checkbox
+                  id={`connections-fee-${key}`}
+                  checked={!!feeState[key]}
+                  onCheckedChange={(checked) =>
+                    setFeeState((prev) => ({
+                      ...prev,
+                      [key]: checked === true,
+                    }))
+                  }
+                />
+                <Label
+                  htmlFor={`connections-fee-${key}`}
+                  className="cursor-pointer text-sm font-normal"
+                >
+                  {translateTradovateFeeType(t, key)}
+                </Label>
+              </div>
+            ))}
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              className={secondaryButtonClassName}
+              onClick={() =>
+                setFeeState(
+                  Object.fromEntries(
+                    TRADOVATE_FEE_TYPE_KEYS.map((key) => [key, !allSelected])
+                  )
+                )
+              }
+            >
+              {allSelected
+                ? t('tradovateSync.multiAccount.deselectAllFees')
+                : t('tradovateSync.multiAccount.selectAllFees')}
+            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className={secondaryButtonClassName}
+                onClick={() => onOpenChange(false)}
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                type="button"
+                className={cn(primaryButtonClassName)}
+                disabled={saving}
+                onClick={() => void onSave(feeState)}
+              >
+                {t('common.save')}
+              </button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/[locale]/dashboard/connections/components/tradovate-fee-example-picker.tsx
+++ b/app/[locale]/dashboard/connections/components/tradovate-fee-example-picker.tsx
@@ -4,12 +4,12 @@ import { useRef } from 'react'
 import { useCurrentLocale, useI18n } from '@/locales/client'
 import { cn } from '@/lib/utils'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import {
   TRADOVATE_FEE_EXAMPLE,
   getTotalFeeFromFillFee,
@@ -83,67 +83,65 @@ export function TradovateFeeExamplePicker({
   onDismiss: () => void | Promise<void>
 }) {
   const t = useI18n()
-  // A pick closes the dialog; do not treat that close as a skip (which would
-  // persist commission-only and overwrite the choice).
-  const settledRef = useRef(false)
-
-  const settle = (action: () => void | Promise<void>) => {
-    if (settledRef.current) return
-    settledRef.current = true
-    void action()
-  }
+  const choseRef = useRef(false)
 
   return (
-    <Dialog
+    <AlertDialog
       open={open}
       onOpenChange={(next) => {
         if (next) {
-          settledRef.current = false
+          choseRef.current = false
           onOpenChange(true)
           return
         }
-        if (!settledRef.current) {
-          settle(onDismiss)
-        }
         onOpenChange(false)
+        if (!choseRef.current) void onDismiss()
       }}
     >
-      <DialogContent
+      <AlertDialogContent
         className="rounded-sm border-black/10 dark:border-white/10"
         data-testid="tradovate-fee-example-picker"
       >
-        <DialogHeader>
-          <DialogTitle className="font-normal tracking-tight">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="font-normal tracking-tight">
             {t('tradovateSync.multiAccount.feeExample.title')}
-          </DialogTitle>
-          <DialogDescription className="text-black/55 dark:text-white/55">
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-black/55 dark:text-white/55">
             {t('tradovateSync.multiAccount.feeExample.description', {
               instrument: TRADOVATE_FEE_EXAMPLE.instrument,
               quantity: TRADOVATE_FEE_EXAMPLE.quantity,
             })}
-          </DialogDescription>
-        </DialogHeader>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
         <div className="space-y-3">
           <p className="text-xs text-black/45 dark:text-white/45">
             {t('tradovateSync.multiAccount.feeExample.exampleNote')}
           </p>
           <ExampleChoiceCard
             choice="commission-only"
-            onSelect={(choice) => settle(() => onChoose(choice))}
+            onSelect={(choice) => {
+              choseRef.current = true
+              onOpenChange(false)
+              void onChoose(choice)
+            }}
           />
           <ExampleChoiceCard
             choice="all-fees"
-            onSelect={(choice) => settle(() => onChoose(choice))}
+            onSelect={(choice) => {
+              choseRef.current = true
+              onOpenChange(false)
+              void onChoose(choice)
+            }}
           />
           <button
             type="button"
             className={cn(skipButtonClassName, 'w-full')}
-            onClick={() => settle(onDismiss)}
+            onClick={() => onOpenChange(false)}
           >
             {t('tradovateSync.multiAccount.feeExample.skip')}
           </button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }

--- a/app/[locale]/dashboard/connections/components/tradovate-fee-example-picker.tsx
+++ b/app/[locale]/dashboard/connections/components/tradovate-fee-example-picker.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useRef } from 'react'
+import { useCurrentLocale, useI18n } from '@/locales/client'
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  TRADOVATE_FEE_EXAMPLE,
+  getTotalFeeFromFillFee,
+  includedFeeTypesForExampleChoice,
+  type TradovateFeeExampleChoice,
+} from '@/app/[locale]/dashboard/components/import/tradovate/sync/fee-types'
+
+const skipButtonClassName =
+  'inline-flex h-9 items-center justify-center rounded-sm px-3 text-sm font-medium text-black/55 transition-[opacity,transform,background-color,color] duration-150 hover:bg-black/5 hover:text-black active:scale-[0.96] dark:text-white/55 dark:hover:bg-white/5 dark:hover:text-white'
+
+function formatExampleAmount(amount: number, locale: string): string {
+  return new Intl.NumberFormat(locale === 'fr' ? 'fr-FR' : 'en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+function ExampleChoiceCard({
+  choice,
+  onSelect,
+}: {
+  choice: TradovateFeeExampleChoice
+  onSelect: (choice: TradovateFeeExampleChoice) => void
+}) {
+  const t = useI18n()
+  const locale = useCurrentLocale()
+  const amount = getTotalFeeFromFillFee(
+    TRADOVATE_FEE_EXAMPLE.fill,
+    includedFeeTypesForExampleChoice(choice)
+  )
+  const title =
+    choice === 'commission-only'
+      ? t('tradovateSync.multiAccount.feeExample.commissionOnlyTitle')
+      : t('tradovateSync.multiAccount.feeExample.allFeesTitle')
+  const hint =
+    choice === 'commission-only'
+      ? t('tradovateSync.multiAccount.feeExample.commissionOnlyHint')
+      : t('tradovateSync.multiAccount.feeExample.allFeesHint')
+
+  return (
+    <button
+      type="button"
+      data-testid={`tradovate-fee-example-${choice}`}
+      className="flex w-full items-baseline justify-between gap-4 rounded-sm border border-black/20 px-4 py-4 text-left transition-[background-color,border-color,transform] duration-150 hover:bg-black/5 active:scale-[0.99] dark:border-white/20 dark:hover:bg-white/5"
+      onClick={() => onSelect(choice)}
+    >
+      <span className="min-w-0">
+        <span className="block text-sm font-medium tracking-tight">{title}</span>
+        <span className="mt-1 block text-sm text-black/55 dark:text-white/55">
+          {hint}
+        </span>
+      </span>
+      <span className="shrink-0 text-xl font-normal tabular-nums tracking-tight md:text-2xl">
+        {formatExampleAmount(amount, locale)}
+      </span>
+    </button>
+  )
+}
+
+export function TradovateFeeExamplePicker({
+  open,
+  onOpenChange,
+  onChoose,
+  onDismiss,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onChoose: (choice: TradovateFeeExampleChoice) => void | Promise<void>
+  onDismiss: () => void | Promise<void>
+}) {
+  const t = useI18n()
+  // A pick closes the dialog; do not treat that close as a skip (which would
+  // persist commission-only and overwrite the choice).
+  const settledRef = useRef(false)
+
+  const settle = (action: () => void | Promise<void>) => {
+    if (settledRef.current) return
+    settledRef.current = true
+    void action()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (next) {
+          settledRef.current = false
+          onOpenChange(true)
+          return
+        }
+        if (!settledRef.current) {
+          settle(onDismiss)
+        }
+        onOpenChange(false)
+      }}
+    >
+      <DialogContent
+        className="rounded-sm border-black/10 dark:border-white/10"
+        data-testid="tradovate-fee-example-picker"
+      >
+        <DialogHeader>
+          <DialogTitle className="font-normal tracking-tight">
+            {t('tradovateSync.multiAccount.feeExample.title')}
+          </DialogTitle>
+          <DialogDescription className="text-black/55 dark:text-white/55">
+            {t('tradovateSync.multiAccount.feeExample.description', {
+              instrument: TRADOVATE_FEE_EXAMPLE.instrument,
+              quantity: TRADOVATE_FEE_EXAMPLE.quantity,
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-xs text-black/45 dark:text-white/45">
+            {t('tradovateSync.multiAccount.feeExample.exampleNote')}
+          </p>
+          <ExampleChoiceCard
+            choice="commission-only"
+            onSelect={(choice) => settle(() => onChoose(choice))}
+          />
+          <ExampleChoiceCard
+            choice="all-fees"
+            onSelect={(choice) => settle(() => onChoose(choice))}
+          />
+          <button
+            type="button"
+            className={cn(skipButtonClassName, 'w-full')}
+            onClick={() => settle(onDismiss)}
+          >
+            {t('tradovateSync.multiAccount.feeExample.skip')}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/context/tradovate-sync-context.tsx
+++ b/context/tradovate-sync-context.tsx
@@ -72,7 +72,8 @@ export function TradovateSyncContextProvider({ children }: { children: ReactNode
     try {
       const response = await fetch("/api/tradovate/synchronizations", {
         method: "GET",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+        cache: "no-store",
       })
 
       if (!response.ok) {

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2344,6 +2344,7 @@ export default {
         allFeesTitle: "All fees",
         allFeesHint: "Commission, exchange, clearing, NFA, and the rest",
         skip: "Skip — use commission only",
+        setFees: "Choose fees",
       },
       presets: {
         morning: "Morning (8:00 AM)",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2334,6 +2334,17 @@ export default {
         brokerageFee: "Brokerage",
         orderRoutingFee: "Order routing",
       },
+      feeExample: {
+        title: "Which fees match your platform?",
+        description:
+          "Example: {quantity} {instrument}, round-turn. Pick the total you expect.",
+        exampleNote: "Illustrative example — not a live quote.",
+        commissionOnlyTitle: "Commission only",
+        commissionOnlyHint: "Broker commission line only",
+        allFeesTitle: "All fees",
+        allFeesHint: "Commission, exchange, clearing, NFA, and the rest",
+        skip: "Skip — use commission only",
+      },
       presets: {
         morning: "Morning (8:00 AM)",
         midday: "Midday (12:00 PM)",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2466,6 +2466,17 @@ export default {
         brokerageFee: "Courtage",
         orderRoutingFee: "Routage d'ordres",
       },
+      feeExample: {
+        title: "Quels frais correspondent à votre plateforme ?",
+        description:
+          "Exemple : {quantity} {instrument}, aller-retour. Choisissez le total que vous attendez.",
+        exampleNote: "Exemple illustratif — pas un cours en direct.",
+        commissionOnlyTitle: "Commission seule",
+        commissionOnlyHint: "Ligne de commission uniquement",
+        allFeesTitle: "Tous les frais",
+        allFeesHint: "Commission, exchange, clearing, NFA, et le reste",
+        skip: "Passer — commission seule",
+      },
       presets: {
         morning: "Matin (8:00)",
         midday: "Midi (12:00)",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -2476,6 +2476,7 @@ export default {
         allFeesTitle: "Tous les frais",
         allFeesHint: "Commission, exchange, clearing, NFA, et le reste",
         skip: "Passer — commission seule",
+        setFees: "Choisir les frais",
       },
       presets: {
         morning: "Matin (8:00)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Connexions (`/dashboard/connections`) can now configure Tradovate fee buckets next to **Synchroniser**, and a first-sync picker appears when the preference is unset.

- Gear on Tradovate rows opens **Config des commissions** (Commission, Exchange/Bourse, Clearing, NFA, Brokerage/Courtage, Order routing/Routage d’ordres).
- First-import / first-sync picker when `includedFeeTypes` is unset: **Commission seule** ($2.34) vs **Tous les frais** ($5.70) on an illustrative MNQ ×3 fill.
- Dismiss keeps commission-only and does not block forever.
- EN + FR copy. Tradovate only.

## Walkthrough (French UI)

<a href="https://cursor.com/agents/bc-eef4e031-78d0-4db5-b8a0-676b9483fc89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnexions-frais-tradovate-fr.mp4"><img src="https://cursor.com/artifacts/c/art-40dabd11-2cc5-4020-8b0c-155f6b9f470f" alt="connexions-frais-tradovate-fr.mp4" /></a>

![Config des commissions — commission seule par défaut](https://cursor.com/artifacts/c/art-46c29444-f8d0-446d-89a9-6834e3163f17)
![Sélecteur premier sync — Commission seule 2,34 $ vs Tous les frais 5,70 $](https://cursor.com/artifacts/c/art-8ed12403-47fc-41a3-8e14-4116a1443f58)
![Config des commissions — tous les types cochés après Tous les frais](https://cursor.com/artifacts/c/art-8bf498db-fb8d-4600-a541-aae95817602c)

## Test plan

- [x] Unit tests in `fee-types.test.ts` (picker mapping, unset detection, settings visibility)
- [x] French Connexions: gear opens fee dialog (commission-only default when unset)
- [x] **Choisir les frais** opens the example picker
- [x] **Tous les frais** persists all six types; gear then shows all checked
- [ ] Live Tradovate sync with a real token (dummy token used locally)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eef4e031-78d0-4db5-b8a0-676b9483fc89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eef4e031-78d0-4db5-b8a0-676b9483fc89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

