### PR TITLE
Weekly recap blurb: Luna High + honest 1-day week prompts

### DIFF
--- a/app/api/email/weekly-summary/[userid]/actions/analysis.test.ts
+++ b/app/api/email/weekly-summary/[userid]/actions/analysis.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const streamObject = vi.hoisted(() => vi.fn())
+
+vi.mock("ai", () => ({
+  streamObject,
+}))
+
+import { generateTradingAnalysis } from "./analysis"
+
+async function* objectStream(
+  parts: Array<{ intro?: string; tips?: string }>,
+) {
+  for (const part of parts) {
+    yield part
+  }
+}
+
+describe("generateTradingAnalysis", () => {
+  beforeEach(() => {
+    streamObject.mockReset()
+  })
+
+  it("calls GPT-5.6 Luna High with the week-shape prompt", async () => {
+    streamObject.mockReturnValue({
+      partialObjectStream: objectStream([
+        {
+          intro: "One session this week, +120€ on Monday.",
+          tips: "Open the calendar and tag that session in the journal.",
+        },
+      ]),
+    })
+
+    const result = await generateTradingAnalysis(
+      [{ date: new Date("2026-08-31T00:00:00.000Z"), pnl: 120 }],
+      "en",
+    )
+
+    expect(result.resultAnalysisIntro).toBe(
+      "One session this week, +120€ on Monday.",
+    )
+    expect(result.tipsForNextWeek).toContain("calendar")
+
+    expect(streamObject).toHaveBeenCalledOnce()
+    const call = streamObject.mock.calls[0]?.[0]
+    expect(call.model).toBe("openai/gpt-5.6-luna")
+    expect(call.providerOptions?.openai?.reasoningEffort).toBe("high")
+    expect(call.prompt).toContain("Trading days this week: 1")
+    expect(call.prompt).toContain("single-day")
+    expect(call.prompt).not.toContain("gpt-4.1-nano")
+  })
+
+  it("skips the model on an empty series", async () => {
+    const result = await generateTradingAnalysis([], "fr")
+    expect(streamObject).not.toHaveBeenCalled()
+    expect(result.resultAnalysisIntro).toContain("statistiques")
+  })
+})

--- a/app/api/email/weekly-summary/[userid]/actions/analysis.ts
+++ b/app/api/email/weekly-summary/[userid]/actions/analysis.ts
@@ -1,13 +1,13 @@
 'use server'
 
-import { openai } from "@ai-sdk/openai"
 import { streamObject } from "ai"
 import { z } from 'zod/v3';
-
-const DELTALYTIX_CONTEXT = {
-  fr: `Deltalytix est une plateforme web pour day traders de futures, avec une interface intuitive et personnalisable. Conçue à partir de mon expérience personnelle en tant que day trader de futures, utilisant des stratégies de scalping, elle propose des fonctionnalités comme la gestion de multiple compte, le suivi des challenges propfirms, et des tableaux de bord personnalisables. Notre but est de fournir aux traders des analyses approfondies sur leurs habitudes de trading pour optimiser leurs stratégies et améliorer leur prise de décision.`,
-  en: `Deltalytix is a web platform for futures day traders, featuring an intuitive and customizable interface. Designed from my personal experience as a futures day trader using scalping strategies, it offers features like multiple account management, propfirm challenge tracking, and customizable dashboards. Our goal is to provide traders with in-depth analysis of their trading habits to optimize their strategies and improve decision-making.`
-}
+import {
+  WEEKLY_ANALYSIS_MODEL,
+  WEEKLY_ANALYSIS_REASONING_EFFORT,
+  buildWeeklyAnalysisPrompt,
+  type DailyPnL,
+} from "@/lib/weekly-recap-analysis"
 
 const analysisSchema = z.object({
   intro: z.string().describe("A very short analysis (1 sentence) of the week's performance"),
@@ -17,11 +17,6 @@ const analysisSchema = z.object({
 interface AnalysisResult {
   resultAnalysisIntro: string
   tipsForNextWeek: string
-}
-
-interface DailyPnL {
-  date: Date
-  pnl: number
 }
 
 export async function generateTradingAnalysis(
@@ -38,104 +33,20 @@ export async function generateTradingAnalysis(
   }
 
   try {
-    // Sort trades by date
     const sortedTrades = [...dailyPnL].sort((a, b) => a.date.getTime() - b.date.getTime())
-    
-    // Group trades by week
-    const tradesByWeek = sortedTrades.reduce((acc, trade) => {
-      const weekNumber = getWeekNumber(trade.date)
-      if (!acc[weekNumber]) {
-        acc[weekNumber] = []
-      }
-      acc[weekNumber].push(trade)
-      return acc
-    }, {} as Record<number, DailyPnL[]>)
-
-    // Get the two most recent weeks
-    const weekNumbers = Object.keys(tradesByWeek).map(Number).sort((a, b) => b - a)
-    const lastTwoWeeks = weekNumbers.slice(0, 2).map(weekNum => tradesByWeek[weekNum])
+    if (sortedTrades.length === 0) {
+      return defaultAnalysis
+    }
 
     const { partialObjectStream } = streamObject({
-      model: openai("gpt-4.1-nano-2025-04-14"),
+      model: WEEKLY_ANALYSIS_MODEL,
       schema: analysisSchema,
-      prompt: language === 'fr'
-        ? `Tu es un coach en trading qui aide les traders à progresser. Tu es toujours positif et encourageant.
-${DELTALYTIX_CONTEXT.fr}
-
-Voici les résultats de trading des deux dernières semaines :
-
-Données de performance journalières :
-${lastTwoWeeks.map((week, index) => {
-  const isCurrentWeek = index === 0;
-  const weekLabel = isCurrentWeek ? 'Semaine en cours' : 'Semaine précédente';
-  return `${weekLabel}:\n${week.map(day => 
-    `- ${day.date.toLocaleDateString('fr-FR', { weekday: 'long', day: '2-digit', month: 'long' })}: ${day.pnl}€`
-  ).join('\n')}`
-}).join('\n\n')}
-
-Pour l'analyse (intro) :
-1. Fais une phrase simple qui explique comment s'est passée la semaine en cours
-2. Trouve toujours quelque chose de positif à dire, même si c'est petit
-3. Parle comme à un ami, avec des mots simples
-4. Tu peux faire jusqu'à 60 mots
-5. Regarde comment les résultats changent chaque jour
-6. Dis ce qui va bien et ce qui peut être amélioré, mais toujours gentiment
-7. Compare avec la semaine précédente si possible
-8. Prends en compte le jour de la semaine pour l'analyse
-9. Mets l'accent sur la semaine en cours, en utilisant la semaine précédente comme point de référence
-
-Pour les conseils (tips) :
-1. Donne un conseil simple et facile à suivre
-2. Tu peux faire jusqu'à 36 mots
-3. Parle d'un outil de Deltalytix qui peut aider
-4. Explique comment ce conseil peut aider à faire mieux
-5. Sois précis sur ce qu'il faut faire
-6. Regarde les bons et les moins bons jours pour donner un conseil utile
-7. Dis les choses de façon positive, comme une chance de s'améliorer
-8. Utilise des mots simples et clairs
-9. Prends en compte les tendances sur les deux semaines
-10. Concentre-toi sur les améliorations possibles pour la semaine à venir
-
-Fais une analyse qui aide le trader à progresser :`
-        : `You are a trading coach who helps traders improve. You are always positive and encouraging.
-${DELTALYTIX_CONTEXT.en}
-
-Here are the trading results for the last two weeks:
-
-Daily performance data:
-${lastTwoWeeks.map((week, index) => {
-  const isCurrentWeek = index === 0;
-  const weekLabel = isCurrentWeek ? 'Current Week' : 'Previous Week';
-  return `${weekLabel}:\n${week.map(day => 
-    `- ${day.date.toLocaleDateString('en-US', { weekday: 'long', day: '2-digit', month: 'long' })}: ${day.pnl}€`
-  ).join('\n')}`
-}).join('\n\n')}
-
-For the analysis (intro):
-1. Write a simple sentence explaining how the current week went
-2. Always find something positive to say, even if it's small
-3. Speak like you're talking to a friend, using simple words
-4. You can use up to 60 words
-5. Look at how the results change each day
-6. Say what's working well and what can be better, but always kindly
-7. Compare with the previous week if possible
-8. Take into account the day of the week for analysis
-9. Focus on the current week, using the previous week as a reference point
-
-For the tips:
-1. Give a simple and easy-to-follow tip
-2. You can use up to 36 words
-3. Talk about a Deltalytix tool that can help
-4. Explain how this tip can help do better
-5. Be specific about what to do
-6. Look at the good and not-so-good days to give useful advice
-7. Say things in a positive way, like a chance to improve
-8. Use simple and clear words
-9. Take into account trends over the two weeks
-10. Focus on possible improvements for the upcoming week
-
-Write an analysis that helps the trader improve:`,
-      temperature: 0.7,
+      prompt: buildWeeklyAnalysisPrompt(sortedTrades, language),
+      providerOptions: {
+        openai: {
+          reasoningEffort: WEEKLY_ANALYSIS_REASONING_EFFORT,
+        },
+      },
     })
 
     const content = { intro: "", tips: "" }
@@ -156,11 +67,4 @@ Write an analysis that helps the trader improve:`,
     console.error('Error generating analysis:', error)
     return defaultAnalysis
   }
-}
-
-// Helper function to get week number
-function getWeekNumber(date: Date): number {
-  const firstDayOfYear = new Date(date.getFullYear(), 0, 1)
-  const pastDaysOfYear = (date.getTime() - firstDayOfYear.getTime()) / 86400000
-  return Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7)
 }

--- a/lib/weekly-recap-analysis.test.ts
+++ b/lib/weekly-recap-analysis.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest"
+import {
+  WEEKLY_ANALYSIS_MODEL,
+  WEEKLY_ANALYSIS_REASONING_EFFORT,
+  buildWeeklyAnalysisPrompt,
+  formatWeekShapeForPrompt,
+  summarizeWeekShape,
+} from "./weekly-recap-analysis"
+
+const monday = new Date("2026-08-31T00:00:00.000Z")
+const tuesday = new Date("2026-09-01T00:00:00.000Z")
+const wednesday = new Date("2026-09-02T00:00:00.000Z")
+
+describe("WEEKLY_ANALYSIS_MODEL", () => {
+  it("defaults to GPT-5.6 Luna on the AI Gateway (Luna High)", () => {
+    expect(WEEKLY_ANALYSIS_MODEL).toBe("openai/gpt-5.6-luna")
+    expect(WEEKLY_ANALYSIS_REASONING_EFFORT).toBe("high")
+  })
+})
+
+describe("summarizeWeekShape", () => {
+  it("marks an empty series", () => {
+    expect(summarizeWeekShape([])).toEqual({
+      tradingDayCount: 0,
+      kind: "empty",
+      allowShapeLanguage: false,
+    })
+  })
+
+  it("marks a one-day week so the model cannot invent a ramp", () => {
+    expect(summarizeWeekShape([{ date: monday, pnl: 420 }])).toEqual({
+      tradingDayCount: 1,
+      kind: "single-day",
+      allowShapeLanguage: false,
+    })
+  })
+
+  it("forbids shape language when two days are flat", () => {
+    expect(
+      summarizeWeekShape([
+        { date: monday, pnl: 100 },
+        { date: tuesday, pnl: 100 },
+      ]),
+    ).toEqual({
+      tradingDayCount: 2,
+      kind: "flat",
+      allowShapeLanguage: false,
+    })
+  })
+
+  it("allows shape language only when ≥2 days vary", () => {
+    expect(
+      summarizeWeekShape([
+        { date: monday, pnl: 80 },
+        { date: tuesday, pnl: 40 },
+        { date: wednesday, pnl: 210 },
+      ]),
+    ).toEqual({
+      tradingDayCount: 3,
+      kind: "varied",
+      allowShapeLanguage: true,
+    })
+  })
+})
+
+describe("formatWeekShapeForPrompt", () => {
+  it("states a single-day week in French and bans ramp language", () => {
+    const text = formatWeekShapeForPrompt(
+      { tradingDayCount: 1, kind: "single-day", allowShapeLanguage: false },
+      "fr",
+    )
+    expect(text).toContain("Jours de trading cette semaine : 1")
+    expect(text).toContain("single-day")
+    expect(text).toContain("monté en puissance")
+    expect(text).toContain("interdit")
+  })
+
+  it("states a single-day week in English and bans ramp language", () => {
+    const text = formatWeekShapeForPrompt(
+      { tradingDayCount: 1, kind: "single-day", allowShapeLanguage: false },
+      "en",
+    )
+    expect(text).toContain("Trading days this week: 1")
+    expect(text).toContain("single-day")
+    expect(text).toContain("started soft then climbed")
+    expect(text).toContain("forbidden")
+  })
+})
+
+describe("buildWeeklyAnalysisPrompt", () => {
+  const oneDay = [{ date: monday, pnl: 275.5 }]
+  const variedDays = [
+    { date: monday, pnl: 40 },
+    { date: tuesday, pnl: 180 },
+  ]
+
+  it("writes FR rules that block 1-day ramps and vague fluff", () => {
+    const prompt = buildWeeklyAnalysisPrompt(oneDay, "fr")
+    expect(prompt).toContain("Jours de trading cette semaine : 1")
+    expect(prompt).toContain("une séance / un jour")
+    expect(prompt).toContain("commencé doucement")
+    expect(prompt).toContain("monté en puissance")
+    expect(prompt).toContain("énergie positive")
+    expect(prompt).toContain("jusqu'à 60 mots")
+    expect(prompt).toContain("jusqu'à 36 mots")
+    expect(prompt).toContain("tableau de bord")
+    expect(prompt).not.toContain("toujours positif")
+    expect(prompt).not.toContain("Trouve toujours quelque chose de positif")
+    expect(prompt).toContain("275.5€")
+  })
+
+  it("writes EN rules that block 1-day ramps and vague fluff", () => {
+    const prompt = buildWeeklyAnalysisPrompt(oneDay, "en")
+    expect(prompt).toContain("Trading days this week: 1")
+    expect(prompt).toContain("one session / one day")
+    expect(prompt).toContain("started soft")
+    expect(prompt).toContain("ramped up")
+    expect(prompt).toContain("positive energy")
+    expect(prompt).toContain("up to 60 words")
+    expect(prompt).toContain("up to 36 words")
+    expect(prompt).toContain("dashboard")
+    expect(prompt).not.toContain("always positive")
+    expect(prompt).not.toContain("Always find something positive")
+    expect(prompt).toContain("275.5€")
+  })
+
+  it("allows day-to-day language only for a varied multi-day series", () => {
+    const fr = buildWeeklyAnalysisPrompt(variedDays, "fr")
+    const en = buildWeeklyAnalysisPrompt(variedDays, "en")
+    expect(fr).toContain("Jours de trading cette semaine : 2")
+    expect(fr).toContain("varied")
+    expect(fr).toContain("autorisé uniquement si les chiffres du jour le montrent")
+    expect(en).toContain("Trading days this week: 2")
+    expect(en).toContain("allowed only when the daily numbers support it")
+  })
+
+  it("does not ask the model to compare a previous week that is not in the data", () => {
+    const prompt = buildWeeklyAnalysisPrompt(oneDay, "fr")
+    expect(prompt).toContain("il n'y a pas de série de la semaine précédente")
+    expect(prompt).not.toContain("Compare avec la semaine précédente")
+    expect(prompt).not.toContain("tendances sur les deux semaines")
+  })
+})

--- a/lib/weekly-recap-analysis.ts
+++ b/lib/weekly-recap-analysis.ts
@@ -1,0 +1,176 @@
+/**
+ * Weekly recap LLM blurb: week-shape metadata + FR/EN prompts.
+ *
+ * Production callers pass only the recap week's daily PnL (Mon–Sun UTC).
+ * The model must not invent a multi-day ramp from a single session —
+ * Sep 6 2026 1-day weeks (Gregoire, Corentin) failed that way.
+ */
+
+export const WEEKLY_ANALYSIS_MODEL =
+  process.env.WEEKLY_ANALYSIS_MODEL ?? "openai/gpt-5.6-luna"
+
+/** Cursor "Luna High" = GPT-5.6 Luna with high reasoning via AI Gateway. */
+export const WEEKLY_ANALYSIS_REASONING_EFFORT = "high" as const
+
+export type DailyPnL = {
+  date: Date
+  pnl: number
+}
+
+export type WeekShapeKind = "empty" | "single-day" | "flat" | "varied"
+
+export type WeekShapeSummary = {
+  tradingDayCount: number
+  kind: WeekShapeKind
+  /** Day-to-day / shape language only when ≥2 days with meaningful PnL spread. */
+  allowShapeLanguage: boolean
+}
+
+const MEANINGFUL_PNL_SPREAD = 0.01
+
+const DELTALYTIX_CONTEXT = {
+  fr: `Deltalytix est une plateforme web pour day traders de futures, avec une interface intuitive et personnalisable. Conçue à partir de mon expérience personnelle en tant que day trader de futures, utilisant des stratégies de scalping, elle propose des fonctionnalités comme la gestion de multiple compte, le suivi des challenges propfirms, et des tableaux de bord personnalisables. Notre but est de fournir aux traders des analyses approfondies sur leurs habitudes de trading pour optimiser leurs stratégies et améliorer leur prise de décision.`,
+  en: `Deltalytix is a web platform for futures day traders, featuring an intuitive and customizable interface. Designed from my personal experience as a futures day trader using scalping strategies, it offers features like multiple account management, propfirm challenge tracking, and customizable dashboards. Our goal is to provide traders with in-depth analysis of their trading habits to optimize their strategies and improve decision-making.`,
+} as const
+
+export function summarizeWeekShape(days: DailyPnL[]): WeekShapeSummary {
+  const tradingDayCount = days.length
+  if (tradingDayCount === 0) {
+    return { tradingDayCount: 0, kind: "empty", allowShapeLanguage: false }
+  }
+  if (tradingDayCount === 1) {
+    return { tradingDayCount: 1, kind: "single-day", allowShapeLanguage: false }
+  }
+
+  const pnls = days.map((day) => day.pnl)
+  const spread = Math.max(...pnls) - Math.min(...pnls)
+  const varied = spread >= MEANINGFUL_PNL_SPREAD
+  return {
+    tradingDayCount,
+    kind: varied ? "varied" : "flat",
+    allowShapeLanguage: varied,
+  }
+}
+
+export function formatDailyPnLForPrompt(
+  days: DailyPnL[],
+  language: "fr" | "en",
+): string {
+  const locale = language === "fr" ? "fr-FR" : "en-US"
+  if (days.length === 0) {
+    return language === "fr"
+      ? "(aucune journée avec des données)"
+      : "(no days with data)"
+  }
+
+  return [...days]
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+    .map((day) => {
+      const label = day.date.toLocaleDateString(locale, {
+        weekday: "long",
+        day: "2-digit",
+        month: "long",
+        timeZone: "UTC",
+      })
+      return `- ${label}: ${day.pnl}€`
+    })
+    .join("\n")
+}
+
+export function formatWeekShapeForPrompt(
+  shape: WeekShapeSummary,
+  language: "fr" | "en",
+): string {
+  if (language === "fr") {
+    const kindLabel = {
+      empty: "aucune donnée",
+      "single-day": "un seul jour de trading",
+      flat: "plusieurs jours, série plate (peu ou pas de variation)",
+      varied: "plusieurs jours avec variation significative",
+    }[shape.kind]
+    const shapeRule = shape.allowShapeLanguage
+      ? "autorisé uniquement si les chiffres du jour le montrent"
+      : "interdit — ne pas inventer de rampe, d'escalade, ni de « commencé doucement / monté en puissance »"
+    return `Contexte factuel (à respecter, ne pas ignorer) :
+- Jours de trading cette semaine : ${shape.tradingDayCount}
+- Forme de la série : ${shape.kind} (${kindLabel})
+- Langage jour-après-jour / forme de semaine : ${shapeRule}`
+  }
+
+  const kindLabel = {
+    empty: "no data",
+    "single-day": "exactly one trading day",
+    flat: "several days, flat series (little or no variation)",
+    varied: "several days with meaningful variation",
+  }[shape.kind]
+  const shapeRule = shape.allowShapeLanguage
+    ? "allowed only when the daily numbers support it"
+    : 'forbidden — do not invent a ramp, escalation, or "started soft then climbed"'
+  return `Factual context (follow this, do not ignore it):
+- Trading days this week: ${shape.tradingDayCount}
+- Series shape: ${shape.kind} (${kindLabel})
+- Day-to-day / week-shape language: ${shapeRule}`
+}
+
+export function buildWeeklyAnalysisPrompt(
+  days: DailyPnL[],
+  language: "fr" | "en",
+): string {
+  const shape = summarizeWeekShape(days)
+  const series = formatDailyPnLForPrompt(days, language)
+  const meta = formatWeekShapeForPrompt(shape, language)
+
+  if (language === "fr") {
+    return `Tu es un coach en trading. Tu restes concret, amical et honnête sur les chiffres. Tu n'inventes jamais une histoire de semaine.
+${DELTALYTIX_CONTEXT.fr}
+
+${meta}
+
+P&L journalier de la semaine du récap (ce sont les seules journées — il n'y a pas de série de la semaine précédente) :
+${series}
+
+Pour l'analyse (intro) :
+1. Une phrase simple sur la semaine en cours, jusqu'à 60 mots
+2. Si la série est single-day (exactement un jour de trading), dis-le clairement (une séance / un jour). Interdit : « commencé doucement », « monté en puissance », ou toute rampe inventée
+3. Un langage jour-après-jour ou de forme de semaine uniquement si le contexte factuel l'autorise (≥2 jours avec variation réelle)
+4. Pas de fluff motivationnel vague (« énergie positive », « belle dynamique » sans chiffre)
+5. Parle comme à un ami, avec des mots simples
+6. N'invente ni jours supplémentaires, ni comparaison avec une semaine précédente absente des données
+7. Toute affirmation sur un jour plus fort ou plus faible doit correspondre à la liste de P&L
+
+Pour les conseils (tips) :
+1. Un conseil simple, jusqu'à 36 mots
+2. Si possible, cite un outil Deltalytix utile (tableau de bord, journal, calendrier, filtres, vues de comptes)
+3. Sois précis sur l'action à faire la semaine prochaine
+4. Reste honnête : un seul jour ne justifie pas un conseil basé sur une « tendance de la semaine »
+5. Mots simples, concrets, pas de slogan
+
+Écris une analyse utile et fidèle aux données :`
+  }
+
+  return `You are a trading coach. Stay concrete, friendly, and honest about the numbers. Never invent a week-long story.
+${DELTALYTIX_CONTEXT.en}
+
+${meta}
+
+Daily P&L for the recap week (these are the only days — there is no previous-week series):
+${series}
+
+For the analysis (intro):
+1. One simple sentence about the current week, up to 60 words
+2. If the series is single-day (exactly one trading day), say that plainly (one session / one day). Forbidden: "started soft", "ramped up", "monté en puissance", or any invented escalation
+3. Day-to-day or week-shape language only when the factual context allows it (≥2 days with real variation)
+4. No vague motivational fluff ("positive energy", "great momentum" with no number)
+5. Speak like a friend, using simple words
+6. Do not invent extra days or a previous-week comparison that is not in the data
+7. Any claim about a stronger or weaker day must match the P&L list
+
+For the tips:
+1. One simple tip, up to 36 words
+2. When it fits, name a Deltalytix tool that helps (dashboard, journal, calendar, filters, account views)
+3. Be specific about what to do next week
+4. Stay honest: one day does not justify advice based on a "week-long trend"
+5. Simple, concrete words — no slogans
+
+Write an analysis that is useful and faithful to the data:`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The weekly recap paragraph under net P&L (`generateTradingAnalysis`) was using `openai("gpt-4.1-nano-2025-04-14")` with an always-positive FR/EN prompt that told the model to “always find something positive” and to look at day-to-day change.

**Sep 6 2026 audit (1-day / thin weeks):**
- Stock FR lines like “monté en puissance” and “commencé doucement” invented a week-long ramp when there was only one trading day (Gregoire + Corentin **FAIL**).
- Vague fluff (“énergie positive”) is unwanted.
- Concrete day/shape claims should appear **only** when the daily PnL series supports them.

## What changed

- Rewrote FR + EN prompts so they:
  1. Never invent a week-long progression from a single day or sparse/flat series.
  2. State a one-session / one-day week plainly.
  3. Allow day-to-day / shape language only when ≥2 days have meaningful PnL variation.
  4. Drop vague motivational fluff; stay concrete, friendly, and short (60 / 36 word caps kept).
  5. Keep coaching tips tied to Deltalytix tools when it fits, but stay honest about the data.
- Pass explicit **week-shape metadata** into the prompt (`tradingDayCount`, `single-day` / `flat` / `varied`, whether shape language is allowed) so the model cannot ignore the series shape.
- Production already sends only the recap week’s daily PnL (Mon–Sun UTC). The prompt no longer pretends a previous-week series exists.

## Model: Luna High

Hugo: “change the model to Luna High.”

| Layer | Id |
| --- | --- |
| Cursor catalog | `gpt-5.6-luna` + reasoning=high |
| Deltalytix / AI SDK / Vercel AI Gateway | `openai/gpt-5.6-luna` |
| Reasoning | `providerOptions.openai.reasoningEffort: "high"` |

This is the same Gateway string pattern already used for support/chat (`openai/gpt-5-mini`, `openai/gpt-5-nano`) and needs **no new secrets** (`AI_GATEWAY_API_KEY` / Vercel OIDC already used in production). Optional override: `WEEKLY_ANALYSIS_MODEL`.

Luna is **not** wired through the old `@ai-sdk/openai` `openai("…")` helper that this file used for nano. That path is left behind on purpose.

## Tests

- `lib/weekly-recap-analysis.test.ts` — week-shape helper + FR/EN prompt rules (1-day ramp ban, fluff ban, metadata).
- `app/api/email/weekly-summary/[userid]/actions/analysis.test.ts` — mocked `streamObject` asserts Luna High wiring.

## Out of scope

- Email chrome / send gate / cron
- Other AI routes still on `gpt-4o-*` or `gpt-5-mini`
- No merge (targets **beta** only, never main)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6ede006-d57b-44a3-a882-0628fb0a1188?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6ede006-d57b-44a3-a882-0628fb0a1188&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

